### PR TITLE
redis[patch]: Add RedisAddOptions to .fromDocuments method in order to perform upsert/update

### DIFF
--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -282,7 +282,7 @@ export class RedisVectorStore extends VectorStore {
     metadatas: object[] | object,
     embeddings: EmbeddingsInterface,
     dbConfig: RedisVectorStoreConfig,
-    docsOptions?: RedisAddOptions,
+    docsOptions?: RedisAddOptions
   ): Promise<RedisVectorStore> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -293,7 +293,12 @@ export class RedisVectorStore extends VectorStore {
       });
       docs.push(newDoc);
     }
-    return RedisVectorStore.fromDocuments(docs, embeddings, dbConfig, docsOptions);
+    return RedisVectorStore.fromDocuments(
+      docs,
+      embeddings,
+      dbConfig,
+      docsOptions
+    );
   }
 
   /**
@@ -309,7 +314,7 @@ export class RedisVectorStore extends VectorStore {
     docs: Document[],
     embeddings: EmbeddingsInterface,
     dbConfig: RedisVectorStoreConfig,
-    docsOptions?: RedisAddOptions,
+    docsOptions?: RedisAddOptions
   ): Promise<RedisVectorStore> {
     const instance = new this(embeddings, dbConfig);
     await instance.addDocuments(docs, docsOptions);


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

By adding the optional parameter "docsOptions" to the RedisVectorStore.fromDocuments method we are now able to define the index schema directly from there. 

This should be useful when performing upserts or updating already existing keys in general.