### PR TITLE
langchain[patch]: Add eval source links

### DIFF
--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -1,10 +1,10 @@
 import { BaseLanguageModel } from "@langchain/core/language_models/base";
+import { RunnableConfig } from "@langchain/core/runnables";
 import { Example, Run } from "langsmith";
 import { EvaluationResult, RunEvaluator } from "langsmith/evaluation";
 import { Criteria } from "../evaluation/index.js";
 import { LoadEvaluatorOptions } from "../evaluation/loader.js";
 import { EvaluatorType } from "../evaluation/types.js";
-import { RunnableConfig } from "@langchain/core/runnables";
 
 export type EvaluatorInputs = {
   input?: string | unknown;

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -4,6 +4,7 @@ import { EvaluationResult, RunEvaluator } from "langsmith/evaluation";
 import { Criteria } from "../evaluation/index.js";
 import { LoadEvaluatorOptions } from "../evaluation/loader.js";
 import { EvaluatorType } from "../evaluation/types.js";
+import { RunnableConfig } from "@langchain/core/runnables";
 
 export type EvaluatorInputs = {
   input?: string | unknown;
@@ -40,8 +41,14 @@ export type DynamicRunEvaluatorParams = {
  * pass a function to the runner. This type allows us to do that.
  */
 export type RunEvaluatorLike =
-  | ((props: DynamicRunEvaluatorParams) => Promise<EvaluationResult>)
-  | ((props: DynamicRunEvaluatorParams) => EvaluationResult);
+  | ((
+      props: DynamicRunEvaluatorParams,
+      options?: { config?: RunnableConfig }
+    ) => Promise<EvaluationResult>)
+  | ((
+      props: DynamicRunEvaluatorParams,
+      options?: { config?: RunnableConfig }
+    ) => EvaluationResult);
 
 /**
  * Configuration class for running evaluations on datasets.

--- a/langchain/src/smith/runner_utils.ts
+++ b/langchain/src/smith/runner_utils.ts
@@ -35,7 +35,7 @@ export type ChainOrFactory =
   | (() => (obj: unknown) => unknown)
   | (() => (obj: unknown) => Promise<unknown>);
 
-class RunIdResolver {
+class RunIdExtractor {
   runIdPromiseResolver: (runId: string) => void;
 
   runIdPromise: Promise<string>;
@@ -76,7 +76,7 @@ class DynamicRunEvaluator implements RunEvaluator {
    * @returns A promise that extracts to the evaluation result.
    */
   async evaluateRun(run: Run, example?: Example): Promise<EvaluationResult> {
-    const extracter = new RunIdResolver();
+    const extractor = new RunIdExtractor();
     const result = await this.evaluator.invoke(
       {
         run,
@@ -86,10 +86,10 @@ class DynamicRunEvaluator implements RunEvaluator {
         reference: example?.outputs,
       },
       {
-        callbacks: [extracter],
+        callbacks: [extractor],
       }
     );
-    const runId = await extracter.extract();
+    const runId = await extractor.extract();
     return {
       sourceRunId: runId,
       ...result,
@@ -168,7 +168,7 @@ class PreparedRunEvaluator implements RunEvaluator {
       rawReferenceOutput: example?.outputs,
       run,
     });
-    const extracter = new RunIdResolver();
+    const extractor = new RunIdExtractor();
     if (this.isStringEvaluator) {
       const evalResult = await this.evaluator.evaluateStrings(
         {
@@ -177,10 +177,10 @@ class PreparedRunEvaluator implements RunEvaluator {
           input: input as string,
         },
         {
-          callbacks: [extracter],
+          callbacks: [extractor],
         }
       );
-      const runId = await extracter.extract();
+      const runId = await extractor.extract();
       return {
         key: this.evaluationName,
         comment: evalResult?.reasoning,


### PR DESCRIPTION
We want to auto-populate the traces from evaluators, where possible. This PR enables that