### PR TITLE
Account for versioned instruct models

### DIFF
--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -138,10 +138,9 @@ export class OpenAI
     configuration?: ClientOptions & LegacyOpenAIInput
   ) {
     if (
-      (fields?.modelName?.startsWith("gpt-3.5-turbo") &&
-        !fields?.modelName?.includes("-instruct")) ||
-      fields?.modelName?.startsWith("gpt-4") ||
-      fields?.modelName?.startsWith("gpt-4-32k")
+      (fields?.modelName?.startsWith("gpt-3.5-turbo") ||
+        fields?.modelName?.startsWith("gpt-4")) &&
+      !fields?.modelName?.includes("-instruct")
     ) {
       // eslint-disable-next-line no-constructor-return, @typescript-eslint/no-explicit-any
       return new OpenAIChat(fields, configuration) as any as OpenAI;

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -138,10 +138,10 @@ export class OpenAI
     configuration?: ClientOptions & LegacyOpenAIInput
   ) {
     if (
-      (fields?.modelName?.startsWith("gpt-3.5-turbo") ||
-        fields?.modelName?.startsWith("gpt-4") ||
-        fields?.modelName?.startsWith("gpt-4-32k")) &&
-      !fields?.modelName.endsWith("-instruct")
+      (fields?.modelName?.startsWith("gpt-3.5-turbo") &&
+        !fields?.modelName?.includes("-instruct")) ||
+      fields?.modelName?.startsWith("gpt-4") ||
+      fields?.modelName?.startsWith("gpt-4-32k")
     ) {
       // eslint-disable-next-line no-constructor-return, @typescript-eslint/no-explicit-any
       return new OpenAIChat(fields, configuration) as any as OpenAI;

--- a/langchain/src/llms/tests/openai.int.test.ts
+++ b/langchain/src/llms/tests/openai.int.test.ts
@@ -105,6 +105,14 @@ test("Test OpenAI with instruct model returns OpenAI", async () => {
   expect(typeof res).toBe("string");
 });
 
+test("Test OpenAI with versioned instruct model returns OpenAI", async () => {
+  const model = new OpenAI({ modelName: "gpt-3.5-turbo-instruct-0914" });
+  expect(model).toBeInstanceOf(OpenAI);
+  const res = await model.call("Print hello world");
+  console.log({ res });
+  expect(typeof res).toBe("string");
+});
+
 test("Test ChatOpenAI tokenUsage", async () => {
   let tokenUsage = {
     completionTokens: 0,


### PR DESCRIPTION
This PR fixes the issue where versioned `gpt-3.5-turbo-instruct` models, like `gpt-3.5-turbo-instruct-0914` were treated as Chat Models, throwing a fatal error and not allowing this model to be used.

<!-- Remove if not applicable -->

Fixes #2669 

My twitter handle: https://twitter.com/getcreatr :)

Thank you!