### PR TITLE
Update OpenAIAgent to support Runnable models

### DIFF
--- a/langchain/src/agents/openai/index.ts
+++ b/langchain/src/agents/openai/index.ts
@@ -232,24 +232,16 @@ export class OpenAIAgent extends Agent {
     const promptValue =
       await this.llmChain.prompt.formatPromptValue(valuesForPrompt);
 
-    let message: BaseMessage;
-    if (Runnable.isRunnable(llm)) {
-      message = await (
-        llm as Runnable<
-          BaseLanguageModelInput,
-          BaseMessageChunk,
-          ChatOpenAICallOptions
-        >
-      ).invoke(promptValue.toChatMessages(), {
-        callbacks: callbackManager,
-      });
-    } else {
-      message = await (llm as ChatOpenAI).predictMessages(
-        promptValue.toChatMessages(),
-        valuesForLLM,
-        callbackManager,
-      );
-    }
+    const message = await (llm as 
+      Runnable<
+        BaseLanguageModelInput,
+        BaseMessageChunk,
+        ChatOpenAICallOptions
+      >
+    ).invoke(promptValue.toChatMessages(), {
+      ...valuesForLLM,
+      callbacks: callbackManager,
+    });
     return this.outputParser.parseAIMessage(message);
   }
 }

--- a/langchain/src/agents/openai/index.ts
+++ b/langchain/src/agents/openai/index.ts
@@ -1,5 +1,5 @@
 import { CallbackManager } from "../../callbacks/manager.js";
-import { ChatOpenAI } from "../../chat_models/openai.js";
+import { ChatOpenAI, ChatOpenAICallOptions } from "../../chat_models/openai.js";
 import { BasePromptTemplate } from "../../prompts/base.js";
 import {
   AIMessage,
@@ -10,6 +10,7 @@ import {
   FunctionMessage,
   ChainValues,
   SystemMessage,
+  BaseMessageChunk,
 } from "../../schema/index.js";
 import { StructuredTool } from "../../tools/base.js";
 import { Agent, AgentArgs } from "../agent.js";
@@ -21,13 +22,20 @@ import {
   MessagesPlaceholder,
   SystemMessagePromptTemplate,
 } from "../../prompts/chat.js";
-import { BaseLanguageModel } from "../../base_language/index.js";
+import {
+  BaseLanguageModel,
+  BaseLanguageModelInput,
+} from "../../base_language/index.js";
 import { LLMChain } from "../../chains/llm_chain.js";
 import {
   FunctionsAgentAction,
   OpenAIFunctionsAgentOutputParser,
 } from "./output_parser.js";
 import { formatToOpenAIFunction } from "../../tools/convert_to_openai.js";
+import { Runnable } from "../../schema/runnable/base.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CallOptionsIfAvailable<T> = T extends { CallOptions: infer CO } ? CO : any;
 
 /**
  * Checks if the given action is a FunctionsAgentAction.
@@ -199,28 +207,49 @@ export class OpenAIAgent extends Agent {
     }
 
     // Split inputs between prompt and llm
-    const llm = this.llmChain.llm as ChatOpenAI;
+    const llm = this.llmChain.llm as
+      | ChatOpenAI
+      | Runnable<
+          BaseLanguageModelInput,
+          BaseMessageChunk,
+          ChatOpenAICallOptions
+        >;
+
     const valuesForPrompt = { ...newInputs };
-    const valuesForLLM: (typeof llm)["CallOptions"] = {
+    const valuesForLLM: CallOptionsIfAvailable<typeof llm> = {
       functions: this.tools.map(formatToOpenAIFunction),
     };
     const callKeys =
       "callKeys" in this.llmChain.llm ? this.llmChain.llm.callKeys : [];
     for (const key of callKeys) {
       if (key in inputs) {
-        valuesForLLM[key as keyof (typeof llm)["CallOptions"]] = inputs[key];
+        valuesForLLM[key as keyof CallOptionsIfAvailable<typeof llm>] =
+          inputs[key];
         delete valuesForPrompt[key];
       }
     }
 
-    const promptValue = await this.llmChain.prompt.formatPromptValue(
-      valuesForPrompt
-    );
-    const message = await llm.predictMessages(
-      promptValue.toChatMessages(),
-      valuesForLLM,
-      callbackManager
-    );
+    const promptValue =
+      await this.llmChain.prompt.formatPromptValue(valuesForPrompt);
+
+    let message: BaseMessage;
+    if (Runnable.isRunnable(llm)) {
+      message = await (
+        llm as Runnable<
+          BaseLanguageModelInput,
+          BaseMessageChunk,
+          ChatOpenAICallOptions
+        >
+      ).invoke(promptValue.toChatMessages(), {
+        callbacks: callbackManager,
+      });
+    } else {
+      message = await (llm as ChatOpenAI).predictMessages(
+        promptValue.toChatMessages(),
+        valuesForLLM,
+        callbackManager,
+      );
+    }
     return this.outputParser.parseAIMessage(message);
   }
 }

--- a/langchain/src/agents/openai/index.ts
+++ b/langchain/src/agents/openai/index.ts
@@ -229,11 +229,12 @@ export class OpenAIAgent extends Agent {
       }
     }
 
-    const promptValue =
-      await this.llmChain.prompt.formatPromptValue(valuesForPrompt);
+    const promptValue = await this.llmChain.prompt.formatPromptValue(
+      valuesForPrompt
+    );
 
-    const message = await (llm as 
-      Runnable<
+    const message = await (
+      llm as Runnable<
         BaseLanguageModelInput,
         BaseMessageChunk,
         ChatOpenAICallOptions

--- a/langchain/src/agents/tests/runnable.int.test.ts
+++ b/langchain/src/agents/tests/runnable.int.test.ts
@@ -61,7 +61,7 @@ test("Runnable variant", async () => {
 
   const query = "What is the weather in New York?";
   console.log(`Calling agent executor with query: ${query}`);
-  const result = await executor.call({
+  const result = await executor.invoke({
     input: query,
   });
   console.log(result);
@@ -75,9 +75,15 @@ test("Runnable variant works with executor", async () => {
     temperature: 0,
   }).bind({});
 
+  const prompt = ChatPromptTemplate.fromMessages([
+    ["ai", "You are a helpful assistant"],
+    ["human", "{input}"],
+    new MessagesPlaceholder("agent_scratchpad"),
+  ]);
+
   // Prepare agent chain
   const llmChain = new LLMChain({
-    prompt: ChatPromptTemplate.fromTemplate("What is the weather in New York?"),
+    prompt,
     llm: runnableModel,
   });
   const agent = new OpenAIAgent({
@@ -90,5 +96,9 @@ test("Runnable variant works with executor", async () => {
     agent,
     tools,
   });
-  await executor.call({});
+  const result = await executor.invoke({
+    input: "What is the weather in New York?",
+  });
+
+  console.log(result);
 });


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
Handles the case when an `OpenAIAgent` is called with `.plan` on an `llmChain` instantiated with a `Runnable` instead of a regular chat model. Currently, this case is not handled and results in an error: `TypeError: llm.predictMessages is not a function`. This resolves the bug by checking if it's runnable and appropriately calling `runnable.invoke`

<!-- Remove if not applicable -->

Fixes #3344
