### PR TITLE
fix: remove blank space between words when use pdf-loader

### DIFF
--- a/langchain/src/document_loaders/fs/pdf.ts
+++ b/langchain/src/document_loaders/fs/pdf.ts
@@ -76,7 +76,7 @@ export class PDFLoader extends BufferLoader {
         }
       }
 
-      const text = textItems.join(" ");
+      const text = textItems.join("");
 
       documents.push(
         new Document({

--- a/langchain/src/document_loaders/fs/pdf.ts
+++ b/langchain/src/document_loaders/fs/pdf.ts
@@ -11,13 +11,16 @@ export class PDFLoader extends BufferLoader {
 
   private pdfjs: typeof PDFLoaderImports;
 
+  private skipBlank: boolean;
+
   constructor(
     filePathOrBlob: string | Blob,
-    { splitPages = true, pdfjs = PDFLoaderImports } = {}
+    { splitPages = true, pdfjs = PDFLoaderImports, skipBlank = false } = {}
   ) {
     super(filePathOrBlob);
     this.splitPages = splitPages;
     this.pdfjs = pdfjs;
+    this.skipBlank = skipBlank;
   }
 
   /**
@@ -76,7 +79,7 @@ export class PDFLoader extends BufferLoader {
         }
       }
 
-      const text = textItems.join("");
+      const text = textItems.join(this.skipBlank ? "" : " ");
 
       documents.push(
         new Document({

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -61,7 +61,7 @@ export class WebPDFLoader extends BaseDocumentLoader {
           lastY = item.transform[5];
         }
       }
-      const text = textItems.join(" ");
+      const text = textItems.join("");
 
       documents.push(
         new Document({

--- a/langchain/src/document_loaders/web/pdf.ts
+++ b/langchain/src/document_loaders/web/pdf.ts
@@ -12,14 +12,17 @@ export class WebPDFLoader extends BaseDocumentLoader {
 
   private pdfjs: typeof PDFLoaderImports;
 
+  private skipBlank = false;
+
   constructor(
     blob: Blob,
-    { splitPages = true, pdfjs = PDFLoaderImports } = {}
+    { splitPages = true, pdfjs = PDFLoaderImports, skipBlank = false } = {}
   ) {
     super();
     this.blob = blob;
     this.splitPages = splitPages ?? this.splitPages;
     this.pdfjs = pdfjs;
+    this.skipBlank = skipBlank ?? this.skipBlank;
   }
 
   /**
@@ -61,7 +64,7 @@ export class WebPDFLoader extends BaseDocumentLoader {
           lastY = item.transform[5];
         }
       }
-      const text = textItems.join("");
+      const text = textItems.join(this.skipBlank ? "" : " ");
 
       documents.push(
         new Document({


### PR DESCRIPTION
Extends #3218 