### PR TITLE
Support meta.llama2-13b-chat-v1

### DIFF
--- a/langchain/src/llms/bedrock/web.ts
+++ b/langchain/src/llms/bedrock/web.ts
@@ -81,7 +81,7 @@ export class Bedrock extends LLM implements BaseBedrockInput {
     super(fields ?? {});
 
     this.model = fields?.model ?? this.model;
-    const allowedModels = ["ai21", "anthropic", "amazon", "cohere"];
+    const allowedModels = ["ai21", "anthropic", "amazon", "cohere", "meta"];
     if (!allowedModels.includes(this.model.split(".")[0])) {
       throw new Error(
         `Unknown model: '${this.model}', only these are supported: ${allowedModels}`


### PR DESCRIPTION
Amazon Bedrock now provides access to Meta’s Llama 2 Chat 13B model
https://aws.amazon.com/blogs/aws/amazon-bedrock-now-provides-access-to-llama-2-chat-13b-model/

