### PR TITLE
core[minor]: Move chunk array to core

### DIFF
--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -94,6 +94,9 @@ tracers/tracer_langchain.d.ts
 utils/async_caller.cjs
 utils/async_caller.js
 utils/async_caller.d.ts
+utils/chunk_array.cjs
+utils/chunk_array.js
+utils/chunk_array.d.ts
 utils/env.cjs
 utils/env.js
 utils/env.d.ts

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -244,6 +244,11 @@
       "import": "./utils/async_caller.js",
       "require": "./utils/async_caller.cjs"
     },
+    "./utils/chunk_array": {
+      "types": "./utils/chunk_array.d.ts",
+      "import": "./utils/chunk_array.js",
+      "require": "./utils/chunk_array.cjs"
+    },
     "./utils/env": {
       "types": "./utils/env.d.ts",
       "import": "./utils/env.js",
@@ -394,6 +399,9 @@
     "utils/async_caller.cjs",
     "utils/async_caller.js",
     "utils/async_caller.d.ts",
+    "utils/chunk_array.cjs",
+    "utils/chunk_array.js",
+    "utils/chunk_array.d.ts",
     "utils/env.cjs",
     "utils/env.js",
     "utils/env.d.ts",

--- a/langchain-core/scripts/create-entrypoints.js
+++ b/langchain-core/scripts/create-entrypoints.js
@@ -40,6 +40,7 @@ const entrypoints = {
   "tracers/tracer_langchain_v1": "tracers/tracer_langchain_v1",
   "tracers/tracer_langchain": "tracers/tracer_langchain",
   "utils/async_caller": "utils/async_caller",
+  "utils/chunk_array": "utils/chunk_array",
   "utils/env": "utils/env",
   "utils/hash": "utils/hash",
   "utils/json_patch": "utils/json_patch",

--- a/langchain-core/src/load/import_map.ts
+++ b/langchain-core/src/load/import_map.ts
@@ -31,6 +31,7 @@ export * as tracers__run_collector from "../tracers/run_collector.js";
 export * as tracers__tracer_langchain_v1 from "../tracers/tracer_langchain_v1.js";
 export * as tracers__tracer_langchain from "../tracers/tracer_langchain.js";
 export * as utils__async_caller from "../utils/async_caller.js";
+export * as utils__chunk_array from "../utils/chunk_array.js";
 export * as utils__env from "../utils/env.js";
 export * as utils__hash from "../utils/hash.js";
 export * as utils__json_patch from "../utils/json_patch.js";

--- a/langchain-core/src/utils/chunk_array.ts
+++ b/langchain-core/src/utils/chunk_array.ts
@@ -1,0 +1,8 @@
+export const chunkArray = <T>(arr: T[], chunkSize: number) =>
+  arr.reduce((chunks, elem, index) => {
+    const chunkIndex = Math.floor(index / chunkSize);
+    const chunk = chunks[chunkIndex] || [];
+    // eslint-disable-next-line no-param-reassign
+    chunks[chunkIndex] = chunk.concat([elem]);
+    return chunks;
+  }, [] as T[][]);


### PR DESCRIPTION
Currently, it's defined inside `@langchain/community`, `@langchain/openai`, and `@langchain/mistralai`

Moving it to core will allow for deleting the duplicated code.

I'll put up a PR after core releases this, refactoring the other packages.