### PR TITLE
Fix: Text splitter invalid loc.lines in case of chunk overlap

### DIFF
--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -1,183 +1,340 @@
-import { test, expect } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { Document } from "../document.js";
 import {
   CharacterTextSplitter,
-  MarkdownTextSplitter,
   LatexTextSplitter,
+  MarkdownTextSplitter,
   RecursiveCharacterTextSplitter,
   TokenTextSplitter,
 } from "../text_splitter.js";
 
-test("Test splitting by character count.", async () => {
-  const text = "foo bar baz 123";
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 7,
-    chunkOverlap: 3,
+function textLineGenerator(char: string, length: number) {
+  const line = new Array(length).join(char);
+  return `${line}\n`;
+}
+
+describe("Character text splitter", () => {
+  test("Test splitting by character count.", async () => {
+    const text = "foo bar baz 123";
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 7,
+      chunkOverlap: 3,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = ["foo bar", "bar baz", "baz 123"];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = ["foo bar", "bar baz", "baz 123"];
-  expect(output).toEqual(expectedOutput);
-});
 
-test("Test splitting by character count doesn't create empty documents.", async () => {
-  const text = "foo  bar";
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 2,
-    chunkOverlap: 0,
+  test("Test splitting by character count doesn't create empty documents.", async () => {
+    const text = "foo  bar";
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 2,
+      chunkOverlap: 0,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = ["foo", "bar"];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = ["foo", "bar"];
-  expect(output).toEqual(expectedOutput);
-});
 
-test("Test splitting by character count on long words.", async () => {
-  const text = "foo bar baz a a";
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 3,
-    chunkOverlap: 1,
+  test("Test splitting by character count on long words.", async () => {
+    const text = "foo bar baz a a";
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 3,
+      chunkOverlap: 1,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = ["foo", "bar", "baz", "a a"];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = ["foo", "bar", "baz", "a a"];
-  expect(output).toEqual(expectedOutput);
-});
 
-test("Test splitting by character count when shorter words are first.", async () => {
-  const text = "a a foo bar baz";
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 3,
-    chunkOverlap: 1,
+  test("Test splitting by character count when shorter words are first.", async () => {
+    const text = "a a foo bar baz";
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 3,
+      chunkOverlap: 1,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = ["a a", "foo", "bar", "baz"];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = ["a a", "foo", "bar", "baz"];
-  expect(output).toEqual(expectedOutput);
-});
 
-test("Test splitting by characters when splits not found easily.", async () => {
-  const text = "foo bar baz 123";
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 1,
-    chunkOverlap: 0,
+  test("Test splitting by characters when splits not found easily.", async () => {
+    const text = "foo bar baz 123";
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 1,
+      chunkOverlap: 0,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = ["foo", "bar", "baz", "123"];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = ["foo", "bar", "baz", "123"];
-  expect(output).toEqual(expectedOutput);
-});
 
-test("Test invalid arguments.", () => {
-  expect(() => {
-    const res = new CharacterTextSplitter({ chunkSize: 2, chunkOverlap: 4 });
-    console.log(res);
-  }).toThrow();
-});
-
-test("Test create documents method.", async () => {
-  const texts = ["foo bar", "baz"];
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 3,
-    chunkOverlap: 0,
+  test("Test invalid arguments.", () => {
+    expect(() => {
+      const res = new CharacterTextSplitter({ chunkSize: 2, chunkOverlap: 4 });
+      console.log(res);
+    }).toThrow();
   });
-  const docs = await splitter.createDocuments(texts);
-  const metadata = { loc: { lines: { from: 1, to: 1 } } };
-  const expectedDocs = [
-    new Document({ pageContent: "foo", metadata }),
-    new Document({ pageContent: "bar", metadata }),
-    new Document({ pageContent: "baz", metadata }),
-  ];
-  expect(docs).toEqual(expectedDocs);
-});
 
-test("Test create documents with metadata method.", async () => {
-  const texts = ["foo bar", "baz"];
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 3,
-    chunkOverlap: 0,
+  test("Test create documents method.", async () => {
+    const texts = ["foo bar", "baz"];
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 3,
+      chunkOverlap: 0,
+    });
+    const docs = await splitter.createDocuments(texts);
+    const metadata = { loc: { lines: { from: 1, to: 1 } } };
+    const expectedDocs = [
+      new Document({ pageContent: "foo", metadata }),
+      new Document({ pageContent: "bar", metadata }),
+      new Document({ pageContent: "baz", metadata }),
+    ];
+    expect(docs).toEqual(expectedDocs);
   });
-  const docs = await splitter.createDocuments(texts, [
-    { source: "1" },
-    { source: "2" },
-  ]);
-  const loc = { lines: { from: 1, to: 1 } };
-  const expectedDocs = [
-    new Document({ pageContent: "foo", metadata: { source: "1", loc } }),
-    new Document({
-      pageContent: "bar",
-      metadata: { source: "1", loc },
-    }),
-    new Document({ pageContent: "baz", metadata: { source: "2", loc } }),
-  ];
-  expect(docs).toEqual(expectedDocs);
-});
 
-test("Test create documents method with metadata and an added chunk header.", async () => {
-  const texts = ["foo bar", "baz"];
-  const splitter = new CharacterTextSplitter({
-    separator: " ",
-    chunkSize: 3,
-    chunkOverlap: 0,
+  test("Test create documents with metadata method.", async () => {
+    const texts = ["foo bar", "baz"];
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 3,
+      chunkOverlap: 0,
+    });
+    const docs = await splitter.createDocuments(texts, [
+      { source: "1" },
+      { source: "2" },
+    ]);
+    const loc = { lines: { from: 1, to: 1 } };
+    const expectedDocs = [
+      new Document({ pageContent: "foo", metadata: { source: "1", loc } }),
+      new Document({
+        pageContent: "bar",
+        metadata: { source: "1", loc },
+      }),
+      new Document({ pageContent: "baz", metadata: { source: "2", loc } }),
+    ];
+    expect(docs).toEqual(expectedDocs);
   });
-  const docs = await splitter.createDocuments(
-    texts,
-    [{ source: "1" }, { source: "2" }],
-    {
-      chunkHeader: `SOURCE NAME: testing\n-----\n`,
-      appendChunkOverlapHeader: true,
-    }
-  );
-  const loc = { lines: { from: 1, to: 1 } };
-  const expectedDocs = [
-    new Document({
-      pageContent: "SOURCE NAME: testing\n-----\nfoo",
-      metadata: { source: "1", loc },
-    }),
-    new Document({
-      pageContent: "SOURCE NAME: testing\n-----\n(cont'd) bar",
-      metadata: { source: "1", loc },
-    }),
-    new Document({
-      pageContent: "SOURCE NAME: testing\n-----\nbaz",
-      metadata: { source: "2", loc },
-    }),
-  ];
-  expect(docs).toEqual(expectedDocs);
+
+  test("Test create documents method with metadata and an added chunk header.", async () => {
+    const texts = ["foo bar", "baz"];
+    const splitter = new CharacterTextSplitter({
+      separator: " ",
+      chunkSize: 3,
+      chunkOverlap: 0,
+    });
+    const docs = await splitter.createDocuments(
+      texts,
+      [{ source: "1" }, { source: "2" }],
+      {
+        chunkHeader: `SOURCE NAME: testing\n-----\n`,
+        appendChunkOverlapHeader: true,
+      }
+    );
+    const loc = { lines: { from: 1, to: 1 } };
+    const expectedDocs = [
+      new Document({
+        pageContent: "SOURCE NAME: testing\n-----\nfoo",
+        metadata: { source: "1", loc },
+      }),
+      new Document({
+        pageContent: "SOURCE NAME: testing\n-----\n(cont'd) bar",
+        metadata: { source: "1", loc },
+      }),
+      new Document({
+        pageContent: "SOURCE NAME: testing\n-----\nbaz",
+        metadata: { source: "2", loc },
+      }),
+    ];
+    expect(docs).toEqual(expectedDocs);
+  });
 });
 
-test("Test iterative text splitter.", async () => {
-  const text = `Hi.\n\nI'm Harrison.\n\nHow? Are? You?\nOkay then f f f f.
+describe("RecursiveCharacter text splitter", () => {
+  test("One unique chunk", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 0,
+    });
+    const content = textLineGenerator("A", 70);
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: content.trim(),
+        metadata: { loc: { lines: { from: 1, to: 1 } } },
+      }),
+    ];
+
+    expect(docs).toEqual(expectedDocs);
+  });
+
+  test("Test iterative text splitter.", async () => {
+    const text = `Hi.\n\nI'm Harrison.\n\nHow? Are? You?\nOkay then f f f f.
 This is a weird text to write, but gotta test the splittingggg some how.\n\n
 Bye!\n\n-H.`;
-  const splitter = new RecursiveCharacterTextSplitter({
-    chunkSize: 10,
-    chunkOverlap: 1,
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 10,
+      chunkOverlap: 1,
+    });
+    const output = await splitter.splitText(text);
+    const expectedOutput = [
+      "Hi.",
+      "I'm",
+      "Harrison.",
+      "How? Are?",
+      "You?",
+      "Okay then",
+      "f f f f.",
+      "This is a",
+      "weird",
+      "text to",
+      "write,",
+      "but gotta",
+      "test the",
+      "splitting",
+      "gggg",
+      "some how.",
+      "Bye!",
+      "-H.",
+    ];
+    expect(output).toEqual(expectedOutput);
   });
-  const output = await splitter.splitText(text);
-  const expectedOutput = [
-    "Hi.",
-    "I'm",
-    "Harrison.",
-    "How? Are?",
-    "You?",
-    "Okay then",
-    "f f f f.",
-    "This is a",
-    "weird",
-    "text to",
-    "write,",
-    "but gotta",
-    "test the",
-    "splitting",
-    "gggg",
-    "some how.",
-    "Bye!",
-    "-H.",
-  ];
-  expect(output).toEqual(expectedOutput);
+
+  test("A basic chunked document", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 0,
+    });
+    const line1 = textLineGenerator("A", 70);
+    const line2 = textLineGenerator("B", 70);
+    const content = line1 + line2;
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: line1.trim(),
+        metadata: { loc: { lines: { from: 1, to: 1 } } },
+      }),
+      new Document({
+        pageContent: line2.trim(),
+        metadata: { loc: { lines: { from: 2, to: 2 } } },
+      }),
+    ];
+
+    expect(docs).toEqual(expectedDocs);
+  });
+
+  test("A chunked document with similar text", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 0,
+    });
+    const line = textLineGenerator("A", 70);
+    const content = line + line;
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: line.trim(),
+        metadata: { loc: { lines: { from: 1, to: 1 } } },
+      }),
+      new Document({
+        pageContent: line.trim(),
+        metadata: { loc: { lines: { from: 2, to: 2 } } },
+      }),
+    ];
+
+    expect(docs).toEqual(expectedDocs);
+  });
+
+  test("A chunked document starting with new lines", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 0,
+    });
+    const line1 = textLineGenerator("\n", 2);
+    const line2 = textLineGenerator("A", 70);
+    const line3 = textLineGenerator("\n", 4);
+    const line4 = textLineGenerator("B", 70);
+    const line5 = textLineGenerator("\n", 4);
+    const content = line1 + line2 + line3 + line4 + line5;
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: line2.trim(),
+        metadata: { loc: { lines: { from: 3, to: 3 } } },
+      }),
+      new Document({
+        pageContent: line4.trim(),
+        metadata: { loc: { lines: { from: 8, to: 8 } } },
+      }),
+    ];
+
+    expect(docs).toEqual(expectedDocs);
+  });
+
+  test("A chunked with overlap", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 30,
+    });
+    const line1 = textLineGenerator("A", 70);
+    const line2 = textLineGenerator("B", 20);
+    const line3 = textLineGenerator("C", 70);
+    const content = line1 + line2 + line3;
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: line1 + line2.trim(),
+        metadata: { loc: { lines: { from: 1, to: 2 } } },
+      }),
+      new Document({
+        pageContent: line2 + line3.trim(),
+        metadata: { loc: { lines: { from: 2, to: 3 } } },
+      }),
+    ];
+
+    expect(docs).toEqual(expectedDocs);
+  });
+
+  test("Chunks with overlap that contains new lines", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 100,
+      chunkOverlap: 30,
+    });
+    const line1 = textLineGenerator("A", 70);
+    const line2 = textLineGenerator("B", 10);
+    const line3 = textLineGenerator("C", 10);
+    const line4 = textLineGenerator("D", 70);
+    const content = line1 + line2 + line3 + line4;
+
+    const docs = await splitter.createDocuments([content]);
+
+    const expectedDocs = [
+      new Document({
+        pageContent: line1 + line2 + line3.trim(),
+        metadata: { loc: { lines: { from: 1, to: 3 } } },
+      }),
+      new Document({
+        pageContent: line2 + line3 + line4.trim(),
+        metadata: { loc: { lines: { from: 2, to: 4 } } },
+      }),
+    ];
+    expect(docs).toEqual(expectedDocs);
+  });
 });
 
 test("Token text splitter", async () => {
@@ -193,7 +350,7 @@ test("Token text splitter", async () => {
   expect(output).toEqual(expectedOutput);
 });
 
-test("Test markdown text splitter.", async () => {
+test("Test markdown text splitter", async () => {
   const text =
     "# 🦜️🔗 LangChain\n" +
     "\n" +


### PR DESCRIPTION
# Text splitter invalid loc.lines in case of chunk overlap on multiple lignes

- In case of text splitting with the overlap option, _metadata.loc.lines_ can be wrong if the overlaped text contain line separator.
- In case first chunk start with a new line

Added tests  _A first chunked with overlap_  & _Chunks with overlap on multiple lines_ was failing before the fix.
Value of **_loc.lines.to_** was grater than the number of line of the content ....


