### PR TITLE
all[infra]: Allow yarn clean to run from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "example": "yarn workspace examples start",
     "precommit": "turbo run precommit",
     "docs": "yarn workspace @langchain/core_docs start",
-    "docs:api_refs": "yarn workspace @langchain/api_refs start"
+    "docs:api_refs": "yarn workspace @langchain/api_refs start",
+    "clean": "yarn turbo run clean"
   },
   "author": "LangChain",
   "license": "MIT",

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,9 @@
     "precommit": {},
     "start": {
       "cache": false
+    },
+    "clean": {
+      "dependsOn": ["^clean"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -50,6 +50,7 @@
       "cache": false
     },
     "clean": {
+      "outputs": ["**/dist/**", "**/dist-cjs/**", "**/.turbo/**"],
       "dependsOn": ["^clean"]
     }
   }


### PR DESCRIPTION
This allows you to run `yarn clean` from root and each sub package with `yarn clean` as a script will run.