### PR TITLE
Remove console.log from googlevertexai-connection.ts

### DIFF
--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -57,16 +57,12 @@ export abstract class GoogleConnection<
       opts.responseType = "json";
     }
 
-    try {
-      const callResponse = await this.caller.callWithOptions(
-        { signal: options?.signal },
-        async () => this.client.request(opts)
-      );
-      const response: unknown = callResponse; // Done for typecast safety, I guess
-      return <ResponseType>response;
-    } catch (x) {
-      throw x;
-    }
+    const callResponse = await this.caller.callWithOptions(
+      { signal: options?.signal },
+      async () => this.client.request(opts)
+    );
+    const response: unknown = callResponse; // Done for typecast safety, I guess
+    return <ResponseType>response;
   }
 }
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -65,7 +65,6 @@ export abstract class GoogleConnection<
       const response: unknown = callResponse; // Done for typecast safety, I guess
       return <ResponseType>response;
     } catch (x) {
-      console.error(JSON.stringify(x, null, 1));
       throw x;
     }
   }


### PR DESCRIPTION
Remove console.log from googlevertexai-connection.ts

Problem:
- In case of invalid address, an error is logged exposing authentication token  in logs.
- this log should be handled by langchain callback mechanism.

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
