### PR TITLE
feat: add token buffer based memory, port of ConversationTokenBufferMemory in langchain python

### DIFF
--- a/langchain/src/memory/token_buffer.ts
+++ b/langchain/src/memory/token_buffer.ts
@@ -1,0 +1,136 @@
+import { BaseLanguageModel } from "../base_language/index.js";
+import {
+    getBufferString,
+    InputValues,
+    MemoryVariables,
+    OutputValues,
+} from "./base.js";
+import { BaseChatMemory, BaseChatMemoryInput } from "./chat_memory.js";
+
+interface BufferMemoryInput extends BaseChatMemoryInput {
+    humanPrefix?: string;
+    aiPrefix?: string;
+    memoryKey?: string;
+    maxTokenLimit?: number;
+    llm: BaseLanguageModel;
+}
+
+export default class ConversationTokenBufferMemory extends BaseChatMemory {
+    humanPrefix = "Human";
+
+    aiPrefix = "AI";
+
+    memoryKey = "history";
+
+    maxTokenLimit = 1024;
+
+    llm: BaseLanguageModel;
+
+    constructor(fields: BufferMemoryInput) {
+        super({
+            chatHistory: fields?.chatHistory,
+            returnMessages: fields?.returnMessages ?? false,
+            inputKey: fields?.inputKey,
+            outputKey: fields?.outputKey,
+        });
+
+        this.llm = fields.llm;
+        this.humanPrefix = fields.humanPrefix ?? this.humanPrefix;
+        this.aiPrefix = fields.aiPrefix ?? this.aiPrefix;
+        this.memoryKey = fields.memoryKey ?? this.memoryKey;
+
+        this.maxTokenLimit = fields.maxTokenLimit || this.maxTokenLimit;
+    }
+
+    get memoryKeys() {
+        return [this.memoryKey];
+    }
+
+
+    async loadMemoryVariables(_values: InputValues): Promise<MemoryVariables> {
+        const messages = await this.chatHistory.getMessages();
+        if (this.returnMessages) {
+            const result = {
+                [this.memoryKey]: messages,
+            };
+            return result;
+        }
+        const result = {
+            [this.memoryKey]: getBufferString(messages, this.humanPrefix, this.aiPrefix),
+        };
+        return result;
+    }
+
+    /*
+    async saveContext(
+        inputValues: InputValues,
+        outputValues: OutputValues
+    ): Promise<void> {
+        await super.saveContext(inputValues, outputValues);
+
+        const buffer = await this.chatHistory.getMessages();
+        let bufferString = getBufferString(buffer, this.humanPrefix, this.aiPrefix);
+
+        let totalTokensCount = await this.llm.getNumTokens(bufferString);
+
+        if (totalTokensCount > this.maxTokenLimit) {
+            const prunedMemory = [];
+
+            while (totalTokensCount > this.maxTokenLimit) {
+                prunedMemory.push(buffer.shift());
+
+                bufferString = getBufferString(buffer, this.humanPrefix, this.aiPrefix);
+                totalTokensCount = await this.llm.getNumTokens(bufferString);
+            }
+        }
+    }
+    */
+
+    async saveContext(
+        inputValues: InputValues,
+        outputValues: OutputValues
+    ): Promise<void> {
+        await super.saveContext(inputValues, outputValues);
+
+        const buffer = await this.chatHistory.getMessages();
+        let bufferString = getBufferString(buffer, this.humanPrefix, this.aiPrefix);
+        
+        let totalTokensCount = await this.llm.getNumTokens(bufferString);
+        
+        // Binary window approach to find the largest buffer of messages that fits within the maxTokenLimit
+        if (totalTokensCount > this.maxTokenLimit) {
+            let prunedMemory;
+            let sliceIndex = Math.floor(buffer.length / 2);
+            let safeWindowTokenCount = 0;
+
+            let windowStartIndex = Math.floor(buffer.length / 2),
+                windowEndIndex = buffer.length;
+
+            while (windowStartIndex < windowEndIndex && windowStartIndex >= 0) {
+                const newBufferWindow = buffer.slice(windowStartIndex, windowEndIndex);
+
+                if (newBufferWindow.length >= 1) {
+                    const bufferString = getBufferString(newBufferWindow, this.humanPrefix, this.aiPrefix);
+                    const newWindowTokensCount = await this.llm.getNumTokens(bufferString);
+
+                    const _safeWindowTokenCount = (safeWindowTokenCount + newWindowTokensCount);
+
+                    if (_safeWindowTokenCount === this.maxTokenLimit) {
+                        safeWindowTokenCount += _safeWindowTokenCount;
+                        break;
+                    } else if (_safeWindowTokenCount < this.maxTokenLimit) {
+                        safeWindowTokenCount += _safeWindowTokenCount;
+                        sliceIndex = windowStartIndex;
+
+                        windowEndIndex = windowStartIndex;
+                        windowStartIndex = Math.floor(windowStartIndex / 2);
+                    } else {
+                        windowStartIndex = Math.ceil((windowEndIndex + windowStartIndex) / 2);
+                    }
+                }
+            }
+
+            prunedMemory = buffer.splice(0, sliceIndex);
+        }
+    }
+}


### PR DESCRIPTION
JS port of python version [here](https://github.com/hwchase17/langchain/blob/master/langchain/memory/token_buffer.py)
`k window` based memory doesn't work in scenarios where the answer length cannot be predicted, so openai doesn't return any response in such cases or the answer doesn't have natural STOP. So, this `token` based buffer memory allows to insert chat history safely.

- [x] Local testing
- [ ] Test cases - TBD after [this warning](https://github.com/hwchase17/langchainjs/issues/985#issuecomment-1546898014) is fixed. Not a blocker as it fallbacks to approx tiktoken calculation but prior to this PR, langchainJS doesn't have any token based library, so this warning has never surfaced. Since it is polluting the global logs, this must be fixed in original repo.

<img width="1099" alt="image" src="https://github.com/hwchase17/langchainjs/assets/6055628/35edd27f-77bf-47a6-9f6e-4f15a95d6b38">
