### PR TITLE
Fixed JSON parsePartialJson  undefined value

### DIFF
--- a/langchain/src/output_parsers/json.ts
+++ b/langchain/src/output_parsers/json.ts
@@ -2,6 +2,11 @@
 // MIT License
 
 export function parsePartialJson(s: string) {
+  // If the input is undefined, return null to indicate failure.
+  if (typeof s === "undefined") {
+    return null;
+  }
+
   // Attempt to parse the string as-is.
   try {
     return JSON.parse(s);


### PR DESCRIPTION
Fixed JSON parsePartialJson issue. It will happen when using `JsonOutputFunctionsParser` with the stream method.
```
TypeError: s is not iterable
    at parsePartialJson (langchain@0.0.196_@opensearch-project+opensearch@1.2.0_axios@1.3.2/node_modules/langchain/dist/output_parsers/json.js:18:22)
    at JsonOutputFunctionsParser.parsePartialResult (langchain@0.0.196_@opensearch-project+opensearch@1.2.0_axios@1.3.2/node_modules/langchain/dist/output_parsers/openai_functions.js:115:20)
```

<img width="634" alt="Screenshot 2023-11-27 at 1 13 09 AM" src="https://github.com/langchain-ai/langchainjs/assets/289419/4c516304-b8d8-469b-82d7-307fc748b1e8">

---

### Environments:
- package: `langchain: ^0.0.196`

### Reproduce:
```typescript
new ChatOpenAI({
  temperature: 0.9,
  azureOpenAIApiKey: `API_KEY`,
  azureOpenAIApiVersion: "2023-09-01-preview",
  azureOpenAIApiDeploymentName: "gpt-4-32k",
  azureOpenAIBasePath: `${OPENAI_ENDPOINT}/openai/deployments`,
})

const stream = await chat.bind({
  functions: [extractionFunctionSchema],
  function_call: { name: "extractor" }, 
})
.pipe(new JsonOutputFunctionsParser())
.stream([
    new HumanMessage(
        "what a beautiful day?"
    )]
);

for await (const chunk of stream) {
  console.log(chunk);
}
```

### Result:


| before   | after   |
|---|---|
| <img width="1016" alt="Screenshot 2023-11-27 at 1 09 53 AM" src="https://github.com/langchain-ai/langchainjs/assets/289419/d660800e-7566-4087-8ce8-de266c7bc519">  |   <img width="571" alt="Screenshot 2023-11-27 at 1 22 24 AM" src="https://github.com/langchain-ai/langchainjs/assets/289419/81feb122-f1c1-470e-9424-0e7628a133dc"> |

