### PR TITLE
docs[patch]: relevant example for map reduce

### DIFF
--- a/examples/src/chains/question_answering_map_reduce.ts
+++ b/examples/src/chains/question_answering_map_reduce.ts
@@ -6,11 +6,19 @@ import { Document } from "langchain/document";
 const model = new OpenAI({ temperature: 0, maxConcurrency: 10 });
 const chain = loadQAMapReduceChain(model);
 const docs = [
-  new Document({ pageContent: "harrison went to harvard" }),
-  new Document({ pageContent: "ankush went to princeton" }),
+  new Document({ pageContent: "Harrison went to harvard" }),
+  new Document({ pageContent: "Harrison obtained his degree in 2020" }),
+  new Document({ pageContent: "Ankush went to princeton" }),
+  new Document({ pageContent: "Ankush obtained his degree in 2019" }),
 ];
 const res = await chain.call({
   input_documents: docs,
-  question: "Where did harrison go to college",
+  question: "Where and when did Harrison obtain his degree?",
 });
-console.log({ res });
+
+console.log(res);
+/*
+{
+  text: 'Harrison obtained his degree at Harvard in 2020.'
+}
+*/


### PR DESCRIPTION
The old example doesn't showcase the utility of loadQAMapReduceChain, and the console.log output is not displayed in the docs. The new example is more relevant and includes a console.log output.