### PR TITLE
fix: ollama not using callbacks

### DIFF
--- a/langchain/src/chat_models/ollama.ts
+++ b/langchain/src/chat_models/ollama.ts
@@ -236,21 +236,16 @@ export class ChatOllama extends SimpleChatModel implements OllamaInput {
   /** @ignore */
   async _call(
     messages: BaseMessage[],
-    options: this["ParsedCallOptions"]
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
   ): Promise<string> {
-    const stream = await this.caller.call(async () =>
-      createOllamaStream(
-        this.baseUrl,
-        {
-          ...this.invocationParams(options),
-          prompt: this._formatMessagesAsPrompt(messages),
-        },
-        options
-      )
-    );
     const chunks = [];
-    for await (const chunk of stream) {
-      chunks.push(chunk.response);
+    for await (const chunk of this._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      chunks.push(chunk.message.content);
     }
     return chunks.join("");
   }

--- a/langchain/src/chat_models/tests/chatollama.int.test.ts
+++ b/langchain/src/chat_models/tests/chatollama.int.test.ts
@@ -14,6 +14,27 @@ test.skip("test call", async () => {
   console.log({ result });
 });
 
+test.skip("test call with callback", async () => {
+  const ollama = new ChatOllama({
+    baseUrl: "http://localhost:11434",
+  });
+  const tokens: string[] = [];
+  const result = await ollama.predict(
+    "What is a good name for a company that makes colorful socks?",
+    {
+      callbacks: [
+        {
+          handleLLMNewToken(token) {
+            tokens.push(token);
+          },
+        },
+      ],
+    }
+  );
+  expect(tokens.length).toBeGreaterThan(1);
+  expect(result).toEqual(tokens.join(""));
+});
+
 test.skip("test streaming call", async () => {
   const ollama = new ChatOllama({
     baseUrl: "http://localhost:11434",

--- a/langchain/src/llms/tests/ollama.int.test.ts
+++ b/langchain/src/llms/tests/ollama.int.test.ts
@@ -11,6 +11,27 @@ test.skip("test call", async () => {
   console.log({ result });
 });
 
+test.skip("test call with callback", async () => {
+  const ollama = new Ollama({
+    baseUrl: "http://localhost:11434",
+  });
+  const tokens: string[] = [];
+  const result = await ollama.predict(
+    "What is a good name for a company that makes colorful socks?",
+    {
+      callbacks: [
+        {
+          handleLLMNewToken(token) {
+            tokens.push(token);
+          },
+        },
+      ],
+    }
+  );
+  expect(tokens.length).toBeGreaterThan(1);
+  expect(result).toEqual(tokens.join(""));
+});
+
 test.skip("test streaming call", async () => {
   const ollama = new Ollama({
     baseUrl: "http://localhost:11434",


### PR DESCRIPTION
Ollama was not using any callbacks when called through it's _call method. Now it just uses it's internal method _streamResponseChunks that does use those callbacks.

Fixes #2671 