### PR TITLE
feat: add inference for RunnableMap output

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -29,11 +29,15 @@ export type RunnableFunc<RunInput, RunOutput> = (
   }
 ) => RunOutput | Promise<RunOutput>;
 
+export type RunnableMapLike<RunInput, RunOutput extends Record<string, any>> = {
+  [K in keyof RunOutput]: RunnableLike<RunInput, RunOutput[K]>
+} 
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RunnableLike<RunInput = any, RunOutput = any> =
   | Runnable<RunInput, RunOutput>
   | RunnableFunc<RunInput, RunOutput>
-  | { [key: string]: RunnableLike<RunInput, RunOutput> };
+  | RunnableMapLike<RunInput, Record<string, any> & RunOutput>;
 
 export type RunnableBatchOptions = {
   maxConcurrency?: number;
@@ -1402,10 +1406,9 @@ export class RunnableSequence<
  * const result = await mapChain.invoke({ topic: "bear" });
  * ```
  */
-export class RunnableMap<RunInput> extends Runnable<
+export class RunnableMap<RunInput, RunOutput extends Record<string, any> = Record<string, any>> extends Runnable<
   RunInput,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Record<string, any>
+  RunOutput
 > {
   static lc_name() {
     return "RunnableMap";
@@ -1421,7 +1424,7 @@ export class RunnableMap<RunInput> extends Runnable<
     return Object.keys(this.steps);
   }
 
-  constructor(fields: { steps: Record<string, RunnableLike<RunInput>> }) {
+  constructor(fields: { steps: RunnableMapLike<RunInput, RunOutput> }) {
     super(fields);
     this.steps = {};
     for (const [key, value] of Object.entries(fields.steps)) {
@@ -1429,15 +1432,17 @@ export class RunnableMap<RunInput> extends Runnable<
     }
   }
 
-  static from<RunInput>(steps: Record<string, RunnableLike<RunInput>>) {
-    return new RunnableMap<RunInput>({ steps });
+  static from<RunInput, RunOutput extends Record<string, any> = Record<string, any>>(
+    steps: RunnableMapLike<RunInput, RunOutput>
+  ): RunnableMap<RunInput, RunOutput> {
+    return new RunnableMap<RunInput, RunOutput>({ steps });
   }
 
   async invoke(
     input: RunInput,
     options?: Partial<BaseCallbackConfig>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Promise<Record<string, any>> {
+  ): Promise<RunOutput> {
     const callbackManager_ = await getCallbackMangerForConfig(options);
     const runManager = await callbackManager_?.handleChainStart(
       this.toJSON(),
@@ -1466,7 +1471,7 @@ export class RunnableMap<RunInput> extends Runnable<
       throw e;
     }
     await runManager?.handleChainEnd(output);
-    return output;
+    return output as RunOutput;
   }
 }
 
@@ -1699,7 +1704,7 @@ export function _coerceToRunnable<RunInput, RunOutput>(
     for (const [key, value] of Object.entries(coerceable)) {
       runnables[key] = _coerceToRunnable(value);
     }
-    return new RunnableMap<RunInput>({
+    return new RunnableMap({
       steps: runnables,
     }) as unknown as Runnable<RunInput, Exclude<RunOutput, Error>>;
   } else {

--- a/langchain-core/src/runnables/tests/runnable.test.ts
+++ b/langchain-core/src/runnables/tests/runnable.test.ts
@@ -22,7 +22,7 @@ import {
   FakeRunnable,
   FakeListChatModel,
 } from "../../utils/testing/index.js";
-import { RunnableSequence, RunnableMap, RunnableLambda, Runnable, RunnableMapLike, _coerceToRunnable, RunnableFunc, RunnableLike } from "../base.js";
+import { RunnableSequence, RunnableMap, RunnableLambda, _coerceToRunnable } from "../base.js";
 import { RouterRunnable } from "../router.js";
 import { Document } from "../../documents/document.js";
 

--- a/langchain-core/src/runnables/tests/runnable.test.ts
+++ b/langchain-core/src/runnables/tests/runnable.test.ts
@@ -22,7 +22,7 @@ import {
   FakeRunnable,
   FakeListChatModel,
 } from "../../utils/testing/index.js";
-import { RunnableSequence, RunnableMap, RunnableLambda } from "../base.js";
+import { RunnableSequence, RunnableMap, RunnableLambda, Runnable, RunnableMapLike, _coerceToRunnable, RunnableFunc, RunnableLike } from "../base.js";
 import { RouterRunnable } from "../router.js";
 import { Document } from "../../documents/document.js";
 
@@ -80,16 +80,18 @@ test("Create a runnable sequence with a runnable map", async () => {
       `Context:\n{documents}\n\nQuestion:\n{question}`
     ),
   ]);
+
   const llm = new FakeChatModel({});
   const inputs = {
-    question: (input: string) => input,
+    question: ((input: string) => input),
     documents: RunnableSequence.from([
       new FakeRetriever(),
       (docs: Document[]) => JSON.stringify(docs),
     ]),
     extraField: new FakeLLM({}),
   };
-  const runnable = new RunnableMap({ steps: inputs })
+
+  const runnable = new RunnableMap<string>({ steps: inputs })
     .pipe(promptTemplate)
     .pipe(llm);
   const result = await runnable.invoke("Do you know the Muffin Man?");


### PR DESCRIPTION
This PR adds a new RunnableMapLike type that helps with type inference when using RunnableMaps. Currently, RunnableMaps only output `Record<string, any>`. This allows the output type to be narrowed, which helps with type safety when composing multiple Runnables together.

This works when building RunnableMaps using the `from` methods or constructor
<img width="595" alt="image" src="https://github.com/langchain-ai/langchainjs/assets/5846912/4e45528f-7f25-4f5a-b456-aa173b610948">


And also when composing RunnableMaps in within a RunnableSequence
<img width="456" alt="image" src="https://github.com/langchain-ai/langchainjs/assets/5846912/ea09ca82-c6ff-4d6c-84a8-df2b75cf7369">

