### PR TITLE
WebPDFLoader: allow usage of custom pdfjs build

### DIFF
--- a/docs/docs/modules/data_connection/document_loaders/integrations/web_loaders/pdf.mdx
+++ b/docs/docs/modules/data_connection/document_loaders/integrations/web_loaders/pdf.mdx
@@ -15,3 +15,23 @@ import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/document_loaders/web_pdf.ts";
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
+
+
+## Usage, custom `pdfjs` build
+
+By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatible with most environments, including Node.js and modern browsers. If you want to use a more recent version of `pdfjs-dist` or if you want to use a custom build of `pdfjs-dist`, you can do so by providing a custom `pdfjs` function that returns a promise that resolves to the `PDFJS` object.
+
+In the following example we use the "legacy" (see [pdfjs docs](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported)) build of `pdfjs-dist`, which includes several polyfills not included in the default build.
+
+```bash npm2yarn
+npm install pdfjs-dist
+```
+
+```typescript
+import { WebPDFLoader } from "langchain/document_loaders/web/pdf";
+
+const loader = new WebPDFLoader("src/document_loaders/example_data/example.pdf", {
+  // you may need to add `.then(m => m.default)` to the end of the import
+  pdfjs: () => import("pdfjs-dist/legacy/build/pdf.js"),
+});
+```

--- a/docs/docs/modules/data_connection/document_loaders/integrations/web_loaders/pdf.mdx
+++ b/docs/docs/modules/data_connection/document_loaders/integrations/web_loaders/pdf.mdx
@@ -16,7 +16,6 @@ import Example from "@examples/document_loaders/web_pdf.ts";
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-
 ## Usage, custom `pdfjs` build
 
 By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatible with most environments, including Node.js and modern browsers. If you want to use a more recent version of `pdfjs-dist` or if you want to use a custom build of `pdfjs-dist`, you can do so by providing a custom `pdfjs` function that returns a promise that resolves to the `PDFJS` object.
@@ -30,8 +29,11 @@ npm install pdfjs-dist
 ```typescript
 import { WebPDFLoader } from "langchain/document_loaders/web/pdf";
 
-const loader = new WebPDFLoader("src/document_loaders/example_data/example.pdf", {
-  // you may need to add `.then(m => m.default)` to the end of the import
-  pdfjs: () => import("pdfjs-dist/legacy/build/pdf.js"),
-});
+const loader = new WebPDFLoader(
+  "src/document_loaders/example_data/example.pdf",
+  {
+    // you may need to add `.then(m => m.default)` to the end of the import
+    pdfjs: () => import("pdfjs-dist/legacy/build/pdf.js"),
+  }
+);
 ```

--- a/langchain/src/document_loaders/tests/webpdf.int.test.ts
+++ b/langchain/src/document_loaders/tests/webpdf.int.test.ts
@@ -47,3 +47,50 @@ test("Test Web PDF loader from blob", async () => {
     }
   `);
 });
+
+test("Test Web PDF loader with custom pdfjs", async () => {
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/1706.03762.pdf"
+  );
+  const loader = new WebPDFLoader(
+    new Blob([await fs.readFile(filePath)], {
+      type: "application/pdf",
+    }),
+    {
+      pdfjs: () => import("pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js"),
+    }
+  );
+  const docs = await loader.load();
+
+  expect(docs.length).toBe(15);
+  expect(docs[0].pageContent).toContain("Attention Is All You Need");
+  expect(docs[0].metadata).toMatchInlineSnapshot(`
+    {
+      "loc": {
+        "pageNumber": 1,
+      },
+      "pdf": {
+        "info": {
+          "Author": "",
+          "CreationDate": "D:20171207010315Z",
+          "Creator": "LaTeX with hyperref package",
+          "IsAcroFormPresent": false,
+          "IsXFAPresent": false,
+          "Keywords": "",
+          "ModDate": "D:20171207010315Z",
+          "PDFFormatVersion": "1.5",
+          "Producer": "pdfTeX-1.40.17",
+          "Subject": "",
+          "Title": "",
+          "Trapped": {
+            "name": "False",
+          },
+        },
+        "metadata": null,
+        "totalPages": 15,
+        "version": "1.10.100",
+      },
+    }
+  `);
+});

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -13,7 +13,10 @@ export class WebPDFLoader extends BaseDocumentLoader {
 
   private pdfjs: typeof PDFLoaderImports;
 
-  constructor(blob: Blob, { splitPages = true, pdfjs = PDFLoaderImports } = {}) {
+  constructor(
+    blob: Blob,
+    { splitPages = true, pdfjs = PDFLoaderImports } = {}
+  ) {
     super();
     this.blob = blob;
     this.splitPages = splitPages ?? this.splitPages;

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -1,8 +1,4 @@
-import {
-  getDocument,
-  version,
-  type TextItem,
-} from "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js";
+import { type TextItem } from "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js";
 
 import { Document } from "../../document.js";
 import { BaseDocumentLoader } from "../base.js";
@@ -15,10 +11,13 @@ export class WebPDFLoader extends BaseDocumentLoader {
 
   protected splitPages = true;
 
-  constructor(blob: Blob, { splitPages = true } = {}) {
+  private pdfjs: typeof PDFLoaderImports;
+
+  constructor(blob: Blob, { splitPages = true, pdfjs = PDFLoaderImports } = {}) {
     super();
     this.blob = blob;
     this.splitPages = splitPages ?? this.splitPages;
+    this.pdfjs = pdfjs;
   }
 
   /**
@@ -26,6 +25,7 @@ export class WebPDFLoader extends BaseDocumentLoader {
    * @returns An array of Documents representing the retrieved data.
    */
   async load(): Promise<Document[]> {
+    const { getDocument, version } = await this.pdfjs();
     const parsedPdf = await getDocument({
       data: new Uint8Array(await this.blob.arrayBuffer()),
       useWorkerFetch: false,
@@ -89,5 +89,20 @@ export class WebPDFLoader extends BaseDocumentLoader {
     ];
 
     return documents;
+  }
+}
+
+async function PDFLoaderImports() {
+  try {
+    const { default: mod } = await import(
+      "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js"
+    );
+    const { getDocument, version } = mod;
+    return { getDocument, version };
+  } catch (e) {
+    console.error(e);
+    throw new Error(
+      "Failed to load pdf-parse. Please install it with eg. `npm install pdf-parse`."
+    );
   }
 }


### PR DESCRIPTION
The node version of the `PDFLoader` allows for passing in a custom `pdfjs` build. Let's add that for the `WebPDFLoader` as well.

This allows fixing of errors like `Error: No "GlobalWorkerOptions.workerSrc" specified.` as issued here for example https://github.com/langchain-ai/langchainjs/issues/1296. It's a pretty common error when working with `pdfjs` -> https://github.com/mozilla/pdf.js/issues/10478#issuecomment-518673665
