### PR TITLE
add an example and how to documentation page for cancelling LCEL chains

### DIFF
--- a/docs/docs/expression_language/how_to/cancellation.mdx
+++ b/docs/docs/expression_language/how_to/cancellation.mdx
@@ -1,0 +1,10 @@
+# Cancelling requests
+
+You can cancel a LCEL request by binding a `signal`.
+
+import CodeBlock from "@theme/CodeBlock";
+import BasicExample from "@examples/guides/expression_language/cancellation.ts";
+
+<CodeBlock language="typescript">{CancellationExample}</CodeBlock>
+
+Note, this will only cancel the outgoing request if the underlying provider exposes that option. LangChain will cancel the underlying request if possible, otherwise it will cancel the processing of the response.

--- a/examples/src/guides/expression_language/how_to_cancellation.ts
+++ b/examples/src/guides/expression_language/how_to_cancellation.ts
@@ -1,0 +1,29 @@
+import { PromptTemplate } from "langchain/prompts";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+const controller = new AbortController();
+
+// Create a new LLMChain from a PromptTemplate and an LLM in streaming mode.
+const llm = new ChatOpenAI({ temperature: 0.9 });
+const model = llm.bind({ signal: controller.signal });
+const prompt = PromptTemplate.fromTemplate(
+  "Please write a 500 word essay about {topic}."
+);
+const chain = prompt.pipe(model);
+
+// Call `controller.abort()` somewhere to cancel the request.
+setTimeout(() => {
+  controller.abort();
+}, 3000);
+
+try {
+  // Call the chain with the inputs and a callback for the streamed tokens
+  const stream = await chain.stream({ topic: "Bonobos" });
+
+  for await (const chunk of stream) {
+    console.log(chunk);
+  }
+} catch (e) {
+  console.log(e);
+  // Error: Cancel: canceled
+}


### PR DESCRIPTION
I added documentation for cancelling LCEL/RunnableSequence invocations. @jacoblee93 mentioned that this was a documentation oversight!


Fixes # (issue) https://github.com/langchain-ai/langchainjs/issues/3096



------

@ shoutouts (I don't use twitter/x very much):
https://twitter.com/jon_will_do_it / https://linkedin/com/in/willisjon / https://github.com/jondwillis