### PR TITLE
allow empty arrays for Weaviate metadata

### DIFF
--- a/libs/langchain-community/src/vectorstores/tests/weaviate.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/weaviate.test.ts
@@ -14,6 +14,7 @@ test("flattenObjectForWeaviate", () => {
           string: "even a deeper string",
         },
       },
+      emptyArray: [],
     })
   ).toMatchInlineSnapshot(`
     {
@@ -23,6 +24,7 @@ test("flattenObjectForWeaviate", () => {
       ],
       "deep_deepdeep_string": "even a deeper string",
       "deep_string": "deep string",
+      "emptyArray": [],
     }
   `);
 });

--- a/libs/langchain-community/src/vectorstores/weaviate.ts
+++ b/libs/langchain-community/src/vectorstores/weaviate.ts
@@ -35,8 +35,9 @@ export const flattenObjectForWeaviate = (
         }
       }
     } else if (Array.isArray(value)) {
-      if (
-        value.length > 0 &&
+      if (value.length === 0) {
+        flattenedObject[key] = value;
+      } else if (
         typeof value[0] !== "object" &&
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         value.every((el: any) => typeof el === typeof value[0])


### PR DESCRIPTION
Weaviate metadata may be of type array. This means, also empty array values are supported.
The current implementation of the `flattenObjectForWeaviate` function however more or less accidentally omits empty arrays completely, so they never arrive at Weaviate.
If one specifies an empty array as metadata value, then this value should also arrive at Weaviate.
This PR fixes this.