### PR TITLE
feat(apify): pass through Document metadata generic type

### DIFF
--- a/langchain/src/document_loaders/web/apify_dataset.ts
+++ b/langchain/src/document_loaders/web/apify_dataset.ts
@@ -1,28 +1,27 @@
 import {
+  ActorCallOptions,
   ApifyClient,
   ApifyClientOptions,
-  ActorCallOptions,
   TaskCallOptions,
 } from "apify-client";
 
-import { Document } from "../../document.js";
 import { BaseDocumentLoader, DocumentLoader } from "../base.js";
+import { Document } from "../../document.js";
 import { getEnvironmentVariable } from "../../util/env.js";
 
 /**
  * A type that represents a function that takes a single object (an Apify
  * dataset item) and converts it to an instance of the Document class.
  */
-export type ApifyDatasetMappingFunction = (
-  item: Record<string | number, unknown>
-) => Document;
+export type ApifyDatasetMappingFunction<Metadata extends Record<string, any>> =
+  (item: Record<string | number, unknown>) => Document<Metadata>;
 
 /**
  * A class that extends the BaseDocumentLoader and implements the
  * DocumentLoader interface. It represents a document loader that loads
  * documents from an Apify dataset.
  */
-export class ApifyDatasetLoader
+export class ApifyDatasetLoader<Metadata extends Record<string, any>>
   extends BaseDocumentLoader
   implements DocumentLoader
 {
@@ -32,12 +31,12 @@ export class ApifyDatasetLoader
 
   protected datasetMappingFunction: (
     item: Record<string | number, unknown>
-  ) => Document;
+  ) => Document<Metadata>;
 
   constructor(
     datasetId: string,
     config: {
-      datasetMappingFunction: ApifyDatasetMappingFunction;
+      datasetMappingFunction: ApifyDatasetMappingFunction<Metadata>;
       clientOptions?: ApifyClientOptions;
     }
   ) {
@@ -63,7 +62,7 @@ export class ApifyDatasetLoader
    * instances.
    * @returns An array of Document instances.
    */
-  async load(): Promise<Document[]> {
+  async load(): Promise<Document<Metadata>[]> {
     const datasetItems = (
       await this.apifyClient.dataset(this.datasetId).listItems({ clean: true })
     ).items;
@@ -78,15 +77,15 @@ export class ApifyDatasetLoader
    * @param options.datasetMappingFunction A function that takes a single object (an Apify dataset item) and converts it to an instance of the Document class.
    * @returns An instance of `ApifyDatasetLoader` with the results from the Actor run.
    */
-  static async fromActorCall(
+  static async fromActorCall<Metadata extends Record<string, any>>(
     actorId: string,
     input: Record<string | number, unknown>,
     config: {
       callOptions?: ActorCallOptions;
       clientOptions?: ApifyClientOptions;
-      datasetMappingFunction: ApifyDatasetMappingFunction;
+      datasetMappingFunction: ApifyDatasetMappingFunction<Metadata>;
     }
-  ): Promise<ApifyDatasetLoader> {
+  ): Promise<ApifyDatasetLoader<Metadata>> {
     const apifyApiToken = ApifyDatasetLoader._getApifyApiToken(
       config.clientOptions
     );
@@ -110,15 +109,15 @@ export class ApifyDatasetLoader
    * @param options.datasetMappingFunction A function that takes a single object (an Apify dataset item) and converts it to an instance of the Document class.
    * @returns An instance of `ApifyDatasetLoader` with the results from the task's run.
    */
-  static async fromActorTaskCall(
+  static async fromActorTaskCall<Metadata extends Record<string, any>>(
     taskId: string,
     input: Record<string | number, unknown>,
     config: {
       callOptions?: TaskCallOptions;
       clientOptions?: ApifyClientOptions;
-      datasetMappingFunction: ApifyDatasetMappingFunction;
+      datasetMappingFunction: ApifyDatasetMappingFunction<Metadata>;
     }
-  ): Promise<ApifyDatasetLoader> {
+  ): Promise<ApifyDatasetLoader<Metadata>> {
     const apifyApiToken = ApifyDatasetLoader._getApifyApiToken(
       config.clientOptions
     );


### PR DESCRIPTION
This PR gives users of the `ApifyDatasetLoader` class the ability to pass through their custom Document metadata generic type. Currently, the `datasetMappingFunction` of the `ApifyDatasetLoader` returns a type of `Document[]` which despite the fact that the user is explicitly setting specific properties on the document, from the docs

```
const loader = new ApifyDatasetLoader("your-dataset-id", {
  datasetMappingFunction: (item) =>
    new Document({
      pageContent: (item.text || "") as string,
      metadata: { source: item.url },
    }),
  clientOptions: {
    token: "your-apify-token", // Or set as process.env.APIFY_API_TOKEN
  },
});

const docs = await loader.load();
```

One would expect that the type of `docs` to be `Document<{ source: string }>[]` but it ends up being `Document[]` because the types are not plumbed through. This is slightly annoying if you want to then pass the `docs` to another function that is expecting certain metadata to be present because you need to add an unnecessary type check. With the changes of this PR, you could provide your Metadata type up front and get the type safety

<img width="484" alt="Screen Shot 2023-11-01 at 10 16 17 AM" src="https://github.com/langchain-ai/langchainjs/assets/16735699/0c333494-bbd2-4162-b427-c686a97e3b18">
