### PR TITLE
add sql 'OR' op on PrismaSqlFilter by using array

### DIFF
--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -354,23 +354,24 @@ export class PrismaVectorStore<
 
   buildSqlFilterStr(filter?: TFilterModel) {
     if (filter == null) return null;
-    const opsTemplate = (key: string, ops: object | undefined) => Object.entries(ops).map(([opName, value]) => {
-      // column name, operators cannot be parametrised
-      // these fields are thus not escaped by Prisma and can be dangerous if user input is used
-      const colRaw = this.Prisma.raw(`"${key}"`);
-      const opRaw = this.Prisma.raw(OpMap[opName as keyof typeof OpMap]);
-      return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
-    });
+    const opsTemplate = (key: string, ops: object | undefined) =>
+      Object.entries(ops || {}).map(([opName, value]) => {
+        // column name, operators cannot be parametrised
+        // these fields are thus not escaped by Prisma and can be dangerous if user input is used
+        const colRaw = this.Prisma.raw(`"${key}"`);
+        const opRaw = this.Prisma.raw(OpMap[opName as keyof typeof OpMap]);
+        return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
+      });
     return this.Prisma.join(
-      Object.entries(filter).flatMap(([key, ops]) => 
+      Object.entries(filter).flatMap(([key, ops]) =>
         Array.isArray(ops)
-        ? this.Prisma.join(
-            ops.flatMap(orOps => opsTemplate(key, orOps)),
-            " OR ",
-            " ( ",
-            " ) "
-        )
-        : opsTemplate(key, ops)
+          ? this.Prisma.join(
+              ops.flatMap((orOps) => opsTemplate(key, orOps)),
+              " OR ",
+              " ( ",
+              " ) "
+            )
+          : opsTemplate(key, ops)
       ),
       " AND ",
       " WHERE "


### PR DESCRIPTION
Hi!

That's the solution i referenced in my [issue](https://github.com/hwchase17/langchainjs/issues/2290).

The idea is to be able to filter documents by many values of a field by passing an array with the opts.

Fixes #2290  