### PR TITLE
experimental[patch]: Add threadId and runId to OpenAIAssistantRunnable returnValues for AgentExecutor

### DIFF
--- a/langchain/src/experimental/openai_assistant/index.ts
+++ b/langchain/src/experimental/openai_assistant/index.ts
@@ -301,6 +301,8 @@ export class OpenAIAssistantRunnable<
         return {
           returnValues: {
             output: answerString,
+            runId,
+            threadId,
           },
           log: "",
           runId,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Hi I couldn't figure out a good way to get threadId for OpenAIAssistantRunnable when used with AgentExecutor. It is returned when invoking the Runnable but it looks like AgentExecutor only returns values in `returnValues`.

Motivation:
Trying to send messages from client to api route and keep the same threadId for history.

The PR simply duplicates `runId` and `threadId` to `returnValues` which is the behavior in the python repository, [link](https://github.com/langchain-ai/langchain/blob/3925071dd61363db0d483412c9e64bc5a7c60307/libs/langchain/langchain/agents/openai_assistant/base.py#L493-L502).

```python
            return OpenAIAssistantFinish(
                return_values={
                    "output": answer,
                    "thread_id": run.thread_id,
                    "run_id": run.id,
                },
                log="",
                run_id=run.id,
                thread_id=run.thread_id,
            )
```

Then it can be used to run on the same thread as shown in the python docs.

```typescript
  // Use case
  const { threadId } = await req.json()

  const assistantAgent = await OpenAIAssistantRunnable.createAssistant({
    model: 'gpt-4-turbo-preview',
    instructions,
    name: 'Health Assistant',
    asAgent: true,
    tools
  })
  const agentExecutor = new AgentExecutor({
    agent: assistantAgent,
    tools,
    verbose: true
  })
  const outputs = await agentExecutor.invoke({
    content: 'my name is jeff!'
  })
  console.log(outputs)
  /*
  {
  content: 'my name is jeff!',
  output: 'Hello Jeff! How can I assist you today?',
  runId: 'run_CGPgN5H95WqaMZOBZqL8j8mG',
  threadId: 'thread_z8Y2h8sh5kvnCGdJGVKpE9QE'
  }
  */
  const outputs2 = await agentExecutor.invoke({
    content: "What's my name?",
    threadId: outputs.threadId
  })
  console.log(outputs2)
  /*
  {
  content: "What's my name?",
  threadId: 'thread_z8Y2h8sh5kvnCGdJGVKpE9QE',
  output: 'Your name is Jeff! How can I help you today, Jeff?',
  runId: 'run_1sPcY73ivqTwnvwECOnTyLrJ'
  }
  */

// Use case
return Response.json({threadId})
```

Trace of same code without PR (no threadId in AgentExecutor).
```shell
[chain/start] [1:chain:AgentExecutor] Entering Chain run with input: {
  "content": "my name is jeff!"
}
[chain/end] [1:chain:AgentExecutor] [3.24s] Exiting Chain run with output: {
  "content": "my name is jeff!",
  "output": "Hello, Jeff! How can I assist you today?"
}
{
  content: 'my name is jeff!',
  output: 'Hello, Jeff! How can I assist you today?'
}
[chain/start] [1:chain:AgentExecutor] Entering Chain run with input: {
  "content": "What's my name?"
}
[chain/error] [1:chain:AgentExecutor] [294ms] Chain run errored with error: "404 No thread found with id 'undefined'.\n\nError: 404 No thread found with id 'undefined'.\n
...
...
```


Fixes #4391
