### PR TITLE
Fixes a bug in the NotionAPI loader for getTitle

### DIFF
--- a/langchain/src/document_loaders/tests/example_data/notion_api/notion_database_response.json
+++ b/langchain/src/document_loaders/tests/example_data/notion_api/notion_database_response.json
@@ -1,0 +1,246 @@
+{
+  "object": "database",
+  "id": "c393f19c-3903-440d-a0d3-4bf9c6c12ff2",
+  "cover": null,
+  "icon": null,
+  "created_time": "2023-06-14T10:29:00.000Z",
+  "created_by": {
+    "object": "user",
+    "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
+  },
+  "last_edited_time": "2023-09-27T09:07:00.000Z",
+  "title": [
+    {
+      "type": "text",
+      "text": { "content": "Example ", "link": null },
+      "annotations": {
+        "bold": false,
+        "italic": false,
+        "strikethrough": false,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "Example ",
+      "href": null
+    },
+    {
+      "type": "text",
+      "text": { "content": "Database", "link": null },
+      "annotations": {
+        "bold": true,
+        "italic": true,
+        "strikethrough": true,
+        "underline": false,
+        "code": false,
+        "color": "default"
+      },
+      "plain_text": "Database",
+      "href": null
+    }
+  ],
+  "description": [],
+  "is_inline": true,
+  "properties": {
+    "File": { "id": "%3DAK%3F", "name": "File", "type": "files", "files": {} },
+    "Number": {
+      "id": "%3FD%7CI",
+      "name": "Number",
+      "type": "number",
+      "number": { "format": "number" }
+    },
+    "Rollup": {
+      "id": "%3FROk",
+      "name": "Rollup",
+      "type": "rollup",
+      "rollup": {
+        "rollup_property_name": "Name",
+        "relation_property_name": "Related Example Database",
+        "rollup_property_id": "title",
+        "relation_property_id": "\\tQ[",
+        "function": "show_original"
+      }
+    },
+    "Status": {
+      "id": "%40mqJ",
+      "name": "Status",
+      "type": "status",
+      "status": {
+        "options": [
+          {
+            "id": "9f08647c-ad39-463d-ada7-18b0851806e1",
+            "name": "Not started",
+            "color": "default"
+          },
+          {
+            "id": "6d4f47e4-d554-485b-a3b5-38f41218502d",
+            "name": "In progress",
+            "color": "blue"
+          },
+          {
+            "id": "e07004b9-d05a-4ead-a752-fd46444d5b20",
+            "name": "Done",
+            "color": "green"
+          }
+        ],
+        "groups": [
+          {
+            "id": "6a9b9293-ead5-4ec4-a46f-a86fc5ec8579",
+            "name": "To-do",
+            "color": "gray",
+            "option_ids": ["9f08647c-ad39-463d-ada7-18b0851806e1"]
+          },
+          {
+            "id": "183249c1-103e-4ddf-8c7d-76feda6073fe",
+            "name": "In progress",
+            "color": "blue",
+            "option_ids": ["6d4f47e4-d554-485b-a3b5-38f41218502d"]
+          },
+          {
+            "id": "71ab78cb-5c7c-4af2-8e28-64c82e9ab4be",
+            "name": "Complete",
+            "color": "green",
+            "option_ids": ["e07004b9-d05a-4ead-a752-fd46444d5b20"]
+          }
+        ]
+      }
+    },
+    "Multi-select": {
+      "id": "GpEZ",
+      "name": "Multi-select",
+      "type": "multi_select",
+      "multi_select": {
+        "options": [
+          {
+            "id": "02733568-8d80-4b3e-8d7d-a2fcd547fc3f",
+            "name": "Red",
+            "color": "red"
+          },
+          {
+            "id": "426a6876-f5db-498b-a528-5d32ac11a57d",
+            "name": "Green",
+            "color": "green"
+          },
+          {
+            "id": "e4063033-ca88-4541-ac81-348f9f409443",
+            "name": "Blue",
+            "color": "blue"
+          }
+        ]
+      }
+    },
+    "Select": {
+      "id": "OMmU",
+      "name": "Select",
+      "type": "select",
+      "select": {
+        "options": [
+          {
+            "id": "123c9765-bef8-4c91-93e3-73205973ce29",
+            "name": "Yellow",
+            "color": "yellow"
+          },
+          {
+            "id": "40278f77-e412-417a-a1d9-dad665e57242",
+            "name": "Magenta",
+            "color": "pink"
+          }
+        ]
+      }
+    },
+    "Last edited time": {
+      "id": "Okfy",
+      "name": "Last edited time",
+      "type": "last_edited_time",
+      "last_edited_time": {}
+    },
+    "Text": {
+      "id": "VWez",
+      "name": "Text",
+      "type": "rich_text",
+      "rich_text": {}
+    },
+    "title": {
+      "id": "VdnU",
+      "name": "title",
+      "type": "rich_text",
+      "rich_text": {}
+    },
+    "Last edited by": {
+      "id": "Yfu%7B",
+      "name": "Last edited by",
+      "type": "last_edited_by",
+      "last_edited_by": {}
+    },
+    "Related Example Database": {
+      "id": "%5CtQ%5B",
+      "name": "Related Example Database",
+      "type": "relation",
+      "relation": {
+        "database_id": "c393f19c-3903-440d-a0d3-4bf9c6c12ff2",
+        "synced_property_id": "\\tQ[",
+        "synced_property_name": "Related Example Database"
+      }
+    },
+    "Created by": {
+      "id": "_qQv",
+      "name": "Created by",
+      "type": "created_by",
+      "created_by": {}
+    },
+    "Checkbox": {
+      "id": "aSh%3F",
+      "name": "Checkbox",
+      "type": "checkbox",
+      "checkbox": {}
+    },
+    "Formula": {
+      "id": "cnSn",
+      "name": "Formula",
+      "type": "formula",
+      "formula": {
+        "expression": "{{notion:block_property:lsSy:928ad4d3-c992-4931-b295-2c5bc13595dd:7f86f3d2-0f6c-4541-a93b-9593d6dc3f0a}}.split('-').last().toNumber() == \"1\""
+      }
+    },
+    "Phone": {
+      "id": "faWC",
+      "name": "Phone",
+      "type": "phone_number",
+      "phone_number": {}
+    },
+    "Email": { "id": "hMx%3C", "name": "Email", "type": "email", "email": {} },
+    "URL": { "id": "k~K%3C", "name": "URL", "type": "url", "url": {} },
+    "Created time": {
+      "id": "lYCY",
+      "name": "Created time",
+      "type": "created_time",
+      "created_time": {}
+    },
+    "ID": {
+      "id": "lsSy",
+      "name": "ID",
+      "type": "unique_id",
+      "unique_id": { "prefix": null }
+    },
+    "Date": { "id": "pbgc", "name": "Date", "type": "date", "date": {} },
+    "Person": {
+      "id": "~GU~",
+      "name": "Person",
+      "type": "people",
+      "people": {}
+    },
+    "Name": { "id": "title", "name": "Name", "type": "title", "title": {} }
+  },
+  "parent": {
+    "type": "page_id",
+    "page_id": "b34ca03f-219c-4420-a604-6fc4bdfdf7b4"
+  },
+  "url": "https://www.notion.so/c393f19c3903440da0d34bf9c6c12ff2",
+  "public_url": "https://skarard.notion.site/c393f19c3903440da0d34bf9c6c12ff2",
+  "archived": false,
+  "developer_survey": "https://notionup.typeform.com/to/bllBsoI4?utm_source=postman"
+}

--- a/langchain/src/document_loaders/tests/example_data/notion_api/notion_page_response.json
+++ b/langchain/src/document_loaders/tests/example_data/notion_api/notion_page_response.json
@@ -2,7 +2,7 @@
   "object": "page",
   "id": "7a1c25f2-d8a7-46d9-a2da-c9e39e018a56",
   "created_time": "2023-06-14T10:29:00.000Z",
-  "last_edited_time": "2023-08-09T16:06:00.000Z",
+  "last_edited_time": "2023-09-27T09:11:00.000Z",
   "created_by": {
     "object": "user",
     "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
@@ -27,17 +27,13 @@
           "name": "MetaLumna Logo Square.png",
           "type": "file",
           "file": {
-            "url": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/8ad37e93-7788-499e-8fe5-35c714c0022f/MetaLumna_Logo_Square.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20230809%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230809T160622Z&X-Amz-Expires=3600&X-Amz-Signature=164ce8273219415d078670e5fca017d7ee2ac3b421284fed8e8d5508e957deaf&X-Amz-SignedHeaders=host&x-id=GetObject",
-            "expiry_time": "2023-08-09T17:06:22.823Z"
+            "url": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/8ad37e93-7788-499e-8fe5-35c714c0022f/MetaLumna_Logo_Square.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20230927%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230927T091149Z&X-Amz-Expires=3600&X-Amz-Signature=292d6ed32186f0364aa844e4e5654c54c3364fb5e60f5d880591d41585df16e3&X-Amz-SignedHeaders=host&x-id=GetObject",
+            "expiry_time": "2023-09-27T10:11:49.797Z"
           }
         }
       ]
     },
-    "Number": {
-      "id": "%3FD%7CI",
-      "type": "number",
-      "number": 1234
-    },
+    "Number": { "id": "%3FD%7CI", "type": "number", "number": 1234 },
     "Rollup": {
       "id": "%3FROk",
       "type": "rollup",
@@ -71,10 +67,7 @@
             "title": [
               {
                 "type": "text",
-                "text": {
-                  "content": "An example page in a database",
-                  "link": null
-                },
+                "text": { "content": "An example ", "link": null },
                 "annotations": {
                   "bold": false,
                   "italic": false,
@@ -83,7 +76,35 @@
                   "code": false,
                   "color": "default"
                 },
-                "plain_text": "An example page in a database",
+                "plain_text": "An example ",
+                "href": null
+              },
+              {
+                "type": "text",
+                "text": { "content": "page", "link": null },
+                "annotations": {
+                  "bold": false,
+                  "italic": false,
+                  "strikethrough": true,
+                  "underline": false,
+                  "code": false,
+                  "color": "default"
+                },
+                "plain_text": "page",
+                "href": null
+              },
+              {
+                "type": "text",
+                "text": { "content": " in a database", "link": null },
+                "annotations": {
+                  "bold": false,
+                  "italic": false,
+                  "strikethrough": false,
+                  "underline": false,
+                  "code": false,
+                  "color": "default"
+                },
+                "plain_text": " in a database",
                 "href": null
               }
             ]
@@ -156,7 +177,7 @@
     "Last edited time": {
       "id": "Okfy",
       "type": "last_edited_time",
-      "last_edited_time": "2023-08-09T16:06:00.000Z"
+      "last_edited_time": "2023-09-27T09:11:00.000Z"
     },
     "Text": {
       "id": "VWez",
@@ -164,10 +185,7 @@
       "rich_text": [
         {
           "type": "text",
-          "text": {
-            "content": "This is just some ",
-            "link": null
-          },
+          "text": { "content": "This is just some ", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -181,10 +199,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "text",
-            "link": null
-          },
+          "text": { "content": "text", "link": null },
           "annotations": {
             "bold": true,
             "italic": false,
@@ -215,10 +230,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "italic",
-            "link": null
-          },
+          "text": { "content": "italic", "link": null },
           "annotations": {
             "bold": false,
             "italic": true,
@@ -232,10 +244,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "\n",
-            "link": null
-          },
+          "text": { "content": "\n", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -249,10 +258,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "bold",
-            "link": null
-          },
+          "text": { "content": "bold", "link": null },
           "annotations": {
             "bold": true,
             "italic": false,
@@ -266,10 +272,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "\n",
-            "link": null
-          },
+          "text": { "content": "\n", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -283,10 +286,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "inline code",
-            "link": null
-          },
+          "text": { "content": "inline code", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -300,10 +300,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "\n",
-            "link": null
-          },
+          "text": { "content": "\n", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -317,10 +314,7 @@
         },
         {
           "type": "text",
-          "text": {
-            "content": "strike through",
-            "link": null
-          },
+          "text": { "content": "strike through", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -334,27 +328,45 @@
         }
       ]
     },
+    "title": {
+      "id": "VdnU",
+      "type": "rich_text",
+      "rich_text": [
+        {
+          "type": "text",
+          "text": { "content": "So this counts as a title 1", "link": null },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "So this counts as a title 1",
+          "href": null
+        }
+      ]
+    },
     "Last edited by": {
       "id": "Yfu%7B",
       "type": "last_edited_by",
       "last_edited_by": {
         "object": "user",
-        "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
+        "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd",
+        "name": "Richard Casemore",
+        "avatar_url": "https://s3-us-west-2.amazonaws.com/public.notion-static.com/fa55636a-5a2b-411d-ad24-6d26b6468bf1/12034277_879339035492383_624157532974474889_o.jpg",
+        "type": "person",
+        "person": { "email": "skarard@gmail.com" }
       }
     },
     "Related Example Database": {
       "id": "%5CtQ%5B",
       "type": "relation",
       "relation": [
-        {
-          "id": "7d9d1b96-34fa-4da3-b70d-9f71a75e1291"
-        },
-        {
-          "id": "7a1c25f2-d8a7-46d9-a2da-c9e39e018a56"
-        },
-        {
-          "id": "67662914-f22b-47fd-98aa-19988c40c77d"
-        }
+        { "id": "7d9d1b96-34fa-4da3-b70d-9f71a75e1291" },
+        { "id": "7a1c25f2-d8a7-46d9-a2da-c9e39e018a56" },
+        { "id": "67662914-f22b-47fd-98aa-19988c40c77d" }
       ],
       "has_more": false
     },
@@ -363,37 +375,26 @@
       "type": "created_by",
       "created_by": {
         "object": "user",
-        "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
+        "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd",
+        "name": "Richard Casemore",
+        "avatar_url": "https://s3-us-west-2.amazonaws.com/public.notion-static.com/fa55636a-5a2b-411d-ad24-6d26b6468bf1/12034277_879339035492383_624157532974474889_o.jpg",
+        "type": "person",
+        "person": { "email": "skarard@gmail.com" }
       }
     },
-    "Checkbox": {
-      "id": "aSh%3F",
-      "type": "checkbox",
-      "checkbox": true
-    },
+    "Checkbox": { "id": "aSh%3F", "type": "checkbox", "checkbox": true },
     "Formula": {
       "id": "cnSn",
       "type": "formula",
-      "formula": {
-        "type": "boolean",
-        "boolean": false
-      }
+      "formula": { "type": "boolean", "boolean": false }
     },
     "Phone": {
       "id": "faWC",
       "type": "phone_number",
       "phone_number": "555-1234"
     },
-    "Email": {
-      "id": "hMx%3C",
-      "type": "email",
-      "email": "skarard@gmail.com"
-    },
-    "URL": {
-      "id": "k~K%3C",
-      "type": "url",
-      "url": "https://example.com"
-    },
+    "Email": { "id": "hMx%3C", "type": "email", "email": "skarard@gmail.com" },
+    "URL": { "id": "k~K%3C", "type": "url", "url": "https://example.com" },
     "Created time": {
       "id": "lYCY",
       "type": "created_time",
@@ -402,10 +403,7 @@
     "ID": {
       "id": "lsSy",
       "type": "unique_id",
-      "unique_id": {
-        "prefix": null,
-        "number": 2
-      }
+      "unique_id": { "prefix": null, "number": 2 }
     },
     "Date": {
       "id": "pbgc",
@@ -422,11 +420,19 @@
       "people": [
         {
           "object": "user",
-          "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"
+          "id": "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd",
+          "name": "Richard Casemore",
+          "avatar_url": "https://s3-us-west-2.amazonaws.com/public.notion-static.com/fa55636a-5a2b-411d-ad24-6d26b6468bf1/12034277_879339035492383_624157532974474889_o.jpg",
+          "type": "person",
+          "person": { "email": "skarard@gmail.com" }
         },
         {
           "object": "user",
-          "id": "9d6b0c60-efdd-48d1-b63e-027d9b7d66a0"
+          "id": "9d6b0c60-efdd-48d1-b63e-027d9b7d66a0",
+          "name": "MetaLumna Admin",
+          "avatar_url": null,
+          "type": "person",
+          "person": { "email": "team@metalumna.com" }
         }
       ]
     },
@@ -436,10 +442,7 @@
       "title": [
         {
           "type": "text",
-          "text": {
-            "content": "An example page in a database",
-            "link": null
-          },
+          "text": { "content": "An example ", "link": null },
           "annotations": {
             "bold": false,
             "italic": false,
@@ -448,7 +451,35 @@
             "code": false,
             "color": "default"
           },
-          "plain_text": "An example page in a database",
+          "plain_text": "An example ",
+          "href": null
+        },
+        {
+          "type": "text",
+          "text": { "content": "page", "link": null },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": true,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "page",
+          "href": null
+        },
+        {
+          "type": "text",
+          "text": { "content": " in a database", "link": null },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": " in a database",
           "href": null
         }
       ]

--- a/langchain/src/document_loaders/tests/notionapi.int.test.ts
+++ b/langchain/src/document_loaders/tests/notionapi.int.test.ts
@@ -9,8 +9,10 @@ test("Test Notion API Loader Page", async () => {
       auth: process.env.NOTION_INTEGRATION_TOKEN,
     },
     id: process.env.NOTION_PAGE_ID ?? "",
-    onDocumentLoaded: (current, total, currentTitle) => {
-      console.log(`Loaded Page: ${currentTitle} (${current}/${total})`);
+    onDocumentLoaded: (current, total, currentTitle, rootTitle) => {
+      console.log(
+        `Loaded ${currentTitle} in ${rootTitle}:  (${current}/${total})`
+      );
     },
   });
 
@@ -26,8 +28,10 @@ test("Test Notion API Loader Database", async () => {
       auth: process.env.NOTION_INTEGRATION_TOKEN,
     },
     id: process.env.NOTION_DATABASE_ID ?? "",
-    onDocumentLoaded: (current, total, currentTitle) => {
-      console.log(`Loaded Page: ${currentTitle} (${current}/${total})`);
+    onDocumentLoaded: (current, total, currentTitle, rootTitle) => {
+      console.log(
+        `Loaded ${currentTitle} in ${rootTitle}:  (${current}/${total})`
+      );
     },
   });
 
@@ -35,4 +39,25 @@ test("Test Notion API Loader Database", async () => {
   const titles = docs.map((doc) => doc.metadata.properties._title);
   console.log("Titles:", titles);
   console.log(`Loaded ${docs.length} pages from the database`);
+});
+
+test("Test Notion API Loader onDocumentLoad", async () => {
+  const onDocumentLoadedCheck: string[] = [];
+  const loader = new NotionAPILoader({
+    clientOptions: {
+      auth: process.env.NOTION_INTEGRATION_TOKEN,
+    },
+    id: process.env.NOTION_DATABASE_ID ?? "",
+    onDocumentLoaded: (current, total, currentTitle, rootTitle) => {
+      onDocumentLoadedCheck.push(
+        `Loaded ${currentTitle} from ${rootTitle}: (${current}/${total})`
+      );
+    },
+  });
+
+  await loader.load();
+
+  expect(onDocumentLoadedCheck.length).toBe(3);
+
+  console.log(onDocumentLoadedCheck);
 });

--- a/langchain/src/document_loaders/tests/notionapi.test.ts
+++ b/langchain/src/document_loaders/tests/notionapi.test.ts
@@ -101,3 +101,30 @@ test("Get Title (page)", async () => {
 
   expect(title).toBe("An example ~~page~~ in a database");
 });
+
+test("Get Title (database)", async () => {
+  const loader = new NotionAPILoader({
+    clientOptions: {
+      auth: process.env.NOTION_INTEGRATION_TOKEN,
+    },
+    id: process.env.NOTION_PAGE_ID ?? "",
+    onDocumentLoaded: (current, total, currentTitle) => {
+      console.log(`Loaded Page: ${currentTitle} (${current}/${total})`);
+    },
+  });
+
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/notion_api/notion_database_response.json"
+  );
+
+  const dbDetails: DatabaseObjectResponse = JSON.parse(
+    fs.readFileSync(filePath).toString()
+  );
+
+  // Accessing private class method
+  // eslint-disable-next-line dot-notation
+  const title = loader["getTitle"](dbDetails);
+
+  expect(title).toBe("Example ~~_**Database**_~~");
+});

--- a/langchain/src/document_loaders/tests/notionapi.test.ts
+++ b/langchain/src/document_loaders/tests/notionapi.test.ts
@@ -4,7 +4,11 @@ import * as fs from "node:fs";
 import * as url from "node:url";
 import * as path from "node:path";
 import { test } from "@jest/globals";
-import { NotionAPILoader, PageObjectResponse } from "../web/notionapi.js";
+import {
+  DatabaseObjectResponse,
+  NotionAPILoader,
+  PageObjectResponse,
+} from "../web/notionapi.js";
 
 test("Properties Parser", async () => {
   const loader = new NotionAPILoader({
@@ -36,7 +40,7 @@ test("Properties Parser", async () => {
   expect(contents.Status).toBe("In progress");
   expect(contents["Multi-select"]).toBe('["Red", "Green", "Blue"]');
   expect(contents.Select).toBe("Magenta");
-  expect(contents["Last edited time"]).toBe("2023-08-09T16:06:00.000Z");
+  expect(contents["Last edited time"]).toBe("2023-09-27T09:11:00.000Z");
   expect(contents.Text).toBe(
     "This is just some **text** with some formatting and new lines.\n" +
       "\n" +
@@ -67,11 +71,11 @@ test("Properties Parser", async () => {
   expect(contents.Person).toBe(
     '[["user", "c9b34ba3-5b62-4aa9-aae2-ed6024ffb0fd"], ["user", "9d6b0c60-efdd-48d1-b63e-027d9b7d66a0"]]'
   );
-  expect(contents.Name).toBe("An example page in a database");
-  expect(contents._title).toBe("An example page in a database");
+  expect(contents.Name).toBe("An example ~~page~~ in a database");
+  expect(contents._title).toBe("An example ~~page~~ in a database");
 });
 
-test("Get Title", async () => {
+test("Get Title (page)", async () => {
   const loader = new NotionAPILoader({
     clientOptions: {
       auth: process.env.NOTION_INTEGRATION_TOKEN,
@@ -95,5 +99,5 @@ test("Get Title", async () => {
   // eslint-disable-next-line dot-notation
   const title = loader["getTitle"](pageDetails);
 
-  expect(title).toBe("An example page in a database");
+  expect(title).toBe("An example ~~page~~ in a database");
 });

--- a/langchain/src/document_loaders/tests/notionapi.test.ts
+++ b/langchain/src/document_loaders/tests/notionapi.test.ts
@@ -70,3 +70,30 @@ test("Properties Parser", async () => {
   expect(contents.Name).toBe("An example page in a database");
   expect(contents._title).toBe("An example page in a database");
 });
+
+test("Get Title", async () => {
+  const loader = new NotionAPILoader({
+    clientOptions: {
+      auth: process.env.NOTION_INTEGRATION_TOKEN,
+    },
+    id: process.env.NOTION_PAGE_ID ?? "",
+    onDocumentLoaded: (current, total, currentTitle) => {
+      console.log(`Loaded Page: ${currentTitle} (${current}/${total})`);
+    },
+  });
+
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/notion_api/notion_page_response.json"
+  );
+
+  const pageDetails: PageObjectResponse = JSON.parse(
+    fs.readFileSync(filePath).toString()
+  );
+
+  // Accessing private class method
+  // eslint-disable-next-line dot-notation
+  const title = loader["getTitle"](pageDetails);
+
+  expect(title).toBe("An example page in a database");
+});

--- a/langchain/src/document_loaders/web/notionapi.ts
+++ b/langchain/src/document_loaders/web/notionapi.ts
@@ -354,7 +354,7 @@ export class NotionAPILoader extends BaseDocumentLoader {
     this.onDocumentLoaded(
       this.documents.length,
       this.pageQueueTotal,
-      pageDocument.metadata.properties.title,
+      this.getTitle(pageDetails) || undefined,
       this.rootTitle
     );
   }

--- a/langchain/src/document_loaders/web/notionapi.ts
+++ b/langchain/src/document_loaders/web/notionapi.ts
@@ -150,7 +150,12 @@ export class NotionAPILoader extends BaseDocumentLoader {
       );
       if (titleProp) return this.getPropValue(titleProp);
     }
-    if (isDatabase(obj)) return obj.title[0]?.plain_text;
+    if (isDatabase(obj))
+      return obj.title
+        .map((v) =>
+          this.n2mClient.annotatePlainText(v.plain_text, v.annotations)
+        )
+        .join("");
     return null;
   }
 

--- a/langchain/src/document_loaders/web/notionapi.ts
+++ b/langchain/src/document_loaders/web/notionapi.ts
@@ -144,8 +144,11 @@ export class NotionAPILoader extends BaseDocumentLoader {
    * @returns The string of the title.
    */
   private getTitle(obj: GetResponse) {
-    if (isPage(obj) && obj.properties.title.type === "title") {
-      return obj.properties.title.title[0]?.plain_text;
+    if (isPage(obj)) {
+      const titleProp = Object.values(obj.properties).find(
+        (prop) => prop.type === "title"
+      );
+      if (titleProp) return this.getPropValue(titleProp);
     }
     if (isDatabase(obj)) return obj.title[0]?.plain_text;
     return null;


### PR DESCRIPTION
- Fixes a bug with a page title properties being renamed in the database and getTitle failing to get the new name. 
- Adds unit tests that allow annotated titles for pages and databases