### PR TITLE
Fix: validate input or throw when using MessagesPlaceholder

### DIFF
--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -158,9 +158,7 @@ export class MessagesPlaceholder<
     return [this.variableName];
   }
 
-  validateInputOrThrow(
-    input: Array<unknown>
-  ): input is BaseMessage[] {
+  validateInputOrThrow(input: Array<unknown>): input is BaseMessage[] {
     let isInputBaseMessage = false;
 
     if (Array.isArray(input)) {

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -175,7 +175,7 @@ export class MessagesPlaceholder<
     if (!isInputBaseMessage) {
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
-  
+
       const error = new Error(
         `Error: Field "${variableName}" in prompt uses a MessagesPlaceholder, which expects an array of BaseMessages as an input value. Received: ${readableInput}`
       );

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -158,9 +158,35 @@ export class MessagesPlaceholder<
     return [this.variableName];
   }
 
+  validateInputOrThrow(
+    input: Array<unknown>
+  ): input is BaseMessage[] {
+    let isInputBaseMessage = false;
+
+    if (Array.isArray(input)) {
+      isInputBaseMessage = input.every((message) =>
+        isBaseMessage(message as BaseMessage)
+      );
+    } else {
+      isInputBaseMessage = isBaseMessage(input as BaseMessage);
+    }
+
+    if (!isInputBaseMessage) {
+      const readableInput =
+        typeof input === "string" ? input : JSON.stringify(input, null, 2);
+      throw new Error(
+        `Expected an array of BaseMessage instances but received: ${readableInput}`
+      );
+    }
+
+    return true;
+  }
+
   formatMessages(
     values: TypedPromptInputValues<RunInput>
   ): Promise<BaseMessage[]> {
+    this.validateInputOrThrow(values[this.variableName]);
+
     return Promise.resolve(values[this.variableName] as BaseMessage[]);
   }
 }

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -158,7 +158,7 @@ export class MessagesPlaceholder<
     return [this.variableName];
   }
 
-  validateInputOrThrow(input: Array<unknown>): input is BaseMessage[] {
+  validateInputOrThrow(input: Array<unknown>, variableName: Extract<keyof RunInput, string>): input is BaseMessage[] {
     let isInputBaseMessage = false;
 
     if (Array.isArray(input)) {
@@ -173,7 +173,7 @@ export class MessagesPlaceholder<
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
       throw new Error(
-        `MessagesPlaceholder expects an instance of BaseMessage as input, but received: ${readableInput}`
+        `Error: Field "${variableName}" in prompt uses a MessagesPlaceholder, which expects an array of BaseMessages as an input value. Received: ${readableInput}`
       );
     }
 
@@ -183,7 +183,7 @@ export class MessagesPlaceholder<
   formatMessages(
     values: TypedPromptInputValues<RunInput>
   ): Promise<BaseMessage[]> {
-    this.validateInputOrThrow(values[this.variableName]);
+    this.validateInputOrThrow(values[this.variableName], this.variableName);
 
     return Promise.resolve(values[this.variableName] as BaseMessage[]);
   }

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -158,7 +158,10 @@ export class MessagesPlaceholder<
     return [this.variableName];
   }
 
-  validateInputOrThrow(input: Array<unknown>, variableName: Extract<keyof RunInput, string>): input is BaseMessage[] {
+  validateInputOrThrow(
+    input: Array<unknown>,
+    variableName: Extract<keyof RunInput, string>
+  ): input is BaseMessage[] {
     let isInputBaseMessage = false;
 
     if (Array.isArray(input)) {

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -186,12 +186,12 @@ export class MessagesPlaceholder<
     return true;
   }
 
-  formatMessages(
+  async formatMessages(
     values: TypedPromptInputValues<RunInput>
   ): Promise<BaseMessage[]> {
     this.validateInputOrThrow(values[this.variableName], this.variableName);
 
-    return Promise.resolve(values[this.variableName] as BaseMessage[]);
+    return values[this.variableName];
   }
 }
 

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -162,19 +162,9 @@ export class MessagesPlaceholder<
     let isInputBaseMessage = false;
 
     if (Array.isArray(input)) {
-      // Filter out null/undefined values
-      const inputWithoutNull = input.filter(
-        (message) => message !== null && message !== undefined
+      isInputBaseMessage = input.every((message) =>
+        isBaseMessage(message as BaseMessage)
       );
-
-      isInputBaseMessage = inputWithoutNull.every(
-        (message) =>
-          isBaseMessage(message as BaseMessage) ||
-          message === null ||
-          message === undefined
-      );
-    } else if (input === null || input === undefined) {
-      isInputBaseMessage = true;
     } else {
       isInputBaseMessage = isBaseMessage(input as BaseMessage);
     }
@@ -183,7 +173,7 @@ export class MessagesPlaceholder<
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
       throw new Error(
-        `Class 'MessagesPlaceholder' expects an array of BaseMessage instances but received: ${readableInput}`
+        `MessagesPlaceholder expects an instance of BaseMessage as input, but received: ${readableInput}`
       );
     }
 

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -183,7 +183,7 @@ export class MessagesPlaceholder<
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
       throw new Error(
-        `Class MessagesPlaceholder expects an array of BaseMessage instances but received: ${readableInput}`
+        `Class 'MessagesPlaceholder' expects an array of BaseMessage instances but received: ${readableInput}`
       );
     }
 

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -162,9 +162,19 @@ export class MessagesPlaceholder<
     let isInputBaseMessage = false;
 
     if (Array.isArray(input)) {
-      isInputBaseMessage = input.every((message) =>
-        isBaseMessage(message as BaseMessage)
+      // Filter out null/undefined values
+      const inputWithoutNull = input.filter(
+        (message) => message !== null && message !== undefined
       );
+
+      isInputBaseMessage = inputWithoutNull.every(
+        (message) =>
+          isBaseMessage(message as BaseMessage) ||
+          message === null ||
+          message === undefined
+      );
+    } else if (input === null || input === undefined) {
+      isInputBaseMessage = true;
     } else {
       isInputBaseMessage = isBaseMessage(input as BaseMessage);
     }
@@ -173,7 +183,7 @@ export class MessagesPlaceholder<
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
       throw new Error(
-        `Expected an array of BaseMessage instances but received: ${readableInput}`
+        `Class MessagesPlaceholder expects an array of BaseMessage instances but received: ${readableInput}`
       );
     }
 

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -175,9 +175,12 @@ export class MessagesPlaceholder<
     if (!isInputBaseMessage) {
       const readableInput =
         typeof input === "string" ? input : JSON.stringify(input, null, 2);
-      throw new Error(
+  
+      const error = new Error(
         `Error: Field "${variableName}" in prompt uses a MessagesPlaceholder, which expects an array of BaseMessages as an input value. Received: ${readableInput}`
       );
+      error.name = "InputFormatError";
+      throw error;
     }
 
     return true;

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -311,21 +311,40 @@ test("Throws if trying to pass non BaseMessage inputs to MessagesPlaceholder", a
     new MessagesPlaceholder("chatHistory"),
     ["human", "{question}"],
   ]);
-  const values = "this is not a prompt template!";
+  const value = "this is not a valid input type!";
 
   try {
     await prompt.formatMessages({
-      chatHistory: values,
+      chatHistory: value,
       question: "What is the meaning of life?",
     });
   } catch (e) {
     // eslint-disable-next-line no-instanceof/no-instanceof
     if (e instanceof Error) {
       expect(e.message).toBe(
-        "Expected an array of BaseMessage instances but received: this is not a prompt template!"
+        "Class MessagesPlaceholder expects an array of BaseMessage instances but received: this is not a valid input type!"
       );
     } else {
       throw e;
     }
   }
+});
+
+test("Does not throw if null or undefined is passed as input to MessagesPlaceholder", async () => {
+  const prompt = ChatPromptTemplate.fromMessages([
+    ["system", "some string"],
+    new MessagesPlaceholder("chatHistory"),
+    new MessagesPlaceholder("chatHistory2"),
+    ["human", "{question}"],
+  ]);
+  const value1 = null;
+  const value2 = undefined;
+
+  const formatted = await prompt.formatMessages({
+    chatHistory: value1,
+    chatHistory2: value2,
+    question: "What is the meaning of life?",
+  });
+
+  expect(formatted).toHaveLength(4);
 });

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -344,5 +344,5 @@ test("Does not throw if null or undefined is passed as input to MessagesPlacehol
     question: "What is the meaning of life?",
   });
 
-  expect(formatted).toHaveLength(4);
+  expect(formatted).toHaveLength(2);
 });

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -321,9 +321,7 @@ test("Throws if trying to pass non BaseMessage inputs to MessagesPlaceholder", a
   } catch (e) {
     // eslint-disable-next-line no-instanceof/no-instanceof
     if (e instanceof Error) {
-      expect(e.message).toBe(
-        "MessagesPlaceholder expects an instance of BaseMessage as input, but received: this is not a valid input type!"
-      );
+      expect(e.name).toBe("InputFormatError");
     } else {
       throw e;
     }

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -322,7 +322,7 @@ test("Throws if trying to pass non BaseMessage inputs to MessagesPlaceholder", a
     // eslint-disable-next-line no-instanceof/no-instanceof
     if (e instanceof Error) {
       expect(e.message).toBe(
-        "Class MessagesPlaceholder expects an array of BaseMessage instances but received: this is not a valid input type!"
+        "MessagesPlaceholder expects an instance of BaseMessage as input, but received: this is not a valid input type!"
       );
     } else {
       throw e;

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -328,7 +328,7 @@ test("Throws if trying to pass non BaseMessage inputs to MessagesPlaceholder", a
   }
 });
 
-test("Does not throw if null or undefined is passed as input to MessagesPlaceholder", async () => {
+test("Does not throws if null or undefined is passed as input to MessagesPlaceholder", async () => {
   const prompt = ChatPromptTemplate.fromMessages([
     ["system", "some string"],
     new MessagesPlaceholder("chatHistory"),
@@ -338,11 +338,18 @@ test("Does not throw if null or undefined is passed as input to MessagesPlacehol
   const value1 = null;
   const value2 = undefined;
 
-  const formatted = await prompt.formatMessages({
-    chatHistory: value1,
-    chatHistory2: value2,
-    question: "What is the meaning of life?",
-  });
-
-  expect(formatted).toHaveLength(2);
+  try {
+    await prompt.formatMessages({
+      chatHistory: value1,
+      chatHistory2: value2,
+      question: "What is the meaning of life?",
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-instanceof/no-instanceof
+    if (e instanceof Error) {
+      expect(e.name).toBe("InputFormatError");
+    } else {
+      throw e;
+    }
+  }
 });

--- a/langchain/src/prompts/tests/chat.test.ts
+++ b/langchain/src/prompts/tests/chat.test.ts
@@ -304,3 +304,28 @@ test("Test BaseMessage", async () => {
     new FunctionMessage({ content: "{}", name: "get_weather" }),
   ]);
 });
+
+test("Throws if trying to pass non BaseMessage inputs to MessagesPlaceholder", async () => {
+  const prompt = ChatPromptTemplate.fromMessages([
+    ["system", "some string"],
+    new MessagesPlaceholder("chatHistory"),
+    ["human", "{question}"],
+  ]);
+  const values = "this is not a prompt template!";
+
+  try {
+    await prompt.formatMessages({
+      chatHistory: values,
+      question: "What is the meaning of life?",
+    });
+  } catch (e) {
+    // eslint-disable-next-line no-instanceof/no-instanceof
+    if (e instanceof Error) {
+      expect(e.message).toBe(
+        "Expected an array of BaseMessage instances but received: this is not a prompt template!"
+      );
+    } else {
+      throw e;
+    }
+  }
+});

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -459,13 +459,13 @@ export type BaseMessageLike =
   | string;
 
 export function isBaseMessage(
-  messageLike: BaseMessageLike | null | undefined
-): messageLike is BaseMessage | null | undefined {
-  if (messageLike === null || messageLike === undefined) {
-    return true;
-  }
-
-  return typeof (messageLike as BaseMessage)._getType === "function";
+  messageLike?: unknown
+): messageLike is BaseMessage {
+  return (
+    typeof (messageLike as BaseMessage)?._getType === "function" ||
+    messageLike === null ||
+    messageLike === undefined
+  );
 }
 
 export function coerceMessageLikeToMessage(

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -464,7 +464,7 @@ export function isBaseMessage(
   if (messageLike === null || messageLike === undefined) {
     return true;
   }
-  
+
   return typeof (messageLike as BaseMessage)._getType === "function";
 }
 

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -461,11 +461,7 @@ export type BaseMessageLike =
 export function isBaseMessage(
   messageLike?: unknown
 ): messageLike is BaseMessage {
-  return (
-    typeof (messageLike as BaseMessage)?._getType === "function" ||
-    messageLike === null ||
-    messageLike === undefined
-  );
+  return typeof (messageLike as BaseMessage)?._getType === "function";
 }
 
 export function coerceMessageLikeToMessage(

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -459,8 +459,12 @@ export type BaseMessageLike =
   | string;
 
 export function isBaseMessage(
-  messageLike: BaseMessageLike
-): messageLike is BaseMessage {
+  messageLike: BaseMessageLike | null | undefined
+): messageLike is BaseMessage | null | undefined {
+  if (messageLike === null || messageLike === undefined) {
+    return true;
+  }
+  
   return typeof (messageLike as BaseMessage)._getType === "function";
 }
 


### PR DESCRIPTION
Closes #2871 

Throw when input passed to `MessagesPlaceholder.formatMessages` is not of correct type
