### PR TITLE
Adding ability to group supabase vectors into buckets

### DIFF
--- a/docs/docs/modules/indexes/retrievers/supabase-hybrid.mdx
+++ b/docs/docs/modules/indexes/retrievers/supabase-hybrid.mdx
@@ -27,10 +27,11 @@ create table documents (
 );
 
 -- Create a function to similarity search for documents
-create function match_documents (
+CREATE OR REPLACE FUNCTION match_documents (
   query_embedding vector(1536),
   match_count int,
-  filter jsonb DEFAULT '{}'
+  filter jsonb DEFAULT '{}',
+  bucket_id text DEFAULT NULL
 ) returns table (
   id bigint,
   content text,
@@ -49,6 +50,7 @@ begin
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
   where metadata @> filter
+  and (bucket_id IS NULL or documents."bucketId" = bucket_id)
   order by documents.embedding <=> query_embedding
   limit match_count;
 end;
@@ -69,6 +71,20 @@ limit $2')
 using query_text, match_count;
 end;
 $$ language plpgsql;
+```
+
+### Privileges
+
+You will need to add privileges inside supabase sql for the wanted role to be able to use this function. Here is an example how to do that with service_role
+
+```sql
+GRANT USAGE ON SCHEMA public TO service_role;
+
+GRANT EXECUTE ON FUNCTION public.match_documents TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "documents" TO service_role;
+
+GRANT USAGE, SELECT ON SEQUENCE documents_id_seq TO service_role;
 ```
 
 ## Usage

--- a/docs/docs/modules/indexes/vector_stores/integrations/supabase.mdx
+++ b/docs/docs/modules/indexes/vector_stores/integrations/supabase.mdx
@@ -24,13 +24,15 @@ create table documents (
   content text, -- corresponds to Document.pageContent
   metadata jsonb, -- corresponds to Document.metadata
   embedding vector(1536) -- 1536 works for OpenAI embeddings, change if needed
+  bucketId text, -- used to separate out different buckets of vectors
 );
 
 -- Create a function to search for documents
-create function match_documents (
+CREATE OR REPLACE FUNCTION match_documents (
   query_embedding vector(1536),
   match_count int,
-  filter jsonb DEFAULT '{}'
+  filter jsonb DEFAULT '{}',
+  bucket_id text DEFAULT NULL
 ) returns table (
   id bigint,
   content text,
@@ -49,10 +51,25 @@ begin
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
   where metadata @> filter
+  and (bucket_id IS NULL or documents."bucketId" = bucket_id)
   order by documents.embedding <=> query_embedding
   limit match_count;
 end;
 $$;
+```
+
+### Privileges
+
+You will need to add privileges inside supabase sql for the wanted role to be able to use this function. Here is an example how to do that with service_role
+
+```sql
+GRANT USAGE ON SCHEMA public TO service_role;
+
+GRANT EXECUTE ON FUNCTION public.match_documents TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON "documents" TO service_role;
+
+GRANT USAGE, SELECT ON SEQUENCE documents_id_seq TO service_role;
 ```
 
 ## Usage

--- a/examples/src/agents/mrkl.ts
+++ b/examples/src/agents/mrkl.ts
@@ -2,15 +2,20 @@ import { initializeAgentExecutorWithOptions } from "langchain/agents";
 import { OpenAI } from "langchain/llms/openai";
 import { SerpAPI } from "langchain/tools";
 import { Calculator } from "langchain/tools/calculator";
+import { WebBrowser } from 'langchain/tools/webbrowser';
+import { OpenAIEmbeddings } from 'langchain/embeddings/openai';
 
-const model = new OpenAI({ temperature: 0 });
+const embeddings = new OpenAIEmbeddings();
+
+const model = new OpenAI({ temperature: 0, modelName: "gpt-4" });
 const tools = [
+  new WebBrowser({ model, embeddings }),
   new SerpAPI(process.env.SERPAPI_API_KEY, {
     location: "Austin,Texas,United States",
     hl: "en",
     gl: "us",
   }),
-  new Calculator(),
+
 ];
 
 const executor = await initializeAgentExecutorWithOptions(tools, model, {
@@ -18,6 +23,6 @@ const executor = await initializeAgentExecutorWithOptions(tools, model, {
   verbose: true,
 });
 
-const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+const input = `What is the wether like in Washington DC`;
 
 const result = await executor.call({ input });

--- a/examples/src/indexes/vector_stores/supabase_with_buckets.ts
+++ b/examples/src/indexes/vector_stores/supabase_with_buckets.ts
@@ -1,0 +1,71 @@
+import { SupabaseVectorStore } from "langchain/vectorstores/supabase";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { createClient } from "@supabase/supabase-js";
+
+// First, follow set-up instructions at
+// https://js.langchain.com/docs/modules/indexes/vector_stores/integrations/supabase
+
+const privateKey = process.env.SUPABASE_PRIVATE_KEY;
+if (!privateKey) throw new Error(`Expected env var SUPABASE_PRIVATE_KEY`);
+
+const url = process.env.SUPABASE_URL;
+if (!url) throw new Error(`Expected env var SUPABASE_URL`);
+
+export const run = async () => {
+  const client = createClient(url, privateKey);
+
+  // Bucket ID is useful if you want to separate your documents into different
+  // buckets. For example, if you have a multi-tenant application, you might
+  // want to separate documents by tenant ID.
+  const bucketIdTenant001 = "tenantId-001";
+
+  const vectorStoreTenant001 = await SupabaseVectorStore.fromTexts(
+    ["Chat message 1, Tenant001", "Chat message 2, Tenant001", "Chat message 3, Tenant001"],
+    [{ timeStamp: 1 }, { timeStamp: 2 }, { timeStamp: 3 }],
+    new OpenAIEmbeddings(),
+    {
+      client,
+      tableName: "documents",
+      queryName: "match_documents",
+      bucketId: bucketIdTenant001,
+    }
+  );
+
+  const resultTenant001 = await vectorStoreTenant001.similaritySearch("Message 1", 1);
+
+  /*
+  [
+    Document {
+      pageContent: 'Chat message 1, Tenant001',
+      metadata: { timeStamp: 1 }
+    }
+  ]
+  */
+  console.log(resultTenant001);
+
+  const bucketIdTenant002 = "tenantId-002";
+
+  const vectorStoreTenant002 = await SupabaseVectorStore.fromTexts(
+    ["Chat message 1, Tenant002", "Chat message 2, Tenant002", "Chat message 3, Tenant002"],
+    [{ timeStamp: 1 }, { timeStamp: 2 }, { timeStamp: 3 }],
+    new OpenAIEmbeddings(),
+    {
+      client,
+      tableName: "documents",
+      queryName: "match_documents",
+      bucketId: bucketIdTenant002,
+    }
+  );
+
+  const resultTenant0012 = await vectorStoreTenant002.similaritySearch("Message 1", 1);
+
+  /*
+  [
+    Document {
+      pageContent: 'Chat message 1, Tenant002',
+      metadata: { timeStamp: 1 }
+    }
+  ]
+  */
+  console.log(resultTenant0012);
+};


### PR DESCRIPTION
### The issue this addresses
When using supabase vector search, all your documents are in table. This works well if you don't need to separate out information. There is filtering based search with supabase, but this falls short when you are using a chain that handles all the vector searching, and you don't have access to break out the filter. 

### Solution
With this solution, the vectors are separated out into "buckets". These buckets are defined on creation of the vector store. This allows you to not worry about the underlying chain.

### Use cases
This is great for if you have live agents or some other chain that has similar data. You might want to keep all your chat bots / agents history in the same database, but separate it by the user that is using the agent.