### PR TITLE
Ollama embedding

### DIFF
--- a/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
+++ b/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
@@ -26,7 +26,7 @@ import { OllamaEmbeddings } from "langchain/embeddings/ollama";
 
 const embeddings = new OllamaEmbeddings({
   model: "llama2", // default value
-  baseUrl: "http://localhost:11434", // default value
+  baseUrl: "http://127.0.0.1:11434", // default value
   requestOptions: {
     useMMap: true, // use_mmap 1
     numThread: 6, // num_thread 6
@@ -42,10 +42,10 @@ import { OllamaEmbeddings } from "langchain/embeddings/ollama";
 
 const embeddings = new OllamaEmbeddings({
   model: "llama2", // default value
-  baseUrl: "http://localhost:11434", // default value
+  baseUrl: "http://127.0.0.1:11434", // default value
   requestOptions: {
     useMMap: true,
-    numThreads: 6,
+    numThread: 6,
     numGpu: 1,
   },
 });

--- a/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
+++ b/docs/docs/modules/data_connection/text_embedding/integrations/ollama.mdx
@@ -15,7 +15,7 @@ import { OllamaEmbeddings } from "langchain/embeddings/ollama";
 
 const embeddings = new OllamaEmbeddings({
   model: "llama2", // default value
-  baseUrl: "http://localhost:11434", // default value
+  baseUrl: "http://127.0.0.1:11434", // default value
 });
 ```
 

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -24,7 +24,7 @@ interface OllamaEmbeddingsParams extends EmbeddingsParams {
 export class OllamaEmbeddings extends Embeddings {
   model = "llama2";
 
-  baseUrl = "http://localhost:11434";
+  baseUrl = "http://127.0.0.1:11434";
 
   requestOptions?: OllamaRequestParams["options"];
 


### PR DESCRIPTION
[Link to discussion](https://github.com/langchain-ai/langchainjs/pull/3083#issuecomment-1783917599)

1. Updates `numThreads` to `numThread` in the docs to use the API correctly [ref](https://github.com/langchain-ai/langchainjs/blob/b80dc8f5d8aaad857c72aade9053f2b355e10970/langchain/src/embeddings/ollama.ts#L68C7-L68C7)
2. Updates the default baseUrl to from `localhost` to `127.0.0.1` in the docs to reflect the default (see below)
3. Updates baseUrl in the `OllamaEmbeddings` class from `localhost` to `127.0.0.1` to work out of the box with node's fetch since it default resolves to ipv6 (`::1`) which Ollama server isn't listening to. Now it works out of the box. Issue is related to node's native fetch command not working when fetching `localhost` that isn't listening on the ipv6 localhost address but the ipv4 localhost address of `127.0.0.1` as per [this](https://github.com/node-fetch/node-fetch/issues/1624#issuecomment-1235826631) 


<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
