### PR TITLE
feat: add support for collection name in PG Vector

### DIFF
--- a/langchain/src/vectorstores/pgvector.ts
+++ b/langchain/src/vectorstores/pgvector.ts
@@ -149,7 +149,9 @@ export class PGVectorStore extends VectorStore {
       SELECT uuid from ${this.collectionTableName}
       WHERE name = $1;
     `;
-    const queryResult = await this.pool.query(queryString, [this.collectionName]);
+    const queryResult = await this.pool.query(queryString, [
+      this.collectionName,
+    ]);
     let collectionId = queryResult.rows[0]?.uuid;
 
     if (!collectionId) {
@@ -166,7 +168,10 @@ export class PGVectorStore extends VectorStore {
         )
         RETURNING uuid;
       `;
-      const insertResult = await this.pool.query(insertString, [this.collectionName, this.collectionMetadata]);
+      const insertResult = await this.pool.query(insertString, [
+        this.collectionName,
+        this.collectionMetadata,
+      ]);
       collectionId = insertResult.rows[0]?.uuid;
     }
 
@@ -180,7 +185,10 @@ export class PGVectorStore extends VectorStore {
    * @param numOfColumns - The number of columns we are inserting data into.
    * @returns The SQL placeholders for the row values.
    */
-  private generatePlaceholderForRowAt(index: number, numOfColumns: number): string {
+  private generatePlaceholderForRowAt(
+    index: number,
+    numOfColumns: number
+  ): string {
     const placeholders = [];
     for (let i = 0; i < numOfColumns; i += 1) {
       placeholders.push(`$${index * numOfColumns + i + 1}`);
@@ -204,7 +212,7 @@ export class PGVectorStore extends VectorStore {
     const columns = [
       this.contentColumnName,
       this.vectorColumnName,
-      this.metadataColumnName
+      this.metadataColumnName,
     ];
 
     if (collectionId) {
@@ -303,9 +311,7 @@ export class PGVectorStore extends VectorStore {
       LIMIT $3;
     `;
 
-    const documents = (
-      await this.pool.query(queryString, parameters)
-    ).rows;
+    const documents = (await this.pool.query(queryString, parameters)).rows;
 
     const results = [] as [Document, number][];
     for (const doc of documents) {
@@ -365,7 +371,7 @@ export class PGVectorStore extends VectorStore {
           ON DELETE CASCADE;
       `);
     } catch (e) {
-      if (!(e as Error).message.includes('already exists')) {
+      if (!(e as Error).message.includes("already exists")) {
         console.error(e);
         throw new Error(`Error adding column: ${(e as Error).message}`);
       }

--- a/langchain/src/vectorstores/tests/pgvector.int.test.ts
+++ b/langchain/src/vectorstores/tests/pgvector.int.test.ts
@@ -18,6 +18,8 @@ describe("PGVectorStore", () => {
         database: "api",
       } as PoolConfig,
       tableName: "testlangchain",
+      collectionTableName: "langchain_pg_collection",
+      collectionName: "langchain",
       columns: {
         idColumnName: "id",
         vectorColumnName: "vector",


### PR DESCRIPTION
## Description
This PR adds support for collection names in the PG Vector store integration that currently [already exists](https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/vectorstores/pgvector.py#L113) in the python version of langchain. Collections add a nice way to logically group document embeddings in the vector store. My specific use case is around privilege preservation of certain types of documents. I'm creating and loading my embeddings table from the python version, but I'd like to be able to query it using the javascript version.

The gist of it is there's another table added and a foreign key referencing the uuid from the collections table. My goal is to make this a seamless addition by not causing any breaking changes to anyone not already using collections. So I updated the creation and insert logic to conditionally support the collection feature also, not just the query logic. Let me know if there's a better way to introduce this change or an easier approach.

## Alternatives Considered
I thought about using a filter, however filters are currently implemented in a way that only applies to metadata. So then I thought about abandoning collections altogether and using some field of the metadata, but I found that the metadata fields are too inconsistent across different document loaders for that to be a valuable approach. Plus I think the goal of this library is to eventually reach feature parity with the python version.

## Testing
To test this, I ran a local build with my changes implemented into my client. I also ran a modified version of the pgvector example in `examples/src/indexes/vector_stores/pgvector_vectorstore/pgvector.ts` to make sure that each branch of logic worked the way that I would expect it to.