### PR TITLE
fix(doc): Sidebar how_to (tools)

### DIFF
--- a/docs/core_docs/docs/modules/agents/tools/how_to/_category_.yml
+++ b/docs/core_docs/docs/modules/agents/tools/how_to/_category_.yml
@@ -1,0 +1,2 @@
+label: "How-to"
+position: 2

--- a/docs/core_docs/docs/modules/agents/tools/how_to/agents_with_vectorstores.mdx
+++ b/docs/core_docs/docs/modules/agents/tools/how_to/agents_with_vectorstores.mdx
@@ -1,7 +1,3 @@
----
-sidebar_class_name: hidden
----
-
 # Vector stores as tools
 
 This notebook covers how to combine agents and vector stores. The use case for this is that you’ve ingested your data into a vector store and want to interact with it in an agentic manner.


### PR DESCRIPTION
- Fix position and name failure by adding _category_.yml file.
- Do not hide the agents_with_vectorstores.mdx just because there is only one document in the how-to.

![Screenshot 2023-12-31 at 01 44 47](https://github.com/langchain-ai/langchainjs/assets/20043417/c7fd9b43-b2e1-4f24-926a-fecafe9368cc)

