### PR TITLE
Improve OutputParserException handling by adding observation and sendToLLM

### DIFF
--- a/langchain/src/agents/executor.ts
+++ b/langchain/src/agents/executor.ts
@@ -161,7 +161,7 @@ export class AgentExecutor extends BaseChain {
           if (this.handleParsingErrors === true) {
             if (e.sendToLLM) {
               observation = e.observation;
-              text = e.output ?? "";
+              text = e.llmOutput ?? "";
             } else {
               observation = "Invalid or incomplete response";
             }

--- a/langchain/src/agents/executor.ts
+++ b/langchain/src/agents/executor.ts
@@ -157,8 +157,14 @@ export class AgentExecutor extends BaseChain {
         // eslint-disable-next-line no-instanceof/no-instanceof
         if (e instanceof OutputParserException) {
           let observation;
+          let text = e.message;
           if (this.handleParsingErrors === true) {
-            observation = "Invalid or incomplete response";
+            if (e.sendToLLM) {
+              observation = e.observation;
+              text = e.output ?? "";
+            } else {
+              observation = "Invalid or incomplete response";
+            }
           } else if (typeof this.handleParsingErrors === "string") {
             observation = this.handleParsingErrors;
           } else if (typeof this.handleParsingErrors === "function") {
@@ -169,8 +175,8 @@ export class AgentExecutor extends BaseChain {
           output = {
             tool: "_Exception",
             toolInput: observation,
-            log: e.message,
-          };
+            log: text,
+          } as AgentAction;
         } else {
           throw e;
         }

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -227,15 +227,34 @@ export class BytesOutputParser extends BaseTransformOutputParser<Uint8Array> {
 }
 
 /**
- * Custom error class used to handle exceptions related to output parsing.
- * It extends the built-in `Error` class and adds an optional `output`
- * property that can hold the output that caused the exception.
+ * Exception that output parsers should raise to signify a parsing error.
+ *
+ * This exists to differentiate parsing errors from other code or execution errors
+ * that also may arise inside the output parser. OutputParserExceptions will be
+ * available to catch and handle in ways to fix the parsing error, while other
+ * errors will be raised.
+ *
+ * Args:
+ *     message: The error that's being re-raised or an error message.
+ *     observation: String explanation of error which can be passed to a
+ *         model to try and remediate the issue.
+ *     output: String model output which is error-ing.
+ *     sendToLLM: Whether to send the observation and llm_output back to an Agent
+ *         after an OutputParserException has been raised. This gives the underlying
+ *         model driving the agent the context that the previous output was improperly
+ *         structured, in the hopes that it will update the output to the correct
+ *         format.
  */
 export class OutputParserException extends Error {
+  observation?: string;
+
   output?: string;
 
-  constructor(message: string, output?: string) {
+  sendToLLM: boolean;
+
+  constructor(message: string, output?: string, sendToLLM = false) {
     super(message);
     this.output = output;
+    this.sendToLLM = sendToLLM;
   }
 }

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -234,27 +234,35 @@ export class BytesOutputParser extends BaseTransformOutputParser<Uint8Array> {
  * available to catch and handle in ways to fix the parsing error, while other
  * errors will be raised.
  *
- * Args:
- *     message: The error that's being re-raised or an error message.
- *     observation: String explanation of error which can be passed to a
- *         model to try and remediate the issue.
- *     output: String model output which is error-ing.
- *     sendToLLM: Whether to send the observation and llm_output back to an Agent
- *         after an OutputParserException has been raised. This gives the underlying
- *         model driving the agent the context that the previous output was improperly
- *         structured, in the hopes that it will update the output to the correct
- *         format.
+ * @param message - The error that's being re-raised or an error message.
+ * @param llmOutput - String model output which is error-ing.
+ * @param observation - String explanation of error which can be passed to a
+ *     model to try and remediate the issue.
+ * @param sendToLLM - Whether to send the observation and llm_output back to an Agent
+ *     after an OutputParserException has been raised. This gives the underlying
+ *     model driving the agent the context that the previous output was improperly
+ *     structured, in the hopes that it will update the output to the correct
+ *     format.
  */
 export class OutputParserException extends Error {
-  observation?: string;
+  llmOutput?: string;
 
-  output?: string;
+  observation?: string;
 
   sendToLLM: boolean;
 
-  constructor(message: string, output?: string, sendToLLM = false) {
+  constructor(message: string, llmOutput?: string, observation?: string, sendToLLM = false) {
     super(message);
-    this.output = output;
+    this.llmOutput = llmOutput;
+    this.observation = observation;
     this.sendToLLM = sendToLLM;
+
+    if (sendToLLM) {
+      if (observation === undefined || llmOutput === undefined) {
+        throw new Error(
+          "Arguments 'observation' & 'llmOutput' are required if 'sendToLlm' is true"
+        );
+      }
+    }
   }
 }

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -251,7 +251,12 @@ export class OutputParserException extends Error {
 
   sendToLLM: boolean;
 
-  constructor(message: string, llmOutput?: string, observation?: string, sendToLLM = false) {
+  constructor(
+    message: string,
+    llmOutput?: string,
+    observation?: string,
+    sendToLLM = false
+  ) {
     super(message);
     this.llmOutput = llmOutput;
     this.observation = observation;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Inspired by the same OutputParserException in python library, used the [LangChain Python to JS translator](https://langchain-translator.vercel.app/) to translate some code, that was pretty cool. This also keeps the existing ordering of the constructor params to avoid changes to existing code using the constructor.

Python library code:
- Output parser: https://github.com/langchain-ai/langchain/blob/96023f94d9db48b4ca3d6849711f030010c2454b/libs/langchain/langchain/schema/output_parser.py#L326-L362
- Agent executor: https://github.com/langchain-ai/langchain/blob/1bc3244db92faef6ac7961f935a6b45b6df7eab3/libs/langchain/langchain/agents/agent.py#L932-L937