### PR TITLE
Allow vectorstore retrievers in SemanticSimilarityExampleSelector.ts

### DIFF
--- a/docs/docs/modules/model_io/prompts/example_selectors/similarity.mdx
+++ b/docs/docs/modules/model_io/prompts/example_selectors/similarity.mdx
@@ -36,3 +36,12 @@ import ExampleSimilarityMetadataFiltering from "@examples/prompts/semantic_simil
 <CodeBlock language="typescript">
   {ExampleSimilarityMetadataFiltering}
 </CodeBlock>
+
+## Custom vectorstore retrievers
+
+You can also pass a vectorstore retriever instead of a vectorstore. One way this could be useful is if you want to use retrieval
+besides similarity search such as maximal marginal relevance:
+
+import ExampleSimilarityCustomRetriever from "@examples/prompts/semantic_similarity_example_selector_custom_retriever.ts";
+
+<CodeBlock language="typescript">{ExampleSimilarityCustomRetriever}</CodeBlock>

--- a/examples/src/prompts/semantic_similarity_example_selector_custom_retriever.ts
+++ b/examples/src/prompts/semantic_similarity_example_selector_custom_retriever.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// Requires a vectorstore that supports maximal marginal relevance search
+import { Pinecone } from "@pinecone-database/pinecone";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { PineconeStore } from "langchain/vectorstores/pinecone";
+import {
+  SemanticSimilarityExampleSelector,
+  PromptTemplate,
+  FewShotPromptTemplate,
+} from "langchain/prompts";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+const pinecone = new Pinecone();
+
+const pineconeIndex = pinecone.Index(process.env.PINECONE_INDEX!);
+
+const pineconeVectorstore = await PineconeStore.fromExistingIndex(
+  new OpenAIEmbeddings(),
+  { pineconeIndex }
+);
+
+const pineconeMmrRetriever = pineconeVectorstore.asRetriever({
+  searchType: "mmr",
+  k: 2,
+});
+
+const examples = [
+  {
+    query: "healthy food",
+    output: `lettuce`,
+    food_type: "vegetable",
+  },
+  {
+    query: "healthy food",
+    output: `schnitzel`,
+    food_type: "veal",
+  },
+  {
+    query: "foo",
+    output: `bar`,
+    food_type: "baz",
+  },
+];
+
+const exampleSelector = new SemanticSimilarityExampleSelector({
+  vectorStoreRetriever: pineconeMmrRetriever,
+  // Only embed the "query" key of each example
+  inputKeys: ["query"],
+});
+
+for (const example of examples) {
+  // Format and add an example to the underlying vector store
+  await exampleSelector.addExample(example);
+}
+
+// Create a prompt template that will be used to format the examples.
+const examplePrompt = PromptTemplate.fromTemplate(`<example>
+  <user_input>
+    {query}
+  </user_input>
+  <output>
+    {output}
+  </output>
+</example>`);
+
+// Create a FewShotPromptTemplate that will use the example selector.
+const dynamicPrompt = new FewShotPromptTemplate({
+  // We provide an ExampleSelector instead of examples.
+  exampleSelector,
+  examplePrompt,
+  prefix: `Answer the user's question, using the below examples as reference:`,
+  suffix: "User question:\n{query}",
+  inputVariables: ["query"],
+});
+
+const model = new ChatOpenAI({});
+
+const chain = dynamicPrompt.pipe(model);
+
+const result = await chain.invoke({
+  query: "What is exactly one type of healthy food?",
+});
+
+console.log(result);
+
+/*
+  AIMessage {
+    content: 'lettuce.',
+    additional_kwargs: { function_call: undefined }
+  }
+*/

--- a/langchain/src/prompts/tests/selectors.test.ts
+++ b/langchain/src/prompts/tests/selectors.test.ts
@@ -55,3 +55,22 @@ test("Test using SemanticSimilarityExampleSelector with metadata filtering", asy
   const chosen = await selector.selectExamples({ id: 1 });
   expect(chosen).toEqual([{ id: 2 }]);
 });
+
+test("Test using SemanticSimilarityExampleSelector with a passed in retriever", async () => {
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new FakeEmbeddings() // not using  OpenAIEmbeddings() because would be extra dependency
+  );
+  const selector = new SemanticSimilarityExampleSelector({
+    vectorStoreRetriever: vectorStore.asRetriever({ k: 5 }),
+  });
+  const chosen = await selector.selectExamples({ id: 1 });
+  expect(chosen).toEqual([
+    { id: 2 },
+    { id: 1 },
+    { id: 3 },
+    { id: 4 },
+    { id: 5 },
+  ]);
+});


### PR DESCRIPTION
This will allow e.g. MMR searches in the selector.

@nfcampos can you take a quick look?

TODO: docs