### PR TITLE
Update YandexGPT API

### DIFF
--- a/docs/core_docs/docs/integrations/chat/yandex.mdx
+++ b/docs/core_docs/docs/integrations/chat/yandex.mdx
@@ -17,6 +17,10 @@ Next, you have two authentication options:
 - [API key](https://cloud.yandex.com/en/docs/iam/operations/api-key/create)
   You can specify the key in a constructor parameter as `api_key` or in an environment variable `YC_API_KEY`.
 
+To specify the model you can use `model_uri` parameter, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.
+
+By default, the latest version of `yandexgpt-lite` is used from the folder specified in the parameter `folder_id` or `YC_FOLDER_ID` environment variable.
+
 ## Usage
 
 import CodeBlock from "@theme/CodeBlock";

--- a/docs/core_docs/docs/integrations/llms/yandex.mdx
+++ b/docs/core_docs/docs/integrations/llms/yandex.mdx
@@ -13,6 +13,10 @@ Next, you have two authentication options:
 - [API key](https://cloud.yandex.com/en/docs/iam/operations/api-key/create)
   You can specify the key in a constructor parameter `api_key` or in an environment variable `YC_API_KEY`.
 
+To specify the model you can use `model_uri` parameter, see [the documentation](https://cloud.yandex.com/en/docs/yandexgpt/concepts/models#yandexgpt-generation) for more details.
+
+By default, the latest version of `yandexgpt-lite` is used from the folder specified in the parameter `folder_id` or `YC_FOLDER_ID` environment variable.
+
 ## Usage
 
 import CodeBlock from "@theme/CodeBlock";

--- a/libs/langchain-community/src/chat_models/yandex.ts
+++ b/libs/langchain-community/src/chat_models/yandex.ts
@@ -6,16 +6,16 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 import { YandexGPTInputs } from "../llms/yandex.js";
 
-const apiUrl = "https://llm.api.cloud.yandex.net/llm/v1alpha/chat";
+const apiUrl =
+  "https://llm.api.cloud.yandex.net/foundationModels/v1/completion";
 
 interface ParsedMessage {
   role: string;
   text: string;
 }
 
-function _parseChatHistory(history: BaseMessage[]): [ParsedMessage[], string] {
+function _parseChatHistory(history: BaseMessage[]): ParsedMessage[] {
   const chatHistory: ParsedMessage[] = [];
-  let instruction = "";
 
   for (const message of history) {
     if (typeof message.content !== "string") {
@@ -29,12 +29,12 @@ function _parseChatHistory(history: BaseMessage[]): [ParsedMessage[], string] {
       } else if (message._getType() === "ai") {
         chatHistory.push({ role: "assistant", text: message.content });
       } else if (message._getType() === "system") {
-        instruction = message.content;
+        chatHistory.push({ role: "system", text: message.content });
       }
     }
   }
 
-  return [chatHistory, instruction];
+  return chatHistory;
 }
 
 /**
@@ -60,7 +60,13 @@ export class ChatYandexGPT extends BaseChatModel {
 
   maxTokens = 1700;
 
-  model = "general";
+  model = "yandexgpt-lite";
+
+  modelVersion = "latest";
+
+  modelURI?: string;
+
+  folderID?: string;
 
   constructor(fields?: YandexGPTInputs) {
     super(fields ?? {});
@@ -69,17 +75,32 @@ export class ChatYandexGPT extends BaseChatModel {
 
     const iamToken = fields?.iamToken ?? getEnvironmentVariable("YC_IAM_TOKEN");
 
+    const folderID = fields?.folderID ?? getEnvironmentVariable("YC_FOLDER_ID");
+
     if (apiKey === undefined && iamToken === undefined) {
       throw new Error(
         "Please set the YC_API_KEY or YC_IAM_TOKEN environment variable or pass it to the constructor as the apiKey or iamToken field."
       );
     }
 
+    this.modelURI = fields?.modelURI;
     this.apiKey = apiKey;
     this.iamToken = iamToken;
+    this.folderID = folderID;
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;
     this.temperature = fields?.temperature ?? this.temperature;
     this.model = fields?.model ?? this.model;
+    this.modelVersion = fields?.modelVersion ?? this.modelVersion;
+
+    if (this.modelURI === undefined && folderID === undefined) {
+      throw new Error(
+        "Please set the YC_FOLDER_ID environment variable or pass Yandex GPT model URI to the constructor as the modelURI field."
+      );
+    }
+
+    if (!this.modelURI) {
+      this.modelURI = `gpt://${this.folderID}/${this.model}/${this.modelVersion}`;
+    }
   }
 
   _llmType() {
@@ -96,21 +117,27 @@ export class ChatYandexGPT extends BaseChatModel {
     options: this["ParsedCallOptions"],
     _?: CallbackManagerForLLMRun | undefined
   ): Promise<ChatResult> {
-    const [messageHistory, instruction] = _parseChatHistory(messages);
-    const headers = { "Content-Type": "application/json", Authorization: "" };
+    const messageHistory = _parseChatHistory(messages);
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: "",
+      "x-folder-id": "",
+    };
     if (this.apiKey !== undefined) {
       headers.Authorization = `Api-Key ${this.apiKey}`;
+      if (this.folderID !== undefined) {
+        headers["x-folder-id"] = this.folderID;
+      }
     } else {
       headers.Authorization = `Bearer ${this.iamToken}`;
     }
     const bodyData = {
-      model: this.model,
-      generationOptions: {
+      modelUri: this.modelURI,
+      completionOptions: {
         temperature: this.temperature,
         maxTokens: this.maxTokens,
       },
       messages: messageHistory,
-      instructionText: instruction,
     };
     const response = await fetch(apiUrl, {
       method: "POST",
@@ -125,8 +152,8 @@ export class ChatYandexGPT extends BaseChatModel {
     }
     const responseData = await response.json();
     const { result } = responseData;
-    const { text } = result.message;
-    const totalTokens = result.num_tokens;
+    const { text } = result.alternatives[0].message;
+    const { totalTokens } = result.usage;
     const generations: ChatGeneration[] = [
       { text, message: new AIMessage(text) },
     ];

--- a/libs/langchain-community/src/llms/yandex.ts
+++ b/libs/langchain-community/src/llms/yandex.ts
@@ -1,7 +1,8 @@
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import { LLM, type BaseLLMParams } from "@langchain/core/language_models/llms";
 
-const apiUrl = "https://llm.api.cloud.yandex.net/llm/v1alpha/instruct";
+const apiUrl =
+  "https://llm.api.cloud.yandex.net/foundationModels/v1/completion";
 
 export interface YandexGPTInputs extends BaseLLMParams {
   /**
@@ -19,6 +20,17 @@ export interface YandexGPTInputs extends BaseLLMParams {
   /** Model name to use. */
   model?: string;
 
+  /** Model version to use. */
+  modelVersion?: string;
+
+  /** Model URI to use. */
+  modelURI?: string;
+
+  /**
+   * Yandex Cloud Folder ID
+   */
+  folderID?: string;
+
   /**
    * Yandex Cloud Api Key for service account
    * with the `ai.languageModels.user` role.
@@ -26,7 +38,7 @@ export interface YandexGPTInputs extends BaseLLMParams {
   apiKey?: string;
 
   /**
-   * Yandex Cloud IAM token for service account
+   * Yandex Cloud IAM token for service or user account
    * with the `ai.languageModels.user` role.
    */
   iamToken?: string;
@@ -43,6 +55,7 @@ export class YandexGPT extends LLM implements YandexGPTInputs {
     return {
       apiKey: "YC_API_KEY",
       iamToken: "YC_IAM_TOKEN",
+      folderID: "YC_FOLDER_ID",
     };
   }
 
@@ -50,18 +63,25 @@ export class YandexGPT extends LLM implements YandexGPTInputs {
 
   maxTokens = 1700;
 
-  model = "general";
+  model = "yandexgpt-lite";
+
+  modelVersion = "latest";
+
+  modelURI?: string;
 
   apiKey?: string;
 
   iamToken?: string;
 
+  folderID?: string;
+
   constructor(fields?: YandexGPTInputs) {
     super(fields ?? {});
-
     const apiKey = fields?.apiKey ?? getEnvironmentVariable("YC_API_KEY");
 
     const iamToken = fields?.iamToken ?? getEnvironmentVariable("YC_IAM_TOKEN");
+
+    const folderID = fields?.folderID ?? getEnvironmentVariable("YC_FOLDER_ID");
 
     if (apiKey === undefined && iamToken === undefined) {
       throw new Error(
@@ -69,11 +89,24 @@ export class YandexGPT extends LLM implements YandexGPTInputs {
       );
     }
 
+    this.modelURI = fields?.modelURI;
     this.apiKey = apiKey;
     this.iamToken = iamToken;
+    this.folderID = folderID;
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;
     this.temperature = fields?.temperature ?? this.temperature;
     this.model = fields?.model ?? this.model;
+    this.modelVersion = fields?.modelVersion ?? this.modelVersion;
+
+    if (this.modelURI === undefined && folderID === undefined) {
+      throw new Error(
+        "Please set the YC_FOLDER_ID environment variable or pass Yandex GPT model URI to the constructor as the modelURI field."
+      );
+    }
+
+    if (!this.modelURI) {
+      this.modelURI = `gpt://${this.folderID}/${this.model}/${this.modelVersion}`;
+    }
   }
 
   _llmType() {
@@ -87,20 +120,27 @@ export class YandexGPT extends LLM implements YandexGPTInputs {
   ): Promise<string> {
     // Hit the `generate` endpoint on the `large` model
     return this.caller.callWithOptions({ signal: options.signal }, async () => {
-      const headers = { "Content-Type": "application/json", Authorization: "" };
+      const headers = {
+        "Content-Type": "application/json",
+        Authorization: "",
+        "x-folder-id": "",
+      };
       if (this.apiKey !== undefined) {
         headers.Authorization = `Api-Key ${this.apiKey}`;
       } else {
         headers.Authorization = `Bearer ${this.iamToken}`;
+        if (this.folderID !== undefined) {
+          headers["x-folder-id"] = this.folderID;
+        }
       }
       const bodyData = {
-        model: this.model,
-        generationOptions: {
+        modelUri: this.modelURI,
+        completionOptions: {
           temperature: this.temperature,
           maxTokens: this.maxTokens,
         },
 
-        requestText: prompt,
+        messages: [{ role: "user", text: prompt }],
       };
 
       try {
@@ -116,7 +156,7 @@ export class YandexGPT extends LLM implements YandexGPTInputs {
         }
 
         const responseData = await response.json();
-        return responseData.result.alternatives[0].text;
+        return responseData.result.alternatives[0].message.text;
       } catch (error) {
         throw new Error(`Failed to fetch ${apiUrl} from YandexGPT ${error}`);
       }

--- a/libs/langchain-community/src/load/import_type.d.ts
+++ b/libs/langchain-community/src/load/import_type.d.ts
@@ -354,6 +354,7 @@ export interface SecretMap {
   WRITER_API_KEY?: string;
   WRITER_ORG_ID?: string;
   YC_API_KEY?: string;
+  YC_FOLDER_ID?: string;
   YC_IAM_TOKEN?: string;
   ZEP_API_KEY?: string;
   ZEP_API_URL?: string;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This pull request proposes to stop using the deprecated YandexGPT API v1alpha. Go to use  [Foundation Models API](https://cloud.yandex.com/en/docs/yandexgpt/api-ref/v1/).