### PR TITLE
Fixed order of LCEL menu and added tables in interface page

### DIFF
--- a/docs/docs/expression_language/cookbook/_category_.yml
+++ b/docs/docs/expression_language/cookbook/_category_.yml
@@ -1,2 +1,2 @@
-label: 'Cookbook'
-position: 1
+label: "Cookbook"
+position: 2

--- a/docs/docs/expression_language/how_to/_category_.yml
+++ b/docs/docs/expression_language/how_to/_category_.yml
@@ -1,2 +1,2 @@
-label: 'How to'
-position: 0
+label: "How to"
+position: 1

--- a/docs/docs/expression_language/interface.mdx
+++ b/docs/docs/expression_language/interface.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 0
+---
+
 import CodeBlock from "@theme/CodeBlock";
 
 # Interface
@@ -9,9 +13,26 @@ This is a standard interface with a few different methods, which make it easy to
 - `invoke`: call the chain on an input
 - `batch`: call the chain on a list of inputs
 
-The type of the input varies by component. For a prompt it is an object, for a retriever it is a single string, for a model either a single string, a list of chat messages, or a PromptValue.
+The **input type** varies by component :
 
-The output type also varies by component. For an LLM it is a string, for a ChatModel it's a ChatMessage, for a prompt it's a PromptValue, and for a retriever it's a list of documents.
+| Component      | Input Type                                          |
+| -------------- | --------------------------------------------------- |
+| Prompt         | Object                                              |
+| Retriever      | Single string                                       |
+| LLM, ChatModel | Single string, list of chat messages or PromptValue |
+| Tool           | Single string, or object, depending on the tool     |
+| OutputParser   | The output of an LLM or ChatModel                   |
+
+The **output type** also varies by component :
+
+| Component    | Input Type            |
+| ------------ | --------------------- |
+| LLM          | String                |
+| ChatModel    | ChatMessage           |
+| Prompt       | PromptValue           |
+| Retriever    | List of documents     |
+| Tool         | Depends on the tool   |
+| OutputParser | Depends on the parser |
 
 You can combine runnables (and runnable-like objects such as functions and objects whose values are all functions) into sequences in two ways:
 

--- a/docs/docs/expression_language/why.mdx
+++ b/docs/docs/expression_language/why.mdx
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Why use LCEL?
 
 The LangChain Expression Language was designed from day 1 to **support putting prototypes in production, with no code changes**, from the simplest “prompt + LLM” chain to the most complex chains (we’ve seen folks successfully running in production LCEL chains with 100s of steps). To highlight a few of the reasons you might want to use LCEL:


### PR DESCRIPTION
Fixes # (issue)

Fixed the ordering of the LCEL sub menu which was not in sync with the python docs and not correctly ordered.
Also added input type and output type table in the interface page of better readability. 