### PR TITLE
export InitializeAgentExecutorOptionsStructured

### DIFF
--- a/langchain/src/agents/index.ts
+++ b/langchain/src/agents/index.ts
@@ -42,6 +42,7 @@ export {
   initializeAgentExecutor,
   initializeAgentExecutorWithOptions,
   type InitializeAgentExecutorOptions,
+  type InitializeAgentExecutorOptionsStructured,
 } from "./initialize.js";
 export {
   ZeroShotAgent,


### PR DESCRIPTION
I had a use-case to wrap the construction of the "default" agents that can be constructed with `initializeAgentExecutorWithOptions`. 

There is a structured and non-structured version of this function:

```ts

/**
 * Initialize an agent executor with options
 * @param tools Array of tools to use in the agent
 * @param llm LLM or ChatModel to use in the agent
 * @param options Options for the agent, including agentType, agentArgs, and other options for AgentExecutor.fromAgentAndTools
 * @returns AgentExecutor
 */
export declare function initializeAgentExecutorWithOptions(tools: StructuredTool[], llm: BaseLanguageModel, options: InitializeAgentExecutorOptionsStructured): Promise<AgentExecutor>;
export declare function initializeAgentExecutorWithOptions(tools: Tool[], llm: BaseLanguageModel, options?: InitializeAgentExecutorOptions): Promise<AgentExecutor>;
```

While `InitializeAgentExecutorOptions` is exported from `initialize.ts`, `InitializeAgentExecutorOptionsStructured` is not.

So, to maintain type safety, I have to import from langchain/dist, which does indeed export `InitializeAgentExecutorOptionsStructured`. This seems like a small oversight! 

my use case:

```ts
import {
  initializeAgentExecutorWithOptions,
  type InitializeAgentExecutorOptions,
} from "langchain/agents";
import { type InitializeAgentExecutorOptionsStructured } from "langchain/dist/agents/initialize";
...
let executor;
let options:
    | InitializeAgentExecutorOptions
    | InitializeAgentExecutorOptionsStructured;
if (isStructured) { 
    options = ...
} else {
    options = ...
}

executor = await initializeAgentExecutorWithOptions(
  tools,
  llm,
  options,
);
```