### PR TITLE
fix: update imports for "parent_document_retriever" example

### DIFF
--- a/examples/src/retrievers/parent_document_retriever.ts
+++ b/examples/src/retrievers/parent_document_retriever.ts
@@ -1,12 +1,12 @@
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { MemoryVectorStore } from "langchain/vectorstores/memory";
-import { InMemoryStore } from "langchain/storage/in_memory";
+import { InMemoryDocstore } from "langchain/stores/doc/in_memory";
 import { ParentDocumentRetriever } from "langchain/retrievers/parent_document";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { TextLoader } from "langchain/document_loaders/fs/text";
 
 const vectorstore = new MemoryVectorStore(new OpenAIEmbeddings());
-const docstore = new InMemoryStore();
+const docstore = new InMemoryDocstore();
 const retriever = new ParentDocumentRetriever({
   vectorstore,
   docstore,


### PR DESCRIPTION
There is an incorrect storage module import used in the "parent_document_retriever" example.