### PR TITLE
Adds option to only allow specified file types

### DIFF
--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -86,6 +86,7 @@ export interface GithubRepoLoaderParams extends AsyncCallerParams {
   accessToken?: string;
   ignoreFiles?: (string | RegExp)[];
   ignorePaths?: string[];
+  onlyAllowFileTypes: string[];
   verbose?: boolean;
   /**
    * The maximum number of concurrent calls that can be made. Defaults to 2.
@@ -143,6 +144,8 @@ export class GithubRepoLoader
 
   public ignorePaths?: string[];
 
+  public onlyAllowFileTypes?: string[];
+
   private submoduleInfos: SubmoduleInfo[];
 
   constructor(
@@ -156,6 +159,7 @@ export class GithubRepoLoader
       processSubmodules = false,
       unknown = UnknownHandling.Warn,
       ignoreFiles = [],
+      onlyAllowFileTypes = [],
       ignorePaths,
       verbose = false,
       maxConcurrency = 2,
@@ -172,6 +176,7 @@ export class GithubRepoLoader
     this.initialPath = path;
     this.branch = branch;
     this.recursive = recursive;
+    this.onlyAllowFileTypes = onlyAllowFileTypes;
     // processing submodules without processing contents of other directories makes no sense
     if (processSubmodules && !recursive) {
       throw new Error(
@@ -368,6 +373,7 @@ export class GithubRepoLoader
         processSubmodules: this.processSubmodules,
         unknown: this.unknown,
         ignoreFiles: this.ignoreFiles,
+        onlyAllowFileTypes: this.onlyAllowFileTypes,
         ignorePaths: this.ignorePaths,
         verbose: this.verbose,
         maxConcurrency: this.maxConcurrency,
@@ -389,6 +395,9 @@ export class GithubRepoLoader
     }
     if (this.ignore !== undefined) {
       return this.ignore.ignores(path);
+    }
+    if(this.onlyAllowFileTypes && this.onlyAllowFileTypes.length > 0) {
+      return !this.onlyAllowFileTypes.includes(fileType);
     }
     return (
       fileType !== "dir" &&


### PR DESCRIPTION
Adds a new parameter to github loader which will contain an array of allowed file types e.g ["js", "html", "ts"] - currently this process is arduous as you have to select which files/paths you *don't* want (which could be a lot) rather than what you *do* want.

Fixes # (issue)

https://github.com/langchain-ai/langchainjs/issues/3360
