### PR TITLE
fix: textFieldMaxLength parameter missing

### DIFF
--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -490,18 +490,7 @@ export class Milvus extends VectorStore {
     embeddings: EmbeddingsInterface,
     dbConfig?: MilvusLibArgs
   ): Promise<Milvus> {
-    const args: MilvusLibArgs = {
-      collectionName: dbConfig?.collectionName || genCollectionName(),
-      url: dbConfig?.url,
-      ssl: dbConfig?.ssl,
-      username: dbConfig?.username,
-      password: dbConfig?.password,
-      textField: dbConfig?.textField,
-      primaryField: dbConfig?.primaryField,
-      vectorField: dbConfig?.vectorField,
-      clientConfig: dbConfig?.clientConfig,
-      autoId: dbConfig?.autoId,
-    };
+    const args: MilvusLibArgs = dbConfig ?? {};
     const instance = new this(embeddings, args);
     await instance.addDocuments(docs);
     return instance;

--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -490,7 +490,10 @@ export class Milvus extends VectorStore {
     embeddings: EmbeddingsInterface,
     dbConfig?: MilvusLibArgs
   ): Promise<Milvus> {
-    const args: MilvusLibArgs = dbConfig ?? {};
+    const args: MilvusLibArgs = {
+      ...(dbConfig ? dbConfig : {}),
+      collectionName: dbConfig?.collectionName ?? genCollectionName(),
+    };
     const instance = new this(embeddings, args);
     await instance.addDocuments(docs);
     return instance;

--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -491,7 +491,7 @@ export class Milvus extends VectorStore {
     dbConfig?: MilvusLibArgs
   ): Promise<Milvus> {
     const args: MilvusLibArgs = {
-      ...(dbConfig ? dbConfig : {}),
+      ...dbConfig,
       collectionName: dbConfig?.collectionName ?? genCollectionName(),
     };
     const instance = new this(embeddings, args);


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Currently, the textFieldMaxLength in the dbconfig parameter is lost when using the Milvus.fromDocuments method
```
const vectorStore = await Milvus.fromDocuments(docs, new OpenAIEmbeddings(), {
  collectionName: "goldel_escher_bach",
  textFieldMaxLength: 1024
});
```

