### PR TITLE
fix: wildcard suffix for yielding keys

### DIFF
--- a/langchain/src/storage/ioredis.ts
+++ b/langchain/src/storage/ioredis.ts
@@ -104,7 +104,8 @@ export class RedisByteStore extends BaseStore<string, Uint8Array> {
   async *yieldKeys(prefix?: string): AsyncGenerator<string> {
     let pattern;
     if (prefix) {
-      pattern = this._getPrefixedKey(prefix);
+      const wildcardPrefix = prefix.endsWith("*") ? prefix : `${prefix}*`;
+      pattern = this._getPrefixedKey(wildcardPrefix);
     } else {
       pattern = this._getPrefixedKey("*");
     }

--- a/langchain/src/storage/tests/ioredis.int.test.ts
+++ b/langchain/src/storage/tests/ioredis.int.test.ts
@@ -4,27 +4,57 @@ import { test } from "@jest/globals";
 import { Redis } from "ioredis";
 import { RedisByteStore } from "../ioredis.js";
 
-test("RedisByteStore", async () => {
-  const store = new RedisByteStore({
-    client: new Redis({}),
+describe("RedisByteStore", () => {
+  const client = new Redis({});
+
+  afterEach(async () => await client.flushall());
+
+  afterAll(() => client.disconnect());
+
+  test("RedisByteStore", async () => {
+    const store = new RedisByteStore({
+      client,
+    });
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const value1 = new Date().toISOString();
+    const value2 = new Date().toISOString() + new Date().toISOString();
+    await store.mset([
+      ["key1", encoder.encode(value1)],
+      ["key2", encoder.encode(value2)],
+    ]);
+    const retrievedValues = await store.mget(["key1", "key2"]);
+    expect(retrievedValues.map((v) => decoder.decode(v))).toEqual([
+      value1,
+      value2,
+    ]);
+    for await (const key of store.yieldKeys()) {
+      console.log(key);
+    }
+    await store.mdelete(["key1", "key2"]);
+    const retrievedValues2 = await store.mget(["key1", "key2"]);
+    expect(retrievedValues2).toEqual([undefined, undefined]);
   });
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  const value1 = new Date().toISOString();
-  const value2 = new Date().toISOString() + new Date().toISOString();
-  await store.mset([
-    ["key1", encoder.encode(value1)],
-    ["key2", encoder.encode(value2)],
-  ]);
-  const retrievedValues = await store.mget(["key1", "key2"]);
-  expect(retrievedValues.map((v) => decoder.decode(v))).toEqual([
-    value1,
-    value2,
-  ]);
-  for await (const key of store.yieldKeys()) {
-    console.log(key);
-  }
-  await store.mdelete(["key1", "key2"]);
-  const retrievedValues2 = await store.mget(["key1", "key2"]);
-  expect(retrievedValues2).toEqual([undefined, undefined]);
+
+  test("RedisByteStore yield keys with prefix", async () => {
+    const prefix = "prefix_";
+    const prefixedKeys = [`${prefix}key1`, `${prefix}key2`];
+    const store = new RedisByteStore({
+      client,
+    });
+    const encoder = new TextEncoder();
+    const value1 = new Date().toISOString();
+    const value2 = new Date().toISOString() + new Date().toISOString();
+    await store.mset([
+      [prefixedKeys[0], encoder.encode(value1)],
+      [prefixedKeys[1], encoder.encode(value2)],
+    ]);
+
+    const yieldedKeys = [];
+    for await (const key of store.yieldKeys(prefix)) {
+      yieldedKeys.push(key);
+    }
+    console.log(yieldedKeys);
+    expect(yieldedKeys).toEqual(expect.arrayContaining(prefixedKeys));
+  });
 });

--- a/langchain/src/storage/tests/vercel_kv.int.test.ts
+++ b/langchain/src/storage/tests/vercel_kv.int.test.ts
@@ -25,7 +25,7 @@ describe("VercelKVStore", () => {
 
   afterEach(async () => await client.flushall());
 
-  test.only("VercelKVStore can preform all operations", async () => {
+  test("VercelKVStore can preform all operations", async () => {
     const store = new VercelKVStore({
       client,
     });

--- a/langchain/src/storage/tests/vercel_kv.int.test.ts
+++ b/langchain/src/storage/tests/vercel_kv.int.test.ts
@@ -7,58 +7,100 @@ import { VercelKVStore } from "../vercel_kv.js";
 import { createDocumentStoreFromByteStore } from "../encoder_backed.js";
 import { Document } from "../../document.js";
 
-test("VercelKVStore", async () => {
-  const store = new VercelKVStore({
-    client: createClient({
-      url: process.env.VERCEL_KV_API_URL!,
-      token: process.env.VERCEL_KV_API_TOKEN!,
-    }),
+const getClient = () => {
+  if (!process.env.VERCEL_KV_API_URL || !process.env.VERCEL_KV_API_TOKEN) {
+    throw new Error(
+      "VERCEL_KV_API_URL and VERCEL_KV_API_TOKEN must be set in the environment"
+    );
+  }
+  const client = createClient({
+    url: process.env.VERCEL_KV_API_URL,
+    token: process.env.VERCEL_KV_API_TOKEN,
   });
-  const value1 = new Date().toISOString();
-  const value2 = new Date().toISOString() + new Date().toISOString();
-  const encoder = new TextEncoder();
-  await store.mset([
-    ["key1", encoder.encode(value1)],
-    ["key2", encoder.encode(value2)],
-  ]);
-  const retrievedValues = await store.mget(["key1", "key2"]);
-  expect(retrievedValues).toEqual([
-    encoder.encode(value1),
-    encoder.encode(value2),
-  ]);
-  for await (const key of store.yieldKeys()) {
-    console.log(key);
-  }
-  await store.mdelete(["key1", "key2"]);
-  const retrievedValues2 = await store.mget(["key1", "key2"]);
-  expect(retrievedValues2).toEqual([undefined, undefined]);
-});
+  return client;
+};
 
-test("Encoder-backed", async () => {
-  const store = createDocumentStoreFromByteStore(
-    new VercelKVStore({
-      client: createClient({
-        url: process.env.VERCEL_KV_API_URL!,
-        token: process.env.VERCEL_KV_API_TOKEN!,
-      }),
-    })
-  );
-  const value1 = new Date().toISOString();
-  const value2 = new Date().toISOString() + new Date().toISOString();
-  const [doc1, doc2] = [
-    new Document({ pageContent: value1 }),
-    new Document({ pageContent: value2 }),
-  ];
-  await store.mset([
-    ["key1", doc1],
-    ["key2", doc2],
-  ]);
-  const retrievedValues = await store.mget(["key1", "key2"]);
-  expect(retrievedValues).toEqual([doc1, doc2]);
-  for await (const key of store.yieldKeys()) {
-    console.log(key);
-  }
-  await store.mdelete(["key1", "key2"]);
-  const retrievedValues2 = await store.mget(["key1", "key2"]);
-  expect(retrievedValues2).toEqual([undefined, undefined]);
+describe("VercelKVStore", () => {
+  const client = getClient();
+
+  afterEach(async () => await client.flushall());
+
+  test.only("VercelKVStore can preform all operations", async () => {
+    const store = new VercelKVStore({
+      client,
+    });
+    const value1 = new Date().toISOString();
+    const value2 = new Date().toISOString() + new Date().toISOString();
+    const encoder = new TextEncoder();
+    await store.mset([
+      ["key1", encoder.encode(value1)],
+      ["key2", encoder.encode(value2)],
+    ]);
+    const retrievedValues = await store.mget(["key1", "key2"]);
+    expect(retrievedValues).toEqual([
+      encoder.encode(value1),
+      encoder.encode(value2),
+    ]);
+    for await (const key of store.yieldKeys()) {
+      console.log(key);
+    }
+    await store.mdelete(["key1", "key2"]);
+    const retrievedValues2 = await store.mget(["key1", "key2"]);
+    expect(retrievedValues2).toEqual([undefined, undefined]);
+  });
+
+  test("Encoder-backed", async () => {
+    const store = createDocumentStoreFromByteStore(
+      new VercelKVStore({
+        client,
+      })
+    );
+    const value1 = new Date().toISOString();
+    const value2 = new Date().toISOString() + new Date().toISOString();
+    const [doc1, doc2] = [
+      new Document({ pageContent: value1 }),
+      new Document({ pageContent: value2 }),
+    ];
+    await store.mset([
+      ["key1", doc1],
+      ["key2", doc2],
+    ]);
+    const retrievedValues = await store.mget(["key1", "key2"]);
+    expect(retrievedValues).toEqual([doc1, doc2]);
+    for await (const key of store.yieldKeys()) {
+      console.log(key);
+    }
+    await store.mdelete(["key1", "key2"]);
+    const retrievedValues2 = await store.mget(["key1", "key2"]);
+    expect(retrievedValues2).toEqual([undefined, undefined]);
+  });
+
+  test("VercelKVStore can yield keys with prefix", async () => {
+    const prefix = "prefix_";
+    const prefixedKeys = [`${prefix}key1`, `${prefix}key2`];
+    const store = new VercelKVStore({
+      client,
+    });
+    const value1 = new Date().toISOString();
+    const value2 = new Date().toISOString() + new Date().toISOString();
+    const encoder = new TextEncoder();
+    await store.mset([
+      [prefixedKeys[0], encoder.encode(value1)],
+      [prefixedKeys[1], encoder.encode(value2)],
+    ]);
+    const retrievedValues = await store.mget(prefixedKeys);
+    expect(retrievedValues).toEqual([
+      encoder.encode(value1),
+      encoder.encode(value2),
+    ]);
+    const yieldedKeys = [];
+    for await (const key of store.yieldKeys(prefix)) {
+      yieldedKeys.push(key);
+    }
+    console.log(yieldedKeys);
+    expect(yieldedKeys).toEqual(expect.arrayContaining(prefixedKeys));
+    await store.mdelete(prefixedKeys);
+    const retrievedValues2 = await store.mget(prefixedKeys);
+    expect(retrievedValues2).toEqual([undefined, undefined]);
+  });
 });

--- a/langchain/src/storage/vercel_kv.ts
+++ b/langchain/src/storage/vercel_kv.ts
@@ -109,7 +109,8 @@ export class VercelKVStore extends BaseStore<string, Uint8Array> {
   async *yieldKeys(prefix?: string): AsyncGenerator<string> {
     let pattern;
     if (prefix) {
-      pattern = this._getPrefixedKey(prefix);
+      const wildcardPrefix = prefix.endsWith("*") ? prefix : `${prefix}*`;
+      pattern = this._getPrefixedKey(wildcardPrefix);
     } else {
       pattern = this._getPrefixedKey("*");
     }


### PR DESCRIPTION
When yielding keys, the `.yieldKeys(...)` method on `vercel_kv` & `ioredis` automatically checks if the prefix ends with `*`, and if not it applies it to the end.

Refactored tests a little to automatically clear all keys/disconnect