### PR TITLE
Do not recreate LlamaChatSession on every prompt

### DIFF
--- a/langchain/src/llms/llama_cpp.ts
+++ b/langchain/src/llms/llama_cpp.ts
@@ -85,6 +85,8 @@ export class LlamaCpp extends LLM<LlamaCppCallOptions> {
 
   _context: LlamaContext;
 
+  _session: LlamaChatSession;
+
   static lc_name() {
     return "LlamaCpp";
   }
@@ -105,6 +107,7 @@ export class LlamaCpp extends LLM<LlamaCppCallOptions> {
     this.vocabOnly = inputs.vocabOnly;
     this._model = new LlamaModel(inputs);
     this._context = new LlamaContext({ model: this._model });
+    this._session = new LlamaChatSession({ context: this._context });
   }
 
   _llmType() {
@@ -116,13 +119,11 @@ export class LlamaCpp extends LLM<LlamaCppCallOptions> {
     prompt: string,
     options?: this["ParsedCallOptions"]
   ): Promise<string> {
-    const session = new LlamaChatSession({ context: this._context });
-
     try {
-      const compleation = await session.prompt(prompt, options);
-      return compleation;
+      const completion = await this._session.prompt(prompt, options);
+      return completion;
     } catch (e) {
-      throw new Error("Error getting prompt compleation.");
+      throw new Error("Error getting prompt completion.");
     }
   }
 }

--- a/langchain/src/llms/tests/llama_cpp.int.test.ts
+++ b/langchain/src/llms/tests/llama_cpp.int.test.ts
@@ -16,3 +16,16 @@ test.skip("Test Llama_CPP", async () => {
   const res = await model.call("Where do Pandas live?");
   console.log(res);
 }, 100000);
+
+test.skip("Test Llama_CPP", async () => {
+  const model = new LlamaCpp({ modelPath: llamaPath });
+
+  // Attempt to make several queries and make sure that the system prompt
+  // is not returned as part of any follow-on query.
+  for (let i = 0; i < 5; i += 1) {
+    const res = await model.call("Where do Pandas live?");
+    expect(res).not.toContain(
+      "You are a helpful, respectful and honest assistant."
+    );
+  }
+}, 100000);


### PR DESCRIPTION
After a few responses, the system prompt starts to be returned at the end of each response. It is then duplicated with each subsequent response. The underlying LlamaContext is mutated in place which leads to differences in behavior within the LlamaChatSession when it is newly created for each new prompt. Instead of creating a new session for each prompt, create it once within the constructor.

This appears to fix the underlying issue for me with limited testing. However, I am not super familiar with this library and unsure if it is necessary to have a 1:1 mapping between context and session objects or if a 1:* should work as is currently implemented.

Fixes https://github.com/langchain-ai/langchainjs/issues/2561