### PR TITLE
Add Neo4j lossless integer parameter

### DIFF
--- a/langchain/src/graphs/neo4j_graph.ts
+++ b/langchain/src/graphs/neo4j_graph.ts
@@ -5,6 +5,7 @@ interface Neo4jGraphConfig {
   username: string;
   password: string;
   database?: string;
+  disableLosslessIntegers?: boolean;
 }
 
 export class Neo4jGraph {
@@ -19,9 +20,12 @@ export class Neo4jGraph {
     username,
     password,
     database = "neo4j",
+    disableLosslessIntegers = true,
   }: Neo4jGraphConfig) {
     try {
-      this.driver = neo4j.driver(url, neo4j.auth.basic(username, password));
+      this.driver = neo4j.driver(url, neo4j.auth.basic(username, password), {
+        disableLosslessIntegers,
+      });
       this.database = database;
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
Neo4j JS driver by default supports large integers, but returns values like:

`Integer: {low:1536, high:0}`

Which could be confusing to an LLM. That's why we added a parameter that by default returns a normal integer, but added the option for experienced users to disable it if they know what they are doing.