### PR TITLE
Fix for Prisma vectorstore build query IN filter

### DIFF
--- a/langchain/src/vectorstores/prisma.ts
+++ b/langchain/src/vectorstores/prisma.ts
@@ -436,7 +436,7 @@ export class PrismaVectorStore<
                   )}`
                 );
               }
-              return this.Prisma.sql`${colRaw} ${opRaw} (${value.join(",")})`;
+              return this.Prisma.sql`${colRaw} ${opRaw} (${this.Prisma.join(value)})`;
             }
             case OpMap.isNull:
             case OpMap.isNotNull:


### PR DESCRIPTION
Fixing an issue, where the `IN` query filter created an incorrect value syntax by joining the values as a single value `("value1,value2")`. By using the Prisma join, the syntax is corrected again `("value1","value2")`.

Fixes #3460 
