### PR TITLE
core[patch]: fix: update dereference.ts to match upstream

### DIFF
--- a/langchain-core/src/utils/@cfworker/json-schema/src/dereference.ts
+++ b/langchain-core/src/utils/@cfworker/json-schema/src/dereference.ts
@@ -67,12 +67,12 @@ export const ignoredKeyword: Record<string, boolean> = {
  */
 export let initialBaseURI =
   // @ts-ignore
-  typeof self !== "undefined" && self.location
+  typeof self !== 'undefined' &&
+  self.location &&
+  self.location.origin !== 'null'
     ? //@ts-ignore
-      /* #__PURE__ */ new URL(
-        self.location.origin + self.location.pathname + location.search
-      )
-    : /* #__PURE__ */ new URL("https://github.com/cfworker");
+      new URL(self.location.origin + self.location.pathname + location.search)
+    : new URL('https://github.com/cfworker');
 
 export function dereference(
   schema: Schema | boolean,

--- a/langchain-core/src/utils/@cfworker/json-schema/src/dereference.ts
+++ b/langchain-core/src/utils/@cfworker/json-schema/src/dereference.ts
@@ -67,12 +67,12 @@ export const ignoredKeyword: Record<string, boolean> = {
  */
 export let initialBaseURI =
   // @ts-ignore
-  typeof self !== 'undefined' &&
+  typeof self !== "undefined" &&
   self.location &&
-  self.location.origin !== 'null'
+  self.location.origin !== "null"
     ? //@ts-ignore
       new URL(self.location.origin + self.location.pathname + location.search)
-    : new URL('https://github.com/cfworker');
+    : new URL("https://github.com/cfworker");
 
 export function dereference(
   schema: Schema | boolean,


### PR DESCRIPTION
dereference.ts is taken from an upstream repo https://raw.githubusercontent.com/cfworker/cfworker/main/packages/json-schema/src/dereference.ts

which contains a fix for when self.location.origin is null (which can happen if being used in a nodejs environment). This PR ports over the fix in line with upstream