### PR TITLE
examples[patch]: Fixes type error in vectara example

### DIFF
--- a/examples/src/indexes/vector_stores/vectara.ts
+++ b/examples/src/indexes/vector_stores/vectara.ts
@@ -7,7 +7,7 @@ const store = new VectaraStore({
   customerId: Number(process.env.VECTARA_CUSTOMER_ID),
   corpusId: Number(process.env.VECTARA_CORPUS_ID),
   apiKey: String(process.env.VECTARA_API_KEY),
-  verbose: true,
+  verbose: true
 });
 
 // Add two documents with some metadata.
@@ -15,15 +15,15 @@ const doc_ids = await store.addDocuments([
   new Document({
     pageContent: "Do I dare to eat a peach?",
     metadata: {
-      foo: "baz",
-    },
+      foo: "baz"
+    }
   }),
   new Document({
     pageContent: "In the room the women come and go talking of Michelangelo",
     metadata: {
-      foo: "bar",
-    },
-  }),
+      foo: "bar"
+    }
+  })
 ]);
 
 // Perform a similarity search.
@@ -31,40 +31,13 @@ const resultsWithScore = await store.similaritySearchWithScore(
   "What were the women talking about?",
   1,
   {
-    lambda: 0.025,
+    lambda: 0.025
   }
 );
 
 // Print the results.
 console.log(JSON.stringify(resultsWithScore, null, 2));
-/*
-[
-  [
-    [
-      {
-        "pageContent": "In the room the women come and go talking of Michelangelo",
-        "metadata": {
-          "lang": "eng",
-          "offset": "0",
-          "len": "57",
-          "foo": "bar"
-        }
-      }
-    ],
-    0.69189274
-  ]
-*/
-
-const retriever = new VectaraSummaryRetriever({ vectara: store, topK: 3 });
-const [documents, summary] = await retriever.getRelevantDocuments(
-  "What were the women talking about?",
-  {
-    lambda: 0.025,
-  },
-  true
-);
-
-console.log(JSON.stringify(documents, null, 2));
+console.log("\n\n\n");
 /*
 [
   [
@@ -76,26 +49,48 @@ console.log(JSON.stringify(documents, null, 2));
         "len": "57",
         "foo": "bar"
       }
-    }
-  ],
-  [
-    {
-      "pageContent": "Do I dare to eat a peach?",
-      "metadata": {
-        "lang": "eng",
-        "offset": "0",
-        "len": "25",
-        "foo": "baz"
-      }
-    }
+    },
+    0.4678752
   ]
 ]
 */
 
-console.log(JSON.stringify(summary, null, 2));
+const retriever = new VectaraSummaryRetriever({ vectara: store, topK: 3 });
+const documents = await retriever.getRelevantDocuments(
+  "What were the women talking about?"
+);
+
+console.log(JSON.stringify(documents, null, 2));
 /*
-"I risultati della ricerca non contenevano informazioni sufficienti per essere riassunti in una risposta utile alla tua domanda. 
-Ti prego di provare una ricerca diversa o di riformulare la tua domanda in modo diverso."
+[
+  {
+    "pageContent": "<b>In the room the women come and go talking of Michelangelo</b>",
+    "metadata": {
+      "lang": "eng",
+      "offset": "0",
+      "len": "57",
+      "foo": "bar"
+    }
+  },
+  {
+    "pageContent": "<b>In the room the women come and go talking of Michelangelo</b>",
+    "metadata": {
+      "lang": "eng",
+      "offset": "0",
+      "len": "57",
+      "foo": "bar"
+    }
+  },
+  {
+    "pageContent": "<b>In the room the women come and go talking of Michelangelo</b>",
+    "metadata": {
+      "lang": "eng",
+      "offset": "0",
+      "len": "57",
+      "foo": "bar"
+    }
+  }
+]
 */
 
 // Delete the documents.

--- a/examples/src/indexes/vector_stores/vectara.ts
+++ b/examples/src/indexes/vector_stores/vectara.ts
@@ -7,7 +7,7 @@ const store = new VectaraStore({
   customerId: Number(process.env.VECTARA_CUSTOMER_ID),
   corpusId: Number(process.env.VECTARA_CORPUS_ID),
   apiKey: String(process.env.VECTARA_API_KEY),
-  verbose: true
+  verbose: true,
 });
 
 // Add two documents with some metadata.
@@ -15,15 +15,15 @@ const doc_ids = await store.addDocuments([
   new Document({
     pageContent: "Do I dare to eat a peach?",
     metadata: {
-      foo: "baz"
-    }
+      foo: "baz",
+    },
   }),
   new Document({
     pageContent: "In the room the women come and go talking of Michelangelo",
     metadata: {
-      foo: "bar"
-    }
-  })
+      foo: "bar",
+    },
+  }),
 ]);
 
 // Perform a similarity search.
@@ -31,7 +31,7 @@ const resultsWithScore = await store.similaritySearchWithScore(
   "What were the women talking about?",
   1,
   {
-    lambda: 0.025
+    lambda: 0.025,
   }
 );
 

--- a/examples/src/indexes/vector_stores/vectara.ts
+++ b/examples/src/indexes/vector_stores/vectara.ts
@@ -37,7 +37,6 @@ const resultsWithScore = await store.similaritySearchWithScore(
 
 // Print the results.
 console.log(JSON.stringify(resultsWithScore, null, 2));
-console.log("\n\n\n");
 /*
 [
   [


### PR DESCRIPTION
Don't have enough context to know why the `summary` element is no longer returned, removed for now. cc @jacoblee93 