### PR TITLE
fix: update llm_streaming_stream_method.ts doc

### DIFF
--- a/examples/src/models/llm/llm_streaming_stream_method.ts
+++ b/examples/src/models/llm/llm_streaming_stream_method.ts
@@ -3,6 +3,7 @@ import { OpenAI } from "langchain/llms/openai";
 // To enable streaming, we pass in `streaming: true` to the LLM constructor.
 const model = new OpenAI({
   maxTokens: 25,
+  streaming: true,
 });
 
 const stream = await model.stream("Tell me a joke.");

--- a/examples/src/models/llm/llm_streaming_stream_method.ts
+++ b/examples/src/models/llm/llm_streaming_stream_method.ts
@@ -1,7 +1,6 @@
 import { OpenAI } from "langchain/llms/openai";
 
 // To enable streaming, we pass in `streaming: true` to the LLM constructor.
-// Additionally, we pass in a handler for the `handleLLMNewToken` event.
 const model = new OpenAI({
   maxTokens: 25,
 });

--- a/examples/src/models/llm/llm_streaming_stream_method.ts
+++ b/examples/src/models/llm/llm_streaming_stream_method.ts
@@ -1,9 +1,7 @@
 import { OpenAI } from "langchain/llms/openai";
 
-// To enable streaming, we pass in `streaming: true` to the LLM constructor.
 const model = new OpenAI({
   maxTokens: 25,
-  streaming: true,
 });
 
 const stream = await model.stream("Tell me a joke.");


### PR DESCRIPTION
Removes unneeded comments that can cause confusion
- `.stream()` works without the need to add `streaming: true` to the LLM constructor
- Removes reference to `handleLLMNewToken` since `handleLLMNewToken` does not exist within [this example](https://js.langchain.com/docs/modules/model_io/models/llms/how_to/streaming_llm#using-stream)

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

https://twitter.com/cjtantay