### PR TITLE
feat: update version of closevector-web and its usage

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -1025,7 +1025,7 @@
     "chromadb": "*",
     "closevector-common": "0.1.0-alpha.1",
     "closevector-node": "0.1.0-alpha.10",
-    "closevector-web": "0.1.0-alpha.16",
+    "closevector-web": "0.1.0-alpha.17",
     "cohere-ai": ">=6.0.0",
     "convex": "^1.3.1",
     "d3-dsv": "^2.0.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -1025,7 +1025,7 @@
     "chromadb": "*",
     "closevector-common": "0.1.0-alpha.1",
     "closevector-node": "0.1.0-alpha.10",
-    "closevector-web": "0.1.0-alpha.17",
+    "closevector-web": "0.1.0-alpha.18",
     "cohere-ai": ">=6.0.0",
     "convex": "^1.3.1",
     "d3-dsv": "^2.0.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -907,7 +907,7 @@
     "chromadb": "^1.5.3",
     "closevector-common": "0.1.0-alpha.1",
     "closevector-node": "0.1.0-alpha.10",
-    "closevector-web": "0.1.0-alpha.15",
+    "closevector-web": "0.1.0-alpha.18",
     "cohere-ai": ">=6.0.0",
     "convex": "^1.3.1",
     "d3-dsv": "^2.0.0",

--- a/langchain/src/vectorstores/closevector/web.ts
+++ b/langchain/src/vectorstores/closevector/web.ts
@@ -59,13 +59,13 @@ export class CloseVectorWeb extends CloseVector<CloseVectorHNSWWeb> {
       uuid?: string;
     }
   ) {
-    if (!this.instance.uuid && !options.uuid) {
+    const _options = options;
+    if (!this.instance.uuid && !_options.uuid) {
       throw new Error("No uuid provided");
     }
-    if (!this.instance.uuid) {
-      this.instance._uuid = options.uuid;
+    if (this.instance.uuid && !_options.uuid) {
+      _options.uuid = this.instance.uuid;
     }
-    await this.save(this.instance.uuid);
     await this.instance.saveToCloud(options);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22441,7 +22441,7 @@ __metadata:
     chromadb: "*"
     closevector-common: 0.1.0-alpha.1
     closevector-node: 0.1.0-alpha.10
-    closevector-web: 0.1.0-alpha.16
+    closevector-web: 0.1.0-alpha.17
     cohere-ai: ">=6.0.0"
     convex: ^1.3.1
     d3-dsv: ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -14667,9 +14667,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"closevector-web@npm:0.1.0-alpha.15":
-  version: 0.1.0-alpha.15
-  resolution: "closevector-web@npm:0.1.0-alpha.15"
+"closevector-web@npm:0.1.0-alpha.18":
+  version: 0.1.0-alpha.18
+  resolution: "closevector-web@npm:0.1.0-alpha.18"
   dependencies:
     axios: ^1.4.0
     closevector-browserify-zlib: 0.1.0-alpha.3
@@ -14680,7 +14680,7 @@ __metadata:
     gunzip-maybe: ^1.4.2
     tar-stream: ^3.1.6
     typescript: ^5.1.6
-  checksum: 2f8b0b53b0aa944a00ffda9215d5b3ddafedbae3bee7e78ed49d0b183b03f2ec6340876a21b020381f2e193578b29e067f76ca0e4c34c10d439232147c93ace8
+  checksum: b7fa154ccf3b1600b09abe870b937d159931d113fae5176a321afaaba519f2a8033c54f4e774b3ce58c08dab2c71d0a086a4001b42899599e383838e0fc5a429
   languageName: node
   linkType: hard
 
@@ -22307,7 +22307,7 @@ __metadata:
     chromadb: ^1.5.3
     closevector-common: 0.1.0-alpha.1
     closevector-node: 0.1.0-alpha.10
-    closevector-web: 0.1.0-alpha.15
+    closevector-web: 0.1.0-alpha.18
     cohere-ai: ">=6.0.0"
     convex: ^1.3.1
     d3-dsv: ^2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -22441,7 +22441,7 @@ __metadata:
     chromadb: "*"
     closevector-common: 0.1.0-alpha.1
     closevector-node: 0.1.0-alpha.10
-    closevector-web: 0.1.0-alpha.17
+    closevector-web: 0.1.0-alpha.18
     cohere-ai: ">=6.0.0"
     convex: ^1.3.1
     d3-dsv: ^2.0.0


### PR DESCRIPTION
Hi, I'm currently updating the version of CloseVector-Web. This update is necessary because the previous version requires setting a private attribute _uuid.