### PR TITLE
Refactor the MessageContent type.

### DIFF
--- a/langchain-core/src/messages/index.ts
+++ b/langchain-core/src/messages/index.ts
@@ -34,18 +34,37 @@ export type MessageType =
   | "function"
   | "tool";
 
+export type MessageContentText =
+  {
+    type: "text";
+    text: string;
+  };
+
+export type MessageContentImageUrl =
+  {
+    type: "image_url";
+    image_url: string | { url: string; detail?: "auto" | "low" | "high" };
+  };
+
+export type MessageContentBlobUrl =
+  {
+    type: "blob_url";
+    blob_url: {
+      url: string;
+      content_type: string;
+    };
+  };
+
+export type MessageContentComplex =
+  (
+    | MessageContentText
+    | MessageContentImageUrl
+    | MessageContentBlobUrl
+  );
+
 export type MessageContent =
   | string
-  | (
-      | {
-          type: "text";
-          text: string;
-        }
-      | {
-          type: "image_url";
-          image_url: string | { url: string; detail?: "auto" | "low" | "high" };
-        }
-    )[];
+  | MessageContentComplex[];
 
 export interface FunctionCall {
   /**
@@ -134,11 +153,6 @@ export abstract class BaseMessage
   lc_namespace = ["langchain_core", "messages"];
 
   lc_serializable = true;
-
-  get lc_aliases(): Record<string, string> {
-    // exclude snake case conversion to pascal case
-    return { additional_kwargs: "additional_kwargs" };
-  }
 
   /**
    * @deprecated
@@ -467,11 +481,6 @@ export class FunctionMessageChunk extends BaseMessageChunk {
 export class ToolMessage extends BaseMessage {
   static lc_name() {
     return "ToolMessage";
-  }
-
-  get lc_aliases(): Record<string, string> {
-    // exclude snake case conversion to pascal case
-    return { tool_call_id: "tool_call_id" };
   }
 
   tool_call_id: string;


### PR DESCRIPTION
- Break it into individual subtypes to make it clear what the definition is and to be able to use these subtypes as parameter or return types.
- Add a new subtype blob_url which takes a required URL and a required content type (MIME type). This is for models that require the mime type (Gemini, for example) and makes it clear that this may be used for content besides images (ie - video, 3-d models, etc).
