### PR TITLE
Update ollama.mdx - `numThreads` to `numThread`

### DIFF
--- a/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
+++ b/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
@@ -29,7 +29,7 @@ const embeddings = new OllamaEmbeddings({
   baseUrl: "http://localhost:11434", // default value
   requestOptions: {
     useMMap: true, // use_mmap 1
-    numThreads: 6, // num_thread 6
+    numThread: 6, // num_thread 6
     numGpu: 1, // num_gpu 1
   },
 });


### PR DESCRIPTION
The example in this [the docs](https://js.langchain.com/docs/modules/data_connection/text_embedding/integrations/ollama) for `OllamaEmbeddings` shows `numThreads: 6` for `OllamaEmbeddings` but it should actually accept a `numThread` key, not `numThreads`.

```ts
import { OllamaEmbeddings } from "langchain/embeddings/ollama";

const embeddings = new OllamaEmbeddings({
  model: "llama2", // default value
  baseUrl: "http://localhost:11434", // default value
  requestOptions: {
    useMMap: true,
    numThreads: 6, // <---- Should be `numThread`
    numGpu: 1,
  },
});

const documents = ["Hello World!", "Bye Bye"];

const documentEmbeddings = await embeddings.embedDocuments(documents);
```

The link to the [OllamaEmbeddings API source is here](https://github.com/langchain-ai/langchainjs/blob/b80dc8f5d8aaad857c72aade9053f2b355e10970/langchain/src/embeddings/ollama.ts#L68C7-L68C7) to confirm.


<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
