### PR TITLE
Fix deserialisation of additional_kwargs and tool_call_id

### DIFF
--- a/langchain-core/src/messages/index.ts
+++ b/langchain-core/src/messages/index.ts
@@ -135,6 +135,11 @@ export abstract class BaseMessage
 
   lc_serializable = true;
 
+  get lc_aliases(): Record<string, string> {
+    // exclude snake case conversion to pascal case
+    return { additional_kwargs: "additional_kwargs" };
+  }
+
   /**
    * @deprecated
    * Use {@link BaseMessage.content} instead.
@@ -462,6 +467,11 @@ export class FunctionMessageChunk extends BaseMessageChunk {
 export class ToolMessage extends BaseMessage {
   static lc_name() {
     return "ToolMessage";
+  }
+
+  get lc_aliases(): Record<string, string> {
+    // exclude snake case conversion to pascal case
+    return { tool_call_id: "tool_call_id" };
   }
 
   tool_call_id: string;

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -1,6 +1,7 @@
 import { test } from "@jest/globals";
 import { ChatPromptTemplate } from "../../prompts/chat.js";
-import { HumanMessage } from "../index.js";
+import { HumanMessage, AIMessage, ToolMessage } from "../index.js";
+import { load } from "../../load/index.js";
 
 test("Test ChatPromptTemplate can format OpenAI content image messages", async () => {
   const message = new HumanMessage({
@@ -60,4 +61,49 @@ test("Test ChatPromptTemplate can format OpenAI content image messages", async (
   expect(formatted.messages[1].content).toEqual(
     "Will this format with multiple messages?: YES!"
   );
+});
+
+test("Deserialisation and serialisation of additional_kwargs and tool_call_id", async () => {
+  const config = {
+    importMap: { messages: { AIMessage } },
+    optionalImportEntrypoints: [],
+    optionalImportsMap: {},
+    secretsMap: {},
+  };
+
+  const message = new AIMessage({
+    content: "",
+    additional_kwargs: {
+      tool_calls: [
+        {
+          id: "call_tXJNP1S6LHT5tLfaNHCbYCtH",
+          type: "function" as const,
+          function: {
+            name: "Weather",
+            arguments: '{\n  "location": "Prague"\n}',
+          },
+        },
+      ],
+    },
+  });
+
+  const deserialized: AIMessage = await load(JSON.stringify(message), config);
+  expect(deserialized).toEqual(message);
+});
+
+test("Deserialisation and serialisation of tool_call_id", async () => {
+  const config = {
+    importMap: { messages: { ToolMessage } },
+    optionalImportEntrypoints: [],
+    optionalImportsMap: {},
+    secretsMap: {},
+  };
+
+  const message = new ToolMessage({
+    content: '{"value": 32}',
+    tool_call_id: "call_tXJNP1S6LHT5tLfaNHCbYCtH",
+  });
+
+  const deserialized: ToolMessage = await load(JSON.stringify(message), config);
+  expect(deserialized).toEqual(message);
 });


### PR DESCRIPTION
Currently, when deserialising, `additional_kwargs` are passed to constructor as `additionalKwargs`