### PR TITLE
langchain[patch]: Trace in Evaluators Project

### DIFF
--- a/langchain/src/smith/runner_utils.ts
+++ b/langchain/src/smith/runner_utils.ts
@@ -49,13 +49,9 @@ class RunIdExtractor {
   handleChainStart = (
     _chain: Serialized,
     _inputs: ChainValues,
-    runId: string,
-    parentRunId?: string
+    runId: string
   ) => {
-    if (!parentRunId) {
-      // Only resolve root runs
-      this.runIdPromiseResolver(runId);
-    }
+    this.runIdPromiseResolver(runId);
   };
 
   async extract(): Promise<string> {

--- a/langchain/src/smith/runner_utils.ts
+++ b/langchain/src/smith/runner_utils.ts
@@ -49,9 +49,13 @@ class RunIdExtractor {
   handleChainStart = (
     _chain: Serialized,
     _inputs: ChainValues,
-    runId: string
+    runId: string,
+    parentRunId?: string
   ) => {
-    this.runIdPromiseResolver(runId);
+    if (!parentRunId) {
+      // Only resolve root runs
+      this.runIdPromiseResolver(runId);
+    }
   };
 
   async extract(): Promise<string> {
@@ -77,6 +81,7 @@ class DynamicRunEvaluator implements RunEvaluator {
    */
   async evaluateRun(run: Run, example?: Example): Promise<EvaluationResult> {
     const extractor = new RunIdExtractor();
+    const tracer = new LangChainTracer({ projectName: "evaluators" });
     const result = await this.evaluator.invoke(
       {
         run,
@@ -86,7 +91,7 @@ class DynamicRunEvaluator implements RunEvaluator {
         reference: example?.outputs,
       },
       {
-        callbacks: [extractor],
+        callbacks: [extractor, tracer],
       }
     );
     const runId = await extractor.extract();
@@ -169,6 +174,7 @@ class PreparedRunEvaluator implements RunEvaluator {
       run,
     });
     const extractor = new RunIdExtractor();
+    const tracer = new LangChainTracer({ projectName: "evaluators" });
     if (this.isStringEvaluator) {
       const evalResult = await this.evaluator.evaluateStrings(
         {
@@ -177,7 +183,7 @@ class PreparedRunEvaluator implements RunEvaluator {
           input: input as string,
         },
         {
-          callbacks: [extractor],
+          callbacks: [extractor, tracer],
         }
       );
       const runId = await extractor.extract();


### PR DESCRIPTION
Previously, you could get an un-traced run id if `LANGCHAIN_TRACING_V2` was unset. This PR
1. Makes it so the evaluators will predictably be traced within the `runOnDataset` function
2. Sends their races to the `evalators` project (as is done in python)