### PR TITLE
add toString() in `Document`'s ctor to prevent unreadable error message

### DIFF
--- a/langchain/src/document.ts
+++ b/langchain/src/document.ts
@@ -20,7 +20,9 @@ export class Document<
   metadata: Metadata;
 
   constructor(fields?: Partial<DocumentParams<Metadata>>) {
-    this.pageContent = fields?.pageContent ?? this.pageContent;
+    this.pageContent = fields?.pageContent
+      ? fields.pageContent.toString()
+      : this.pageContent;
     this.metadata = fields?.metadata ?? ({} as Metadata);
   }
 }


### PR DESCRIPTION
if I read some text from file by `fs`, sometime I will forget to pass 'utf-8' as arguments and get a Buffer.
And if I use this content to create a vectorStore, I will get a unreadable error message
```
const content = readFileSync(join(__dirname, 'input.txt'))  // should be readFileSync(join(__dirname, 'input.txt'), 'utf-8')
Chroma.fromTexts(
        [content],
        [{}],
        embeddingModel,
        {
            collectionName: "abc",
        }
    );


// will got this error
TypeError: t.replaceAll is not a function
    at file:///T:/_CODE_/langchain-test2/node_modules/langchain/dist/embeddings/openai.js:68:79
    at Array.map (<anonymous>)
    at OpenAIEmbeddings.embedDocuments (file:///T:/_CODE_/langchain-test2/node_modules/langchain/dist/embeddings/openai.js:68:66)
    at Chroma.addDocuments (file:///T:/_CODE_/langchain-test2/node_modules/langchain/dist/vectorstores/chroma.js:39:53)
    at Chroma.fromDocuments (file:///T:/_CODE_/langchain-test2/node_modules/langchain/dist/vectorstores/chroma.js:120:24)
    at Chroma.fromTexts (file:///T:/_CODE_/langchain-test2/node_modules/langchain/dist/vectorstores/chroma.js:116:23)
    at insertIntoChroma (file:///T:/_CODE_/langchain-test2/chroma.mjs:57:18)
    at run (file:///T:/_CODE_/langchain-test2/chroma.mjs:47:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
That is because langchain try to invoke `replaceAll` for the inputting Buffer.

------

This PR add a `toString()` invoke when creating a vectorstore by text. I don't know whether should we check the typeof text or use `toString` directly. If you think it is better to check the type and throw Error, plz let me know.