### PR TITLE
fix: use @gomoment/sdk-core instead of @gomoment/sdk for edge server integrations (#3784)

### DIFF
--- a/libs/langchain-community/src/utils/momento.ts
+++ b/libs/langchain-community/src/utils/momento.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-instanceof/no-instanceof */
-import { ICacheClient, CreateCache } from "@gomomento/sdk";
+import { ICacheClient, CreateCache } from "@gomomento/sdk-core";
 
 /**
  * Utility function to ensure that a Momento cache exists.


### PR DESCRIPTION
Patch for the issue:
 MomentoChatMessageHistory is not working on the Cloudflare Workers because of the SDK difference #3784 

