### PR TITLE
Fix typos and grammer errors in concepts.mdx

### DIFF
--- a/docs/core_docs/docs/modules/model_io/concepts.mdx
+++ b/docs/core_docs/docs/modules/model_io/concepts.mdx
@@ -23,18 +23,18 @@ they take a list of chat messages as input and they return an AI message as outp
 
 ### Considerations
 
-These two API types have pretty different input and output schemas. This means that best way to interact with them may be quite different. Although LangChain makes it possible to treat them interchangeably, that doesn't mean you **should**. In particular, the prompting strategies for LLMs vs ChatModels may be quite different. This means that you will want to make sure the prompt you are using is designed for the model type you are working with.
+These two API types have pretty different input and output schemas. This means that the best way to interact with them may be quite different. Although LangChain makes it possible to treat them interchangeably, that doesn't mean you **should**. In particular, the prompting strategies for LLMs vs ChatModels may be quite different. This means that you will want to make sure the prompt you are using is designed for the model type you are working with.
 
-Additionally, not all models are the same. Different models have different prompting strategies that work best for them. For example, Anthropic's models work best with XML while OpenAI's work best with JSON. This means that the prompt you use for one model may not transfer to other ones. LangChain provides a lot of default prompts, however these are not garunteed to work well with the model are you using. Historically speaking, most prompts work well with OpenAI but are not heavily tested on other models. This is something we are working to address, but it is something you should keep in mind.
+Additionally, not all models are the same. Different models have different prompting strategies that work best for them. For example, Anthropic's models work best with XML while OpenAI's work best with JSON. This means that the prompt you use for one model may not transfer to other ones. LangChain provides a lot of default prompts, however, these are not guaranteed to work well with the model are you using. Historically speaking, most prompts work well with OpenAI but are not heavily tested on other models. This is something we are working to address, but it is something you should keep in mind.
 
 ## Messages
 
-ChatModels take a list of messages as input and return a message. There are a few different types of messages. All messages have a `role` and a `content` property. The `role` describes WHO is saying the message. LangChain has different message classes for different roles. The `content` property described the content of the message. This can be a few different things:
+ChatModels takes a list of messages as input and returns a message. There are a few different types of messages. All messages have a `role` and a `content` property. The `role` describes WHO is saying the message. LangChain has different message classes for different roles. The `content` property describes the content of the message. This can be a few different things:
 
 - A string (most models are this way)
 - A List of dictionaries (this is used for multi-modal input, where the dictionary contains information about that input type and that input location)
 
-In addition, messages have an `additional_kwargs` property. This is where additional information about messages can be passed. This is largely used for input parameters that are _provider specific_ and not general. The best known example of this is `function_call` from OpenAI.
+In addition, messages have an `additional_kwargs` property. This is where additional information about messages can be passed. This is largely used for input parameters that are _provider specific_ and not general. The best-known example of this is `function_call` from OpenAI.
 
 ### HumanMessage
 
@@ -42,7 +42,7 @@ This represents a message from the user. Generally consists only of content.
 
 ### AIMessage
 
-This represents a message from the model. This may have `additional_kwargs` in it - for example `functional_call` if using OpenAI Function calling.
+This represents a message from the model. This may have `additional_kwargs` in it - for example, `functional_call` if using OpenAI Function calling.
 
 ### SystemMessage
 
@@ -54,15 +54,15 @@ This represents the result of a function call. In addition to `role` and `conten
 
 ### ToolMessage
 
-This represents the result of a tool call. This is distinct from a FunctionMessage in order to match OpenAI's `function` and `tool` message types. In addition to `role` and `content`, this message has a `tool_call_id` parameter which conveys the id of the call to the tool that was called to produce this result.
+This represents the result of a tool call. This is distinct from a FunctionMessage to match OpenAI's `function` and `tool` message types. In addition to `role` and `content`, this message has a `tool_call_id` parameter which conveys the id of the call to the tool that was called to produce this result.
 
 ## Prompts
 
-The inputs to language models are often called prompts. Oftentimes, the user input from your app is not the direct input to the model. Rather, their input is transformed in some way to product the string or list of messages that does go into the model. The objects that take user input and transform it into the final string or messages are known as "Prompt Templates". LangChain provides several abstractions to make working with prompts easier.
+The inputs to language models are often called prompts. Oftentimes, the user input from your app is not the direct input to the model. Rather, their input is transformed in some way to produce the string or list of messages that go into the model. The objects that take user input and transform it into the final string or messages are known as "Prompt Templates". LangChain provides several abstractions to make working with prompts easier.
 
 ### PromptValue
 
-ChatModels and LLMs take different input types. PromptValue is class designed to be interoptable between the two. It exposes a method to be cast to a string (to work with LLMs) and another to be cast to a list of messages (to work with ChatModels).
+ChatModels and LLMs take different input types. PromptValue is a class designed to be interoperable between the two. It exposes a method to be cast to a string (to work with LLMs) and another to be cast to a list of messages (to work with ChatModels).
 
 ### PromptTemplate
 
@@ -78,7 +78,7 @@ This is MessagePromptTemplate that produces a HumanMessage.
 
 #### AIMessagePromptTemplate
 
-This is MessagePromptTemplate that produces an AIMessage.
+This is MessagePromptTemplate which produces an AIMessage.
 
 #### SystemMessagePromptTemplate
 
@@ -94,7 +94,7 @@ This is an example of a prompt template. This consists of a list of MessagePromp
 
 ## Output Parsers
 
-The output of models are either strings or a message. Oftentimes, the string or messages contains information formatted in a specific format to be used downstream (e.g. a comma separated list, or JSON blob). Output parsers are responsible for taking in the output of a model and transforming it into a more usable form. These generally work on the `content` of the output message, but occasionally work on values in the `additional_kwargs` field.
+The output of models is either strings or a message. Oftentimes, the string or messages contain information formatted in a specific format to be used downstream (e.g. a comma-separated list, or JSON blob). Output parsers are responsible for taking in the output of a model and transforming it into a more usable form. These generally work on the `content` of the output message but occasionally work on values in the `additional_kwargs` field.
 
 ### StrOutputParser
 

--- a/docs/core_docs/docs/modules/model_io/concepts.mdx
+++ b/docs/core_docs/docs/modules/model_io/concepts.mdx
@@ -29,7 +29,7 @@ Additionally, not all models are the same. Different models have different promp
 
 ## Messages
 
-ChatModels takes a list of messages as input and returns a message. There are a few different types of messages. All messages have a `role` and a `content` property. The `role` describes WHO is saying the message. LangChain has different message classes for different roles. The `content` property describes the content of the message. This can be a few different things:
+ChatModels take a list of messages as input and return a message. There are a few different types of messages. All messages have a `role` and a `content` property. The `role` describes WHO is saying the message. LangChain has different message classes for different roles. The `content` property describes the content of the message. This can be a few different things:
 
 - A string (most models are this way)
 - A List of dictionaries (this is used for multi-modal input, where the dictionary contains information about that input type and that input location)
@@ -42,7 +42,7 @@ This represents a message from the user. Generally consists only of content.
 
 ### AIMessage
 
-This represents a message from the model. This may have `additional_kwargs` in it - for example, `functional_call` if using OpenAI Function calling.
+This represents a message from the model. This may have `additional_kwargs` in it - for example, `function_call` if using OpenAI Function calling.
 
 ### SystemMessage
 


### PR DESCRIPTION
While reading the documentation I noticed some spelling errors, I fixed them in this commit

It is a small change but I would love a shoutout if possible https://twitter.com/barisbll_dev
