### PR TITLE
community[patch]: Allow using a pool for PostgresRecordManager

### DIFF
--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -6,7 +6,8 @@ import {
 } from "./base.js";
 
 export type PostgresRecordManagerOptions = {
-  postgresConnectionOptions: PoolConfig;
+  postgresConnectionOptions?: PoolConfig;
+  pool?: Pool
   tableName?: string;
 };
 
@@ -20,9 +21,19 @@ export class PostgresRecordManager implements RecordManagerInterface {
   namespace: string;
 
   constructor(namespace: string, config: PostgresRecordManagerOptions) {
-    const { postgresConnectionOptions, tableName } = config;
+    const { postgresConnectionOptions, pool, tableName } = config;
     this.namespace = namespace;
-    this.pool = new pg.Pool(postgresConnectionOptions);
+    if (pool instanceof Pool) {
+      this.pool = pool
+    } else {
+      try {
+        this.pool = new pg.Pool(postgresConnectionOptions);
+      } catch (err: unknown) {
+        const error = err as Error
+        console.error('Got neither a valid Pool nor PoolConfig to use for PostgresRecordManager', error.message)
+        throw error
+      }
+    }
     this.tableName = tableName || "upsertion_records";
   }
 


### PR DESCRIPTION
Enable to use a predefined pool for PostgresRecordManager, allowing to use multiple indices per database. Without, each index will create a new pool, leading to Postgres connection exhaustion.

Fixes #4407 
