### PR TITLE
Remove unnecessary `protected` keyword in a few places

### DIFF
--- a/langchain/src/agents/agent_toolkits/zapier/zapier.ts
+++ b/langchain/src/agents/agent_toolkits/zapier/zapier.ts
@@ -5,10 +5,6 @@ import { ZapierNLARunAction, ZapierNLAWrapper } from "../../../tools/zapier.js";
 export class ZapierToolKit extends Toolkit {
   tools: Tool[] = [];
 
-  protected constructor() {
-    super();
-  }
-
   static async fromZapierNLAWrapper(
     zapierNLAWrapper: ZapierNLAWrapper
   ): Promise<ZapierToolKit> {

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -37,9 +37,9 @@ export abstract class BaseLanguageModel implements BaseLanguageModelParams {
    * The async caller should be used by subclasses to make any async calls,
    * which will thus benefit from the concurrency and retry logic.
    */
-  protected caller: AsyncCaller;
+  caller: AsyncCaller;
 
-  protected constructor(params: BaseLanguageModelParams) {
+  constructor(params: BaseLanguageModelParams) {
     this.verbose =
       params.verbose ?? (params.callbackManager ? true : getVerbosity());
     this.callbackManager = params.callbackManager ?? getCallbackManager();

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -28,8 +28,8 @@ export type SerializedLLM = {
 export type BaseChatModelParams = BaseLanguageModelParams;
 
 export abstract class BaseChatModel extends BaseLanguageModel {
-  protected constructor({ ...rest }: BaseChatModelParams) {
-    super(rest);
+  constructor(fields: BaseChatModelParams) {
+    super(fields);
   }
 
   abstract _combineLLMOutput?(

--- a/langchain/src/embeddings/base.ts
+++ b/langchain/src/embeddings/base.ts
@@ -7,7 +7,7 @@ export abstract class Embeddings {
    * The async caller should be used by subclasses to make any async calls,
    * which will thus benefit from the concurrency and retry logic.
    */
-  protected caller: AsyncCaller;
+  caller: AsyncCaller;
 
   constructor(params: EmbeddingsParams) {
     this.caller = new AsyncCaller(params ?? {});

--- a/langchain/src/retrievers/remote/base.ts
+++ b/langchain/src/retrievers/remote/base.ts
@@ -32,7 +32,7 @@ export abstract class RemoteRetriever
 
   asyncCaller: AsyncCaller;
 
-  protected constructor({ url, auth, ...rest }: RemoteRetrieverParams) {
+  constructor({ url, auth, ...rest }: RemoteRetrieverParams) {
     super();
     this.url = url;
     this.auth = auth;

--- a/test-exports-vercel/src/pages/api/hello-edge.ts
+++ b/test-exports-vercel/src/pages/api/hello-edge.ts
@@ -13,6 +13,7 @@ import {
 import { OpenAI } from "langchain/llms/openai";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { CallbackManager } from "langchain/callbacks";
+import { ChatAgent } from "langchain/agents";
 
 import { NextRequest, NextResponse } from "next/server";
 
@@ -26,6 +27,7 @@ export default async function handler(req: NextRequest) {
   const emb = new OpenAIEmbeddings({
     openAIApiKey: process.env.OPENAI_API_KEY,
   });
+  const agent = ChatAgent.fromLLMAndTools(new ChatOpenAI(), []);
 
   // Set up a streaming LLM
   const encoder = new TextEncoder();


### PR DESCRIPTION
These things made up by TS can sometimes be more harm than good sadly, as they don't really protect anything for anyone using JS without TS, and can create strange typing issues