### PR TITLE
Fix ChatPrompts with LLMs

### DIFF
--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -2,6 +2,7 @@
 // Replace with "string" when we are comfortable with a breaking change.
 
 import { BaseCallbackConfig } from "../callbacks/manager.js";
+import { getBufferString } from "../memory/base.js";
 import {
   AIMessage,
   BaseMessage,
@@ -105,7 +106,7 @@ export class ChatPromptValue extends BasePromptValue {
   }
 
   toString() {
-    return JSON.stringify(this.messages);
+    return getBufferString(this.messages);
   }
 
   toChatMessages() {

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -282,7 +282,7 @@ test("Test using partial", async () => {
   expect(partialPrompt.inputVariables).toEqual(["bar"]);
 
   expect(await partialPrompt.format({ bar: "baz" })).toMatchInlineSnapshot(
-    `"[{"lc":1,"type":"constructor","id":["langchain","schema","HumanMessage"],"kwargs":{"content":"foobaz","additional_kwargs":{}}}]"`
+    `"Human: foobaz"`
   );
 });
 


### PR DESCRIPTION
Currently js has a bug, where if you pipe a ChatPromptTemplate into an LLM, it uses the raw json serialization as input to the model :(

- Python: https://smith.langchain.com/public/a2eb85bf-99bf-44c9-a4fb-b090b761577c/r/6935e177-ff27-4d28-8d19-3b3d0d88ffe2
- Javascript: https://smith.langchain.com/public/706de8fb-84db-4435-a1ab-19c7c9202cc5/r/03a0032e-ff17-4d46-81a0-c59cd514e871