### PR TITLE
Fixed parsing of tool_input and final_answer tags

### DIFF
--- a/langchain/src/agents/xml/output_parser.ts
+++ b/langchain/src/agents/xml/output_parser.ts
@@ -38,12 +38,11 @@ export class XMLAgentOutputParser extends AgentActionOutputParser {
    */
   async parse(text: string): Promise<AgentAction | AgentFinish> {
     if (text.includes("</tool>")) {
-      const [tool, toolInput] = text.split("</tool>");
-      const _tool = tool.split("<tool>")[1];
-      const _toolInput = toolInput.split("<tool_input>")[1];
+      const _tool = text.match(/<tool>([^<]*)<\/tool>/)[1];
+      const _toolInput = text.match(/<tool_input>([^<]*)<\/tool_input>/)[1];
       return { tool: _tool, toolInput: _toolInput, log: text };
     } else if (text.includes("<final_answer>")) {
-      const [, answer] = text.split("<final_answer>");
+      const answer = text.match(/<final_answer>([^<]*)<\/final_answer>/)[1];
       return { returnValues: { output: answer }, log: text };
     } else {
       throw new OutputParserException(`Could not parse LLM output: ${text}`);


### PR DESCRIPTION
When parsing the inputs and outputs from a tool, it is not properly renoving the end xml tag. For example for the input, the toolInput includes the </tool_input> which causes problems when passing this argument to the tool.

{
  tool: 'getLengthOfString',
  toolInput: 'This is a Happy String!**</tool_input>**',
  log: '<tool>getLengthOfString</tool><tool_input>This is a Happy String!</tool_input>'
}

Similarly, for the final_answer tag, it returns the end tags as well, for example:

{
  returnValues: {
    output: 'The length of the string "Parangaricutirimícuaro" is 22.**</final_answer>**'
  },
  log: '<final_answer>The length of the string "Parangaricutirimícuaro" is 22.</final_answer>'
}

I have change the code to use a regular expression and properly extract the text between the XML elements.

