### PR TITLE
Update pgvector docker image

### DIFF
--- a/examples/src/indexes/vector_stores/pgvector_vectorstore/docker-compose.example.yml
+++ b/examples/src/indexes/vector_stores/pgvector_vectorstore/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: ankane/pgvector
+    image: pgvector/pgvector:pg16
     ports:
       - 5433:5432
     volumes:


### PR DESCRIPTION
PGVector docker releases became more official:

https://github.com/pgvector/pgvector#docker
https://github.com/pgvector/pgvector?tab=readme-ov-file#docker-1

This updates the pgvector docker image to the new namespace. Old address is deprecated and will not be updated.
