### PR TITLE
Fix invalid usage of defaultProvider in Bedrock web.

### DIFF
--- a/langchain/src/chat_models/bedrock/web.ts
+++ b/langchain/src/chat_models/bedrock/web.ts
@@ -1,5 +1,4 @@
 import { SignatureV4 } from "@smithy/signature-v4";
-import { defaultProvider } from "@aws-sdk/credential-provider-node";
 import { HttpRequest } from "@smithy/protocol-http";
 import { EventStreamCodec } from "@smithy/eventstream-codec";
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8";
@@ -158,7 +157,7 @@ export class BedrockChat extends SimpleChatModel implements BaseBedrockInput {
     }
     this.region = region;
 
-    const credentials = fields?.credentials ?? defaultProvider();
+    const credentials = fields?.credentials;
     if (!credentials) {
       throw new Error(
         "Please set the AWS credentials in the 'credentials' field."


### PR DESCRIPTION
Should match: https://github.com/langchain-ai/langchainjs/blob/c2169e9facf5953cd3eca92f529107eb5cd392c8/langchain/src/llms/bedrock/web.ts#L99

Otherwise, this error is thrown:

```
✘ [ERROR] Could not resolve "@aws-sdk/credential-provider-node"
```