### PR TITLE
Add stacktrace to tracer errors

### DIFF
--- a/langchain-core/src/tracers/base.ts
+++ b/langchain-core/src/tracers/base.ts
@@ -318,7 +318,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
       throw new Error("No chain run to end.");
     }
     run.end_time = Date.now();
-    run.error = error.message + (error?.stack ? `\n\n${error.stack}` : "");
+    run.error = error.message + (error.stack ? `\n\n${error.stack}` : "");
     run.events.push({
       name: "error",
       time: new Date(run.end_time).toISOString(),

--- a/langchain-core/src/tracers/base.ts
+++ b/langchain-core/src/tracers/base.ts
@@ -318,7 +318,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
       throw new Error("No chain run to end.");
     }
     run.end_time = Date.now();
-    run.error = error.message;
+    run.error = error.message + (error?.stack ? `\n\n${error.stack}` : "");
     run.events.push({
       name: "error",
       time: new Date(run.end_time).toISOString(),


### PR DESCRIPTION
@jacoblee93 are there env-specific gotchas with this? would be helpful to see the full stacktrace whenever there is an error