### PR TITLE
Fix null or undefined records causing error in Xata similarity search method

### DIFF
--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -128,20 +128,22 @@ export class XataVectorSearch<
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return records?.map((record: any) => [
-      new Document({
-        pageContent: record.content,
-        metadata: Object.fromEntries(
-          Object.entries(record).filter(
-            ([key]) =>
-              key !== "content" &&
-              key !== "embedding" &&
-              key !== "xata" &&
-              key !== "id"
-          )
-        ),
-      }),
-      record.xata.score,
-    ]) ?? [];
+    return (
+      records?.map((record: any) => [
+        new Document({
+          pageContent: record.content,
+          metadata: Object.fromEntries(
+            Object.entries(record).filter(
+              ([key]) =>
+                key !== "content" &&
+                key !== "embedding" &&
+                key !== "xata" &&
+                key !== "id"
+            )
+          ),
+        }),
+        record.xata.score,
+      ]) ?? []
+    );
   }
 }

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -127,28 +127,21 @@ export class XataVectorSearch<
       }
     );
 
-    let results;
-    if (records) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      results = records?.map((record) => [
-        new Document({
-          pageContent: record.content,
-          metadata: Object.fromEntries(
-            Object.entries(record).filter(
-              ([key]) =>
-                key !== "content" &&
-                key !== "embedding" &&
-                key !== "xata" &&
-                key !== "id"
-            )
-          ),
-        }),
-        record.xata.score,
-      ]);
-    } else {
-      results = [];
-    }
-
-    return results;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return records?.map((record) => [
+      new Document({
+        pageContent: record.content,
+        metadata: Object.fromEntries(
+          Object.entries(record).filter(
+            ([key]) =>
+              key !== "content" &&
+              key !== "embedding" &&
+              key !== "xata" &&
+              key !== "id"
+          )
+        ),
+      }),
+      record.xata.score,
+    ]) ?? [];
   }
 }

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -128,7 +128,7 @@ export class XataVectorSearch<
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return records?.map((record) => [
+    return records?.map((record: any) => [
       new Document({
         pageContent: record.content,
         metadata: Object.fromEntries(

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -127,21 +127,28 @@ export class XataVectorSearch<
       }
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return records.map((record: any) => [
-      new Document({
-        pageContent: record.content,
-        metadata: Object.fromEntries(
-          Object.entries(record).filter(
-            ([key]) =>
-              key !== "content" &&
-              key !== "embedding" &&
-              key !== "xata" &&
-              key !== "id"
-          )
-        ),
-      }),
-      record.xata.score,
-    ]);
+    let results;
+    if (records) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      results = records?.map((record) => [
+        new Document({
+          pageContent: record.content,
+          metadata: Object.fromEntries(
+            Object.entries(record).filter(
+              ([key]) =>
+                key !== "content" &&
+                key !== "embedding" &&
+                key !== "xata" &&
+                key !== "id"
+            )
+          ),
+        }),
+        record.xata.score,
+      ]);
+    } else {
+      results = [];
+    }
+
+    return results;
   }
 }


### PR DESCRIPTION
This pull request fixes an issue where null or undefined records were causing an error in the Xata similarity search method. The method now checks if the records exist before processing them, and returns an empty array if they are null or undefined. This prevents the error from occurring and ensures the method can handle all types of records properly.

Fixes #3418