### PR TITLE
Updated "Add message history" documentation page for missing module import

### DIFF
--- a/docs/core_docs/docs/expression_language/how_to/message_history.mdx
+++ b/docs/core_docs/docs/expression_language/how_to/message_history.mdx
@@ -72,6 +72,8 @@ Crucially, we also need to define a method that takes a `sessionId` string and b
 In this case we'll also want to specify `inputMessagesKey` (the key to be treated as the latest input message) and `historyMessagesKey` (the key to add historical messages to).
 
 ```typescript
+import { RunnableWithMessageHistory } from "@langchain/core/runnables";
+
 const chainWithHistory = new RunnableWithMessageHistory({
   runnable: chain,
   getMessageHistory: (sessionId) =>


### PR DESCRIPTION
Documentation missing a required import statement for the `RunnableWithMessageHistory` module in the code given in the 'Adding message history' section. 

Link to the current live documentation page/section: [Adding message history](https://js.langchain.com/docs/expression_language/how_to/message_history#adding-message-history)

The corresponding code example file already has this required import, but it was missing in the documentation.

Corresponding code example file path: examples/src/guides/expression_language/message_history.ts
