### PR TITLE
Add PrismaVectorStore filter IN operator

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,7 +82,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-Different SQL operators are available to perform filter: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
+The following SQL operators are available as filters: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
 
 The samples above uses the following schema:
 

--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,6 +82,8 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
+Differents SQL operators are available to perform filter: `equals`, `lte`, `lt`, `gt`, `gte`, `not`.
+
 The samples above uses the following schema:
 
 <CodeBlock language="prisma">{Schema}</CodeBlock>

--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,7 +82,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-Differents SQL operators are available to perform filter: `equals`, `lte`, `lt`, `gt`, `gte`, `not`.
+Differents SQL operators are available to perform filter: `equals`, ìn`, `lte`, `lt`, `gt`, `gte`, `not`.
 
 The samples above uses the following schema:
 

--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,7 +82,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-Differents SQL operators are available to perform filter: `equals`, ìn`, `lte`, `lt`, `gt`, `gte`, `not`.
+Differents SQL operators are available to perform filter: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
 
 The samples above uses the following schema:
 

--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,7 +82,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-Differents SQL operators are available to perform filter: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
+Different SQL operators are available to perform filter: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
 
 The samples above uses the following schema:
 

--- a/examples/src/indexes/vector_stores/prisma_vectorstore/prisma.ts
+++ b/examples/src/indexes/vector_stores/prisma_vectorstore/prisma.ts
@@ -58,11 +58,14 @@ export const run = async () => {
   const resultTwo = await vectorStore.similaritySearch("Hello world", 1);
   console.log(resultTwo);
 
-  // Override the local filter
+  // Override the local filter,
   const resultThree = await vectorStore.similaritySearchWithScore(
     "Hello world",
     1,
-    { content: { equals: "different_content" } }
+    {
+      content: { equals: "different_content" },
+      customForeignKey: { in: ["<id1>", "<id2>", "<id3>"] },
+    }
   );
   console.log(resultThree);
 };

--- a/examples/src/indexes/vector_stores/prisma_vectorstore/prisma.ts
+++ b/examples/src/indexes/vector_stores/prisma_vectorstore/prisma.ts
@@ -58,7 +58,7 @@ export const run = async () => {
   const resultTwo = await vectorStore.similaritySearch("Hello world", 1);
   console.log(resultTwo);
 
-  // Override the local filter,
+  // Override the local filter
   const resultThree = await vectorStore.similaritySearchWithScore(
     "Hello world",
     1,

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -61,6 +61,7 @@ type ModelColumns<TModel extends Record<string, unknown>> = {
 export type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
   [K in keyof TModel]?: {
     equals?: TModel[K];
+    in?: TModel[K][];
     lt?: TModel[K];
     lte?: TModel[K];
     gt?: TModel[K];
@@ -71,6 +72,7 @@ export type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
 
 const OpMap = {
   equals: "=",
+  in: "IN",
   lt: "<",
   lte: "<=",
   gt: ">",
@@ -410,9 +412,18 @@ export class PrismaVectorStore<
         Object.entries(ops).map(([opName, value]) => {
           // column name, operators cannot be parametrised
           // these fields are thus not escaped by Prisma and can be dangerous if user input is used
+          const mappedOpName = opName as keyof typeof OpMap;
           const colRaw = this.Prisma.raw(`"${key}"`);
-          const opRaw = this.Prisma.raw(OpMap[opName as keyof typeof OpMap]);
-          return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
+          const opRaw = this.Prisma.raw(OpMap[mappedOpName]);
+
+          switch (OpMap[mappedOpName]) {
+            case OpMap.in:
+              return this.Prisma.sql`${colRaw} ${opRaw} (${(
+                value as string[]
+              ).join(",")})`;
+            default:
+              return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
+          }
         })
       ),
       " AND ",

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -423,7 +423,11 @@ export class PrismaVectorStore<
                 !value.every((v) => typeof v === "string")
               ) {
                 throw new Error(
-                  `Invalid filter: IN operator requires an array of strings. Received: ${JSON.stringify(value, null, 2)}`
+                  `Invalid filter: IN operator requires an array of strings. Received: ${JSON.stringify(
+                    value,
+                    null,
+                    2
+                  )}`
                 );
               }
               return this.Prisma.sql`${colRaw} ${opRaw} (${value.join(",")})`;

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -418,12 +418,15 @@ export class PrismaVectorStore<
 
           switch (OpMap[opNameKey]) {
             case OpMap.in: {
-              if (!Array.isArray(values) || !values.every((v) => typeof v === "string")) {
-                throw new Error("...")
+              if (
+                !Array.isArray(value) ||
+                !value.every((v) => typeof v === "string")
+              ) {
+                throw new Error(
+                  "Invalid filter: IN operator requires an array of strings"
+                );
               }
-              return this.Prisma.sql`${colRaw} ${opRaw} (${(
-                value as string[]
-              ).join(",")})`;
+              return this.Prisma.sql`${colRaw} ${opRaw} (${value.join(",")})`;
             }
             default:
               return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -417,10 +417,14 @@ export class PrismaVectorStore<
           const opRaw = this.Prisma.raw(OpMap[opNameKey]);
 
           switch (OpMap[opNameKey]) {
-            case OpMap.in:
+            case OpMap.in: {
+              if (!Array.isArray(values) || !values.every((v) => typeof v === "string")) {
+                throw new Error("...")
+              }
               return this.Prisma.sql`${colRaw} ${opRaw} (${(
                 value as string[]
               ).join(",")})`;
+            }
             default:
               return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
           }

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -423,7 +423,7 @@ export class PrismaVectorStore<
                 !value.every((v) => typeof v === "string")
               ) {
                 throw new Error(
-                  "Invalid filter: IN operator requires an array of strings"
+                  `Invalid filter: IN operator requires an array of strings. Received: ${JSON.stringify(value, null, 2)}`
                 );
               }
               return this.Prisma.sql`${colRaw} ${opRaw} (${value.join(",")})`;

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -412,11 +412,11 @@ export class PrismaVectorStore<
         Object.entries(ops).map(([opName, value]) => {
           // column name, operators cannot be parametrised
           // these fields are thus not escaped by Prisma and can be dangerous if user input is used
-          const mappedOpName = opName as keyof typeof OpMap;
+          const opNameKey = opName as keyof typeof OpMap;
           const colRaw = this.Prisma.raw(`"${key}"`);
-          const opRaw = this.Prisma.raw(OpMap[mappedOpName]);
+          const opRaw = this.Prisma.raw(OpMap[opNameKey]);
 
-          switch (OpMap[mappedOpName]) {
+          switch (OpMap[opNameKey]) {
             case OpMap.in:
               return this.Prisma.sql`${colRaw} ${opRaw} (${(
                 value as string[]


### PR DESCRIPTION
## Summary
Add support for `IN` operator in `PrismaVectorStore` class to allow filter on multiple possible values

```
PrismaVectorStore.withModel(this.databaseService).create(
  new OpenAIEmbeddings(),
  {
    prisma: Prisma,
    tableName: 'Document',
    vectorColumnName: 'vector',
    columns: {
      id: PrismaVectorStore.IdColumn,
      content: PrismaVectorStore.ContentColumn,
    },
    filter: {
      foreignKeyId: {
        in: ['<id1>', '<id2>', ...],
      },
    },
  },
);
```

The introduced code uses a `switch` instruction to make it easy to add other operators in the future.

Fixes #3301 
