### PR TITLE
core[chore]: widen semver range for langsmith

### DIFF
--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -39,7 +39,7 @@
     "camelcase": "6",
     "decamelize": "1.2.0",
     "js-tiktoken": "^1.0.8",
-    "langsmith": "^0.0.48",
+    "langsmith": "~0.0.48",
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "uuid": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8018,7 +8018,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.8
-    langsmith: ^0.0.48
+    langsmith: ~0.0.48
     p-queue: ^6.6.2
     p-retry: 4
     prettier: ^2.8.3
@@ -23112,7 +23112,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"langsmith@npm:^0.0.48, langsmith@npm:~0.0.48":
+"langsmith@npm:~0.0.48":
   version: 0.0.48
   resolution: "langsmith@npm:0.0.48"
   dependencies:


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

caret in ^0.0.x doesn't do anything, it matches only the exact specified version, whereas tilde ~0.0.x matches that and all 0.0.x versions up to 0.1.0

https://nodesource.com/blog/semver-tilde-and-caret/#majorandminorzero00z00z

Currently it results in two versions of `langsmith` to be installed in `node_modules` together with `langchain` (`0.0.48` and `0.0.49`), as `langchain` permits `~0.0.48` for `langsmith`, which installs the latest available `0.0.x` version, and `@langchain/core` allows only `0.0.48` with `^0.0.48`.

`yarn why langsmith`
<img width="616" alt="288361329-9cbfd7e9-b153-4d54-b767-686f8949bd0d" src="https://github.com/langchain-ai/langchainjs/assets/14310995/014287c2-e508-4122-a0b3-4196f85751ed">

