### PR TITLE
Fix delta role error when using custom LLM

### DIFF
--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -113,14 +113,14 @@ function _convertDeltaToMessageChunk(
   delta: Record<string, any>,
   defaultRole?: OpenAIRoleEnum
 ) {
-  const role = delta.role ?? defaultRole;
-  const content = delta.content ?? "";
+  const role = delta?.role ?? defaultRole;
+  const content = delta?.content ?? "";
   let additional_kwargs;
-  if (delta.function_call) {
+  if (delta?.function_call) {
     additional_kwargs = {
       function_call: delta.function_call,
     };
-  } else if (delta.tool_calls) {
+  } else if (delta?.tool_calls) {
     additional_kwargs = {
       tool_calls: delta.tool_calls,
     };


### PR DESCRIPTION
This addresses a delta chunk issue that happens when you use a custom baseURL on the openai chat model. Some models like llama 2 on openrouter may have a empty delta and result in a undefined error.

Example error:
```
Cannot read properties of undefined (reading 'role')",
  "error.stack": "TypeError: Cannot read properties of undefined (reading 'role')\n    at _convertDeltaToMessageChunk (/home/ubuntu/node_modules/langchain/dist/chat_models/openai.cjs:72:24)\n    at ChatOpenAI._streamResponseChunks (/home/ubuntu/node_modules/langchain/dist/chat_models/openai.cjs:409:27)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ChatOpenAI._streamIterator (/home/ubuntu/node_modules/langchain/dist/chat_models/base.cjs:77:34)\n    at async RunnableSequence._streamIterator (/home/ubuntu/node_modules/langchain/dist/schema/runnable/base.cjs:780:30)\n    at async Object.pull (/home/ubuntu/node_modules/langchain/dist/util/stream.cjs:73:41)
```

on _convertDeltaToMessageChunk, openai works fine but when you start using models from openrouter or other baseURL llms, it doesnt take in account for empty deltas and assumes theres always a value.

I was able to test with a custom baseURL and normal openai that this works with no errors on streaming after this tweak.

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
