### PR TITLE
Fix delta role error when using custom LLM

### DIFF
--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -116,7 +116,7 @@ function _convertDeltaToMessageChunk(
   const role = delta.role ?? defaultRole;
   const content = delta.content ?? "";
   let additional_kwargs;
-  if (delta?.function_call) {
+  if (delta.function_call) {
     additional_kwargs = {
       function_call: delta.function_call,
     };

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -450,7 +450,7 @@ export class ChatOpenAI<
 
       const { delta } = choice;
       const chunk = _convertDeltaToMessageChunk(delta, defaultRole);
-      defaultRole = delta.role ?? defaultRole;
+      defaultRole = delta?.role ?? defaultRole;
       const newTokenIndices = {
         prompt: options.promptIndex ?? 0,
         completion: choice.index ?? 0,

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -113,14 +113,14 @@ function _convertDeltaToMessageChunk(
   delta: Record<string, any>,
   defaultRole?: OpenAIRoleEnum
 ) {
-  const role = delta.role ?? defaultRole;
-  const content = delta.content ?? "";
+  const role = delta?.role ?? defaultRole;
+  const content = delta?.content ?? "";
   let additional_kwargs;
-  if (delta.function_call) {
+  if (delta?.function_call) {
     additional_kwargs = {
       function_call: delta.function_call,
     };
-  } else if (delta.tool_calls) {
+  } else if (delta?.tool_calls) {
     additional_kwargs = {
       tool_calls: delta.tool_calls,
     };

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -463,7 +463,7 @@ export class ChatOpenAI<
       }
       const generationChunk = new ChatGenerationChunk({
         message: chunk,
-        text: chunk.content,
+        text: chunk?.content,
         generationInfo: newTokenIndices,
       });
       yield generationChunk;

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -113,14 +113,14 @@ function _convertDeltaToMessageChunk(
   delta: Record<string, any>,
   defaultRole?: OpenAIRoleEnum
 ) {
-  const role = delta?.role ?? defaultRole;
-  const content = delta?.content ?? "";
+  const role = delta.role ?? defaultRole;
+  const content = delta.content ?? "";
   let additional_kwargs;
   if (delta?.function_call) {
     additional_kwargs = {
       function_call: delta.function_call,
     };
-  } else if (delta?.tool_calls) {
+  } else if (delta.tool_calls) {
     additional_kwargs = {
       tool_calls: delta.tool_calls,
     };
@@ -449,8 +449,11 @@ export class ChatOpenAI<
       }
 
       const { delta } = choice;
+      if (!delta) {
+        continue;
+      }
       const chunk = _convertDeltaToMessageChunk(delta, defaultRole);
-      defaultRole = delta?.role ?? defaultRole;
+      defaultRole = delta.role ?? defaultRole;
       const newTokenIndices = {
         prompt: options.promptIndex ?? 0,
         completion: choice.index ?? 0,
@@ -463,7 +466,7 @@ export class ChatOpenAI<
       }
       const generationChunk = new ChatGenerationChunk({
         message: chunk,
-        text: chunk?.content,
+        text: chunk.content,
         generationInfo: newTokenIndices,
       });
       yield generationChunk;


### PR DESCRIPTION
This addresses a delta chunk issue that happens when you use a custom baseURL on the openai chat model. Some models like llama 2 on openrouter may have a empty delta and result in a undefined error.

Example error:
```
Cannot read properties of undefined (reading 'role')",
  "error.stack": "TypeError: Cannot read properties of undefined (reading 'role')\n    at _convertDeltaToMessageChunk (/home/ubuntu/node_modules/langchain/dist/chat_models/openai.cjs:72:24)\n    at ChatOpenAI._streamResponseChunks (/home/ubuntu/node_modules/langchain/dist/chat_models/openai.cjs:409:27)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ChatOpenAI._streamIterator (/home/ubuntu/node_modules/langchain/dist/chat_models/base.cjs:77:34)\n    at async RunnableSequence._streamIterator (/home/ubuntu/node_modules/langchain/dist/schema/runnable/base.cjs:780:30)\n    at async Object.pull (/home/ubuntu/node_modules/langchain/dist/util/stream.cjs:73:41)
```

on _convertDeltaToMessageChunk, openai works fine but when you start using models from openrouter or other baseURL llms, it doesnt take in account for empty deltas and assumes theres always a value.

I was able to test with a custom baseURL and normal openai that this works with no errors on streaming after this tweak.

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
