### PR TITLE
feat: add Web PDF Loader Support

### DIFF
--- a/langchain/src/document_loaders/tests/pdf-web.int.test.ts
+++ b/langchain/src/document_loaders/tests/pdf-web.int.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@jest/globals";
+import { createRequire } from "module";
+import fs from "fs/promises";
+import * as url from "node:url";
+import * as path from "node:path";
+import { PdfWebBaseLoader } from "../web/pdf.js";
+
+test("Test PDF loader from URL", async () => {
+  const pdfUrl = "https://arxiv.org/pdf/1706.03762.pdf";
+  const requireFunc = createRequire(import.meta.url);
+  const workerSrc = requireFunc.resolve(
+    "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js"
+  );
+  const loader = new PdfWebBaseLoader(pdfUrl, {
+    workerSrc,
+  });
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(15);
+  expect(docs[0].pageContent).toContain("Attention Is All You Need");
+});
+
+test("Test PDF loader from URL to single document", async () => {
+ const pdfUrl = "https://arxiv.org/pdf/1706.03762.pdf";
+  const requireFunc = createRequire(import.meta.url);
+  const workerSrc = requireFunc.resolve(
+    "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js"
+  );
+  const loader = new PdfWebBaseLoader(pdfUrl, {
+    workerSrc,
+    splitPages: false
+  });
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(1);
+  expect(docs[0].pageContent).toContain("Attention Is All You Need");
+});
+
+test("Test PDF loader from Uint8Array", async () => {
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/1706.03762.pdf"
+  );
+  const pdfBuffer = await fs.readFile(filePath);
+  const pdfArray = new Uint8Array(pdfBuffer.buffer);
+  const loader = new PdfWebBaseLoader(pdfArray);
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(15);
+  expect(docs[0].pageContent).toContain("Attention Is All You Need");
+});
+
+test("Test PDF loader from Uint8Array to single document", async () => {
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/1706.03762.pdf"
+  );
+  const pdfBuffer = await fs.readFile(filePath);
+  const pdfArray = new Uint8Array(pdfBuffer.buffer);
+  const loader = new PdfWebBaseLoader(pdfArray, { splitPages: false });
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(1);
+  expect(docs[0].pageContent).toContain("Attention Is All You Need");
+});

--- a/langchain/src/document_loaders/tests/pdf-web.int.test.ts
+++ b/langchain/src/document_loaders/tests/pdf-web.int.test.ts
@@ -21,14 +21,14 @@ test("Test PDF loader from URL", async () => {
 });
 
 test("Test PDF loader from URL to single document", async () => {
- const pdfUrl = "https://arxiv.org/pdf/1706.03762.pdf";
+  const pdfUrl = "https://arxiv.org/pdf/1706.03762.pdf";
   const requireFunc = createRequire(import.meta.url);
   const workerSrc = requireFunc.resolve(
     "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js"
   );
   const loader = new PdfWebBaseLoader(pdfUrl, {
     workerSrc,
-    splitPages: false
+    splitPages: false,
   });
   const docs = await loader.load();
 

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -1,0 +1,182 @@
+import {
+  Metadata,
+  PDFDocumentProxy,
+} from "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js";
+import { isNode } from "browser-or-node";
+import { Document } from "../../document.js";
+import { BaseDocumentLoader } from "../base.js";
+import type { DocumentLoader } from "../base.js";
+
+export class PdfWebBaseLoader
+  extends BaseDocumentLoader
+  implements DocumentLoader
+{
+  private splitPages: boolean;
+
+  private urlOrPdfContent: string | Uint8Array;
+
+  protected pdfContent: Uint8Array;
+
+  private pdfjs: typeof PDFLoaderImports;
+
+  constructor(
+    urlOrPdfContent: string | Uint8Array,
+    {
+      splitPages = true,
+      pdfjs = PDFLoaderImports,
+      workerSrc,
+    }: {
+      splitPages?: boolean;
+      pdfjs?: typeof PDFLoaderImports;
+      workerSrc?: string;
+    } = {}
+  ) {
+    super();
+    this.urlOrPdfContent = urlOrPdfContent;
+    this.pdfjs = pdfjs;
+    this.splitPages = splitPages;
+  
+    if (workerSrc) {
+      this.setWorkerSrc(workerSrc).then(() => {
+        console.log('Worker source set');
+      }).catch((error) => {
+        console.error('Failed to set worker source:', error);
+      });
+    }
+  }
+  
+  private setWorkerSrc(workerSrc: string): Promise<void> {
+    return import(
+      "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js"
+    ).then(({ default: importedMod }) => {
+      const mod = importedMod;
+      mod.GlobalWorkerOptions.workerSrc = workerSrc;
+    });
+  }
+
+  async load(): Promise<Document[]> {
+    try {
+      let pdfData;
+      if (isNode && typeof this.urlOrPdfContent === "string") {
+        const response = await fetch(this.urlOrPdfContent);
+        pdfData = await response.arrayBuffer();
+      } else {
+        pdfData = this.urlOrPdfContent;
+      }
+
+      const { getDocument, version } = await this.pdfjs();
+      const pdf = await getDocument(
+        typeof pdfData === "string"
+          ? pdfData
+          : {
+              data: pdfData,
+              isEvalSupported: false,
+              useSystemFonts: true,
+            }
+      ).promise;
+      const meta = await pdf.getMetadata().catch(() => null);
+      const { numPages } = pdf;
+      const documents: Document[] = [];
+
+      for (let i = 1; i <= numPages; i+=1) {
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent();
+
+        if (content.items.length === 0) {
+          continue;
+        }
+
+        const text = content.items
+          .map((item) => ("str" in item ? item.str : ""))
+          .join("\n");
+
+        documents.push(
+          new Document({
+            pageContent: text,
+            metadata: {
+              pdf: {
+                version,
+                info: meta?.info,
+                metadata: meta?.metadata,
+                totalPages: pdf.numPages,
+              },
+              loc: {
+                pageNumber: i,
+              },
+            },
+          })
+        );
+      }
+
+      if (this.splitPages) {
+        return documents;
+      }
+
+      if (documents.length === 0) {
+        return [];
+      }
+
+      return [
+        new Document({
+          pageContent: documents.map((doc) => doc.pageContent).join("\n\n"),
+          metadata: {
+            pdf: {
+              version,
+              info: meta?.info,
+              metadata: meta?.metadata,
+              totalPages: pdf.numPages,
+            },
+          },
+        }),
+      ];
+    } catch (error) {
+      throw new Error(`Could not load PDF from data: ${error}`);
+    }
+  }
+
+  async processPage(
+    pdf: PDFDocumentProxy,
+    pageIndex: number,
+    meta: {
+      info: object;
+      metadata: Metadata;
+    } | null,
+    version: string
+  ): Promise<Document> {
+    const page = await pdf.getPage(pageIndex);
+    const pageContent = await page.getTextContent();
+    const text = pageContent.items
+      .map((item) => ("str" in item ? item.str : ""))
+      .join(" ");
+
+    return new Document({
+      pageContent: text,
+      metadata: {
+        pdf: {
+          version,
+          info: meta?.info,
+          metadata: meta?.metadata,
+          totalPages: pdf.numPages,
+        },
+        loc: {
+          pageNumber: pageIndex,
+        },
+      },
+    });
+  }
+}
+
+async function PDFLoaderImports() {
+  try {
+    const { default: mod } = await import(
+      "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js"
+    );
+    const { getDocument, version } = mod;
+    return { getDocument, version };
+  } catch (e) {
+    console.error(e);
+    throw new Error(
+      "Failed to load pdfjs-dist. Please install it with eg. `npm install pdfjs-dist`."
+    );
+  }
+}

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -35,23 +35,25 @@ export class PdfWebBaseLoader
     this.urlOrPdfContent = urlOrPdfContent;
     this.pdfjs = pdfjs;
     this.splitPages = splitPages;
-  
+
     if (workerSrc) {
-      this.setWorkerSrc(workerSrc).then(() => {
-        console.log('Worker source set');
-      }).catch((error) => {
-        console.error('Failed to set worker source:', error);
-      });
+      this.setWorkerSrc(workerSrc)
+        .then(() => {
+          console.log("Worker source set");
+        })
+        .catch((error) => {
+          console.error("Failed to set worker source:", error);
+        });
     }
   }
-  
+
   private setWorkerSrc(workerSrc: string): Promise<void> {
-    return import(
-      "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js"
-    ).then(({ default: importedMod }) => {
-      const mod = importedMod;
-      mod.GlobalWorkerOptions.workerSrc = workerSrc;
-    });
+    return import("pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js").then(
+      ({ default: importedMod }) => {
+        const mod = importedMod;
+        mod.GlobalWorkerOptions.workerSrc = workerSrc;
+      }
+    );
   }
 
   async load(): Promise<Document[]> {
@@ -78,7 +80,7 @@ export class PdfWebBaseLoader
       const { numPages } = pdf;
       const documents: Document[] = [];
 
-      for (let i = 1; i <= numPages; i+=1) {
+      for (let i = 1; i <= numPages; i += 1) {
         const page = await pdf.getPage(i);
         const content = await page.getTextContent();
 

--- a/langchain/src/types/pdf-parse.d.ts
+++ b/langchain/src/types/pdf-parse.d.ts
@@ -1,6 +1,7 @@
 /**
  * Type definitions adapted from pdfjs-dist
  * https://github.com/mozilla/pdfjs-dist/blob/master/types/src/display/api.d.ts
+ * https://github.com/mozilla/pdfjs-dist/blob/master/types/src/display/metadata.d.ts
  */
 
 declare module "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js" {
@@ -1406,4 +1407,43 @@ declare module "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js" {
   }
   /** @type {string} */
   export const version: string;
+
+  export class Metadata {
+    constructor({ parsedData, rawData }: { parsedData: any; rawData: any });
+    getRaw(): any;
+    get(name: any): any;
+    getAll(): any;
+    has(name: any): any;
+    #private;
+  }
+}
+
+declare module "pdf-parse/lib/pdf.js/v2.0.550/build/pdf.js" {
+  export type GlobalWorkerOptionsType = {
+    /**
+     * - Defines global port for worker
+     * process. Overrides the `workerSrc` option.
+     */
+    workerPort: Worker | null;
+    /**
+     * - A string containing the path and filename
+     * of the worker file.
+     *
+     * NOTE: The `workerSrc` option should always be set, in order to prevent any
+     * issues when using the PDF.js library.
+     */
+    workerSrc: string;
+  };
+  /**
+   * @typedef {Object} GlobalWorkerOptionsType
+   * @property {Worker | null} workerPort - Defines global port for worker
+   *   process. Overrides the `workerSrc` option.
+   * @property {string} workerSrc - A string containing the path and filename
+   *   of the worker file.
+   *
+   *   NOTE: The `workerSrc` option should always be set, in order to prevent any
+   *         issues when using the PDF.js library.
+   */
+  /** @type {GlobalWorkerOptionsType} */
+  export const GlobalWorkerOptions: GlobalWorkerOptionsType;
 }


### PR DESCRIPTION
This PR introduces support for loading PDFs in a web environment, complementing the existing Node.js support. The new web version can accept two types of sources: static PDF URLs and Uint8Array objects.

Key changes:

- Created a new file langchain/src/document_loaders/web/pdf.ts, which implements the web version of the PDF loader.
- - Added a new file langchain/src/document_loaders/tests/pdf-web.int.test.ts for integration testing of the web PDF loader.
- Updated the type definitions in langchain/src/types/pdf-parse.d.ts to accommodate the new changes.