### PR TITLE
fix: calculate Milvus textlength in bytes

### DIFF
--- a/langchain/src/vectorstores/milvus.ts
+++ b/langchain/src/vectorstores/milvus.ts
@@ -644,11 +644,13 @@ function genCollectionName(): string {
 
 function getTextFieldMaxLength(documents: Document[]) {
   let textMaxLength = 0;
+  const textEncoder = new TextEncoder();
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < documents.length; i++) {
     const text = documents[i].pageContent;
-    if (text.length > textMaxLength) {
-      textMaxLength = text.length;
+    const textLengthInBytes = textEncoder.encode(text).length;
+    if (textLengthInBytes > textMaxLength) {
+      textMaxLength = textLengthInBytes;
     }
   }
   return textMaxLength;


### PR DESCRIPTION
Milvus vector store integration should calculate required length for new collection's `langchain_text` field in bytes instead of characters. Otherwise inserting text containing multibyte characters fails due to actual data not being able to fit into newly created collection's `langchain_text` field.

Example:
```
import { Milvus } from "langchain/vectorstores/milvus";
import { OpenAIEmbeddings } from "langchain/embeddings/openai";

// Env variables OPENAI_API_KEY and MILVUS_URL must be set

await Milvus.fromTexts(
  ["München"],
  [{ id: 1 }],
  new OpenAIEmbeddings(),
  { collectionName: 'milvus_insert_test' }
);
```
... results in ...
```
Error: Error inserting data: {"succ_index":[],"err_index":[0],"status":{"error_code":"IllegalArgument","reason":"the length (8) of 0th string exceeds max length (7): expected=valid length string, actual=string length exceeds max length: invalid parameter","code":1100},"IDs":null,"acknowledged":false,"insert_cnt":"0","delete_cnt":"0","upsert_cnt":"0","timestamp":"0"}
```
... as "München" character length is 7 but byte length is 8.