### PR TITLE
Add missing PrismaVectorStore filter operators

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/prisma.mdx
@@ -82,7 +82,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-The following SQL operators are available as filters: `equals`, `in`, `lt`, `lte`, `gt`, `gte`, `not`.
+The following SQL operators are available as filters: `equals`, `in`, `isNull`, `isNotNull`, `like`, `lt`, `lte`, `gt`, `gte`, `not`.
 
 The samples above uses the following schema:
 

--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -62,6 +62,9 @@ export type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
   [K in keyof TModel]?: {
     equals?: TModel[K];
     in?: TModel[K][];
+    isNull?: TModel[K];
+    isNotNull?: TModel[K];
+    like?: TModel[K];
     lt?: TModel[K];
     lte?: TModel[K];
     gt?: TModel[K];
@@ -73,6 +76,9 @@ export type PrismaSqlFilter<TModel extends Record<string, unknown>> = {
 const OpMap = {
   equals: "=",
   in: "IN",
+  isNull: "IS NULL",
+  isNotNull: "IS NOT NULL",
+  like: "LIKE",
   lt: "<",
   lte: "<=",
   gt: ">",
@@ -432,6 +438,9 @@ export class PrismaVectorStore<
               }
               return this.Prisma.sql`${colRaw} ${opRaw} (${value.join(",")})`;
             }
+            case OpMap.isNull:
+            case OpMap.isNotNull:
+              return this.Prisma.sql`${colRaw} ${opRaw}`;
             default:
               return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
           }


### PR DESCRIPTION
# Summary
Add support for missing SQL operators in `PrismaVectorStore` class filter:
* `isNull`
* `isNotNull`
* `like`

Fixes #3317 