### PR TITLE
Make format_instructions an optional argument in chat agent

### DIFF
--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -25,7 +25,7 @@ export interface ChatCreatePromptArgs {
   prefix?: string;
   /** String to use directly as the human message template. */
   humanMessageTemplate?: string;
-  /** Formatable string to use as the instructions template. */
+  /** Formattable string to use as the instructions template. */
   formatInstructions?: strng;
   /** List of input variables the final prompt will expect. */
   inputVariables?: string[];

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -123,11 +123,12 @@ export class ChatAgent extends Agent {
       prefix = PREFIX,
       suffix = SUFFIX,
       humanMessageTemplate = DEFAULT_HUMAN_MESSAGE_TEMPLATE,
+      format_instructions = FORMAT_INSTRUCTIONS
     } = args ?? {};
     const toolStrings = tools
       .map((tool) => `${tool.name}: ${tool.description}`)
       .join("\n");
-    const template = [prefix, toolStrings, FORMAT_INSTRUCTIONS, suffix].join(
+    const template = [prefix, toolStrings, format_instructions, suffix].join(
       "\n\n"
     );
     const messages = [

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -126,7 +126,7 @@ export class ChatAgent extends Agent {
       prefix = PREFIX,
       suffix = SUFFIX,
       humanMessageTemplate = DEFAULT_HUMAN_MESSAGE_TEMPLATE,
-      formatInstructions = FORMAT_INSTRUCTIONS
+      formatInstructions = FORMAT_INSTRUCTIONS,
     } = args ?? {};
     const toolStrings = tools
       .map((tool) => `${tool.name}: ${tool.description}`)

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -26,7 +26,7 @@ export interface ChatCreatePromptArgs {
   /** String to use directly as the human message template. */
   humanMessageTemplate?: string;
   /** Formattable string to use as the instructions template. */
-  formatInstructions?: strng;
+  formatInstructions?: string;
   /** List of input variables the final prompt will expect. */
   inputVariables?: string[];
 }

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -119,7 +119,7 @@ export class ChatAgent extends Agent {
    * @param args.suffix - String to put after the list of tools.
    * @param args.prefix - String to put before the list of tools.
    * @param args.humanMessageTemplate - String to use directly as the human message template
-   * @param args.formatInstructions - Formatable string to use as the instructions template
+   * @param args.formatInstructions - Formattable string to use as the instructions template
    */
   static createPrompt(tools: Tool[], args?: ChatCreatePromptArgs) {
     const {

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -25,6 +25,8 @@ export interface ChatCreatePromptArgs {
   prefix?: string;
   /** String to use directly as the human message template. */
   humanMessageTemplate?: string;
+  /** Formatable string to use as the instructions template. */
+  formatInstructions?: strng;
   /** List of input variables the final prompt will expect. */
   inputVariables?: string[];
 }
@@ -117,18 +119,19 @@ export class ChatAgent extends Agent {
    * @param args.suffix - String to put after the list of tools.
    * @param args.prefix - String to put before the list of tools.
    * @param args.humanMessageTemplate - String to use directly as the human message template
+   * @param args.formatInstructions - Formatable string to use as the instructions template
    */
   static createPrompt(tools: Tool[], args?: ChatCreatePromptArgs) {
     const {
       prefix = PREFIX,
       suffix = SUFFIX,
       humanMessageTemplate = DEFAULT_HUMAN_MESSAGE_TEMPLATE,
-      format_instructions = FORMAT_INSTRUCTIONS
+      formatInstructions = FORMAT_INSTRUCTIONS
     } = args ?? {};
     const toolStrings = tools
       .map((tool) => `${tool.name}: ${tool.description}`)
       .join("\n");
-    const template = [prefix, toolStrings, format_instructions, suffix].join(
+    const template = [prefix, toolStrings, formatInstructions, suffix].join(
       "\n\n"
     );
     const messages = [


### PR DESCRIPTION
This simple change allows users to fully overwrite the prompts when creating a chat agent, and optimize them for their use case. The change makes the agent code much more generally useful. Previously, they could overwrite everything except for FORMAT_INSTRUCTIONS, which is essential to customization.