### PR TITLE
langchain[patch],docs[patch]: Fix double redirect

### DIFF
--- a/docs/core_docs/vercel.json
+++ b/docs/core_docs/vercel.json
@@ -337,10 +337,6 @@
       "destination": "/docs/modules/agents/tools/integrations/aiplugin-tool/"
     },
     {
-      "source": "/docs/modules/agents/tools/dynamic(/?)",
-      "destination": "/docs/modules/agents/tools/how_to/dynamic/"
-    },
-    {
       "source": "/docs/modules/agents/tools/lambda_agent(/?)",
       "destination": "/docs/modules/agents/tools/integrations/lambda_agent/"
     },

--- a/langchain/src/document_loaders/tests/sitemap.test.ts
+++ b/langchain/src/document_loaders/tests/sitemap.test.ts
@@ -2,7 +2,7 @@ import { test } from "@jest/globals";
 import { SitemapLoader } from "../web/sitemap.js";
 
 test("SitemapLoader", async () => {
-  const regexFailIfNotJsLangChain = /^(?!https:\/\/js\.langchain\.com).*/;
+  const regexFailIfNotJsLangChain = /^https:\/\/js\.langchain\.com\//;
   const regexContainsToolsDynamic = /tools\/dynamic/;
 
   // Filter our 1 bad url (has since been fixed in vercel, but keep the test!)

--- a/langchain/src/document_loaders/tests/sitemap.test.ts
+++ b/langchain/src/document_loaders/tests/sitemap.test.ts
@@ -2,7 +2,16 @@ import { test } from "@jest/globals";
 import { SitemapLoader } from "../web/sitemap.js";
 
 test("SitemapLoader", async () => {
-  const loader = new SitemapLoader("https://www.langchain.com/");
+  const regexFailIfNotJsLangChain = /^(?!https:\/\/js\.langchain\.com).*/;
+  const regexContainsToolsDynamic = /tools\/dynamic/;
+
+  // Filter our 1 bad url (has since been fixed in vercel, but keep the test!)
+  const loader = new SitemapLoader("https://js.langchain.com/", {
+    filterUrls: [
+      regexFailIfNotJsLangChain,
+      regexContainsToolsDynamic,
+    ]
+  });
 
   const docs = await loader.load();
   expect(docs.length).toBeGreaterThan(0);

--- a/langchain/src/document_loaders/tests/sitemap.test.ts
+++ b/langchain/src/document_loaders/tests/sitemap.test.ts
@@ -7,10 +7,7 @@ test("SitemapLoader", async () => {
 
   // Filter our 1 bad url (has since been fixed in vercel, but keep the test!)
   const loader = new SitemapLoader("https://js.langchain.com/", {
-    filterUrls: [
-      regexFailIfNotJsLangChain,
-      regexContainsToolsDynamic,
-    ]
+    filterUrls: [regexFailIfNotJsLangChain, regexContainsToolsDynamic],
   });
 
   const docs = await loader.load();

--- a/langchain/src/document_loaders/web/sitemap.ts
+++ b/langchain/src/document_loaders/web/sitemap.ts
@@ -9,10 +9,10 @@ import { CheerioWebBaseLoader, WebBaseLoaderParams } from "./cheerio.js";
  */
 export interface SitemapLoaderParams extends WebBaseLoaderParams {
   /**
-   * @property {string[] | undefined} filterUrls - A list of regexes. Only URLs that match one of the filter URLs will be loaded.
+   * @property {(string | RegExp)[] | undefined} filterUrls - A list of regexes. Only URLs that match one of the filter URLs will be loaded.
    * WARNING: The filter URLs are interpreted as regular expressions. Escape special characters if needed.
    */
-  filterUrls?: string[];
+  filterUrls?: (string | RegExp)[];
   /**
    * The size to chunk the sitemap URLs into for scraping.
    * @default {300}
@@ -33,7 +33,7 @@ export class SitemapLoader
   extends CheerioWebBaseLoader
   implements SitemapLoaderParams
 {
-  allowUrlPatterns: string[] | undefined;
+  allowUrlPatterns: (string | RegExp)[] | undefined;
 
   chunkSize: number;
 
@@ -51,7 +51,7 @@ export class SitemapLoader
 
   _checkUrlPatterns(url: string): boolean {
     if (!this.allowUrlPatterns) {
-      return true;
+      return false;
     }
     return this.allowUrlPatterns.some((pattern) =>
       new RegExp(pattern).test(url)
@@ -78,7 +78,7 @@ export class SitemapLoader
         return;
       }
 
-      if (!this._checkUrlPatterns(loc)) {
+      if (this._checkUrlPatterns(loc)) {
         return;
       }
 

--- a/langchain/src/document_loaders/web/sitemap.ts
+++ b/langchain/src/document_loaders/web/sitemap.ts
@@ -53,8 +53,8 @@ export class SitemapLoader
     if (!this.allowUrlPatterns) {
       return false;
     }
-    return this.allowUrlPatterns.some((pattern) =>
-      new RegExp(pattern).test(url)
+    return !this.allowUrlPatterns.some(
+      (pattern) => !new RegExp(pattern).test(url)
     );
   }
 


### PR DESCRIPTION
Looks like the path was changed & a redirect was added for backcompat, then it was changed again to the original path, and another redirect was added