### PR TITLE
Improve MessageContent type

### DIFF
--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -118,7 +118,7 @@ export type MessageContent =
         }
       | {
           type: "image_url";
-          image_url: string | { url: string; detail?: "low" | "high" };
+          image_url: string | { url: string; detail?: "auto" | "low" | "high" };
         }
     )[];
 

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -111,11 +111,16 @@ export type MessageType =
 
 export type MessageContent =
   | string
-  | {
-      type: "text" | "image_url";
-      text?: string;
-      image_url?: string | { url: string; detail?: "low" | "high" };
-    }[];
+  | (
+      | {
+          type: "text";
+          text: string;
+        }
+      | {
+          type: "image_url";
+          image_url: string | { url: string; detail?: "low" | "high" };
+        }
+    )[];
 
 export interface BaseMessageFields {
   content: MessageContent;


### PR DESCRIPTION
The fields are mutually exclusive. This represents this in its type.

This will help with both avoiding wrong combinations as well as reduces unnecessary undefined checks.