### PR TITLE
IterableReadableStream.fromReadableStream reader releaseLock

### DIFF
--- a/langchain/src/util/stream.ts
+++ b/langchain/src/util/stream.ts
@@ -54,6 +54,9 @@ export class IterableReadableStream<T> extends ReadableStream<T> {
           });
         }
       },
+      cancel() {
+        reader.releaseLock();
+      },
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #3001 IterableReadableStream.fromReadableStream didn't releaseLock source stream's reader

const reader = stream.getReader();

this reader can't be releaseLock!!! Sometimes, The target IterableReadableStream is cancel, but the source ReadableStream is continue work, e.g the websocket stream. So we should release the reader.
