### PR TITLE
NotionAPILoader: Fix for #2807 and add `propertiesAsHeader` option

### DIFF
--- a/examples/src/document_loaders/notionapi.ts
+++ b/examples/src/document_loaders/notionapi.ts
@@ -27,6 +27,7 @@ const dbLoader = new NotionAPILoader({
   callerOptions: {
     maxConcurrency: 64, // Default value
   },
+  propertiesAsHeader: true, // Prepends a front matter header of the page properties to the page contents
 });
 
 // A database row contents is likely to be less than 1000 characters so it's not split into multiple documents

--- a/langchain/src/document_loaders/tests/notionapi.int.test.ts
+++ b/langchain/src/document_loaders/tests/notionapi.int.test.ts
@@ -53,11 +53,53 @@ test("Test Notion API Loader onDocumentLoad", async () => {
         `Loaded ${currentTitle} from ${rootTitle}: (${current}/${total})`
       );
     },
+    propertiesAsHeader: true,
   });
 
   await loader.load();
 
-  expect(onDocumentLoadedCheck.length).toBe(5);
+  expect(onDocumentLoadedCheck.length).toBe(3);
 
   console.log(onDocumentLoadedCheck);
+});
+
+test("Test docs with empty database page content", async () => {
+  const onDocumentLoadedCheck: string[] = [];
+  const loader = new NotionAPILoader({
+    clientOptions: {
+      auth: process.env.NOTION_INTEGRATION_TOKEN,
+    },
+    id: process.env.NOTION_DATABASE_ID ?? "",
+    onDocumentLoaded: (current, total, currentTitle, rootTitle) => {
+      onDocumentLoadedCheck.push(
+        `Loaded ${currentTitle} from ${rootTitle}: (${current}/${total})`
+      );
+    },
+  });
+
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(0);
+});
+
+test("Test docs with empty database page content and propertiesAsHeader enabled", async () => {
+  const onDocumentLoadedCheck: string[] = [];
+  const loader = new NotionAPILoader({
+    clientOptions: {
+      auth: process.env.NOTION_INTEGRATION_TOKEN,
+    },
+    id: process.env.NOTION_DATABASE_ID ?? "",
+    onDocumentLoaded: (current, total, currentTitle, rootTitle) => {
+      onDocumentLoadedCheck.push(
+        `Loaded ${currentTitle} from ${rootTitle}: (${current}/${total})`
+      );
+    },
+    propertiesAsHeader: true,
+  });
+
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(3);
+
+  console.log(docs);
 });

--- a/langchain/src/document_loaders/web/notionapi.ts
+++ b/langchain/src/document_loaders/web/notionapi.ts
@@ -14,6 +14,7 @@ import type {
   ListBlockChildrenResponseResults,
   MdBlock,
 } from "notion-to-md/build/types";
+import yaml from "js-yaml";
 
 import { Document } from "../../document.js";
 import { BaseDocumentLoader } from "../base.js";
@@ -75,6 +76,7 @@ export type NotionAPILoaderOptions = {
   type?: NotionAPIType; // @deprecated `type` property is now automatically determined.
   callerOptions?: ConstructorParameters<typeof AsyncCaller>[0];
   onDocumentLoaded?: OnDocumentLoadedCallback;
+  propertiesAsHeader?: boolean;
 };
 
 /**
@@ -102,6 +104,8 @@ export class NotionAPILoader extends BaseDocumentLoader {
 
   private onDocumentLoaded: OnDocumentLoadedCallback;
 
+  private propertiesAsHeader: boolean;
+
   constructor(options: NotionAPILoaderOptions) {
     super();
 
@@ -124,6 +128,7 @@ export class NotionAPILoader extends BaseDocumentLoader {
     this.documents = [];
     this.rootTitle = "";
     this.onDocumentLoaded = options.onDocumentLoaded ?? ((_ti, _cu) => {});
+    this.propertiesAsHeader = options.propertiesAsHeader || false;
   }
 
   /**
@@ -340,14 +345,31 @@ export class NotionAPILoader extends BaseDocumentLoader {
       this.caller.call(() => getBlockChildren(this.notionClient, pageId, null)),
     ]);
 
-    if (!isFullPage(pageDetails)) return;
+    if (!isFullPage(pageDetails)) {
+      this.pageCompleted.push(pageId);
+      return;
+    }
 
     const mdBlocks = await this.loadBlocks(pageBlocks);
     const mdStringObject = this.n2mClient.toMarkdownString(mdBlocks);
-    const pageDocument = new Document({
-      pageContent: mdStringObject.parent,
-      metadata: this.parsePageDetails(pageDetails),
-    });
+
+    let pageContent = mdStringObject.parent;
+    const metadata = this.parsePageDetails(pageDetails);
+
+    if (this.propertiesAsHeader) {
+      pageContent =
+        `---\n` +
+        `${yaml.dump(metadata.properties)}` +
+        `---\n\n` +
+        `${pageContent ?? ""}`;
+    }
+
+    if (!pageContent) {
+      this.pageCompleted.push(pageId);
+      return;
+    }
+
+    const pageDocument = new Document({ pageContent, metadata });
 
     this.documents.push(pageDocument);
     this.pageCompleted.push(pageId);


### PR DESCRIPTION
Fixes #2807

Notion databases are often used as the data stored in the page properties, with an empty page. This means a user may expect a similarity search on the page properties. I have enabled an option where a user can prepend the page properties as a frontmatter header to enable similarity search.

It was bought to my attention that the preferred behaviour for the Document class is to not create documents with empty `pageContents`. 

This PR addresses both of these issues.
- Adding an option to prepend page properties as a front matter header
- Ensures would be empty `pageContents` pages do not create Documents

It also
- Adds integration tests for empty pageContents not creating a Document
- Adds integration tests for propertiesAsHeader option
- Update the database example to include propertiesAsHeader

