### PR TITLE
fix: remove "\n" between words when use pdf-loader

### DIFF
--- a/langchain/src/document_loaders/fs/pdf.ts
+++ b/langchain/src/document_loaders/fs/pdf.ts
@@ -61,9 +61,19 @@ export class PDFLoader extends BufferLoader {
         continue;
       }
 
-      const text = content.items
-        .map((item) => (item as TextItem).str)
-        .join("\n");
+      let lastY = undefined;
+      const textItems = [];
+      for (const item of content.items) {
+        if ('str' in item) {
+          if (lastY == item.transform[5] || !lastY) {
+            textItems.push(item.str);
+          } else {
+            textItems.push(`\n${item.str}`);
+          }
+          lastY = item.transform[5];
+        }
+      }
+      const text = textItems.join('');
 
       documents.push(
         new Document({


### PR DESCRIPTION
Fixes #1703 
Reference: https://github.com/albertcui/pdf-parse/blob/7086fc1cc9058545cdf41dd0646d6ae5832c7107/lib/pdf-parse.js#L16
