### PR TITLE
 Correct waitlist instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Looking for the Python version? Check out [LangChain](https://github.com/langcha
 
 To help you ship LangChain apps to production faster, check out [LangSmith](https://smith.langchain.com).
 [LangSmith](https://smith.langchain.com) is a unified developer platform for building, testing, and monitoring LLM applications.
-Fill out [this form](https://airtable.com/appwQzlErAS2qiP0L/shrGtGaVBVAz7NcV2) to get off the waitlist or speak with our sales team.
+Fill out [this form](https://airtable.com/appwQzlErAS2qiP0L/shrGtGaVBVAz7NcV2) to get on the waitlist or speak with our sales team.
 
 ## ⚡️ Quick Install
 


### PR DESCRIPTION
Changed the text "Fill out this form to get off the waitlist or speak with our sales team." to "Fill out this form to get on the waitlist or speak with our sales team."