### PR TITLE
docs[patch]: Remove pinecone node-only warnings

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/pinecone.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/pinecone.mdx
@@ -1,12 +1,4 @@
----
-sidebar_class_name: node-only
----
-
 # Pinecone
-
-:::tip Compatibility
-Only available on Node.js.
-:::
 
 You can use [Pinecone](https://www.pinecone.io/) vectorstores with LangChain.
 To get started, install the integration package and the official Pinecone SDK with:


### PR DESCRIPTION
Removing the Node-only warnings since [the release of v1.0.1](https://github.com/pinecone-io/pinecone-ts-client/releases/tag/v1.0.1), Pinecone can run on Edge. The Pinecone integration [now uses v2.0.0.](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-pinecone/package.json#L38)
