### PR TITLE
Fix typo in output types table

### DIFF
--- a/docs/docs/expression_language/interface.mdx
+++ b/docs/docs/expression_language/interface.mdx
@@ -25,7 +25,7 @@ The **input type** varies by component :
 
 The **output type** also varies by component :
 
-| Component    | Input Type            |
+| Component    | Output Type            |
 | ------------ | --------------------- |
 | LLM          | String                |
 | ChatModel    | ChatMessage           |

--- a/docs/docs/expression_language/interface.mdx
+++ b/docs/docs/expression_language/interface.mdx
@@ -25,7 +25,7 @@ The **input type** varies by component :
 
 The **output type** also varies by component :
 
-| Component    | Output Type            |
+| Component    | Output Type           |
 | ------------ | --------------------- |
 | LLM          | String                |
 | ChatModel    | ChatMessage           |


### PR DESCRIPTION
When describing the [common interface](https://js.langchain.com/docs/expression_language/interface), there is a typo in the table that explains the different output types. 

This PR fixes the typo in the header of the table.