### PR TITLE
Fix loc for repeating text in text_splitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Chinook_Sqlite.sql
 
 firebase-debug.log
 firestore-debug.log
+.vscode

--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -338,7 +338,7 @@ test("Test lines loc counts correct amount of new lines.", async () => {
   });
 
   const docs = await splitter.createDocuments([text]);
-  
+
   const expectedDocs = [
     new Document({
       pageContent: "Hi.\nI'm Harrison.",

--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -323,7 +323,61 @@ test("Test lines loc on iterative text splitter.", async () => {
     }),
     new Document({
       pageContent: "How?\na\nb",
-      metadata: { loc: { lines: { from: 4, to: 6 } } },
+      metadata: { loc: { lines: { from: 2, to: 6 } } },
+    }),
+  ];
+
+  expect(docs).toEqual(expectedDocs);
+});
+
+test("Test lines loc counts correct amount of new lines.", async () => {
+  const text = `Hi.\nI'm Harrison.\n\nHi.\nI'm Harrison.\n\n\n\nHow?\na\nb`;
+  const splitter = new RecursiveCharacterTextSplitter({
+    chunkSize: 20,
+    chunkOverlap: 0,
+  });
+
+  const docs = await splitter.createDocuments([text]);
+  
+  const expectedDocs = [
+    new Document({
+      pageContent: "Hi.\nI'm Harrison.",
+      metadata: { loc: { lines: { from: 1, to: 2 } } },
+    }),
+    new Document({
+      pageContent: "Hi.\nI'm Harrison.",
+      metadata: { loc: { lines: { from: 2, to: 6 } } },
+    }),
+    new Document({
+      pageContent: "How?\na\nb",
+      metadata: { loc: { lines: { from: 6, to: 11 } } },
+    }),
+  ];
+
+  expect(docs).toEqual(expectedDocs);
+});
+
+test("Returns correct loc for equal block strings", async () => {
+  const text = `\n    {\n    {\nhello`;
+
+  const splitter = new RecursiveCharacterTextSplitter({
+    chunkSize: 6,
+    chunkOverlap: 0,
+  });
+  const docs = await splitter.createDocuments([text]);
+
+  const expectedDocs = [
+    new Document({
+      pageContent: "{",
+      metadata: { loc: { lines: { from: 2, to: 3 } } },
+    }),
+    new Document({
+      pageContent: "{",
+      metadata: { loc: { lines: { from: 3, to: 4 } } },
+    }),
+    new Document({
+      pageContent: "hello",
+      metadata: { loc: { lines: { from: 4, to: 5 } } },
     }),
   ];
 

--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -331,9 +331,21 @@ test("Test lines loc on iterative text splitter.", async () => {
 });
 
 test("Test lines loc counts correct amount of new lines.", async () => {
-  const text = `Hi.\nI'm Harrison.\n\nHi.\nI'm Harrison.\n\n\n\nHow?\na\nb`;
+  // lines logic: start from 1. locTo is the line number(starting from 1) of the last line in the chunk.
+
+  let startNewLineCount = 2;
+  let startNewLines = "";
+  for (let i = 0; i < startNewLineCount; i++) {
+    startNewLines += "\n";
+  }
+
+  // first \n\nHi.\nI'm Harrison. - 4 lines (from 1 to 4)
+  // second \n\nHi.\nI'm Harrison. - 4 lines (from 5 to 8)
+  // third \n\n\n\nHow?\na\nb (12 chars) - 7 lines (from 9 to 16)
+
+  const text = `${startNewLines}Hi.\nI'm Harrison.\n\nHi.\nI'm Harrison.\n\n\n\nHow?\na\nb`;
   const splitter = new RecursiveCharacterTextSplitter({
-    chunkSize: 20,
+    chunkSize: startNewLineCount + 17,
     chunkOverlap: 0,
   });
 
@@ -341,16 +353,16 @@ test("Test lines loc counts correct amount of new lines.", async () => {
 
   const expectedDocs = [
     new Document({
-      pageContent: "Hi.\nI'm Harrison.",
-      metadata: { loc: { lines: { from: 1, to: 2 } } },
+      pageContent: "\n\nHi.\nI'm Harrison.",
+      metadata: { loc: { lines: { from: 1, to: 4 } } },
     }),
     new Document({
-      pageContent: "Hi.\nI'm Harrison.",
-      metadata: { loc: { lines: { from: 2, to: 6 } } },
+      pageContent: "\n\nHi.\nI'm Harrison.",
+      metadata: { loc: { lines: { from: 5, to: 8 } } },
     }),
     new Document({
-      pageContent: "How?\na\nb",
-      metadata: { loc: { lines: { from: 6, to: 11 } } },
+      pageContent: "\n\n\n\nHow?\na\nb",
+      metadata: { loc: { lines: { from: 9, to: 16 } } },
     }),
   ];
 

--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -411,10 +411,10 @@ test("Doesn't trim results if configured so", async () => {
   const splitter = new RecursiveCharacterTextSplitter({
     chunkSize: 6,
     chunkOverlap: 0,
+    trimPageContent: false
   });
-  const docs = await splitter.createDocuments([text], [], {
-    trimPageContent: false,
-  });
+  
+  const docs = await splitter.createDocuments([text]);
 
   const expectedDocs = [
     new Document({

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -53,7 +53,7 @@ export abstract class TextSplitter
     return this.splitDocuments(documents, chunkHeaderOptions);
   }
 
-  abstract splitText(text: string, trim?:boolean): Promise<string[]>;
+  abstract splitText(text: string, trim?: boolean): Promise<string[]>;
 
   protected splitOnSeparator(text: string, separator: string): string[] {
     let splits;
@@ -91,11 +91,11 @@ export abstract class TextSplitter
     for (let i = 0; i < texts.length; i += 1) {
       const text = texts[i];
       let lineCounterIndex = 1;
-      let prevChunk:string|null = null;
-      let textTraverser = "" // used to get the latest index of a chunk if they are the same
-      
-      for (const chunk of await this.splitText(text, false)) {    
-        textTraverser += chunk
+      let prevChunk: string | null = null;
+      let textTraverser = ""; // used to get the latest index of a chunk if they are the same
+
+      for (const chunk of await this.splitText(text, false)) {
+        textTraverser += chunk;
         let pageContent = chunkHeader;
 
         // we need to count the \n that are in the text before getting removed by the splitting
@@ -103,7 +103,8 @@ export abstract class TextSplitter
         if (prevChunk) {
           const indexChunk = textTraverser.lastIndexOf(chunk);
           const indexEndPrevChunk =
-          textTraverser.lastIndexOf(prevChunk) + (await this.lengthFunction(prevChunk));
+            textTraverser.lastIndexOf(prevChunk) +
+            (await this.lengthFunction(prevChunk));
           const removedNewlinesFromSplittingText = text.slice(
             indexEndPrevChunk,
             indexChunk
@@ -114,12 +115,11 @@ export abstract class TextSplitter
           if (appendChunkOverlapHeader) {
             pageContent += chunkOverlapHeader;
           }
-        }
-        else {
+        } else {
           // get the newlines from the beginning of the text
           lineCounterIndex += (text.match(/^\n/g) || []).length;
         }
-        
+
         lineCounterIndex += numberOfIntermediateNewLines;
         const newLinesCount = (chunk.match(/\n/g) || []).length;
 
@@ -162,13 +162,21 @@ export abstract class TextSplitter
     return this.createDocuments(texts, metadatas, chunkHeaderOptions);
   }
 
-  private joinDocs(docs: string[], separator: string, trim?: boolean): string | null {
-    let text = docs.join(separator);   
+  private joinDocs(
+    docs: string[],
+    separator: string,
+    trim?: boolean
+  ): string | null {
+    let text = docs.join(separator);
     if (trim) text = text.trim();
     return text === "" ? null : text;
   }
 
-  async mergeSplits(splits: string[], separator: string, trim = true): Promise<string[]> {   
+  async mergeSplits(
+    splits: string[],
+    separator: string,
+    trim = true
+  ): Promise<string[]> {
     const docs: string[] = [];
     const currentDoc: string[] = [];
     let total = 0;
@@ -231,10 +239,14 @@ export class CharacterTextSplitter
     this.separator = fields?.separator ?? this.separator;
   }
 
-  async splitText(text: string, trim = true): Promise<string[]> {   
+  async splitText(text: string, trim = true): Promise<string[]> {
     // First we naively split the large input into a bunch of smaller ones.
     const splits = this.splitOnSeparator(text, this.separator);
-    return this.mergeSplits(splits, this.keepSeparator ? "" : this.separator, trim);
+    return this.mergeSplits(
+      splits,
+      this.keepSeparator ? "" : this.separator,
+      trim
+    );
   }
 }
 
@@ -311,7 +323,11 @@ export class RecursiveCharacterTextSplitter
         goodSplits.push(s);
       } else {
         if (goodSplits.length) {
-          const mergedText = await this.mergeSplits(goodSplits, _separator, trim);
+          const mergedText = await this.mergeSplits(
+            goodSplits,
+            _separator,
+            trim
+          );
           finalChunks.push(...mergedText);
           goodSplits = [];
         }

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -115,9 +115,6 @@ export abstract class TextSplitter
           if (appendChunkOverlapHeader) {
             pageContent += chunkOverlapHeader;
           }
-        } else {
-          // get the newlines from the beginning of the text
-          lineCounterIndex += (text.match(/^\n/g) || []).length;
         }
 
         lineCounterIndex += numberOfIntermediateNewLines;
@@ -136,7 +133,7 @@ export abstract class TextSplitter
           loc,
         };
 
-        pageContent += chunk.trim();
+        pageContent += chunk; //.trim();
         documents.push(
           new Document({
             pageContent,


### PR DESCRIPTION
This PR fixes an issue where the Document `loc` is wrong if there are repeating blocks. This happens especially obviously in code files where there are similar closing blocks. For example `\n    }`. 

The current code erroneously sets the `loc` to more lines there are lines in the file. This is because it doesn't use the lastIndex of the chunk, but instead the first occurrence.

Might also fix issue #1357
