### PR TITLE
Fix Deprecated Import from docs/agents/quick_start.mdx

### DIFF
--- a/docs/core_docs/docs/modules/agents/quick_start.mdx
+++ b/docs/core_docs/docs/modules/agents/quick_start.mdx
@@ -90,7 +90,7 @@ console.log(retrieverResult[0]);
 Now that we have populated our index that we will do doing retrieval over, we can easily turn it into a tool (the format needed for an agent to properly use it):
 
 ```typescript
-import { createRetrieverTool } from "langchain/agents/toolkits";
+import { createRetrieverTool } from "langchain/tools/retriever";
 
 const retrieverTool = createRetrieverTool(retriever, {
   name: "langsmith_search",


### PR DESCRIPTION
This import is deprecated.
import { createRetrieverTool } from "langchain/agents/toolkits";

Should be:
import { createRetrieverTool } from "langchain/tools/retriever";
