### PR TITLE
Use replaceAll instead of replace when generating operationid.

### DIFF
--- a/langchain/src/util/openapi.ts
+++ b/langchain/src/util/openapi.ts
@@ -195,7 +195,10 @@ export class OpenAPISpec {
         updatedPath.startsWith("/") ? updatedPath.slice(1) : updatedPath
       }_${method}`;
     }
-    return operationId.replaceAll("-", "_").replaceAll(".", "_").replaceAll("/", "_");
+    return operationId
+      .replaceAll("-", "_")
+      .replaceAll(".", "_")
+      .replaceAll("/", "_");
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/langchain/src/util/openapi.ts
+++ b/langchain/src/util/openapi.ts
@@ -190,12 +190,12 @@ export class OpenAPISpec {
   ) {
     let { operationId } = operation;
     if (operationId === undefined) {
-      const updatedPath = path.replace(/[^a-zA-Z0-9]/, "_");
+      const updatedPath = path.replaceAll(/[^a-zA-Z0-9]/, "_");
       operationId = `${
         updatedPath.startsWith("/") ? updatedPath.slice(1) : updatedPath
       }_${method}`;
     }
-    return operationId.replace("-", "_").replace(".", "_").replace("/", "_");
+    return operationId.replaceAll("-", "_").replaceAll(".", "_").replaceAll("/", "_");
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #3266.