### PR TITLE
Todo: propagate error in Neo4jGraph

### DIFF
--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -119,7 +119,7 @@ export class Neo4jGraph {
         throw new Error("Procedure not found in Neo4j.");
       }
     }
-    //@TODO Propagate error instead of returning undefined
+    /** @TODO Propagate error instead of returning undefined */
     return undefined;
   }
 

--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -119,6 +119,7 @@ export class Neo4jGraph {
         throw new Error("Procedure not found in Neo4j.");
       }
     }
+    //@TODO Propagate error instead of returning undefined
     return undefined;
   }
 


### PR DESCRIPTION
When a new major version of LangChainJS will be released, please change the code to propagate the error in Neo4jGraph.
Based on https://github.com/langchain-ai/langchainjs/pull/3849