### PR TITLE
bugfixes in google Generative AI chat_model

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -157,8 +157,6 @@ export class ChatGoogleGenerativeAI
 
   stopSequences: string[] = [];
 
-  candidateCount: number = 1;
-
   safetySettings?: SafetySetting[];
 
   apiKey?: string;
@@ -201,9 +199,6 @@ export class ChatGoogleGenerativeAI
     }
 
     this.stopSequences = fields?.stopSequences ?? this.stopSequences;
-    if (this.stopSequences && typeof this.stopSequences == "string") {
-      this.stopSequences = [this.stopSequences];
-    }
 
     this.apiKey = fields?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
     if (!this.apiKey) {

--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -87,6 +87,13 @@ export interface GoogleGenerativeAIChatInput extends BaseChatModelParams {
   stopSequences?: string[];
 
   /**
+   * Same as variable N but for google.
+   * 
+   * Note: stopSequences is only supported for Gemini models
+   */
+  candidateCount?: string[];
+
+  /**
    * A list of unique `SafetySetting` instances for blocking unsafe content. The API will block
    * any prompts and responses that fail to meet the thresholds set by these settings. If there
    * is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use
@@ -157,6 +164,8 @@ export class ChatGoogleGenerativeAI
 
   stopSequences: string[] = [];
 
+  candidateCount: number = 1;
+
   safetySettings?: SafetySetting[];
 
   apiKey?: string;
@@ -198,6 +207,17 @@ export class ChatGoogleGenerativeAI
       throw new Error("`topK` must be a positive integer");
     }
 
+    this.candidateCount = fields?.candidateCount ?? this.candidateCount;
+    if (this.candidateCount && this.candidateCount <= 0) {
+      throw new Error("`candidateCount` must be above 1.");
+    }
+
+    this.stopSequences = fields?.stopSequences ?? this.stopSequences;
+    if(this.stopSequences && typeof this.stopSequences == "string")
+      this.stopSequences = [this.stopSequences];
+
+
+
     this.apiKey = fields?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
     if (!this.apiKey) {
       throw new Error(
@@ -224,7 +244,7 @@ export class ChatGoogleGenerativeAI
       model: this.modelName,
       safetySettings: this.safetySettings as SafetySetting[],
       generationConfig: {
-        candidateCount: 1,
+        candidateCount: this.candidateCount,
         stopSequences: this.stopSequences,
         maxOutputTokens: this.maxOutputTokens,
         temperature: this.temperature,

--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -87,13 +87,6 @@ export interface GoogleGenerativeAIChatInput extends BaseChatModelParams {
   stopSequences?: string[];
 
   /**
-   * Same as variable N but for google.
-   * 
-   * Note: stopSequences is only supported for Gemini models
-   */
-  candidateCount?: string[];
-
-  /**
    * A list of unique `SafetySetting` instances for blocking unsafe content. The API will block
    * any prompts and responses that fail to meet the thresholds set by these settings. If there
    * is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use
@@ -207,16 +200,10 @@ export class ChatGoogleGenerativeAI
       throw new Error("`topK` must be a positive integer");
     }
 
-    this.candidateCount = fields?.candidateCount ?? this.candidateCount;
-    if (this.candidateCount && this.candidateCount <= 0) {
-      throw new Error("`candidateCount` must be above 1.");
-    }
-
     this.stopSequences = fields?.stopSequences ?? this.stopSequences;
-    if(this.stopSequences && typeof this.stopSequences == "string")
+    if (this.stopSequences && typeof this.stopSequences == "string") {
       this.stopSequences = [this.stopSequences];
-
-
+    }
 
     this.apiKey = fields?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
     if (!this.apiKey) {
@@ -244,7 +231,7 @@ export class ChatGoogleGenerativeAI
       model: this.modelName,
       safetySettings: this.safetySettings as SafetySetting[],
       generationConfig: {
-        candidateCount: this.candidateCount,
+        candidateCount: 1,
         stopSequences: this.stopSequences,
         maxOutputTokens: this.maxOutputTokens,
         temperature: this.temperature,

--- a/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
@@ -31,6 +31,8 @@ test("Test Google AI generation with a stop sequence", async () => {
   console.log(JSON.stringify(res, null, 2));
   expect(res).toBeTruthy();
   expect(res.additional_kwargs.finishReason).toBe("STOP");
+  expect(res.content).not.toContain("2")
+  expect(res.content).not.toContain("two")
 });
 
 test("Test Google AI generation with a system message", async () => {

--- a/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
@@ -31,8 +31,8 @@ test("Test Google AI generation with a stop sequence", async () => {
   console.log(JSON.stringify(res, null, 2));
   expect(res).toBeTruthy();
   expect(res.additional_kwargs.finishReason).toBe("STOP");
-  expect(res.content).not.toContain("2")
-  expect(res.content).not.toContain("two")
+  expect(res.content).not.toContain("2");
+  expect(res.content).not.toContain("two");
 });
 
 test("Test Google AI generation with a system message", async () => {

--- a/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-genai/src/tests/chat_models.int.test.ts
@@ -21,6 +21,18 @@ test("Test Google AI generation", async () => {
   expect(res).toBeTruthy();
 });
 
+test("Test Google AI generation with a stop sequence", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    stopSequences: ["two", "2"],
+  });
+  const res = await model.invoke([
+    ["human", `What are the first three positive whole numbers?`],
+  ]);
+  console.log(JSON.stringify(res, null, 2));
+  expect(res).toBeTruthy();
+  expect(res.additional_kwargs.finishReason).toBe("STOP");
+});
+
 test("Test Google AI generation with a system message", async () => {
   const model = new ChatGoogleGenerativeAI({});
   const res = await model.generate([

--- a/libs/langchain-google-genai/src/utils.ts
+++ b/libs/langchain-google-genai/src/utils.ts
@@ -177,7 +177,7 @@ export function mapGenerateContentResultToChatResult(
     message: new AIMessage({
       content: text,
       name: content === null ? undefined : content.role,
-      additional_kwargs: {},
+      additional_kwargs: generationInfo,
     }),
     generationInfo,
   };
@@ -202,6 +202,8 @@ export function convertResponseContentToChatGenerationChunk(
     message: new AIMessageChunk({
       content: text,
       name: content === null ? undefined : content.role,
+      // Each chunk can have unique "generationInfo", and merging strategy is unclear,
+      // so leave blank for now.
       additional_kwargs: {},
     }),
     generationInfo,


### PR DESCRIPTION
Changes to in google Generative AI chat model.

Fixes # (issue)
- Fixed a bug where `stopSequences` not getting sent in the api.

Addition:
- adding `candidateCount` property.