### PR TITLE
langchain[minor]: fix: use zod validation when using createStructuredOutputChainFromZod

### DIFF
--- a/langchain/src/chains/openai_functions/structured_output.ts
+++ b/langchain/src/chains/openai_functions/structured_output.ts
@@ -83,18 +83,17 @@ export class FunctionCallStructuredOutputParser<
           initialResult
         );
       }
+    }
+    const result = this.jsonSchemaValidator.validate(parsedResult);
+    if (result.valid) {
+      return parsedResult;
     } else {
-      const result = this.jsonSchemaValidator.validate(parsedResult);
-      if (result.valid) {
-        return parsedResult;
-      } else {
-        throw new OutputParserException(
-          `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
-            result.errors
-          )}`,
-          initialResult
-        );
-      }
+      throw new OutputParserException(
+        `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
+          result.errors
+        )}`,
+        initialResult
+      );
     }
   }
 }

--- a/langchain/src/chains/openai_functions/structured_output.ts
+++ b/langchain/src/chains/openai_functions/structured_output.ts
@@ -23,10 +23,7 @@ import { BaseFunctionCallOptions } from "../../base_language/index.js";
  */
 export type StructuredOutputChainInput<
   T extends z.AnyZodObject = z.AnyZodObject
-> = Omit<
-  LLMChainInput,
-  "outputParser" | "llm"
-> & {
+> = Omit<LLMChainInput, "outputParser" | "llm"> & {
   outputSchema: JsonSchema7Type;
   prompt: BasePromptTemplate;
   llm?: BaseChatModel<BaseFunctionCallOptions>;
@@ -74,7 +71,7 @@ export class FunctionCallStructuredOutputParser<
     if (this.zodSchema) {
       const zodParsedResult = this.zodSchema.safeParse(parsedResult);
       if (zodParsedResult.success) {
-        zodParsedResult.data;
+        return zodParsedResult.data;
       } else {
         throw new OutputParserException(
           `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
@@ -132,7 +129,10 @@ export function createStructuredOutputChain<
       },
     },
     outputKey,
-    outputParser: new FunctionCallStructuredOutputParser<T>(outputSchema, zodSchema),
+    outputParser: new FunctionCallStructuredOutputParser<T>(
+      outputSchema,
+      zodSchema
+    ),
     ...rest,
   });
 }

--- a/langchain/src/chains/openai_functions/structured_output.ts
+++ b/langchain/src/chains/openai_functions/structured_output.ts
@@ -71,27 +71,30 @@ export class FunctionCallStructuredOutputParser<
       }
       return value;
     });
-    const maybeZodParsedResult = this.zodSchema
-      ? this.zodSchema.safeParse(parsedResult)
-      : { success: true as true, data: parsedResult };
-    if (maybeZodParsedResult.success === false) {
-      throw new OutputParserException(
-        `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
-          maybeZodParsedResult.error.errors
-        )}`,
-        initialResult
-      );
-    }
-    const result = this.jsonSchemaValidator.validate(maybeZodParsedResult.data);
-    if (result.valid) {
-      return parsedResult;
+    if (this.zodSchema) {
+      const zodParsedResult = this.zodSchema.safeParse(parsedResult);
+      if (zodParsedResult.success) {
+        zodParsedResult.data;
+      } else {
+        throw new OutputParserException(
+          `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
+            zodParsedResult.error.errors
+          )}`,
+          initialResult
+        );
+      }
     } else {
-      throw new OutputParserException(
-        `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
-          result.errors
-        )}`,
-        initialResult
-      );
+      const result = this.jsonSchemaValidator.validate(parsedResult);
+      if (result.valid) {
+        return parsedResult;
+      } else {
+        throw new OutputParserException(
+          `Failed to parse. Text: "${initialResult}". Error: ${JSON.stringify(
+            result.errors
+          )}`,
+          initialResult
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Updating createStructuredOutputChainFromZod to use the zod schema.parse function, rather than creating a JSON schema and validating against that.

The reason for this is that Zod provides a useful preprocess method which can be used to catch common incorrect formatting from function calls (especially when using Anthropic). For example, if the LLM returns `"prop": {}` when it is supposed to return `"prop": []`, this can be caught and transformed at the preprocessor stage rather than throwing a validation error.

This increases the reliability of langchain and the the underlying LLMs that we are currently using in production, and reduces costs/latency by requiring fewing retries.

Twitter
@hirespace @wswannell