### PR TITLE
Add generic output type parameter to JsonOutputFunctionsParser

### DIFF
--- a/langchain/src/output_parsers/openai_functions.ts
+++ b/langchain/src/output_parsers/openai_functions.ts
@@ -79,7 +79,9 @@ export class OutputFunctionsParser extends BaseLLMOutputParser<string> {
  * Class for parsing the output of an LLM into a JSON object. Uses an
  * instance of `OutputFunctionsParser` to parse the output.
  */
-export class JsonOutputFunctionsParser extends BaseCumulativeTransformOutputParser<object> {
+export class JsonOutputFunctionsParser<
+  T = object
+> extends BaseCumulativeTransformOutputParser<T> {
   static lc_name() {
     return "JsonOutputFunctionsParser";
   }
@@ -113,7 +115,7 @@ export class JsonOutputFunctionsParser extends BaseCumulativeTransformOutputPars
 
   async parsePartialResult(
     generations: ChatGeneration[]
-  ): Promise<object | undefined> {
+  ): Promise<T | undefined> {
     const generation = generations[0];
     if (!generation.message) {
       return undefined;
@@ -130,7 +132,7 @@ export class JsonOutputFunctionsParser extends BaseCumulativeTransformOutputPars
     return {
       ...functionCall,
       arguments: parsePartialJson(functionCall.arguments),
-    };
+    } as T;
   }
 
   /**
@@ -139,9 +141,7 @@ export class JsonOutputFunctionsParser extends BaseCumulativeTransformOutputPars
    * @param generations The output of the LLM to parse.
    * @returns A JSON object representation of the function call or its arguments.
    */
-  async parseResult(
-    generations: Generation[] | ChatGeneration[]
-  ): Promise<object> {
+  async parseResult(generations: Generation[] | ChatGeneration[]): Promise<T> {
     const result = await this.outputParser.parseResult(generations);
     if (!result) {
       throw new Error(
@@ -151,7 +151,7 @@ export class JsonOutputFunctionsParser extends BaseCumulativeTransformOutputPars
     return this.parse(result);
   }
 
-  async parse(text: string): Promise<object> {
+  async parse(text: string): Promise<T> {
     const parsedResult = JSON.parse(text);
     if (this.argsOnly) {
       return parsedResult;

--- a/langchain/src/output_parsers/tests/openai_functions.int.test.ts
+++ b/langchain/src/output_parsers/tests/openai_functions.int.test.ts
@@ -34,7 +34,9 @@ test("Streaming JSON patch", async () => {
     temperature: 0,
   }).bind(modelParams);
 
-  const parser = new JsonOutputFunctionsParser({ diff: true });
+  const parser = new JsonOutputFunctionsParser<z.infer<typeof schema>>({
+    diff: true,
+  });
   const chain = prompt.pipe(model).pipe(parser);
 
   const stream = await chain.stream({
@@ -46,7 +48,10 @@ test("Streaming JSON patch", async () => {
   for await (const chunk of stream) {
     console.log(chunk);
     chunks.push(chunk);
-    aggregate = applyPatch(aggregate, chunk as Operation[]).newDocument;
+    aggregate = applyPatch(
+      aggregate,
+      chunk as unknown as Operation[]
+    ).newDocument;
   }
 
   expect(chunks.length).toBeGreaterThan(1);
@@ -63,7 +68,9 @@ test("Streaming JSON patch with an event stream output parser", async () => {
     temperature: 0,
   }).bind(modelParams);
 
-  const jsonParser = new JsonOutputFunctionsParser({ diff: true });
+  const jsonParser = new JsonOutputFunctionsParser<z.infer<typeof schema>>({
+    diff: true,
+  });
   const parser = new HttpResponseOutputParser({
     outputParser: jsonParser,
     contentType: "text/event-stream",
@@ -92,7 +99,7 @@ test("Streaming aggregated JSON", async () => {
     temperature: 0,
   }).bind(modelParams);
 
-  const parser = new JsonOutputFunctionsParser();
+  const parser = new JsonOutputFunctionsParser<z.infer<typeof schema>>();
   const chain = prompt.pipe(model).pipe(parser);
 
   const stream = await chain.stream({


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This PR adds a generic type parameter for the json output type. When used in combination with a Zod schema, it is possible to infer the output type from this schema via `z.infer<typeof schema>`.

Example: 
```ts
  const schema = z.object({
    setup: z.string().describe("The setup for the joke"),
    punchline: z.string().describe("The punchline to the joke"),
  });

  const parser = new JsonOutputFunctionsParser<z.infer<typeof schema>>({
    diff: true,
  });
  
  const chain = prompt.pipe(model).pipe(parser);
  //    ^^^^^
  // Inferred as:
  // RunnableSequence<ParamsFromFString<"tell me a long joke about {foo}">, {
  //  setup: string;
  //  punchline: string;
  // }>
```