### PR TITLE
Convex: Fix defaults doc comments

### DIFF
--- a/langchain/src/storage/convex.ts
+++ b/langchain/src/storage/convex.ts
@@ -42,19 +42,33 @@ export type ConvexKVStoreConfig<
   >
 > = {
   readonly ctx: GenericActionCtx<DataModel>;
-  // Defaults to "cache"
+  /**
+   * Defaults to "cache"
+   */
   readonly table?: TableName;
-  // Defaults to "byKey"
+  /**
+   * Defaults to "byKey"
+   */
   readonly index?: IndexName;
-  // Defaults to "key"
+  /**
+   * Defaults to "key"
+   */
   readonly keyField?: KeyFieldName;
-  // Defaults to "value"
+  /**
+   * Defaults to "value"
+   */
   readonly valueField?: ValueFieldName;
-  // Defaults to `internal.langchain.db.upsert`
+  /**
+   * Defaults to `internal.langchain.db.upsert`
+   */
   readonly upsert?: UpsertMutation;
-  // Defaults to `internal.langchain.db.lookup`
+  /**
+   * Defaults to `internal.langchain.db.lookup`
+   */
   readonly lookup?: LookupQuery;
-  // Defaults to `internal.langchain.db.deleteMany`
+  /**
+   * Defaults to `internal.langchain.db.deleteMany`
+   */
   readonly deleteMany?: DeleteManyMutation;
 };
 

--- a/langchain/src/stores/message/convex.ts
+++ b/langchain/src/stores/message/convex.ts
@@ -55,12 +55,33 @@ export type ConvexChatMessageHistoryInput<
 > = {
   readonly ctx: GenericActionCtx<DataModel>;
   readonly sessionId: DocumentByName<DataModel, TableName>[SessionIdFieldName];
+  /**
+   * Defaults to "messages"
+   */
   readonly table?: TableName;
+  /**
+   * Defaults to "bySessionId"
+   */
   readonly index?: IndexName;
+  /**
+   * Defaults to "sessionId"
+   */
   readonly sessionIdField?: SessionIdFieldName;
+  /**
+   * Defaults to "message"
+   */
   readonly messageTextFieldName?: MessageTextFieldName;
+  /**
+   * Defaults to `internal.langchain.db.insert`
+   */
   readonly insert?: InsertMutation;
+  /**
+   * Defaults to `internal.langchain.db.lookup`
+   */
   readonly lookup?: LookupQuery;
+  /**
+   * Defaults to `internal.langchain.db.deleteMany`
+   */
   readonly deleteMany?: DeleteManyMutation;
 };
 

--- a/langchain/src/vectorstores/convex.ts
+++ b/langchain/src/vectorstores/convex.ts
@@ -43,12 +43,33 @@ export type ConvexVectorStoreConfig<
   >
 > = {
   readonly ctx: GenericActionCtx<DataModel>;
+  /**
+   * Defaults to "documents"
+   */
   readonly table?: TableName;
+  /**
+   * Defaults to "byEmbedding"
+   */
   readonly index?: IndexName;
+  /**
+   * Defaults to "text"
+   */
   readonly textField?: TextFieldName;
+  /**
+   * Defaults to "embedding"
+   */
   readonly embeddingField?: EmbeddingFieldName;
+  /**
+   * Defaults to "metadata"
+   */
   readonly metadataField?: MetadataFieldName;
+  /**
+   * Defaults to `internal.langchain.db.insert`
+   */
   readonly insert?: InsertMutation;
+  /**
+   * Defaults to `internal.langchain.db.get`
+   */
   readonly get?: GetQuery;
 };
 


### PR DESCRIPTION
Forgot to update these before merging. Now they will show up in the compiled .d.ts files (where jump to definition will lead people).