### PR TITLE
Update embedQuery to use inputType

### DIFF
--- a/libs/langchain-cohere/src/embeddings.ts
+++ b/libs/langchain-cohere/src/embeddings.ts
@@ -118,6 +118,7 @@ export class CohereEmbeddings
     const { embeddings } = await this.embeddingWithRetry({
       model: this.model,
       texts: [text],
+      inputType: this.inputType,
     });
     if ("float" in embeddings && embeddings.float) {
       return embeddings.float[0];


### PR DESCRIPTION
Input type is a required parameter when using v3 models. It is ignored for v2 models.

Adding it here satisfies both use cases and avoids a Cohere API rejection when using v3 models.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #3900 
