### PR TITLE
Removed **sentence-transformers/distilbert-base-nli-mean-tokens** as default model and added **BAAI/bge-base-en-v1.5** as default model when no model param is given.

### DIFF
--- a/langchain/src/embeddings/hf.ts
+++ b/langchain/src/embeddings/hf.ts
@@ -32,8 +32,7 @@ export class HuggingFaceInferenceEmbeddings
   constructor(fields?: HuggingFaceInferenceEmbeddingsParams) {
     super(fields ?? {});
 
-    this.model =
-      fields?.model ?? "BAAI/bge-base-en-v1.5";
+    this.model = fields?.model ?? "BAAI/bge-base-en-v1.5";
     this.apiKey =
       fields?.apiKey ?? getEnvironmentVariable("HUGGINGFACEHUB_API_KEY");
     this.endpointUrl = fields?.endpointUrl;

--- a/langchain/src/embeddings/hf.ts
+++ b/langchain/src/embeddings/hf.ts
@@ -33,7 +33,7 @@ export class HuggingFaceInferenceEmbeddings
     super(fields ?? {});
 
     this.model =
-      fields?.model ?? "sentence-transformers/distilbert-base-nli-mean-tokens";
+      fields?.model ?? "BAAI/bge-base-en-v1.5";
     this.apiKey =
       fields?.apiKey ?? getEnvironmentVariable("HUGGINGFACEHUB_API_KEY");
     this.endpointUrl = fields?.endpointUrl;


### PR DESCRIPTION
### Update in hf.ts

The model page of **sentence-transformers/distilbert-base-nli-mean-tokens** says that: (This model is deprecated. Please don't use it as it produces sentence embeddings of low quality. [here](https://huggingface.co/sentence-transformers/distilbert-base-nli-mean-tokens)

So, We should consider using newer and better models available on huggingface. The one that performs best on MTEB right now (with 768 dimensions) is **BAAI/bge-base-en-v1.5**.

The problem right now is that we can't change the model now, since it will make previously written code misbehave in current applications.

So if possible please update the model for in upcoming versions.