### PR TITLE
docs[patch]: Fix more core imports

### DIFF
--- a/docs/core_docs/code-block-loader.js
+++ b/docs/core_docs/code-block-loader.js
@@ -90,7 +90,7 @@ async function webpackLoader(content, map, meta) {
       let modulePath;
       CATEGORIES.forEach((category) => {
         // from langchain/src
-        const componentPathLangChain = `${category}/langchain_${moduleName}.${imported}.html`;
+        const componentPathLangChain = `${category}/langchain_${moduleName.startsWith("core_") ? moduleName.replace("core_", "") : moduleName}.${imported}.html`;
         const docsPathLangChain = getDocsPath(componentPathLangChain);
 
         // from packages

--- a/docs/core_docs/code-block-loader.js
+++ b/docs/core_docs/code-block-loader.js
@@ -90,7 +90,11 @@ async function webpackLoader(content, map, meta) {
       let modulePath;
       CATEGORIES.forEach((category) => {
         // from langchain/src
-        const componentPathLangChain = `${category}/langchain_${moduleName.startsWith("core_") ? moduleName.replace("core_", "") : moduleName}.${imported}.html`;
+        const componentPathLangChain = `${category}/langchain_${
+          moduleName.startsWith("core_")
+            ? moduleName.replace("core_", "")
+            : moduleName
+        }.${imported}.html`;
         const docsPathLangChain = getDocsPath(componentPathLangChain);
 
         // from packages

--- a/examples/src/chat/memory.ts
+++ b/examples/src/chat/memory.ts
@@ -1,6 +1,9 @@
 import { ConversationChain } from "langchain/chains";
 import { ChatOpenAI } from "langchain/chat_models/openai";
-import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
+import {
+  ChatPromptTemplate,
+  MessagesPlaceholder,
+} from "@langchain/core/prompts";
 import { BufferMemory } from "langchain/memory";
 
 const chat = new ChatOpenAI({ temperature: 0 });

--- a/examples/src/chat/memory.ts
+++ b/examples/src/chat/memory.ts
@@ -1,6 +1,6 @@
 import { ConversationChain } from "langchain/chains";
 import { ChatOpenAI } from "langchain/chat_models/openai";
-import { ChatPromptTemplate, MessagesPlaceholder } from "langchain/prompts";
+import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
 import { BufferMemory } from "langchain/memory";
 
 const chat = new ChatOpenAI({ temperature: 0 });

--- a/libs/langchain-community/src/utils/momento.ts
+++ b/libs/langchain-community/src/utils/momento.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-instanceof/no-instanceof */
 import { ICacheClient, CreateCache } from "@gomomento/sdk";
+
 /**
  * Utility function to ensure that a Momento cache exists.
  * If the cache does not exist, it is created.

--- a/libs/langchain-community/src/utils/momento.ts
+++ b/libs/langchain-community/src/utils/momento.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-instanceof/no-instanceof */
-import { ICacheClient, CreateCache } from "@gomomento/sdk-core";
-
+import { ICacheClient, CreateCache } from "@gomomento/sdk";
 /**
  * Utility function to ensure that a Momento cache exists.
  * If the cache does not exist, it is created.


### PR DESCRIPTION
@jacoblee93 this will fix the issue you're having in #3802 (unless the import paths differ from the original langchain).

Before when imports were always `langchain/path`, the `moduleName` variable would always be the path. Now that the second arg will be `core` if importing from `core` this breaks.