### PR TITLE
Added extra chat message class to types for history

### DIFF
--- a/langchain-core/src/chat_history.ts
+++ b/langchain-core/src/chat_history.ts
@@ -32,33 +32,3 @@ export abstract class BaseListChatMessageHistory extends Serializable {
     return this.addMessage(new AIMessage(message));
   }
 }
-
-export class FakeChatMessageHistory extends BaseChatMessageHistory {
-  lc_namespace = ["langchain", "core", "message", "fake"];
-
-  messages: Array<BaseMessage> = [];
-
-  constructor() {
-    super();
-  }
-
-  async getMessages(): Promise<BaseMessage[]> {
-    return this.messages;
-  }
-
-  async addMessage(message: BaseMessage): Promise<void> {
-    this.messages.push(message);
-  }
-
-  async addUserMessage(message: string): Promise<void> {
-    this.messages.push(new HumanMessage(message));
-  }
-
-  async addAIChatMessage(message: string): Promise<void> {
-    this.messages.push(new AIMessage(message));
-  }
-
-  async clear(): Promise<void> {
-    this.messages = [];
-  }
-}

--- a/langchain-core/src/runnables/history.ts
+++ b/langchain-core/src/runnables/history.ts
@@ -1,5 +1,5 @@
 import { BaseCallbackConfig } from "../callbacks/manager.js";
-import { BaseChatMessageHistory } from "../chat_history.js";
+import { BaseChatMessageHistory, BaseListChatMessageHistory } from "../chat_history.js";
 import {
   AIMessage,
   BaseMessage,
@@ -19,7 +19,7 @@ import { RunnablePassthrough } from "./passthrough.js";
 type GetSessionHistoryCallable = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...args: Array<any>
-) => Promise<BaseChatMessageHistory>;
+) => Promise<BaseChatMessageHistory | BaseListChatMessageHistory>;
 
 export class RunnableWithMessageHistory<
   RunInput,

--- a/langchain-core/src/runnables/tests/runnable_history.test.ts
+++ b/langchain-core/src/runnables/tests/runnable_history.test.ts
@@ -4,9 +4,14 @@ import { RunnableConfig } from "../config.js";
 import { RunnableWithMessageHistory } from "../history.js";
 import {
   BaseChatMessageHistory,
-  FakeChatMessageHistory,
+  BaseListChatMessageHistory,
 } from "../../chat_history.js";
+import {
+  FakeChatMessageHistory,
+  FakeListChatMessageHistory,
+} from "../../utils/testing/index.js";
 
+// For `BaseChatMessageHistory`
 async function getGetSessionHistory(): Promise<
   (sessionId: string) => Promise<BaseChatMessageHistory>
 > {
@@ -17,6 +22,24 @@ async function getGetSessionHistory(): Promise<
   ): Promise<BaseChatMessageHistory> {
     if (!(sessionId in chatHistoryStore)) {
       chatHistoryStore[sessionId] = new FakeChatMessageHistory();
+    }
+    return chatHistoryStore[sessionId];
+  }
+
+  return getSessionHistory;
+}
+
+// Extends `BaseListChatMessageHistory`
+async function getListSessionHistory(): Promise<
+  (sessionId: string) => Promise<BaseListChatMessageHistory>
+> {
+  const chatHistoryStore: { [key: string]: BaseListChatMessageHistory } = {};
+
+  async function getSessionHistory(
+    sessionId: string
+  ): Promise<BaseListChatMessageHistory> {
+    if (!(sessionId in chatHistoryStore)) {
+      chatHistoryStore[sessionId] = new FakeListChatMessageHistory();
     }
     return chatHistoryStore[sessionId];
   }
@@ -38,6 +61,28 @@ test("Runnable with message history", async () => {
     runnable,
     config: {},
     getMessageHistory,
+  });
+  const config: RunnableConfig = { configurable: { sessionId: "1" } };
+  let output = await withHistory.invoke([new HumanMessage("hello")], config);
+  expect(output).toBe("you said: hello");
+  output = await withHistory.invoke([new HumanMessage("good bye")], config);
+  expect(output).toBe("you said: hello\ngood bye");
+});
+
+test("Runnable with message history work with chat list memory", async () => {
+  const runnable = new RunnableLambda({
+    func: (messages: BaseMessage[]) =>
+      `you said: ${messages
+        .filter((m) => m._getType() === "human")
+        .map((m) => m.content)
+        .join("\n")}`,
+  });
+
+  const getListMessageHistory = await getListSessionHistory();
+  const withHistory = new RunnableWithMessageHistory({
+    runnable,
+    config: {},
+    getMessageHistory: getListMessageHistory,
   });
   const config: RunnableConfig = { configurable: { sessionId: "1" } };
   let output = await withHistory.invoke([new HumanMessage("hello")], config);

--- a/langchain-core/src/utils/testing/index.ts
+++ b/langchain-core/src/utils/testing/index.ts
@@ -5,6 +5,10 @@ import {
   BaseCallbackConfig,
   CallbackManagerForLLMRun,
 } from "../../callbacks/manager.js";
+import {
+  BaseChatMessageHistory,
+  BaseListChatMessageHistory,
+} from "../../chat_history.js";
 import { Document } from "../../documents/document.js";
 import {
   BaseChatModel,
@@ -15,6 +19,7 @@ import {
   BaseMessage,
   AIMessage,
   AIMessageChunk,
+  HumanMessage,
 } from "../../messages/index.js";
 import { BaseOutputParser } from "../../output_parsers/base.js";
 import {
@@ -286,5 +291,49 @@ export class FakeListChatModel extends BaseChatModel {
     } else {
       this.i = 0;
     }
+  }
+}
+
+export class FakeChatMessageHistory extends BaseChatMessageHistory {
+  lc_namespace = ["langchain_core", "message", "fake"];
+
+  messages: Array<BaseMessage> = [];
+
+  constructor() {
+    super();
+  }
+
+  async getMessages(): Promise<BaseMessage[]> {
+    return this.messages;
+  }
+
+  async addMessage(message: BaseMessage): Promise<void> {
+    this.messages.push(message);
+  }
+
+  async addUserMessage(message: string): Promise<void> {
+    this.messages.push(new HumanMessage(message));
+  }
+
+  async addAIChatMessage(message: string): Promise<void> {
+    this.messages.push(new AIMessage(message));
+  }
+
+  async clear(): Promise<void> {
+    this.messages = [];
+  }
+}
+
+export class FakeListChatMessageHistory extends BaseListChatMessageHistory {
+  lc_namespace = ["langchain_core", "message", "fake"];
+
+  messages: Array<BaseMessage> = [];
+
+  constructor() {
+    super();
+  }
+
+  public async addMessage(message: BaseMessage): Promise<void> {
+    this.messages.push(message);
   }
 }


### PR DESCRIPTION
Original implementation required `BaseChatMessageHistory` (matches python) but there are _zero_  classes which extend from that in JS...

This PR adds another base class which the memory can extend from: `BaseListChatMessageHistory`