### PR TITLE
feat(llms/bedrock): support custom bedrock endpoint url

### DIFF
--- a/examples/src/models/llm/bedrock.ts
+++ b/examples/src/models/llm/bedrock.ts
@@ -1,18 +1,15 @@
 import { Bedrock } from "langchain/llms/bedrock";
 
-async function test() {
-  // If no credentials are provided, the default credentials from
-  // @aws-sdk/credential-provider-node will be used.
-  const model = new Bedrock({
-    model: "ai21",
-    region: "us-west-2",
-    // credentials: {
-    //   accessKeyId: "YOUR_AWS_ACCESS_KEY",
-    //   secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
-    // }
-  });
-  const res = await model.call("Tell me a joke");
-  console.log(res);
-}
-
-test();
+// If no credentials are provided, the default credentials from
+// @aws-sdk/credential-provider-node will be used.
+const model = new Bedrock({
+  model: "ai21",
+  region: "us-west-2",
+  // endpointUrl: "custom.amazonaws.com",
+  // credentials: {
+  //   accessKeyId: "YOUR_AWS_ACCESS_KEY",
+  //   secretAccessKey: "YOUR_SECRET_ACCESS_KEY"
+  // }
+});
+const res = await model.call("Tell me a joke");
+console.log(res);

--- a/langchain/src/llms/bedrock.ts
+++ b/langchain/src/llms/bedrock.ts
@@ -97,6 +97,9 @@ export interface BedrockInput {
 
   /** A custom fetch function for low-level access to AWS API. Defaults to fetch() */
   fetchFn?: typeof fetch;
+
+  /** Override the default endpoint url */
+  endpointUrl?: string;
 }
 
 /**
@@ -120,6 +123,8 @@ export class Bedrock extends LLM implements BedrockInput {
   maxTokens?: number | undefined = undefined;
 
   fetchFn: typeof fetch;
+
+  endpointUrl?: string;
 
   codec: EventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
 
@@ -153,6 +158,7 @@ export class Bedrock extends LLM implements BedrockInput {
     this.temperature = fields?.temperature ?? this.temperature;
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;
     this.fetchFn = fields?.fetchFn ?? fetch;
+    this.endpointUrl = fields?.endpointUrl;
   }
 
   /** Call out to Bedrock service model.
@@ -196,8 +202,11 @@ export class Bedrock extends LLM implements BedrockInput {
       this.temperature
     );
 
+    const endpointUrl =
+      this.endpointUrl ?? `${service}.${this.region}.amazonaws.com`;
+
     const url = new URL(
-      `https://${service}.${this.region}.amazonaws.com/model/${this.model}/invoke-with-response-stream`
+      `https://${endpointUrl}/model/${this.model}/invoke-with-response-stream`
     );
 
     const request = new HttpRequest({


### PR DESCRIPTION
Similar to python variant, enable ability to override the endpoint url to support different preview endpoints of bedrock service.

Unlike the Python LangChain Bedrock integration, the TypeScript implementation does not support overriding the **endpoint_url** which is still necessary for some preview access configurations.

https://github.com/langchain-ai/langchain/blob/eaf916f99989a31c398230f012931e97c400cf6e/libs/langchain/langchain/llms/bedrock.py#L74