### PR TITLE
fix: supabase vector store delete params ids typo

### DIFF
--- a/langchain/src/vectorstores/supabase.ts
+++ b/langchain/src/vectorstores/supabase.ts
@@ -136,7 +136,7 @@ export class SupabaseVectorStore extends VectorStore {
    * @param params The parameters for deleting vectors.
    * @returns A promise that resolves when the vectors have been deleted.
    */
-  async delete(params: { ids: string[] }): Promise<void> {
+  async delete(params: { ids: string[] | number[] }): Promise<void> {
     const { ids } = params;
     for (const id of ids) {
       await this.client.from(this.tableName).delete().eq("id", id);


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

## Fix typo in SupabaseVectorStore delete method

Currently, it only accepts an array of strings, but in our Supabase database, we can have a column of IDs as integers.


like your function [example](https://js.langchain.com/docs/modules/data_connection/vectorstores/integrations/supabase#create-a-table-and-search-function-in-your-database):
```sql
create table embeddings (
  id bigserial primary key,
  content text, -- corresponds to Document.pageContent
  metadata jsonb, -- corresponds to Document.metadata
  embedding vector(1536) -- 1536 works for OpenAI embeddings, change if needed
);
```

![image](https://github.com/langchain-ai/langchainjs/assets/69825873/d3c2df4d-c81e-4841-b4b2-37f9bfa4166d)
