### PR TITLE
Add support for MongoDB Atlas $vectorSearch vector search

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/mongodb_atlas.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/mongodb_atlas.mdx
@@ -27,6 +27,8 @@ Next, you'll need create a MongoDB Atlas cluster. Navigate to the [MongoDB Atlas
 
 Create and name a cluster when prompted, then find it under `Database`. Select `Collections` and create either a blank collection or one from the provided sample data.
 
+** Note ** The cluster created must be MongoDB 7.0 or higher.  If you are using a pre-7.0 version of MongoDB, you must use a version of langchainjs<=0.0.163.
+
 ### Creating an Index
 
 After configuring your cluster, you'll need to create an index on the collection field you want to search over.

--- a/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
+++ b/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
@@ -3,8 +3,8 @@
 
 import { test, expect } from "@jest/globals";
 import { MongoClient } from "mongodb";
+import { setTimeout } from "timers/promises";
 import { MongoDBAtlasVectorSearch } from "../mongodb_atlas.js";
-import { setTimeout } from 'timers/promises';
 
 import { Document } from "../../document.js";
 import { OpenAIEmbeddings } from "../../embeddings/openai.js";
@@ -112,7 +112,7 @@ test.skip("MongoDBAtlasVectorSearch with Maximal Marginal Relevance", async () =
       texts,
       {},
       new OpenAIEmbeddings(),
-      { collection, indexName: 'default' }
+      { collection, indexName: "default" }
     );
 
     // we sleep 2 seconds to make sure the index in atlas has replicated the new documents
@@ -157,7 +157,7 @@ test.skip("MongoDBAtlasVectorSearch with Maximal Marginal Relevance", async () =
     const retrieverExpected = ["foo", "foy", "foo"];
     expect(retrieverActual).toEqual(retrieverExpected);
 
-    const similarity = await vectorStore.similaritySearchWithScore('foo', 1);
+    const similarity = await vectorStore.similaritySearchWithScore("foo", 1);
     expect(similarity.length).toBe(1);
   } finally {
     await client.close();

--- a/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
+++ b/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
@@ -16,6 +16,7 @@ import { OpenAIEmbeddings } from "../../embeddings/openai.js";
 {
   "mappings": {
     "fields": {
+      "e": { "type": "number" },
       "embedding": {
         "dimensions": 1536,
         "similarity": "euclidean",
@@ -67,7 +68,7 @@ test("MongoDBAtlasVectorSearch with external ids", async () => {
 
     // we can pre filter the search
     const preFilter = {
-      range: { lte: 1, path: "e" },
+      e: { $lte: 1 },
     };
 
     const filteredResults = await vectorStore.similaritySearch(

--- a/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
+++ b/langchain/src/vectorstores/tests/mongodb_atlas.int.test.ts
@@ -27,7 +27,7 @@ import { OpenAIEmbeddings } from "../../embeddings/openai.js";
 }
 */
 
-test("MongoDBAtlasVectorSearch with external ids", async () => {
+test.skip("MongoDBAtlasVectorSearch with external ids", async () => {
   expect(process.env.MONGODB_ATLAS_URI).toBeDefined();
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -92,7 +92,7 @@ test("MongoDBAtlasVectorSearch with external ids", async () => {
   }
 });
 
-test("MongoDBAtlasVectorSearch with Maximal Marginal Relevance", async () => {
+test.skip("MongoDBAtlasVectorSearch with Maximal Marginal Relevance", async () => {
   expect(process.env.MONGODB_ATLAS_URI).toBeDefined();
   expect(
     process.env.OPENAI_API_KEY || process.env.AZURE_OPENAI_API_KEY


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

This PR is the JS equivalent of https://github.com/langchain-ai/langchain/pull/11139.

This PR add support for the $vectorSearch stage in the MongoDB Atlas VectorStore.  $vectorSearch was announced at MongoDB .local London.

Some notes:

- We don't have access to Cohere, so I changed the existing integration tests to use OpenAI.  I'm happy to change them back if needed but I'll need help getting access to Cohere.  The tests pass locally for me but I left them skipped because they're skipped in `main`.
- I made a few cleanups to the MongoDB atlas implementation and isolated them in [this](https://github.com/langchain-ai/langchainjs/commit/7c4a53b86baf0ca31528b6a5ea50b9f1ed55e2a3) commit.  Happy to revert.

Same as with the Python implementation, this is a breaking change.