### PR TITLE
Update integrations.mdx

### DIFF
--- a/docs/docs/modules/models/chat/integrations.mdx
+++ b/docs/docs/modules/models/chat/integrations.mdx
@@ -10,7 +10,7 @@ LangChain offers a number of Chat Models implementations that integrate with var
 ## `OpenAI`
 
 ```typescript
-import { ChatOpenAI } from "langchain/chat_models/openai";
+import { ChatOpenAI } from "langchain/chat_models";
 
 const model = new ChatOpenAI({
   temperature: 0.9,


### PR DESCRIPTION
import link for ChatOpenAI was broken. updated to import { ChatOpenAI } from 'langchain/chat_models';