### PR TITLE
Introduce GPT4All to langchainjs

### DIFF
--- a/docs/docs/modules/models/llms/integrations.mdx
+++ b/docs/docs/modules/models/llms/integrations.mdx
@@ -1,0 +1,170 @@
+---
+sidebar_position: 3
+sidebar_label: Integrations
+---
+
+# Integrations: LLMs
+
+LangChain offers a number of LLM implementations that integrate with various model providers. These are:
+
+## `OpenAI`
+
+```typescript
+import { OpenAI } from "langchain/llms/openai";
+
+const model = new OpenAI({
+  temperature: 0.9,
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+console.log({ res });
+```
+
+## Azure `OpenAI`
+
+```typescript
+import { OpenAI } from "langchain/llms/openai";
+
+const model = new OpenAI({
+  temperature: 0.9,
+  azureOpenAIApiKey: "YOUR-API-KEY",
+  azureOpenAIApiInstanceName: "YOUR-INSTANCE-NAME",
+  azureOpenAIApiDeploymentName: "YOUR-DEPLOYMENT-NAME",
+  azureOpenAIApiVersion: "YOUR-API-VERSION",
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+console.log({ res });
+```
+
+## `HuggingFaceInference`
+
+```bash npm2yarn
+npm install @huggingface/inference@1
+```
+
+```typescript
+import { HuggingFaceInference } from "langchain/llms/hf";
+
+const model = new HuggingFaceInference({
+  model: "gpt2",
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.HUGGINGFACEHUB_API_KEY
+});
+const res = await model.call("1 + 1 =");
+console.log({ res });
+```
+
+## `Cohere`
+
+```bash npm2yarn
+npm install cohere-ai
+```
+
+```typescript
+import { Cohere } from "langchain/llms/cohere";
+
+const model = new Cohere({
+  maxTokens: 20,
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.COHERE_API_KEY
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+console.log({ res });
+```
+
+## `Replicate`
+
+```bash npm2yarn
+npm install replicate
+```
+
+```typescript
+import { Replicate } from "langchain/llms/replicate";
+
+const model = new Replicate({
+  model:
+    "daanelson/flan-t5:04e422a9b85baed86a4f24981d7f9953e20c5fd82f6103b74ebc431588e1cec8",
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.REPLICATE_API_KEY
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+console.log({ res });
+```
+
+## `GPT4All`
+
+```bash npm2yarn
+npm install gpt4all
+```
+
+```typescript
+import { GPT4All } from "langchain/llms/gpt4all";
+
+const model = new GPT4All({
+  model: "gpt4all-lora-unfiltered-quantized",
+  forceDownload: true, // Defaults to false
+  decoderConfig: {}, // Defaults to {}
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+console.log({ res });
+```
+
+## Additional LLM Implementations
+
+### `PromptLayerOpenAI`
+
+LangChain integrates with PromptLayer for logging and debugging prompts and responses. To add support for PromptLayer:
+
+1. Create a PromptLayer account here: [https://promptlayer.com](https://promptlayer.com).
+2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPTLAYER_API_KEY` environment variable.
+
+```typescript
+import { PromptLayerOpenAI } from "langchain/llms/openai";
+
+const model = new PromptLayerOpenAI({
+  temperature: 0.9,
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+  promptLayerApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.PROMPTLAYER_API_KEY
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+```
+
+### Azure `PromptLayerOpenAI`
+
+LangChain integrates with PromptLayer for logging and debugging prompts and responses. To add support for PromptLayer:
+
+1. Create a PromptLayer account here: [https://promptlayer.com](https://promptlayer.com).
+2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPTLAYER_API_KEY` environment variable.
+
+```typescript
+import { PromptLayerOpenAI } from "langchain/llms/openai";
+
+const model = new PromptLayerOpenAI({
+  temperature: 0.9,
+  azureOpenAIApiKey: "YOUR-AOAI-API-KEY", // In Node.js defaults to process.env.AZURE_OPENAI_API_KEY
+  azureOpenAIApiInstanceName: "YOUR-AOAI-INSTANCE-NAME", // In Node.js defaults to process.env.AZURE_OPENAI_API_INSTANCE_NAME
+  azureOpenAIApiDeploymentName: "YOUR-AOAI-DEPLOYMENT-NAME", // In Node.js defaults to process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME
+  azureOpenAIApiCompletionsDeploymentName:
+    "YOUR-AOAI-COMPLETIONS-DEPLOYMENT-NAME", // In Node.js defaults to process.env.AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME
+  azureOpenAIApiEmbeddingsDeploymentName:
+    "YOUR-AOAI-EMBEDDINGS-DEPLOYMENT-NAME", // In Node.js defaults to process.env.AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME
+  azureOpenAIApiVersion: "YOUR-AOAI-API-VERSION", // In Node.js defaults to process.env.AZURE_OPENAI_API_VERSION
+  promptLayerApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.PROMPTLAYER_API_KEY
+});
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+```
+
+The request and the response will be logged in the [PromptLayer dashboard](https://promptlayer.com/home).
+
+> **_Note:_** In streaming mode PromptLayer will not log the response.

--- a/examples/src/llms/gpt4all.ts
+++ b/examples/src/llms/gpt4all.ts
@@ -1,0 +1,13 @@
+import { GPT4All } from "langchain/llms/gpt4all";
+
+export const run = async () => {
+  const model = new GPT4All({
+    model: "gpt4all-lora-unfiltered-quantized",
+    forceDownload: true, // Defaults to false
+    decoderConfig: {}, // Defaults to {}
+  });
+  const res = await model.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log({ res });
+};

--- a/examples/src/models/llm/gpt4all.ts
+++ b/examples/src/models/llm/gpt4all.ts
@@ -1,0 +1,44 @@
+import { GPT4All } from "langchain/llms/gpt4all";
+
+export const run = async () => {
+  const modelA = new GPT4All({
+    model: "gpt4all-lora-unfiltered-quantized",
+  });
+
+  // `call` is a simple string-in, string-out method for interacting with the model.
+  const resA = await modelA.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log({ resA });
+  /*
+  {
+    resA: 'Color Box'
+  }
+  */
+
+  // `generate` allows you to generate multiple completions for multiple prompts (in a single request for some models).
+  const resB = await modelA.generate([
+    "What would be a good company name a company that makes colorful socks?",
+    "What would be a good company name a company that makes colorful sweaters?",
+  ]);
+  // `resB` is a `LLMResult` object with a `generations` field and `llmOutput` field.
+  // `generations` is a `Generation[][]`, each `Generation` having a `text` field.
+  // Each input to the LLM could have multiple generations (depending on the `n` parameter), hence the list of lists.
+  console.log(JSON.stringify(resB, null, 2));
+  /*
+  {
+    "generations": [
+      [
+        {
+          "text": "apron string"
+        }
+      ],
+      [
+        {
+          "text": "Kulut"
+        }
+      ]
+    ]
+  }
+  */
+};

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -124,6 +124,7 @@ llms/ollama.d.ts
 llms/replicate.cjs
 llms/replicate.js
 llms/replicate.d.ts
+<<<<<<< HEAD
 llms/googlevertexai.cjs
 llms/googlevertexai.js
 llms/googlevertexai.d.ts
@@ -142,6 +143,11 @@ llms/llama_cpp.d.ts
 llms/writer.cjs
 llms/writer.js
 llms/writer.d.ts
+=======
+llms/gpt4all.cjs
+llms/gpt4all.js
+llms/gpt4all.d.ts
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
 prompts.cjs
 prompts.js
 prompts.d.ts

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -124,13 +124,15 @@ llms/ollama.d.ts
 llms/replicate.cjs
 llms/replicate.js
 llms/replicate.d.ts
-<<<<<<< HEAD
 llms/googlevertexai.cjs
 llms/googlevertexai.js
 llms/googlevertexai.d.ts
 llms/googlepalm.cjs
 llms/googlepalm.js
 llms/googlepalm.d.ts
+llms/gpt4all.cjs
+llms/gpt4all.js
+llms/gpt4all.d.ts
 llms/sagemaker_endpoint.cjs
 llms/sagemaker_endpoint.js
 llms/sagemaker_endpoint.d.ts
@@ -143,11 +145,6 @@ llms/llama_cpp.d.ts
 llms/writer.cjs
 llms/writer.js
 llms/writer.d.ts
-=======
-llms/gpt4all.cjs
-llms/gpt4all.js
-llms/gpt4all.d.ts
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
 prompts.cjs
 prompts.js
 prompts.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -136,13 +136,15 @@
     "llms/replicate.cjs",
     "llms/replicate.js",
     "llms/replicate.d.ts",
-<<<<<<< HEAD
     "llms/googlevertexai.cjs",
     "llms/googlevertexai.js",
     "llms/googlevertexai.d.ts",
     "llms/googlepalm.cjs",
     "llms/googlepalm.js",
     "llms/googlepalm.d.ts",
+    "llms/gpt4all.cjs",
+    "llms/gpt4all.js",
+    "llms/gpt4all.d.ts",
     "llms/sagemaker_endpoint.cjs",
     "llms/sagemaker_endpoint.js",
     "llms/sagemaker_endpoint.d.ts",
@@ -155,11 +157,6 @@
     "llms/writer.cjs",
     "llms/writer.js",
     "llms/writer.d.ts",
-=======
-    "llms/gpt4all.cjs",
-    "llms/gpt4all.js",
-    "llms/gpt4all.d.ts",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "prompts.cjs",
     "prompts.js",
     "prompts.d.ts",
@@ -690,13 +687,10 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-no-instanceof": "^1.0.1",
     "eslint-plugin-prettier": "^4.2.1",
-<<<<<<< HEAD
     "faiss-node": "^0.3.0",
     "firebase-admin": "^11.9.0",
     "google-auth-library": "^8.9.0",
-=======
     "gpt4all": "^1.0.0",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "graphql": "^16.6.0",
     "hnswlib-node": "^1.4.2",
     "html-to-text": "^9.0.5",
@@ -783,13 +777,10 @@
     "cohere-ai": "^5.0.2",
     "d3-dsv": "^2.0.0",
     "epub2": "^3.0.1",
-<<<<<<< HEAD
     "faiss-node": "^0.3.0",
     "firebase-admin": "^11.9.0",
     "google-auth-library": "^8.9.0",
-=======
     "gpt4all": "^1.0.0",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "hnswlib-node": "^1.4.2",
     "html-to-text": "^9.0.5",
     "ignore": "^5.2.0",
@@ -956,7 +947,6 @@
     "epub2": {
       "optional": true
     },
-<<<<<<< HEAD
     "faiss-node": {
       "optional": true
     },
@@ -964,9 +954,9 @@
       "optional": true
     },
     "google-auth-library": {
-=======
+      "optional": true
+    },
     "gpt4all": {
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
       "optional": true
     },
     "hnswlib-node": {
@@ -1317,7 +1307,6 @@
       "import": "./llms/replicate.js",
       "require": "./llms/replicate.cjs"
     },
-<<<<<<< HEAD
     "./llms/googlevertexai": {
       "types": "./llms/googlevertexai.d.ts",
       "import": "./llms/googlevertexai.js",
@@ -1327,6 +1316,11 @@
       "types": "./llms/googlepalm.d.ts",
       "import": "./llms/googlepalm.js",
       "require": "./llms/googlepalm.cjs"
+    },
+    "./llms/gpt4all": {
+      "types": "./llms/gpt4all.d.ts",
+      "import": "./llms/gpt4all.js",
+      "require": "./llms/gpt4all.cjs"
     },
     "./llms/sagemaker_endpoint": {
       "types": "./llms/sagemaker_endpoint.d.ts",
@@ -1347,12 +1341,6 @@
       "types": "./llms/writer.d.ts",
       "import": "./llms/writer.js",
       "require": "./llms/writer.cjs"
-=======
-    "./llms/gpt4all": {
-      "types": "./llms/gpt4all.d.ts",
-      "import": "./llms/gpt4all.js",
-      "require": "./llms/gpt4all.cjs"
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     },
     "./prompts": {
       "types": "./prompts.d.ts",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -136,6 +136,7 @@
     "llms/replicate.cjs",
     "llms/replicate.js",
     "llms/replicate.d.ts",
+<<<<<<< HEAD
     "llms/googlevertexai.cjs",
     "llms/googlevertexai.js",
     "llms/googlevertexai.d.ts",
@@ -154,6 +155,11 @@
     "llms/writer.cjs",
     "llms/writer.js",
     "llms/writer.d.ts",
+=======
+    "llms/gpt4all.cjs",
+    "llms/gpt4all.js",
+    "llms/gpt4all.d.ts",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "prompts.cjs",
     "prompts.js",
     "prompts.d.ts",
@@ -684,9 +690,13 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-no-instanceof": "^1.0.1",
     "eslint-plugin-prettier": "^4.2.1",
+<<<<<<< HEAD
     "faiss-node": "^0.3.0",
     "firebase-admin": "^11.9.0",
     "google-auth-library": "^8.9.0",
+=======
+    "gpt4all": "^1.0.0",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "graphql": "^16.6.0",
     "hnswlib-node": "^1.4.2",
     "html-to-text": "^9.0.5",
@@ -773,9 +783,13 @@
     "cohere-ai": "^5.0.2",
     "d3-dsv": "^2.0.0",
     "epub2": "^3.0.1",
+<<<<<<< HEAD
     "faiss-node": "^0.3.0",
     "firebase-admin": "^11.9.0",
     "google-auth-library": "^8.9.0",
+=======
+    "gpt4all": "^1.0.0",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     "hnswlib-node": "^1.4.2",
     "html-to-text": "^9.0.5",
     "ignore": "^5.2.0",
@@ -942,6 +956,7 @@
     "epub2": {
       "optional": true
     },
+<<<<<<< HEAD
     "faiss-node": {
       "optional": true
     },
@@ -949,6 +964,9 @@
       "optional": true
     },
     "google-auth-library": {
+=======
+    "gpt4all": {
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
       "optional": true
     },
     "hnswlib-node": {
@@ -1299,6 +1317,7 @@
       "import": "./llms/replicate.js",
       "require": "./llms/replicate.cjs"
     },
+<<<<<<< HEAD
     "./llms/googlevertexai": {
       "types": "./llms/googlevertexai.d.ts",
       "import": "./llms/googlevertexai.js",
@@ -1328,6 +1347,12 @@
       "types": "./llms/writer.d.ts",
       "import": "./llms/writer.js",
       "require": "./llms/writer.cjs"
+=======
+    "./llms/gpt4all": {
+      "types": "./llms/gpt4all.d.ts",
+      "import": "./llms/gpt4all.js",
+      "require": "./llms/gpt4all.cjs"
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
     },
     "./prompts": {
       "types": "./prompts.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -56,16 +56,13 @@ const entrypoints = {
   "llms/raycast": "llms/raycast",
   "llms/ollama": "llms/ollama",
   "llms/replicate": "llms/replicate",
-<<<<<<< HEAD
   "llms/googlevertexai": "llms/googlevertexai",
   "llms/googlepalm": "llms/googlepalm",
+  "llms/gpt4all": "llms/gpt4all",
   "llms/sagemaker_endpoint": "llms/sagemaker_endpoint",
   "llms/bedrock": "llms/bedrock",
   "llms/llama_cpp": "llms/llama_cpp",
   "llms/writer": "llms/writer",
-=======
-  "llms/gpt4all": "llms/gpt4all",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
   // prompts
   prompts: "prompts/index",
   "prompts/load": "prompts/load",
@@ -276,14 +273,11 @@ const requiresOptionalDependency = [
   "llms/hf",
   "llms/raycast",
   "llms/replicate",
-<<<<<<< HEAD
   "llms/sagemaker_endpoint",
   "llms/bedrock",
   "llms/llama_cpp",
   "llms/writer",
-=======
   "llms/gpt4all",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
   "prompts/load",
   "vectorstores/analyticdb",
   "vectorstores/chroma",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -56,12 +56,16 @@ const entrypoints = {
   "llms/raycast": "llms/raycast",
   "llms/ollama": "llms/ollama",
   "llms/replicate": "llms/replicate",
+<<<<<<< HEAD
   "llms/googlevertexai": "llms/googlevertexai",
   "llms/googlepalm": "llms/googlepalm",
   "llms/sagemaker_endpoint": "llms/sagemaker_endpoint",
   "llms/bedrock": "llms/bedrock",
   "llms/llama_cpp": "llms/llama_cpp",
   "llms/writer": "llms/writer",
+=======
+  "llms/gpt4all": "llms/gpt4all",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
   // prompts
   prompts: "prompts/index",
   "prompts/load": "prompts/load",
@@ -272,10 +276,14 @@ const requiresOptionalDependency = [
   "llms/hf",
   "llms/raycast",
   "llms/replicate",
+<<<<<<< HEAD
   "llms/sagemaker_endpoint",
   "llms/bedrock",
   "llms/llama_cpp",
   "llms/writer",
+=======
+  "llms/gpt4all",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
   "prompts/load",
   "vectorstores/analyticdb",
   "vectorstores/chroma",

--- a/langchain/src/llms/gpt4all.ts
+++ b/langchain/src/llms/gpt4all.ts
@@ -1,0 +1,62 @@
+import { LLM, BaseLLMParams } from "./base.js";
+
+export interface GPT4AllInput {
+  // These are the only two models supported by the gpt4all-ts library currently
+  model: "gpt4all-lora-unfiltered-quantized" | "gpt4all-lora-quantized";
+  forceDownload?: boolean;
+  decoderConfig?: Record<string, unknown>;
+}
+
+export class GPT4All extends LLM implements GPT4AllInput {
+  model: GPT4AllInput["model"];
+
+  forceDownload: boolean;
+
+  decoderConfig: Record<string, unknown>;
+
+  constructor(fields: GPT4AllInput & BaseLLMParams) {
+    super(fields);
+
+    this.model = fields.model;
+    this.forceDownload = fields.forceDownload ?? false;
+    this.decoderConfig = fields.decoderConfig ?? {};
+  }
+
+  _llmType() {
+    return "gpt4all";
+  }
+
+  /** @ignore */
+  async _call(prompt: string, _stop?: string[]): Promise<string> {
+    const imports = await GPT4All.imports();
+
+    const gpt4all = new imports.GPT4All(
+      this.model,
+      this.forceDownload,
+      this.decoderConfig
+    );
+    await gpt4all.init();
+    await gpt4all.open();
+
+    const output = await this.caller.call(
+      async () => await gpt4all.prompt(prompt)
+    );
+
+    gpt4all.close();
+    return output;
+  }
+
+  /** @ignore */
+  static async imports(): Promise<{
+    GPT4All: typeof import("gpt4all").GPT4All;
+  }> {
+    try {
+      const { GPT4All } = await import("gpt4all");
+      return { GPT4All };
+    } catch (e) {
+      throw new Error(
+        "Please install gpt4all as a dependency with, e.g. `yarn add gpt4all`"
+      );
+    }
+  }
+}

--- a/langchain/src/llms/index.ts
+++ b/langchain/src/llms/index.ts
@@ -8,3 +8,4 @@ export { OpenAIChat } from "./openai-chat.js";
 export { Cohere } from "./cohere.js";
 export { HuggingFaceInference } from "./hf.js";
 export { Replicate } from "./replicate.js";
+export { GPT4All } from "./gpt4all.js";

--- a/langchain/src/llms/tests/gpt4all.int.test.ts
+++ b/langchain/src/llms/tests/gpt4all.int.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@jest/globals";
+import { GPT4All } from "../gpt4all.js";
+
+// GPT4All will likely need to download the model, which may take a couple mins
+test(
+  "Test GPT4All",
+  async () => {
+    const startTime = performance.now();
+    const model = new GPT4All({
+      model: "gpt4all-lora-quantized",
+    });
+    const endTime = performance.now();
+    const timeElapsed = endTime - startTime;
+    console.log(`GPT4All: Time elapsed: ${timeElapsed} milliseconds`);
+
+    const res = await model.call("Hello, my name is ");
+
+    expect(typeof res).toBe("string");
+  },
+  600 * 1000
+);

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -72,12 +72,16 @@
       "src/llms/raycast.ts",
       "src/llms/ollama.ts",
       "src/llms/replicate.ts",
+<<<<<<< HEAD
       "src/llms/googlevertexai.ts",
       "src/llms/googlepalm.ts",
       "src/llms/sagemaker_endpoint.ts",
       "src/llms/bedrock.ts",
       "src/llms/llama_cpp.ts",
       "src/llms/writer.ts",
+=======
+      "src/llms/gpt4all.ts",
+>>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
       "src/prompts/index.ts",
       "src/prompts/load.ts",
       "src/vectorstores/analyticdb.ts",

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -72,16 +72,13 @@
       "src/llms/raycast.ts",
       "src/llms/ollama.ts",
       "src/llms/replicate.ts",
-<<<<<<< HEAD
       "src/llms/googlevertexai.ts",
       "src/llms/googlepalm.ts",
+      "src/llms/gpt4all.ts",
       "src/llms/sagemaker_endpoint.ts",
       "src/llms/bedrock.ts",
       "src/llms/llama_cpp.ts",
       "src/llms/writer.ts",
-=======
-      "src/llms/gpt4all.ts",
->>>>>>> 9f9ccb66 (Introduce GPT4All to langchainjs)
       "src/prompts/index.ts",
       "src/prompts/load.ts",
       "src/vectorstores/analyticdb.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8710,6 +8710,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.3.4":
+  version: 1.4.0
+  resolution: "axios@npm:1.4.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^3.1.1":
   version: 3.1.1
   resolution: "axobject-query@npm:3.1.1"
@@ -12878,6 +12889,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gpt4all@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "gpt4all@npm:1.0.0"
+  dependencies:
+    axios: ^1.3.4
+    os: ^0.1.2
+    progress: ^2.0.3
+  checksum: 4950651235818be3c8a8dc08388687395da976392e1cfe861ddc3c7f3574028d0794c085090eae1a83f2ffedd729b5f4e5e9dff3f2ee7276d1956213ca7584d7
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:4.2.10, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
@@ -14954,6 +14976,7 @@ __metadata:
     firebase-admin: ^11.9.0
     flat: ^5.0.2
     google-auth-library: ^8.9.0
+    gpt4all: ^1.0.0
     graphql: ^16.6.0
     hnswlib-node: ^1.4.2
     html-to-text: ^9.0.5
@@ -15056,6 +15079,7 @@ __metadata:
     faiss-node: ^0.3.0
     firebase-admin: ^11.9.0
     google-auth-library: ^8.9.0
+    gpt4all: ^1.0.0
     hnswlib-node: ^1.4.2
     html-to-text: ^9.0.5
     ignore: ^5.2.0
@@ -15181,6 +15205,8 @@ __metadata:
     firebase-admin:
       optional: true
     google-auth-library:
+      optional: true
+    gpt4all:
       optional: true
     hnswlib-node:
       optional: true
@@ -18080,7 +18106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:2.0.3":
+"progress@npm:2.0.3, progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7


### PR DESCRIPTION
This PR introduces GPT4All, putting it in line with the langchain Python package and allowing use of the most popular open source LLMs with langchainjs.

Rather than rebuilding the typings in Javascript, I've used the [gpt4all-ts](https://github.com/nomic-ai/gpt4all-ts) package in the same format as the `Replicate` import.

I've also added a 10min timeout to the `gpt4all` test I've written as it'll likely need to download the binary on a new build, so it's hugely dependant on the server bandwidth that's building the package. I've also added a timer so you can measure the test download time on the server. If you need to skip it to minimise build time feel free – thought it was better to include it for now.

Ping me if you have any questions – thanks!

FYI: #623 #628 @sime2408 @aarashy