### PR TITLE
feat(vectorstore): Add Custom IDs Option param to OpenSearch addVectors Method

### DIFF
--- a/examples/src/indexes/vector_stores/opensearch/opensearch.ts
+++ b/examples/src/indexes/vector_stores/opensearch/opensearch.ts
@@ -1,16 +1,20 @@
 import { Client } from "@opensearch-project/opensearch";
+import { Document } from "langchain/document";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { OpenSearchVectorStore } from "langchain/vectorstores/opensearch";
+import * as uuid from "uuid";
 
 export async function run() {
   const client = new Client({
     nodes: [process.env.OPENSEARCH_URL ?? "http://127.0.0.1:9200"],
   });
 
+  const embeddings = new OpenAIEmbeddings();
+
   const vectorStore = await OpenSearchVectorStore.fromTexts(
     ["Hello world", "Bye bye", "What's this?"],
     [{ id: 2 }, { id: 1 }, { id: 3 }],
-    new OpenAIEmbeddings(),
+    embeddings,
     {
       client,
       indexName: "documents",
@@ -19,4 +23,36 @@ export async function run() {
 
   const resultOne = await vectorStore.similaritySearch("Hello world", 1);
   console.log(resultOne);
+
+  const vectorStore2 = new OpenSearchVectorStore(embeddings, {
+    client,
+    indexName: "custom",
+  });
+
+  const documents = [
+    new Document({
+      pageContent: "Do I dare to eat an apple?",
+      metadata: {
+        foo: "baz",
+      },
+    }),
+    new Document({
+      pageContent: "There is no better place than the hotel lobby",
+      metadata: {
+        foo: "bar",
+      },
+    }),
+    new Document({
+      pageContent: "OpenSearch is a powerful vector db",
+      metadata: {
+        foo: "bat",
+      },
+    }),
+  ];
+  const vectors = Array.from({ length: documents.length }, (_, i) => [i, i + 1, i + 2]);
+  const ids = Array.from({ length: documents.length }, () => uuid.v4());
+  await vectorStore2.addVectors(vectors, documents, { ids });
+
+  const resultTwo = await vectorStore2.similaritySearchVectorWithScore(vectors[0], 3);
+  console.log(resultTwo);
 }

--- a/examples/src/indexes/vector_stores/opensearch/opensearch.ts
+++ b/examples/src/indexes/vector_stores/opensearch/opensearch.ts
@@ -49,10 +49,17 @@ export async function run() {
       },
     }),
   ];
-  const vectors = Array.from({ length: documents.length }, (_, i) => [i, i + 1, i + 2]);
+  const vectors = Array.from({ length: documents.length }, (_, i) => [
+    i,
+    i + 1,
+    i + 2,
+  ]);
   const ids = Array.from({ length: documents.length }, () => uuid.v4());
   await vectorStore2.addVectors(vectors, documents, { ids });
 
-  const resultTwo = await vectorStore2.similaritySearchVectorWithScore(vectors[0], 3);
+  const resultTwo = await vectorStore2.similaritySearchVectorWithScore(
+    vectors[0],
+    3
+  );
   console.log(resultTwo);
 }

--- a/langchain/src/vectorstores/opensearch.ts
+++ b/langchain/src/vectorstores/opensearch.ts
@@ -98,9 +98,14 @@ export class OpenSearchVectorStore extends VectorStore {
    * exists, then adds the vectors and associated documents to the index.
    * @param vectors The vectors to be added to the OpenSearch index.
    * @param documents The documents associated with the vectors.
+   * @param options Optional parameter that can contain the IDs for the documents.
    * @returns Promise resolving to void.
    */
-  async addVectors(vectors: number[][], documents: Document[]): Promise<void> {
+  async addVectors(
+      vectors: number[][],
+      documents: Document[],
+      options?: { ids?: string[] }
+  ): Promise<void> {
     await this.ensureIndexExists(
       vectors[0].length,
       this.engine,
@@ -109,11 +114,13 @@ export class OpenSearchVectorStore extends VectorStore {
       this.efConstruction,
       this.m
     );
+    const documentIds =
+      options?.ids ?? Array.from({ length: vectors.length }, () => uuid.v4());
     const operations = vectors.flatMap((embedding, idx) => [
       {
         index: {
           _index: this.indexName,
-          _id: uuid.v4(),
+          _id: documentIds[idx],
         },
       },
       {

--- a/langchain/src/vectorstores/opensearch.ts
+++ b/langchain/src/vectorstores/opensearch.ts
@@ -102,9 +102,9 @@ export class OpenSearchVectorStore extends VectorStore {
    * @returns Promise resolving to void.
    */
   async addVectors(
-      vectors: number[][],
-      documents: Document[],
-      options?: { ids?: string[] }
+    vectors: number[][],
+    documents: Document[],
+    options?: { ids?: string[] }
   ): Promise<void> {
     await this.ensureIndexExists(
       vectors[0].length,


### PR DESCRIPTION
**Description**:

This PR introduces an enhancement to the `addVectors` method in our OpenSearch module. The primary change is the inclusion of an optional `ids` parameter, which allows users to provide custom IDs for the documents they're adding to the OpenSearch index.

**Key Changes**:
- Added an optional parameter `options` to the `addVectors` function, which can accept a list of custom document IDs.
- If no custom IDs are provided, the method defaults to generating UUIDs, ensuring backward compatibility.
- Updated the `operations` construction logic to accommodate either custom or default UUID-based IDs.

This enhancement provides more flexibility to users who may have specific ID structures in their systems and want to retain them in the OpenSearch index.

Please review the changes and provide feedback!
