### PR TITLE
feat: Added support of terms filter in OpenSearch vector store

### DIFF
--- a/langchain/src/vectorstores/opensearch.ts
+++ b/langchain/src/vectorstores/opensearch.ts
@@ -286,11 +286,12 @@ export class OpenSearchVectorStore extends VectorStore {
 
   private buildMetadataTerms(
     filter?: OpenSearchFilter
-  ): { term: Record<string, unknown> }[] {
+  ): { [key: string]: Record<string, unknown> }[] {
     if (filter == null) return [];
     const result = [];
     for (const [key, value] of Object.entries(filter)) {
-      result.push({ term: { [`metadata.${key}`]: value } });
+      const aggregatorKey = Array.isArray(value) ? "terms" : "term";
+      result.push({ [aggregatorKey]: { [`metadata.${key}`]: value } });
     }
     return result;
   }


### PR DESCRIPTION
Hi,
solves #3297 

In the future it can be extended further to implement other [term-level queries](https://opensearch.org/docs/latest/query-dsl/term/index/), but for now `term` and `terms` is sufficient enough, as they are imho the most used.

Since I am primarily working with OpenSearch in my workplace, I'll gladly add those features when the need arises.
