### PR TITLE
community[minor]: Upgrade Astra client and add support for namespaces

### DIFF
--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -53,7 +53,7 @@
     "@clickhouse/client": "^0.2.5",
     "@cloudflare/ai": "^1.0.12",
     "@cloudflare/workers-types": "^4.20230922.0",
-    "@datastax/astra-db-ts": "0.1.2",
+    "@datastax/astra-db-ts": "^0.1.3",
     "@elastic/elasticsearch": "^8.4.0",
     "@faker-js/faker": "^7.6.0",
     "@getmetal/metal-sdk": "^4.0.0",

--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -23,6 +23,7 @@ export interface AstraLibArgs extends AsyncCallerParams {
   token: string;
   endpoint: string;
   collection: string;
+  namespace?: string;
   idKey?: string;
   contentKey?: string;
   collectionOptions?: CreateCollectionOptions;
@@ -64,13 +65,14 @@ export class AstraDBVectorStore extends VectorStore {
       endpoint,
       collection,
       collectionOptions,
+      namespace,
       idKey,
       contentKey,
       batchSize,
       ...callerArgs
     } = args;
 
-    this.astraDBClient = new AstraDB(token, endpoint);
+    this.astraDBClient = new AstraDB(token, endpoint, namespace);
     this.collectionName = collection;
     this.collectionOptions = collectionOptions;
     this.idKey = idKey ?? "_id";

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -7,8 +7,8 @@ import { OpenAIEmbeddings } from "@langchain/openai";
 import { AstraDBVectorStore, AstraLibArgs } from "../astradb.js";
 
 const clientConfig = {
-  token: process.env.ASTRA_DB_APPLICATION_TOKEN ?? "AstraCS:UtiZALFxZxcQPTeqnSDcTUMd:474d65367195f56f30044274a55a7f0be8229d7c44b1b4146341b692c2925570",
-  endpoint: process.env.ASTRA_DB_ENDPOINT ?? "https://cbfd30a0-243a-4c42-8422-78ce5f4752c9-us-east-2.apps.astra.datastax.com",
+  token: process.env.ASTRA_DB_APPLICATION_TOKEN ?? "dummy",
+  endpoint: process.env.ASTRA_DB_ENDPOINT ?? "dummy",
   namespace: process.env.ASTRA_DB_NAMESPACE ?? "default_keyspace",
 };
 

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -7,8 +7,9 @@ import { OpenAIEmbeddings } from "@langchain/openai";
 import { AstraDBVectorStore, AstraLibArgs } from "../astradb.js";
 
 const clientConfig = {
-  token: process.env.ASTRA_DB_APPLICATION_TOKEN ?? "dummy",
-  endpoint: process.env.ASTRA_DB_ENDPOINT ?? "dummy",
+  token: process.env.ASTRA_DB_APPLICATION_TOKEN ?? "AstraCS:UtiZALFxZxcQPTeqnSDcTUMd:474d65367195f56f30044274a55a7f0be8229d7c44b1b4146341b692c2925570",
+  endpoint: process.env.ASTRA_DB_ENDPOINT ?? "https://cbfd30a0-243a-4c42-8422-78ce5f4752c9-us-east-2.apps.astra.datastax.com",
+  namespace: process.env.ASTRA_DB_NAMESPACE ?? "default_keyspace",
 };
 
 const client = new AstraDB(clientConfig.token, clientConfig.endpoint);
@@ -24,7 +25,7 @@ const astraConfig: AstraLibArgs = {
   },
 };
 
-describe.skip("AstraDBVectorStore", () => {
+describe("AstraDBVectorStore", () => {
   beforeEach(async () => {
     try {
       await client.dropCollection(astraConfig.collection);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6054,14 +6054,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datastax/astra-db-ts@npm:0.1.2":
-  version: 0.1.2
-  resolution: "@datastax/astra-db-ts@npm:0.1.2"
+"@datastax/astra-db-ts@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@datastax/astra-db-ts@npm:0.1.3"
   dependencies:
     axios: ^1.4.0
     bson: ^6.2.0
     winston: ^3.7.2
-  checksum: 15be1b453d1712ae73962eec95ebd4ab904a17c6e318ba669211b2584ac1c565ba3de04f469015fcf5e1aa6113a304c9f43662a758c2ab345274374e4fe0e53b
+  checksum: 22b227d94817513d5a1e7ea0ca1d719ea658d1052d489d36569b5f95e03cac4b28b13da46b5f784d6db6132892ab5e85d27a64fa4040e1fb4479868ecca5b5d9
   languageName: node
   linkType: hard
 
@@ -8208,7 +8208,7 @@ __metadata:
     "@clickhouse/client": ^0.2.5
     "@cloudflare/ai": ^1.0.12
     "@cloudflare/workers-types": ^4.20230922.0
-    "@datastax/astra-db-ts": 0.1.2
+    "@datastax/astra-db-ts": ^0.1.3
     "@elastic/elasticsearch": ^8.4.0
     "@faker-js/faker": ^7.6.0
     "@getmetal/metal-sdk": ^4.0.0


### PR DESCRIPTION
Upgrades the Astra client to `0.1.3` and adds support for namespaces
