### PR TITLE
Expose PrismaSqlFilter type

### DIFF
--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -58,7 +58,7 @@ type ModelColumns<TModel extends Record<string, unknown>> = {
   [K in keyof TModel]?: true | ColumnSymbol;
 };
 
-type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
+export type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
   [K in keyof TModel]?: {
     equals?: TModel[K];
     lt?: TModel[K];


### PR DESCRIPTION
I would like to be able to access the PrismaSqlFilter type so I can create a function like this: 

```
export const initVectorStore = (filter: PrismaSqlFilter<Chunk>) => {
  env.localModelPath = __dirname + "/../../models"

  //@ts-ignore
  env.allowRemoteModels = false

  const vectorStore = PrismaVectorStore.withModel<Chunk>(prisma).create(
    new HuggingFaceTransformersEmbeddings({
      modelName: "BAAI/bge-large-en-v1.5",
    }),
    {
      prisma: Prisma,
      tableName: "Chunk",
      vectorColumnName: "vector",
      columns: {
        id: PrismaVectorStore.IdColumn,
        content: PrismaVectorStore.ContentColumn,
      },
      filter
    },
    
  )

  return vectorStore
}
```