### PR TITLE
Run exports tests in parallel on GitHub CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,21 +83,6 @@ jobs:
         run: yarn run test:unit
 
   test-exports:
-    name: Environment Tests
-    runs-on: ubuntu-latest
-    env:
-      PUPPETEER_SKIP_DOWNLOAD: "true"
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: "yarn"
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Build
-        run: yarn workspace langchain build
-      - name: Test Exports
-        run: yarn run test:exports:docker
+    uses:
+      ./.github/workflows/test-exports.yml
+    secrets: inherit

--- a/.github/workflows/test-exports.yml
+++ b/.github/workflows/test-exports.yml
@@ -1,0 +1,142 @@
+name: Environment tests
+
+on:
+  workflow_dispatch:  # Allows triggering the workflow manually in GitHub UI
+  workflow_call:  # Allows triggering the workflow from another workflow
+
+# If another push to the same PR or branch happens while this workflow is still running,
+# cancel the earlier run in favor of the next run.
+#
+# There's no point in testing an outdated version of the code. GitHub only allows
+# a limited number of job runners to be active at the same time, so it's better to cancel
+# pointless jobs early so that more useful jobs can run sooner.
+concurrency:
+  group: exports-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PUPPETEER_SKIP_DOWNLOAD: "true"
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
+  NODE_VERSION: "18.x"
+
+# Run a separate job for each check in the docker-compose file,
+# so that they run in parallel instead of overwhelming the default 2 CPU runner.
+jobs:
+  exports-esbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test esbuild exports
+        run: docker compose -f docker-compose.yml run test-exports-esbuild
+
+  exports-esm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test esm exports
+        run: docker compose -f docker-compose.yml run test-exports-esm
+
+  exports-cjs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test cjs exports
+        run: docker compose -f docker-compose.yml run test-exports-cjs
+
+  exports-cf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test cf exports
+        run: docker compose -f docker-compose.yml run test-exports-cf
+
+  exports-vercel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test vercel exports
+        run: docker compose -f docker-compose.yml run test-exports-vercel
+
+  exports-vite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test vite exports
+        run: docker compose -f docker-compose.yml run test-exports-vite
+
+  exports-bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: yarn workspace langchain build
+
+      - name: Test bun exports
+        run: docker compose -f docker-compose.yml run test-exports-bun


### PR DESCRIPTION
This is about 6min faster than before: [~13min](https://github.com/langchain-ai/langchainjs/actions/runs/6550835570/job/17790748230) -> ~7min now. The issue previously was that we were running 7 CPU- and network-intensive docker containers on the same tiny 2-core GitHub runner. This PR splits each container on its own runner, which means they all run in parallel.