### PR TITLE
cohere[patch]: Fix use of CohereChat with RunnableWithMessageHistory

### DIFF
--- a/libs/langchain-cohere/src/chat_models.ts
+++ b/libs/langchain-cohere/src/chat_models.ts
@@ -177,14 +177,14 @@ export class ChatCohere<
     // The last message in the array is the most recent, all other messages
     // are apart of the chat history.
     const { message } = cohereMessages[cohereMessages.length - 1];
-    const chat_history: Cohere.ChatMessage[] = [];
+    const chatHistory: Cohere.ChatMessage[] = [];
     if (cohereMessages.length > 1) {
-      chat_history.concat(cohereMessages.slice(0, -1));
+      chatHistory.push(...cohereMessages.slice(0, -1));
     }
     const input = {
       ...params,
       message,
-      chat_history,
+      chatHistory,
     };
 
     // Handle streaming
@@ -274,14 +274,14 @@ export class ChatCohere<
     // The last message in the array is the most recent, all other messages
     // are apart of the chat history.
     const { message } = cohereMessages[cohereMessages.length - 1];
-    const chat_history: Cohere.ChatMessage[] = [];
+    const chatHistory: Cohere.ChatMessage[] = [];
     if (cohereMessages.length > 1) {
-      chat_history.concat(cohereMessages.slice(0, -1));
+      chatHistory.push(...cohereMessages.slice(0, -1));
     }
     const input = {
       ...params,
       message,
-      chat_history,
+      chatHistory,
     };
 
     // All models have a built in `this.caller` property for retries


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- if linkedin works that would be great! https://www.linkedin.com/in/jaiw/ -->

Hi, I've been using `ChatCohere` and wanted chat memory. Using Cohere's internal chat history works fine with `conversationId`. But I was unable to get it working with Langchain's memory system. I was using `RunnableWithMessageHistory`.

I realize it's in beta, and wanted to help.

So it seems like sending messages with Cohere client does not work properly. I was able to get it working by renaming chat_history and changing the behavior of the history array.

1. rename `chat_history` to `chatHistory`

It seems to only work with "chatHistory", their docstring is a little confusing.

https://github.com/cohere-ai/cohere-typescript/blob/c7d02986e6e4378d431ae19df1bf96b3388f7d1d/src/api/client/requests/ChatStreamRequest.ts#L32

2. Another issue seems to be with using `concat` here which returns a copied array but `chat_history` stays empty.

https://github.com/langchain-ai/langchainjs/blob/5df74e39a8b9888ec5a515d43594f856ffc1c2a7/libs/langchain-cohere/src/chat_models.ts#L277-L280

I used push for this pr:
```javascript
const chat_history = [];
if (cohereMessages.length > 1) {
    chat_history.push(...cohereMessages.slice(0, -1));
}
```

this works too:
```javascript
let chat_history = [];
if (cohereMessages.length > 1) {
  chat_history = chat_history.concat(cohereMessages.slice(0, -1));
}
```


Fixes #4186
