### PR TITLE
Update BaseMemory.getInputValue() so it can access nested keys

### DIFF
--- a/langchain/src/memory/base.ts
+++ b/langchain/src/memory/base.ts
@@ -23,7 +23,7 @@ export abstract class BaseMemory {
  * If there are multiple input values, the inputKey must be specified.
  * Keys can be nested using dot notation, e.g. "key1.key2".
  */
-export const getInputValue = (inputValues: InputValues, inputKey?: string) => {
+export const getInputValue = (inputValues: InputValues, inputKey?: string): any => {
   if (inputKey !== undefined) {
     const levels = inputKey.split('.')
     return levels[1] !== undefined

--- a/langchain/src/memory/base.ts
+++ b/langchain/src/memory/base.ts
@@ -21,10 +21,14 @@ export abstract class BaseMemory {
  * This function is used by memory classes to select the input value
  * to use for the memory. If there is only one input value, it is used.
  * If there are multiple input values, the inputKey must be specified.
+ * Keys can be nested using dot notation, e.g. "key1.key2".
  */
 export const getInputValue = (inputValues: InputValues, inputKey?: string) => {
   if (inputKey !== undefined) {
-    return inputValues[inputKey];
+    const levels = inputKey.split('.')
+    return levels[1] !== undefined
+      ? getInputValue(inputValues[levels[0]], levels.slice(1).join('.'))
+      : inputValues[levels[0]];
   }
   const keys = Object.keys(inputValues);
   if (keys.length === 1) {


### PR DESCRIPTION
Update that allows key traversal for Memory that is useful when dealing with structured output. E.g., Motorhead can only store string values, which might be nested deep in the outputValues object.