### PR TITLE
RunnableWithMessageHistory now calls to getMessages

### DIFF
--- a/langchain-core/src/runnables/history.ts
+++ b/langchain-core/src/runnables/history.ts
@@ -145,9 +145,10 @@ export class RunnableWithMessageHistory<
       (this.inputMessagesKey ? input[this.inputMessagesKey] : undefined);
     let historyMessages = [];
     if (history) {
-      historyMessages = history.getMessages
-        ? history.getMessages()
-        : history.messages;
+      historyMessages =
+        history.getMessages && !history.messages
+          ? history.getMessages()
+          : history.messages;
     }
     const returnType = [
       ...historyMessages,

--- a/langchain-core/src/runnables/history.ts
+++ b/langchain-core/src/runnables/history.ts
@@ -143,7 +143,10 @@ export class RunnableWithMessageHistory<
     const inputVal =
       input ||
       (this.inputMessagesKey ? input[this.inputMessagesKey] : undefined);
-    const historyMessages = history ? history.messages : [];
+    let historyMessages = [];
+    if (history) {
+      historyMessages = (history.getMessages) ? history.getMessages() : history.messages;
+    }
     const returnType = [
       ...historyMessages,
       ...this._getInputMessages(inputVal),

--- a/langchain-core/src/runnables/history.ts
+++ b/langchain-core/src/runnables/history.ts
@@ -145,7 +145,9 @@ export class RunnableWithMessageHistory<
       (this.inputMessagesKey ? input[this.inputMessagesKey] : undefined);
     let historyMessages = [];
     if (history) {
-      historyMessages = (history.getMessages) ? history.getMessages() : history.messages;
+      historyMessages = history.getMessages
+        ? history.getMessages()
+        : history.messages;
     }
     const returnType = [
       ...historyMessages,


### PR DESCRIPTION
**Description of Fix**
This PR calls into getMessages() if it is defined (and .messages is not), fixing the semantic error of relying solely on object properties to retrieve messages rather than calling into the getMessages function, which is guaranteed for BaseChatMessageHistory

Fixes #3698 
