### PR TITLE
added force default filter option to mergeFilters

### DIFF
--- a/langchain/src/retrievers/self_query/base.ts
+++ b/langchain/src/retrievers/self_query/base.ts
@@ -45,12 +45,15 @@ export abstract class BaseTranslator<
    * @param defaultFilter The default filter.
    * @param generatedFilter The generated filter.
    * @param mergeType The type of merge to perform. Can be 'and', 'or', or 'replace'.
+   * @param forceDefaultFilter If true, the default filter will be used even if the generated filter is not empty.
    * @returns The merged filter, or undefined if both filters are empty.
    */
   abstract mergeFilters(
     defaultFilter: this["VisitStructuredQueryOutput"]["filter"] | undefined,
     generatedFilter: this["VisitStructuredQueryOutput"]["filter"] | undefined,
-    mergeType?: "and" | "or" | "replace"
+    mergeType?: "and" | "or" | "replace",
+    forceDefaultFilter?: boolean
+
   ): this["VisitStructuredQueryOutput"]["filter"] | undefined;
 }
 
@@ -169,7 +172,8 @@ export class BasicTranslator<
   mergeFilters(
     defaultFilter: VisitorStructuredQueryResult["filter"] | undefined,
     generatedFilter: VisitorStructuredQueryResult["filter"] | undefined,
-    mergeType = "and"
+    mergeType = "and",
+    forceDefaultFilter = false
   ): VisitorStructuredQueryResult["filter"] | undefined {
     if (isFilterEmpty(defaultFilter) && isFilterEmpty(generatedFilter)) {
       return undefined;
@@ -181,6 +185,9 @@ export class BasicTranslator<
       return generatedFilter;
     }
     if (isFilterEmpty(generatedFilter)) {
+      if (forceDefaultFilter) {
+        return defaultFilter;
+      }
       if (mergeType === "and") {
         return undefined;
       }

--- a/langchain/src/retrievers/self_query/base.ts
+++ b/langchain/src/retrievers/self_query/base.ts
@@ -53,7 +53,6 @@ export abstract class BaseTranslator<
     generatedFilter: this["VisitStructuredQueryOutput"]["filter"] | undefined,
     mergeType?: "and" | "or" | "replace",
     forceDefaultFilter?: boolean
-
   ): this["VisitStructuredQueryOutput"]["filter"] | undefined;
 }
 

--- a/langchain/src/retrievers/self_query/functional.ts
+++ b/langchain/src/retrievers/self_query/functional.ts
@@ -196,7 +196,7 @@ export class FunctionalTranslator extends BaseTranslator {
   mergeFilters(
     defaultFilter: FunctionFilter,
     generatedFilter: FunctionFilter,
-    mergeType = "and"
+    mergeType = "and",
   ): FunctionFilter | undefined {
     if (isFilterEmpty(defaultFilter) && isFilterEmpty(generatedFilter)) {
       return undefined;

--- a/langchain/src/retrievers/self_query/functional.ts
+++ b/langchain/src/retrievers/self_query/functional.ts
@@ -196,7 +196,7 @@ export class FunctionalTranslator extends BaseTranslator {
   mergeFilters(
     defaultFilter: FunctionFilter,
     generatedFilter: FunctionFilter,
-    mergeType = "and",
+    mergeType = "and"
   ): FunctionFilter | undefined {
     if (isFilterEmpty(defaultFilter) && isFilterEmpty(generatedFilter)) {
       return undefined;

--- a/langchain/src/retrievers/self_query/index.ts
+++ b/langchain/src/retrievers/self_query/index.ts
@@ -28,6 +28,7 @@ export interface SelfQueryRetrieverArgs<T extends VectorStore>
     k?: number;
     filter?: T["FilterType"];
     mergeFiltersOperator?: "or" | "and" | "replace";
+    forceDefaultFilter?: boolean;
   };
 }
 
@@ -62,7 +63,8 @@ export class SelfQueryRetriever<T extends VectorStore>
     k?: number;
     filter?: T["FilterType"];
     mergeFiltersOperator?: "or" | "and" | "replace";
-  } = { k: 4 };
+    forceDefaultFilter?: boolean;
+  } = { k: 4, forceDefaultFilter: false };
 
   constructor(options: SelfQueryRetrieverArgs<T>) {
     super(options);
@@ -94,7 +96,8 @@ export class SelfQueryRetriever<T extends VectorStore>
     const filter = this.structuredQueryTranslator.mergeFilters(
       this.searchParams?.filter,
       nextArg.filter,
-      this.searchParams?.mergeFiltersOperator
+      this.searchParams?.mergeFiltersOperator,
+      this.searchParams?.forceDefaultFilter
     );
 
     const generatedQuery = generatedStructuredQuery.query;

--- a/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
@@ -600,7 +600,7 @@ describe("Pinecone self query", () => {
           type: "movie",
         },
         mergeFiltersOperator: "and",
-        forceDefaultFilter: true
+        forceDefaultFilter: true,
       },
     });
 
@@ -622,5 +622,4 @@ describe("Pinecone self query", () => {
     console.log(query1, query2, query3, query4, query5); // query 5 should return documents
     expect(query5.length).toBeGreaterThan(0);
   });
-
 });

--- a/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
@@ -465,4 +465,162 @@ describe("Pinecone self query", () => {
     console.log(query1, query2, query3, query4, query5); // query 5 should return empty array
     expect(query5.length).toEqual(0);
   });
+
+  test("Pinecone Store Self Query Retriever Test With Default Filter And Merge Operator With Force Default Filter", async () => {
+    const docs = [
+      new Document({
+        pageContent:
+          "A bunch of scientists bring back dinosaurs and mayhem breaks loose",
+        metadata: {
+          year: 1993,
+          rating: 7.7,
+          genre: "science fiction",
+          type: "movie",
+        },
+      }),
+      new Document({
+        pageContent:
+          "Leo DiCaprio gets lost in a dream within a dream within a dream within a ...",
+        metadata: {
+          year: 2010,
+          director: "Christopher Nolan",
+          rating: 8.2,
+          type: "movie",
+        },
+      }),
+      new Document({
+        pageContent:
+          "A psychologist / detective gets lost in a series of dreams within dreams within dreams and Inception reused the idea",
+        metadata: {
+          year: 2006,
+          director: "Satoshi Kon",
+          rating: 8.6,
+          type: "movie",
+        },
+      }),
+      new Document({
+        pageContent:
+          "A bunch of normal-sized women are supremely wholesome and some men pine after them",
+        metadata: {
+          year: 2019,
+          director: "Greta Gerwig",
+          rating: 8.3,
+          type: "movie",
+        },
+      }),
+      new Document({
+        pageContent: "Toys come alive and have a blast doing so",
+        metadata: { year: 1995, genre: "animated", type: "movie" },
+      }),
+      new Document({
+        pageContent:
+          "Three men walk into the Zone, three men walk out of the Zone",
+        metadata: {
+          year: 1979,
+          director: "Andrei Tarkovsky",
+          genre: "science fiction",
+          rating: 9.9,
+          type: "movie",
+        },
+      }),
+      new Document({
+        pageContent: "10x the previous gecs",
+        metadata: {
+          year: 2023,
+          title: "10000 gecs",
+          artist: "100 gecs",
+          rating: 9.9,
+          type: "album",
+        },
+      }),
+    ];
+
+    const attributeInfo: AttributeInfo[] = [
+      {
+        name: "genre",
+        description: "The genre of the movie",
+        type: "string or array of strings",
+      },
+      {
+        name: "year",
+        description: "The year the movie was released",
+        type: "number",
+      },
+      {
+        name: "director",
+        description: "The director of the movie",
+        type: "string",
+      },
+      {
+        name: "rating",
+        description: "The rating of the movie (1-10)",
+        type: "number",
+      },
+      {
+        name: "length",
+        description: "The length of the movie in minutes",
+        type: "number",
+      },
+    ];
+
+    if (
+      !process.env.PINECONE_API_KEY ||
+      !process.env.PINECONE_ENVIRONMENT ||
+      !testIndexName
+    ) {
+      throw new Error(
+        "PINECONE_ENVIRONMENT and PINECONE_API_KEY and PINECONE_INDEX must be set"
+      );
+    }
+
+    const env = process.env.PINECONE_ENVIRONMENT;
+    const key = process.env.PINECONE_API_KEY;
+
+    const pinecone = new Pinecone({
+      apiKey: key,
+      environment: env,
+    });
+
+    const index = pinecone.Index(testIndexName);
+
+    const embeddings = new OpenAIEmbeddings();
+    const llm = new OpenAI();
+    const documentContents = "Brief summary of a movie";
+    const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
+      pineconeIndex: index,
+    });
+    const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+      llm,
+      vectorStore,
+      documentContents,
+      attributeInfo,
+      structuredQueryTranslator: new PineconeTranslator(),
+      searchParams: {
+        filter: {
+          type: "movie",
+        },
+        mergeFiltersOperator: "and",
+        forceDefaultFilter: true
+      },
+    });
+
+    const query1 = await selfQueryRetriever.getRelevantDocuments(
+      "Which movies are less than 90 minutes?"
+    );
+    const query2 = await selfQueryRetriever.getRelevantDocuments(
+      "Which movies are rated higher than 8.5?"
+    );
+    const query3 = await selfQueryRetriever.getRelevantDocuments(
+      "Which movies are directed by Greta Gerwig?"
+    );
+    const query4 = await selfQueryRetriever.getRelevantDocuments(
+      "Which movies are either comedy or drama and are less than 90 minutes?"
+    );
+    const query5 = await selfQueryRetriever.getRelevantDocuments(
+      "Awawawawa hello hello hello huh where am i?"
+    );
+    console.log(query1, query2, query3, query4, query5); // query 5 should return documents
+    expect(query5.length).toBeGreaterThan(0);
+  });
+
 });


### PR DESCRIPTION
With this change we add a flag to enforce the searchParams as default filter to send to a vector db.

the usage will be:

` const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
      llm,
      vectorStore,
      documentContents,
      attributeInfo,
      structuredQueryTranslator: new PineconeTranslator(),
      searchParams: {
        filter: {
          type: "movie",
        },
        mergeFiltersOperator: "and",
        forceDefaultFilter: true // the filter "type": "movie" will be a default filter for all queries.
      },
    });`



twitter handle: @valdozzz1

Fixes #2875