### PR TITLE
Fix for Bedrock `amazon.titan-text-express-v1`

### DIFF
--- a/langchain/src/chat_models/tests/chatbedrock.int.test.ts
+++ b/langchain/src/chat_models/tests/chatbedrock.int.test.ts
@@ -6,7 +6,7 @@ import { ChatBedrock } from "../bedrock.js";
 import { HumanMessage } from "../../schema/index.js";
 
 test("Test Bedrock chat model: Claude-v2", async () => {
-  const region = process.env.BEDROCK_AWS_REGION!;
+  const region = process.env.BEDROCK_AWS_REGION ?? "us-east-1";
   const model = "anthropic.claude-v2";
 
   const bedrock = new ChatBedrock({
@@ -14,20 +14,14 @@ test("Test Bedrock chat model: Claude-v2", async () => {
     region,
     model,
     maxRetries: 0,
-    credentials: {
-      accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
-    },
   });
 
-  const res = await bedrock.call([
-    new HumanMessage({ content: "What is your name?" }),
-  ]);
+  const res = await bedrock.call([new HumanMessage("What is your name?")]);
   console.log(res);
 });
 
 test("Test Bedrock chat model streaming: Claude-v2", async () => {
-  const region = process.env.BEDROCK_AWS_REGION!;
+  const region = process.env.BEDROCK_AWS_REGION ?? "us-east-1";
   const model = "anthropic.claude-v2";
 
   const bedrock = new ChatBedrock({
@@ -35,10 +29,6 @@ test("Test Bedrock chat model streaming: Claude-v2", async () => {
     region,
     model,
     maxRetries: 0,
-    credentials: {
-      accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
-    },
   });
 
   const stream = await bedrock.stream([
@@ -52,4 +42,25 @@ test("Test Bedrock chat model streaming: Claude-v2", async () => {
     chunks.push(chunk);
   }
   expect(chunks.length).toBeGreaterThan(1);
+});
+
+test.each([
+  "amazon.titan-text-express-v1",
+  // These models should be supported in the future
+  // "amazon.titan-text-lite-v1",
+  // "amazon.titan-text-agile-v1",
+])("Test Bedrock base chat model: %s", async (model) => {
+  const region = process.env.BEDROCK_AWS_REGION ?? "us-east-1";
+
+  const bedrock = new ChatBedrock({
+    region,
+    model,
+    maxRetries: 0,
+    modelKwargs: {},
+  });
+
+  const res = await bedrock.call([new HumanMessage("What is your name?")]);
+  console.log(res);
+
+  expect(res.content.length).toBeGreaterThan(1);
 });

--- a/langchain/src/util/bedrock.ts
+++ b/langchain/src/util/bedrock.ts
@@ -104,6 +104,8 @@ export class BedrockLLMInputOutputAdapter {
     } else if (provider === "ai21") {
       return responseBody?.completions?.[0]?.data?.text ?? "";
     }
-    return responseBody.outputText;
+
+    // I haven't been able to get a response with more than one result in it.
+    return responseBody.results?.[0]?.outputText;
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

The Bedrock chat client was expecting the wrong response object for the Titan express model. This updates it to the correct response body object. During my testing, I could not get Bedrock to respond with more than one result in the response body.

*Fun fact*: Titan Express refers to itself as `Kyoko`.
<!-- Remove if not applicable -->

Fixes #2812 