### PR TITLE
fix(stream): Update "IterableReadableStream" pull method to enqueue nullish data (e.g. empty string)

### DIFF
--- a/langchain/src/util/stream.ts
+++ b/langchain/src/util/stream.ts
@@ -61,9 +61,11 @@ export class IterableReadableStream<T> extends ReadableStream<T> {
     return new IterableReadableStream<T>({
       async pull(controller) {
         const { value, done } = await generator.next();
+        // When no more data needs to be consumed, close the stream
         if (done) {
           controller.close();
-        } else if (value) {
+        // Fix: `else if (value)` will hang the streaming when nullish value (e.g. empty string) is pulled
+        } else {
           controller.enqueue(value);
         }
       },

--- a/langchain/src/util/stream.ts
+++ b/langchain/src/util/stream.ts
@@ -28,7 +28,7 @@ export class IterableReadableStream<T> extends ReadableStream<T> {
     const cancelPromise = this.reader.cancel(); // cancel first, but don't await yet
     this.reader.releaseLock(); // release lock first
     await cancelPromise; // now await it
-    return { done: true, value: undefined as T }; // This cast fixes TS typing, and convention is to ignore chunk value anyway
+    return { done: true, value: undefined as T }; // This cast fixes TS typing, and convention is to ignore final chunk value anyway
   }
 
   [Symbol.asyncIterator]() {
@@ -64,10 +64,9 @@ export class IterableReadableStream<T> extends ReadableStream<T> {
         // When no more data needs to be consumed, close the stream
         if (done) {
           controller.close();
-        // Fix: `else if (value)` will hang the streaming when nullish value (e.g. empty string) is pulled
-        } else {
-          controller.enqueue(value);
         }
+        // Fix: `else if (value)` will hang the streaming when nullish value (e.g. empty string) is pulled
+        controller.enqueue(value);
       },
     });
   }


### PR DESCRIPTION
This PR is to address the issue our team identified while we were integrating `BaseLLM` with our own AI to enable the streaming capability. The issue we faced was, after we implemented `*_streamResponseChunks` generator function, we noticed it did not terminated in many cases.

After investigation, we found out that our response stream would end by yielding empty string, and this behavior, paired with `IterableReadableStream`'s pull method, which only enqueue's value if it is not nullish, will hang the generator. Hence preventing it from terminating successfully.
