### PR TITLE
fix: updated convex chat message history indexes to match documentation

### DIFF
--- a/langchain/src/stores/message/convex.ts
+++ b/langchain/src/stores/message/convex.ts
@@ -10,7 +10,7 @@ import {
   GenericDataModel,
   NamedTableInfo,
   TableNamesInDataModel,
-  VectorIndexNames,
+  IndexNames,
   makeFunctionReference,
 } from "convex/server";
 import { BaseMessage, BaseListChatMessageHistory } from "../../schema/index.js";
@@ -27,7 +27,7 @@ import {
 export type ConvexChatMessageHistoryInput<
   DataModel extends GenericDataModel,
   TableName extends TableNamesInDataModel<DataModel> = "messages",
-  IndexName extends VectorIndexNames<
+  IndexName extends IndexNames<
     NamedTableInfo<DataModel, TableName>
   > = "bySessionId",
   SessionIdFieldName extends FieldPaths<
@@ -91,7 +91,7 @@ export class ConvexChatMessageHistory<
     NamedTableInfo<DataModel, TableName>
   > = "sessionId",
   TableName extends TableNamesInDataModel<DataModel> = "messages",
-  IndexName extends VectorIndexNames<
+  IndexName extends IndexNames<
     NamedTableInfo<DataModel, TableName>
   > = "bySessionId",
   MessageTextFieldName extends FieldPaths<


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Updated the convex index type for ConvexChatMessageHistory as the basic ChatMessage history docs use a normal non-vector index for the session id.  I've included a [link](https://js.langchain.com/docs/integrations/chat_memory/convex) to the docs where the example chat memory setup is done.
