### PR TITLE
Fix records?.map is not a function bug in XataVectorStores

### DIFF
--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -118,7 +118,7 @@ export class XataVectorSearch<
     k: number,
     filter?: XataFilter | undefined
   ): Promise<[Document, number][]> {
-    const records = await this.client.db[this.table].vectorSearch(
+    const { records } = await this.client.db[this.table].vectorSearch(
       "embedding",
       query,
       {


### PR DESCRIPTION
This pull request fixes a bug in the XataVectorStores module where the records?.map function was throwing an error. The bug was caused by incorrect usage of the records variable. This PR updates the code to destructure the records variable correctly before calling the map function. This ensures that the map function is only called when records is not null or undefined. This fix resolves the bug and improves the stability of the XataVectorStores module.

This was previously attempted to be fixed by the PR #3425

This ultimately fixes issue #3418