### PR TITLE
core[minor]: Move function calling definitions and utils to core

### DIFF
--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -100,6 +100,9 @@ utils/chunk_array.d.ts
 utils/env.cjs
 utils/env.js
 utils/env.d.ts
+utils/function_calling.cjs
+utils/function_calling.js
+utils/function_calling.d.ts
 utils/hash.cjs
 utils/hash.js
 utils/hash.d.ts

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -43,7 +43,8 @@
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "uuid": "^9.0.0",
-    "zod": "^3.22.3"
+    "zod": "^3.22.3",
+    "zod-to-json-schema": "3.20.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
@@ -254,6 +255,11 @@
       "import": "./utils/env.js",
       "require": "./utils/env.cjs"
     },
+    "./utils/function_calling": {
+      "types": "./utils/function_calling.d.ts",
+      "import": "./utils/function_calling.js",
+      "require": "./utils/function_calling.cjs"
+    },
     "./utils/hash": {
       "types": "./utils/hash.d.ts",
       "import": "./utils/hash.js",
@@ -405,6 +411,9 @@
     "utils/env.cjs",
     "utils/env.js",
     "utils/env.d.ts",
+    "utils/function_calling.cjs",
+    "utils/function_calling.js",
+    "utils/function_calling.d.ts",
     "utils/hash.cjs",
     "utils/hash.js",
     "utils/hash.d.ts",

--- a/langchain-core/scripts/create-entrypoints.js
+++ b/langchain-core/scripts/create-entrypoints.js
@@ -42,6 +42,7 @@ const entrypoints = {
   "utils/async_caller": "utils/async_caller",
   "utils/chunk_array": "utils/chunk_array",
   "utils/env": "utils/env",
+  "utils/function_calling": "utils/function_calling",
   "utils/hash": "utils/hash",
   "utils/json_patch": "utils/json_patch",
   "utils/json_schema": "utils/json_schema",

--- a/langchain-core/src/language_models/base.ts
+++ b/langchain-core/src/language_models/base.ts
@@ -225,6 +225,11 @@ export interface FunctionDefinition {
   description?: string;
 }
 
+export interface ToolDefinition {
+  type: "function";
+  function: FunctionDefinition;
+}
+
 export type FunctionCallOption = {
   name: string;
 };

--- a/langchain-core/src/load/import_map.ts
+++ b/langchain-core/src/load/import_map.ts
@@ -33,6 +33,7 @@ export * as tracers__tracer_langchain_v1 from "../tracers/tracer_langchain_v1.js
 export * as utils__async_caller from "../utils/async_caller.js";
 export * as utils__chunk_array from "../utils/chunk_array.js";
 export * as utils__env from "../utils/env.js";
+export * as utils__function_calling from "../utils/function_calling.js";
 export * as utils__hash from "../utils/hash.js";
 export * as utils__json_patch from "../utils/json_patch.js";
 export * as utils__json_schema from "../utils/json_schema.js";

--- a/langchain-core/src/utils/function_calling.ts
+++ b/langchain-core/src/utils/function_calling.ts
@@ -1,0 +1,27 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { StructuredToolInterface } from "../tools.js";
+import { FunctionDefinition, ToolDefinition } from "../language_models/base.js";
+
+export function convertToOpenAIFunction(
+  tool: StructuredToolInterface
+): FunctionDefinition {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: zodToJsonSchema(tool.schema),
+  };
+}
+
+export function convertToOpenAITool(
+  tool: StructuredToolInterface
+): ToolDefinition {
+  const schema = zodToJsonSchema(tool.schema);
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: schema,
+    },
+  };
+}

--- a/langchain-core/src/utils/tests/function_calling.test.ts
+++ b/langchain-core/src/utils/tests/function_calling.test.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import { test, expect } from "@jest/globals";
+import {
+  convertToOpenAIFunction,
+  convertToOpenAITool,
+} from "../function_calling.js";
+import { FakeTool } from "../testing/index.js";
+
+test("Can convert tool to OpenAI Functions format", async () => {
+  const tool = new FakeTool({
+    name: "faketesttool",
+    description: "A fake test tool",
+    schema: z.object({
+      prop1: z.string(),
+      prop2: z.number().describe("Some desc"),
+      optionalProp: z.optional(
+        z.array(
+          z.object({
+            nestedRequired: z.string(),
+            nestedOptional: z.optional(z.string()),
+          })
+        )
+      ),
+    }),
+  });
+  const result = convertToOpenAIFunction(tool);
+  expect(result).toEqual({
+    name: "faketesttool",
+    description: "A fake test tool",
+    parameters: {
+      type: "object",
+      properties: {
+        prop1: {
+          type: "string",
+        },
+        prop2: {
+          type: "number",
+          description: "Some desc",
+        },
+        optionalProp: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              nestedRequired: {
+                type: "string",
+              },
+              nestedOptional: {
+                type: "string",
+              },
+            },
+            required: ["nestedRequired"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["prop1", "prop2"],
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#",
+    },
+  });
+});
+
+test("Can convert tool to OpenAI Tool format", async () => {
+  const tool = new FakeTool({
+    name: "faketesttool",
+    description: "A fake test tool",
+    schema: z.object({
+      prop1: z.string(),
+      prop2: z.number().describe("Some desc"),
+      optionalProp: z.optional(
+        z.array(
+          z.object({
+            nestedRequired: z.string(),
+            nestedOptional: z.optional(z.string()),
+          })
+        )
+      ),
+    }),
+  });
+  const result = convertToOpenAITool(tool);
+  expect(result).toEqual({
+    type: "function",
+    function: {
+      name: "faketesttool",
+      description: "A fake test tool",
+      parameters: {
+        type: "object",
+        properties: {
+          prop1: {
+            type: "string",
+          },
+          prop2: {
+            type: "number",
+            description: "Some desc",
+          },
+          optionalProp: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                nestedRequired: {
+                  type: "string",
+                },
+                nestedOptional: {
+                  type: "string",
+                },
+              },
+              required: ["nestedRequired"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["prop1", "prop2"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8591,6 +8591,7 @@ __metadata:
     typescript: ~5.1.6
     uuid: ^9.0.0
     zod: ^3.22.3
+    zod-to-json-schema: 3.20.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
We can look at unpinning/bumping `zod-to-json-schema` (as mentioned in #3983) in a separate PR.