### PR TITLE
Single table designs in dynamo require maximum flexibility. Adding key attribute to DynamoDB Chat History args.

### DIFF
--- a/langchain/src/stores/message/dynamodb.ts
+++ b/langchain/src/stores/message/dynamodb.ts
@@ -124,13 +124,7 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
       Key: this.dynamoKey,
     };
 
-    let response;
-    try {
-      response = await this.client.send(new GetItemCommand(params));
-    } catch (err) {
-      console.log(err);
-      throw new Error('Unexpected error has occurred');
-    }
+    const response = await this.client.send(new GetItemCommand(params));
     const items = response.Item
       ? response.Item[this.messageAttributeName]?.L ?? []
       : [];
@@ -199,12 +193,6 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
       UpdateExpression:
         "SET #m = list_append(if_not_exists(#m, :empty_list), :m)",
     };
-
-    try {
-      await this.client.send(new UpdateItemCommand(params));
-    } catch (err) {
-      console.log(err);
-      throw new Error("Unexpected error has occurred.")
-    }
+    await this.client.send(new UpdateItemCommand(params));
   }
 }

--- a/langchain/src/stores/message/dynamodb.ts
+++ b/langchain/src/stores/message/dynamodb.ts
@@ -33,6 +33,7 @@ export interface DynamoDBChatMessageHistoryFields {
   sortKey?: string;
   messageAttributeName?: string;
   config?: DynamoDBClientConfig;
+  key?: Record<string, AttributeValue>;
 }
 
 /**
@@ -81,7 +82,7 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
 
   private messageAttributeName = "messages";
 
-  private dynamoKey: Record<string, AttributeValue>;
+  private dynamoKey: Record<string, AttributeValue> = {};
 
   constructor({
     tableName,
@@ -90,8 +91,10 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
     sortKey,
     messageAttributeName,
     config,
+    key={},
   }: DynamoDBChatMessageHistoryFields) {
     super();
+
     this.tableName = tableName;
     this.sessionId = sessionId;
     this.client = new DynamoDBClient(config ?? {});
@@ -99,11 +102,14 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
     this.sortKey = sortKey;
     this.messageAttributeName =
       messageAttributeName ?? this.messageAttributeName;
+    this.dynamoKey = key;
 
-    this.dynamoKey = {};
-    this.dynamoKey[this.partitionKey] = { S: this.sessionId };
-    if (this.sortKey) {
-      this.dynamoKey[this.sortKey] = { S: this.sortKey };
+    // override dynamoKey with partition key and sort key when key not specified
+    if (Object.keys(this.dynamoKey).length === 0) {
+      this.dynamoKey[this.partitionKey] = { S: this.sessionId };
+      if (this.sortKey) {
+        this.dynamoKey[this.sortKey] = { S: this.sortKey };
+      }
     }
   }
 
@@ -118,7 +124,13 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
       Key: this.dynamoKey,
     };
 
-    const response = await this.client.send(new GetItemCommand(params));
+    let response;
+    try {
+      response = await this.client.send(new GetItemCommand(params));
+    } catch (err) {
+      console.log(err);
+      throw new Error('Unexpected error has occurred');
+    }
     const items = response.Item
       ? response.Item[this.messageAttributeName]?.L ?? []
       : [];
@@ -187,6 +199,12 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
       UpdateExpression:
         "SET #m = list_append(if_not_exists(#m, :empty_list), :m)",
     };
-    await this.client.send(new UpdateItemCommand(params));
+
+    try {
+      await this.client.send(new UpdateItemCommand(params));
+    } catch (err) {
+      console.log(err);
+      throw new Error("Unexpected error has occurred.")
+    }
   }
 }

--- a/langchain/src/stores/message/dynamodb.ts
+++ b/langchain/src/stores/message/dynamodb.ts
@@ -91,7 +91,7 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
     sortKey,
     messageAttributeName,
     config,
-    key={},
+    key = {},
   }: DynamoDBChatMessageHistoryFields) {
     super();
 

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -9,7 +9,7 @@
       "ES2022.Object",
       "DOM"
     ],
-    "module": "NodeNext",
+    "module": "ES2020",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "declaration": true,

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -9,7 +9,7 @@
       "ES2022.Object",
       "DOM"
     ],
-    "module": "ES2020",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
New Interface:
```typescript
export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
  ...
  private dynamoKey: Record<string, AttributeValue> = {};

  constructor({
    tableName,
    sessionId,
    partitionKey,
    sortKey,
    messageAttributeName,
    config,
    key={},   // <=== added this key attribute and tried to leave partitionKey and sortKey alone for backwards compatability
  }: DynamoDBChatMessageHistoryFields) {
    super();
``` 

This allows conversation items in dynamo to look like this:
```JSON
{
 "pk": "conversation#1111-1111-1111",
 "sk": "1000#workspace#channel",
 "messageAttributes": [
  {
   "text": "whats 5 * 6?",
   "type": "human"
  },
  {
   "text": "5 * 6 equals 30.",
   "type": "ai"
  }
 ]
}
```