### PR TITLE
Bump Zod & Zod-to-Json-Schema, fix imports

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -70,8 +70,8 @@
     "vectordb": "^0.1.4",
     "voy-search": "0.6.2",
     "weaviate-ts-client": "^1.0.0",
-    "zod": "^3.22.3",
-    "zod-to-json-schema": "3.20.3"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -43,8 +43,8 @@
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "uuid": "^9.0.0",
-    "zod": "^3.22.3",
-    "zod-to-json-schema": "3.20.3"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -1217,8 +1217,8 @@
     "p-retry": "4",
     "uuid": "^9.0.0",
     "yaml": "^2.2.1",
-    "zod": "^3.22.3",
-    "zod-to-json-schema": "3.20.3"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
   },
   "publishConfig": {
     "access": "public"

--- a/langchain/src/agents/structured_chat/index.ts
+++ b/langchain/src/agents/structured_chat/index.ts
@@ -1,6 +1,4 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
-
+import { zodToJsonSchema, JsonSchema7ObjectType } from "zod-to-json-schema";
 import type { StructuredToolInterface } from "@langchain/core/tools";
 import type {
   BaseLanguageModel,

--- a/langchain/src/chains/openai_functions/base.ts
+++ b/langchain/src/chains/openai_functions/base.ts
@@ -1,6 +1,5 @@
 import type { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
+import { zodToJsonSchema, JsonSchema7Type } from "zod-to-json-schema";
 
 import type { BaseOutputParser } from "@langchain/core/output_parsers";
 import type { BasePromptTemplate } from "@langchain/core/prompts";

--- a/langchain/src/chains/openai_functions/extraction.ts
+++ b/langchain/src/chains/openai_functions/extraction.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import { zodToJsonSchema, JsonSchema7ObjectType } from "zod-to-json-schema";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { BaseFunctionCallOptions } from "@langchain/core/language_models/base";
 import { PromptTemplate } from "@langchain/core/prompts";

--- a/langchain/src/chains/openai_functions/openapi.ts
+++ b/langchain/src/chains/openai_functions/openapi.ts
@@ -1,7 +1,9 @@
 import type { OpenAIClient } from "@langchain/openai";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
-import { JsonSchema7ArrayType } from "zod-to-json-schema/src/parsers/array.js";
-import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
+import {
+  JsonSchema7ObjectType,
+  JsonSchema7ArrayType,
+  JsonSchema7Type,
+} from "zod-to-json-schema";
 import type { OpenAPIV3_1 } from "openapi-types";
 
 import { ChainValues } from "@langchain/core/utils/types";

--- a/langchain/src/chains/openai_functions/structured_output.ts
+++ b/langchain/src/chains/openai_functions/structured_output.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
+import { zodToJsonSchema, JsonSchema7Type } from "zod-to-json-schema";
 
 import { Validator } from "@langchain/core/utils/json_schema";
 import { ChatOpenAI } from "@langchain/openai";

--- a/langchain/src/chains/openai_functions/tagging.ts
+++ b/langchain/src/chains/openai_functions/tagging.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import { zodToJsonSchema, JsonSchema7ObjectType } from "zod-to-json-schema";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { BaseFunctionCallOptions } from "@langchain/core/language_models/base";
 import { PromptTemplate } from "@langchain/core/prompts";

--- a/langchain/src/chains/openai_functions/tests/openapi.test.ts
+++ b/langchain/src/chains/openai_functions/tests/openapi.test.ts
@@ -1,11 +1,13 @@
 import { test, expect } from "@jest/globals";
 
 import { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
-import { JsonSchema7StringType } from "zod-to-json-schema/src/parsers/string.js";
-import { JsonSchema7NumberType } from "zod-to-json-schema/src/parsers/number.js";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
-import { JsonSchema7ArrayType } from "zod-to-json-schema/src/parsers/array.js";
-import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
+import {
+  JsonSchema7StringType,
+  JsonSchema7NumberType,
+  JsonSchema7ObjectType,
+  JsonSchema7ArrayType,
+  JsonSchema7Type,
+} from "zod-to-json-schema";
 import { OpenAPISpec } from "../../../util/openapi.js";
 import { convertOpenAPISchemaToJSONSchema } from "../openapi.js";
 

--- a/langchain/src/document_transformers/openai_functions.ts
+++ b/langchain/src/document_transformers/openai_functions.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import type { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import {
+  zodToJsonSchema,
+  type JsonSchema7ObjectType,
+} from "zod-to-json-schema";
 
 import {
   Document,

--- a/langchain/src/experimental/autogpt/prompt_generator.ts
+++ b/langchain/src/experimental/autogpt/prompt_generator.ts
@@ -1,5 +1,4 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import { zodToJsonSchema, JsonSchema7ObjectType } from "zod-to-json-schema";
 
 import { ObjectTool, FINISH_NAME } from "./schema.js";
 

--- a/langchain/src/output_parsers/openai_functions.ts
+++ b/langchain/src/output_parsers/openai_functions.ts
@@ -1,4 +1,4 @@
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import { JsonSchema7ObjectType } from "zod-to-json-schema";
 import {
   compare,
   type Operation as JSONPatchOperation,

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
-import { JsonSchema7ArrayType } from "zod-to-json-schema/src/parsers/array.js";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
-import { JsonSchema7StringType } from "zod-to-json-schema/src/parsers/string.js";
-import { JsonSchema7NumberType } from "zod-to-json-schema/src/parsers/number.js";
-import { JsonSchema7NullableType } from "zod-to-json-schema/src/parsers/nullable.js";
+import {
+  zodToJsonSchema,
+  JsonSchema7Type,
+  JsonSchema7ArrayType,
+  JsonSchema7ObjectType,
+  JsonSchema7StringType,
+  JsonSchema7NumberType,
+  JsonSchema7NullableType,
+} from "zod-to-json-schema";
 import {
   BaseOutputParser,
   FormatInstructionsOptions,

--- a/langchain/src/tools/render.ts
+++ b/langchain/src/tools/render.ts
@@ -1,5 +1,4 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+import { zodToJsonSchema, JsonSchema7ObjectType } from "zod-to-json-schema";
 import { StructuredToolInterface } from "@langchain/core/tools";
 
 /**

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -38,8 +38,8 @@
     "@langchain/core": "~0.1.13",
     "js-tiktoken": "^1.0.7",
     "openai": "^4.24.2",
-    "zod": "^3.22.3",
-    "zod-to-json-schema": "3.20.3"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8590,8 +8590,8 @@ __metadata:
     turbo: latest
     typescript: ~5.1.6
     uuid: ^9.0.0
-    zod: ^3.22.3
-    zod-to-json-schema: 3.20.3
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
   languageName: unknown
   linkType: soft
 
@@ -8681,8 +8681,8 @@ __metadata:
     release-it: ^15.10.1
     rimraf: ^5.0.1
     typescript: ~5.1.6
-    zod: ^3.22.3
-    zod-to-json-schema: 3.20.3
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
   languageName: unknown
   linkType: soft
 
@@ -19178,8 +19178,8 @@ __metadata:
     vectordb: ^0.1.4
     voy-search: 0.6.2
     weaviate-ts-client: ^1.0.0
-    zod: ^3.22.3
-    zod-to-json-schema: 3.20.3
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
   languageName: unknown
   linkType: soft
 
@@ -23800,8 +23800,8 @@ __metadata:
     yaml: ^2.2.1
     youtube-transcript: ^1.0.6
     youtubei.js: ^5.8.0
-    zod: ^3.22.3
-    zod-to-json-schema: 3.20.3
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
   peerDependencies:
     "@aws-sdk/client-s3": ^3.310.0
     "@aws-sdk/client-sagemaker-runtime": ^3.310.0
@@ -33804,16 +33804,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:3.20.3":
-  version: 3.20.3
-  resolution: "zod-to-json-schema@npm:3.20.3"
+"zod-to-json-schema@npm:^3.22.3":
+  version: 3.22.3
+  resolution: "zod-to-json-schema@npm:3.22.3"
   peerDependencies:
-    zod: ^3.20.0
-  checksum: 1addf7e6f7d69398404dc90f5c9b76ea44e3f6deeb2fc7c72983a00e15b7340661d7e894b0a4eee3a07334dcdcc79d7064e44de46b4acc37d38ab2f3f7217ec8
+    zod: ^3.22.4
+  checksum: 2747a3d1514f579006939c0edd6a420acae65ad016df223b09c4a542cbc8c0ae61b4d7b391228a211cde973635ed49c47b1449791982f3b32d799319bb174f42
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.3":
+"zod@npm:^3.22.3, zod@npm:^3.22.4":
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f


### PR DESCRIPTION
The version for zod-to-json-schema was originally pinned to solve #3340. This was reported and fixed in the zod-to-json-schema repo in this issue: https://github.com/StefanTerdell/zod-to-json-schema/issues/94

Based on the likeliness of this being the culprit I've bumped it and Zod for good measure. Also fixed some broken type imports.

All tests pass and it _works on my machine<sup>TM</sup>_

Fixes #4021 and #3983 
