### PR TITLE
feat(pinecone): add support for delete by metadata filter

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -27,11 +27,12 @@ export interface PineconeLibArgs extends AsyncCallerParams {
 
 /**
  * Type that defines the parameters for the delete operation in the
- * PineconeStore class. It includes ids, deleteAll flag, and namespace.
+ * PineconeStore class. It includes ids, filter, deleteAll flag, and namespace.
  */
 export type PineconeDeleteParams = {
   ids?: string[];
   deleteAll?: boolean;
+  filter?: object;
   namespace?: string;
 };
 
@@ -161,7 +162,7 @@ export class PineconeStore extends VectorStore {
    * @returns Promise that resolves when the delete operation is complete.
    */
   async delete(params: PineconeDeleteParams): Promise<void> {
-    const { deleteAll, ids } = params;
+    const { deleteAll, ids, filter } = params;
     const namespace = this.pineconeIndex.namespace(this.namespace ?? "");
 
     if (deleteAll) {
@@ -172,6 +173,8 @@ export class PineconeStore extends VectorStore {
         const batchIds = ids.slice(i, i + batchSize);
         await namespace.deleteMany(batchIds);
       }
+    } else if (filter) {
+      await namespace.deleteMany(filter);
     } else {
       throw new Error("Either ids or delete_all must be provided.");
     }

--- a/langchain/src/vectorstores/tests/pinecone.int.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.int.test.ts
@@ -135,6 +135,24 @@ describe("PineconeStore", () => {
     expect(results2.length).toEqual(1);
   });
 
+  test("delete by metadata filter", async () => {
+    const pageContent = faker.lorem.sentence(5);
+
+    await pineconeStore.addDocuments([
+      { pageContent, metadata: { foo: "bar" } },
+      { pageContent, metadata: { foo: "baz" } },
+    ]);
+
+    const results = await pineconeStore.similaritySearch(pageContent, 2);
+    expect(results.length).toEqual(2);
+
+    await pineconeStore.delete({ filter: { foo: "bar" } });
+
+    const results2 = await pineconeStore.similaritySearch(pageContent, 2);
+    expect(results2.length).toEqual(1);
+    expect(results2[0].metadata).toMatchObject({ foo: "baz" });
+  });
+
   test("delete all", async () => {
     const pageContent = faker.lorem.sentence(5);
     const id = uuid.v4();


### PR DESCRIPTION
This PR adds pass-through ability to delete records from Pinecone using metadata filtering which was [officially supported](https://sdk.pinecone.io/typescript/#md:delete-many-by-metadata-filter) in the v1 release of Pinecone's JS client.

This gives users the ability to delete vectors using matching metadata filters which can be more flexible than deleting by ID.