### PR TITLE
Make undefined input optional

### DIFF
--- a/langchain/src/vectorstores/weaviate.ts
+++ b/langchain/src/vectorstores/weaviate.ts
@@ -346,7 +346,7 @@ export class WeaviateStore extends VectorStore {
   override async maxMarginalRelevanceSearch(
     query: string,
     options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>,
-    _callbacks: undefined
+    _callbacks?: undefined
   ): Promise<Document[]> {
     const { k, fetchK = 20, lambda = 0.5, filter } = options;
     const queryEmbedding: number[] = await this.embeddings.embedQuery(query);


### PR DESCRIPTION
Type is undefined but before this PR it was required which doesn't make sense.
Was also causing `examples/` build to fail with this type error