### PR TITLE
Fix typo in createHistoryAwareRetriever documentation

### DIFF
--- a/langchain/src/chains/history_aware_retriever.ts
+++ b/langchain/src/chains/history_aware_retriever.ts
@@ -48,7 +48,7 @@ export type CreateHistoryAwareRetrieverParams = {
  * const rephrasePrompt = await pull("langchain-ai/chat-langchain-rephrase");
  * const llm = new ChatOpenAI({});
  * const retriever = ...
- * const historyAwareRetrieverChain = await createHistoryAwareRetriever({
+ * const chain = await createHistoryAwareRetriever({
  *   llm,
  *   retriever,
  *   rephrasePrompt,


### PR DESCRIPTION
The in-code documentation has a typo:

```ts
const historyAwareRetrieverChain = await createHistoryAwareRetriever({
   llm,
   retriever,
   rephrasePrompt,
});
const result = await chain.invoke({"input": "...", "chat_history": [] })  // <-- `chain` doesn't exist here.
```

twitter: @aristot_3rd