### PR TITLE
Allow configurable responses for the Search tools

### DIFF
--- a/langchain/src/tools/index.ts
+++ b/langchain/src/tools/index.ts
@@ -1,4 +1,8 @@
-export { SerpAPI, SerpAPIParameters, SerpAPIResponseExtractor } from "./serpapi.js";
+export {
+  SerpAPI,
+  SerpAPIParameters,
+  SerpAPIResponseExtractor,
+} from "./serpapi.js";
 export { DadJokeAPI } from "./dadjokeapi.js";
 export { BingSerpAPI } from "./bingserpapi.js";
 export { Tool, ToolParams, StructuredTool } from "./base.js";

--- a/langchain/src/tools/index.ts
+++ b/langchain/src/tools/index.ts
@@ -1,4 +1,4 @@
-export { SerpAPI, SerpAPIParameters } from "./serpapi.js";
+export { SerpAPI, SerpAPIParameters, SerpAPIResponseExtractor } from "./serpapi.js";
 export { DadJokeAPI } from "./dadjokeapi.js";
 export { BingSerpAPI } from "./bingserpapi.js";
 export { Tool, ToolParams, StructuredTool } from "./base.js";
@@ -25,6 +25,6 @@ export {
   ZapierNLAWrapper,
   ZapiterNLAWrapperParams,
 } from "./zapier.js";
-export { Serper, SerperParameters } from "./serper.js";
+export { Serper, SerperParameters, SerperResponseExtractor } from "./serper.js";
 export { AIPluginTool } from "./aiplugin.js";
 export { ReadFileTool, WriteFileTool } from "./fs.js";

--- a/langchain/src/tools/serpapi.ts
+++ b/langchain/src/tools/serpapi.ts
@@ -278,8 +278,8 @@ export interface SerpAPIParameters extends BaseParameters {
   ijn?: string;
 }
 
-
-export type SerpAPIResponseExtractor = (response: any) => Promise<string>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SerpAPIResponseExtractor = (response: any) => Promise<string>;
 
 type UrlParameters = Record<
   string,

--- a/langchain/src/tools/serpapi.ts
+++ b/langchain/src/tools/serpapi.ts
@@ -298,16 +298,16 @@ export class SerpAPI extends Tool {
 
   protected baseUrl: string;
 
-  protected responseExtractor?: SerpAPIResponseExtractor;
+  protected responseExtractor: SerpAPIResponseExtractor;
 
   constructor(
     apiKey: string | undefined = typeof process !== "undefined"
       ? // eslint-disable-next-line no-process-env
-      process.env?.SERPAPI_API_KEY
+        process.env?.SERPAPI_API_KEY
       : undefined,
     params: Partial<SerpAPIParameters> = {},
     baseUrl = "https://serpapi.com",
-    responseExtractor?: SerpAPIResponseExtractor,
+    responseExtractor: SerpAPIResponseExtractor = defaultResponseExtractor
   ) {
     super();
 
@@ -357,42 +357,42 @@ export class SerpAPI extends Tool {
 
     const res = await resp.json();
 
-    if (this.responseExtractor) {
-      return await this.responseExtractor(res);
-    }
-
-
-    if (res.error) {
-      throw new Error(`Got error from serpAPI: ${res.error}`);
-    }
-
-    if (res.answer_box?.answer) {
-      return res.answer_box.answer;
-    }
-
-    if (res.answer_box?.snippet) {
-      return res.answer_box.snippet;
-    }
-
-    if (res.answer_box?.snippet_highlighted_words) {
-      return res.answer_box.snippet_highlighted_words[0];
-    }
-
-    if (res.sports_results?.game_spotlight) {
-      return res.sports_results.game_spotlight;
-    }
-
-    if (res.knowledge_graph?.description) {
-      return res.knowledge_graph.description;
-    }
-
-    if (res.organic_results?.[0]?.snippet) {
-      return res.organic_results[0].snippet;
-    }
-
-    return "No good search result found";
+    return await this.responseExtractor(res);
   }
 
   description =
     "a search engine. useful for when you need to answer questions about current events. input should be a search query.";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function defaultResponseExtractor(res: any) {
+  if (res.error) {
+    throw new Error(`Got error from serpAPI: ${res.error}`);
+  }
+
+  if (res.answer_box?.answer) {
+    return res.answer_box.answer;
+  }
+
+  if (res.answer_box?.snippet) {
+    return res.answer_box.snippet;
+  }
+
+  if (res.answer_box?.snippet_highlighted_words) {
+    return res.answer_box.snippet_highlighted_words[0];
+  }
+
+  if (res.sports_results?.game_spotlight) {
+    return res.sports_results.game_spotlight;
+  }
+
+  if (res.knowledge_graph?.description) {
+    return res.knowledge_graph.description;
+  }
+
+  if (res.organic_results?.[0]?.snippet) {
+    return res.organic_results[0].snippet;
+  }
+
+  return "No good search result found";
 }

--- a/langchain/src/tools/serper.ts
+++ b/langchain/src/tools/serper.ts
@@ -5,7 +5,8 @@ export type SerperParameters = {
   hl?: string;
 };
 
-export type SerperResponseExtractor = (response: any) => Promise<string>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SerperResponseExtractor = (response: any) => Promise<string>;
 
 /**
  * Wrapper around serper.

--- a/langchain/src/tools/serper.ts
+++ b/langchain/src/tools/serper.ts
@@ -20,15 +20,15 @@ export class Serper extends Tool {
 
   protected params: Partial<SerperParameters>;
 
-  protected responseExtractor?: SerperResponseExtractor;
+  protected responseExtractor: SerperResponseExtractor;
 
   constructor(
     apiKey: string | undefined = typeof process !== "undefined"
       ? // eslint-disable-next-line no-process-env
-      process.env?.SERPER_API_KEY
+        process.env?.SERPER_API_KEY
       : undefined,
     params: Partial<SerperParameters> = {},
-    responseExtractor?: SerperResponseExtractor
+    responseExtractor: SerperResponseExtractor = defaultResponseExtractor
   ) {
     super();
 
@@ -67,37 +67,38 @@ export class Serper extends Tool {
 
     const json = await res.json();
 
-    if (this.responseExtractor) {
-      return await this.responseExtractor(json);
-    }
-
-    if (json.answerBox?.answer) {
-      return json.answerBox.answer;
-    }
-
-    if (json.answerBox?.snippet) {
-      return json.answerBox.snippet;
-    }
-
-    if (json.answerBox?.snippet_highlighted_words) {
-      return json.answerBox.snippet_highlighted_words[0];
-    }
-
-    if (json.sportsResults?.game_spotlight) {
-      return json.sportsResults.game_spotlight;
-    }
-
-    if (json.knowledgeGraph?.description) {
-      return json.knowledgeGraph.description;
-    }
-
-    if (json.organic?.[0]?.snippet) {
-      return json.organic[0].snippet;
-    }
-
-    return "No good search result found";
+    return await this.responseExtractor(json);
   }
 
   description =
     "a search engine. useful for when you need to answer questions about current events. input should be a search query.";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function defaultResponseExtractor(json: any) {
+  if (json.answerBox?.answer) {
+    return json.answerBox.answer;
+  }
+
+  if (json.answerBox?.snippet) {
+    return json.answerBox.snippet;
+  }
+
+  if (json.answerBox?.snippet_highlighted_words) {
+    return json.answerBox.snippet_highlighted_words[0];
+  }
+
+  if (json.sportsResults?.game_spotlight) {
+    return json.sportsResults.game_spotlight;
+  }
+
+  if (json.knowledgeGraph?.description) {
+    return json.knowledgeGraph.description;
+  }
+
+  if (json.organic?.[0]?.snippet) {
+    return json.organic[0].snippet;
+  }
+
+  return "No good search result found";
 }

--- a/langchain/src/tools/serper.ts
+++ b/langchain/src/tools/serper.ts
@@ -5,6 +5,8 @@ export type SerperParameters = {
   hl?: string;
 };
 
+export type SerperResponseExtractor = (response: any) => Promise<string>
+
 /**
  * Wrapper around serper.
  *
@@ -17,12 +19,15 @@ export class Serper extends Tool {
 
   protected params: Partial<SerperParameters>;
 
+  protected responseExtractor?: SerperResponseExtractor;
+
   constructor(
     apiKey: string | undefined = typeof process !== "undefined"
       ? // eslint-disable-next-line no-process-env
-        process.env?.SERPER_API_KEY
+      process.env?.SERPER_API_KEY
       : undefined,
-    params: Partial<SerperParameters> = {}
+    params: Partial<SerperParameters> = {},
+    responseExtractor?: SerperResponseExtractor
   ) {
     super();
 
@@ -34,6 +39,7 @@ export class Serper extends Tool {
 
     this.key = apiKey;
     this.params = params;
+    this.responseExtractor = responseExtractor;
   }
 
   name = "search";
@@ -59,6 +65,10 @@ export class Serper extends Tool {
     }
 
     const json = await res.json();
+
+    if (this.responseExtractor) {
+      return await this.responseExtractor(json);
+    }
 
     if (json.answerBox?.answer) {
       return json.answerBox.answer;


### PR DESCRIPTION
Currently the search tools response is very limited and tend to only respond back with a single answer. This is typically not enough for many cases where the main answer is either incomplete of irrelevant to the original question.

I have added to the Serper and the SerpAPI search tool's constructor an optional "response extractor" that users of the tool can set to fully customize the output of the search tool. This way each user can decide what type of results they want to include and in which presentation.

A good use-case for this feature is for Agents that use the Browser tool, developers that have setup agents with access to the browser may want the Search tools to return found links so the agent can navigate to those links thru the browser.

Open question:

- The type signature of the extractor function is `(response: any) => Promise<string>;` where response is the raw result of the search call. Should `response` be typed or should can it stay as `any`?
