### PR TITLE
community[patch]: allow upserts in MongoDB Atlas

### DIFF
--- a/libs/langchain-community/src/vectorstores/mongodb_atlas.ts
+++ b/libs/langchain-community/src/vectorstores/mongodb_atlas.ts
@@ -6,7 +6,10 @@ import {
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { Document } from "@langchain/core/documents";
 import { maximalMarginalRelevance } from "@langchain/core/utils/math";
-import { AsyncCaller, AsyncCallerParams } from "@langchain/core/utils/async_caller";
+import {
+  AsyncCaller,
+  AsyncCallerParams,
+} from "@langchain/core/utils/async_caller";
 
 /**
  * Type that defines the arguments required to initialize the
@@ -27,7 +30,7 @@ export interface MongoDBAtlasVectorSearchLibArgs extends AsyncCallerParams {
   readonly embeddingKey?: string;
   readonly overwrite?: boolean;
   readonly primaryKey?: string;
-};
+}
 
 /**
  * Type that defines the filter used in the
@@ -107,14 +110,6 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
           );
         });
       }
-      // const promises = docs.map((doc) => {
-      //   return this.collection.updateOne(
-      //     { [this.primaryKey]: doc[this.primaryKey] },
-      //     { $set: doc },
-      //     { upsert: true }
-      //   );
-      // });
-      // await Promise.all(promises);
     }
   }
 


### PR DESCRIPTION
Previously the MongoDB Vectorstore could only insert new Documents via `insertMany()`, but that lead to duplicates if you were actively working on said Documents.

Now there are two additional args you can pass when initializing the Vectorstore:
- `primaryKey: string` for setting the key which is used for filtering
- `overwrite: boolean` to update any documents that match the filter, with the new version of the document

Overwriting has upsert enabled by default (and there's currently no way to change it), so if a document doesn't already exist it will get inserted instead.
