### PR TITLE
docs[patch]: corrected typo in output parsers documentation

### DIFF
--- a/docs/core_docs/docs/modules/model_io/output_parsers/index.mdx
+++ b/docs/core_docs/docs/modules/model_io/output_parsers/index.mdx
@@ -1,6 +1,6 @@
 # Output Parsers
 
-Output parsers are responsible for taking the output of an LLM and transforming it to a more suitable format. This is very useful when you are asing LLMs to generate any form of structured data.
+Output parsers are responsible for taking the output of an LLM and transforming it to a more suitable format. This is very useful when you are asking the LLM to generate any form of structured data.
 
 Besides having a large collection of different types of output parsers, one distinguishing benefit of LangChain OutputParsers is that many of them support streaming.
 


### PR DESCRIPTION
There was a typo when I was browsing the [**Output Parsers** page](https://js.langchain.com/docs/modules/model_io/output_parsers/) of the LangChain.js documentation.

This PR corrects that typo.