### PR TITLE
Ensure shell expansions are quoted in docs workflows.

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
       - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > deployment-url.txt
+        run: vercel deploy --prebuilt --token="$VERCEL_TOKEN" > deployment-url.txt
       - name: Post Preview URL Comment
-        run: gh pr comment $PR_URL -F deployment-url.txt
+        run: gh pr comment "$PR_URL" -F deployment-url.txt

--- a/.github/workflows/docs-prod.yml
+++ b/.github/workflows/docs-prod.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token="$VERCEL_TOKEN"
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"


### PR DESCRIPTION
Two improvements:
- Ensure that shell command arguments that use env var expansion are always quoted if they are intended to be one argument. Otherwise they may expand to multiple arguments, and become a vector for shell injection attacks.
- Avoid using GitHub Actions templating (`${{ ... }}`) in shell commands, and use env vars instead. Such templating cannot be escaped against injection attacks since it runs before the shell sees the command, so it's always better to stick the templated data in an env var and use shell expansion instead.

I don't believe the current workflows were exploitable as currently written, but security is hard and it's always better to be safe than sorry.
