### PR TITLE
Add method to identify BaseChatMessage type without using hard coded text like "human"

### DIFF
--- a/langchain/src/chains/conversational_retrieval_chain.ts
+++ b/langchain/src/chains/conversational_retrieval_chain.ts
@@ -68,13 +68,13 @@ export class ConversationalRetrievalQAChain
   static getChatHistoryString(chatHistory: string | BaseChatMessage[]) {
     if (Array.isArray(chatHistory)) {
       return chatHistory
-        .map((chatMessage) => {
-          if (chatMessage._getType() === "human") {
-            return `Human: ${chatMessage.text}`;
-          } else if (chatMessage._getType() === "ai") {
-            return `Assistant: ${chatMessage.text}`;
+        .map((baseChatMessage) => {
+          if (baseChatMessage.isHumanChatMessage()) {
+            return `Human: ${baseChatMessage.text}`;
+          } else if (baseChatMessage.isAIChatMessage()) {
+            return `Assistant: ${baseChatMessage.text}`;
           } else {
-            return `${chatMessage.text}`;
+            return `${baseChatMessage.text}`;
           }
         })
         .join("\n");

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -574,23 +574,23 @@ export class PromptLayerChatOpenAI extends ChatOpenAI {
     );
     const requestEndTime = Date.now();
 
-    const _convertMessageToDict = (message: BaseChatMessage) => {
+    const _convertMessageToDict = (baseChatMessage: BaseChatMessage) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let messageDict: Record<string, any>;
 
-      if (message._getType() === "human") {
-        messageDict = { role: "user", content: message.text };
-      } else if (message._getType() === "ai") {
-        messageDict = { role: "assistant", content: message.text };
-      } else if (message._getType() === "system") {
-        messageDict = { role: "system", content: message.text };
-      } else if (message._getType() === "generic") {
+      if (baseChatMessage.isHumanChatMessage()) {
+        messageDict = { role: "user", content: baseChatMessage.text };
+      } else if (baseChatMessage.isAIChatMessage()) {
+        messageDict = { role: "assistant", content: baseChatMessage.text };
+      } else if (baseChatMessage.isSystemChatMessage()) {
+        messageDict = { role: "system", content: baseChatMessage.text };
+      } else if (baseChatMessage.isGenericChatMessage()) {
         messageDict = {
-          role: (message as ChatMessage).role,
-          content: message.text,
+          role: (baseChatMessage as ChatMessage).role,
+          content: baseChatMessage.text,
         };
       } else {
-        throw new Error(`Got unknown type ${message}`);
+        throw new Error(`Got unknown type ${baseChatMessage}`);
       }
 
       return messageDict;

--- a/langchain/src/memory/base.ts
+++ b/langchain/src/memory/base.ts
@@ -40,25 +40,25 @@ export const getInputValue = (inputValues: InputValues, inputKey?: string) => {
  * of the chat message history, based on the message content and role.
  */
 export function getBufferString(
-  messages: BaseChatMessage[],
+  baseChatMessagess: BaseChatMessage[],
   humanPrefix = "Human",
   aiPrefix = "AI"
 ): string {
   const string_messages: string[] = [];
-  for (const m of messages) {
+  for (const baseChatMessage of baseChatMessagess) {
     let role: string;
-    if (m._getType() === "human") {
+    if (baseChatMessage.isHumanChatMessage()) {
       role = humanPrefix;
-    } else if (m._getType() === "ai") {
+    } else if (baseChatMessage.isAIChatMessage()) {
       role = aiPrefix;
-    } else if (m._getType() === "system") {
+    } else if (baseChatMessage.isSystemChatMessage()) {
       role = "System";
-    } else if (m._getType() === "generic") {
-      role = (m as ChatMessage).role;
+    } else if (baseChatMessage.isGenericChatMessage()) {
+      role = (baseChatMessage as ChatMessage).role;
     } else {
-      throw new Error(`Got unsupported message type: ${m}`);
+      throw new Error(`Got unsupported message type: ${baseChatMessage}`);
     }
-    string_messages.push(`${role}: ${m.text}`);
+    string_messages.push(`${role}: ${baseChatMessage.text}`);
   }
   return string_messages.join("\n");
 }

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -60,7 +60,14 @@ export interface StoredMessage {
   data: StoredMessageData;
 }
 
-export type MessageType = "human" | "ai" | "generic" | "system";
+const MESSAGE_TYPE_HUMAN = "human" as const;
+const MESSAGE_TYPE_AI = "ai" as const;
+const MESSAGE_TYPE_SYSTEM = "system" as const;
+const MESSAGE_TYPE_GENERIC = "generic" as const;
+
+const messageTypes = [MESSAGE_TYPE_HUMAN, MESSAGE_TYPE_AI, MESSAGE_TYPE_SYSTEM, MESSAGE_TYPE_GENERIC];
+export type MessageType = typeof messageTypes[number];
+
 
 export abstract class BaseChatMessage {
   /** The text of the message. */
@@ -85,23 +92,39 @@ export abstract class BaseChatMessage {
       },
     };
   }
+
+  isHumanChatMessage(): boolean {
+    return this._getType() === MESSAGE_TYPE_HUMAN;
+  }
+
+  isAIChatMessage(): boolean {
+    return this._getType() === MESSAGE_TYPE_AI;
+  }
+
+  isSystemChatMessage(): boolean {
+    return this._getType() === MESSAGE_TYPE_SYSTEM;
+  }
+
+  isGenericChatMessage(): boolean {
+    return this._getType() === MESSAGE_TYPE_GENERIC;
+  }
 }
 
 export class HumanChatMessage extends BaseChatMessage {
   _getType(): MessageType {
-    return "human";
+    return MESSAGE_TYPE_HUMAN;
   }
 }
 
 export class AIChatMessage extends BaseChatMessage {
   _getType(): MessageType {
-    return "ai";
+    return MESSAGE_TYPE_AI;
   }
 }
 
 export class SystemChatMessage extends BaseChatMessage {
   _getType(): MessageType {
-    return "system";
+    return MESSAGE_TYPE_SYSTEM;
   }
 }
 
@@ -114,7 +137,7 @@ export class ChatMessage extends BaseChatMessage {
   }
 
   _getType(): MessageType {
-    return "generic";
+    return MESSAGE_TYPE_GENERIC;
   }
 }
 


### PR DESCRIPTION
When trying to guess the type of ChatMessage there is a lot of equality calculation based on hard coded string like === "human", this MR is just about refactoring this to use isXX ( eg isHuman() ) instead .

