### PR TITLE
langchain[minor]: Fix missing traces when traceable used in runOnDataset, API update

### DIFF
--- a/docs/core_docs/docs/guides/langsmith_evaluation.mdx
+++ b/docs/core_docs/docs/guides/langsmith_evaluation.mdx
@@ -173,7 +173,7 @@ LLM is sure about what it has generated. You can perform much more sophisticated
 external APIs.
 
 ```typescript
-import type { RunEvalConfig, DynamicRunEvaluatorParams } from "langchain/smith";
+import type { RunEvalType, DynamicRunEvaluatorParams } from "langchain/smith";
 
 // An illustrative custom evaluator example
 const notUnsure = async ({
@@ -194,20 +194,26 @@ const notUnsure = async ({
   };
 };
 
-const evaluators: RunEvalConfig = {
-  evaluators: [
-    // LangChain's built-in evaluators
-    LabeledCriteria("correctness"),
-    Criteria("conciseness"),
+const evaluators: RunEvalType[] = [
+  // LangChain's built-in evaluators
+  LabeledCriteria("correctness"),
 
-    // Custom evaluators can be user-defined RunEvaluator's
-    // or a compatible function
-    notUnsure,
-  ],
-};
+  // (Optional) Format the raw input and output from the chain and example correctly
+  Criteria("conciseness", {
+    formatEvaluatorInputs: (run) => ({
+      input: run.rawInput.question,
+      prediction: run.rawPrediction.output,
+      reference: run.rawReferenceOutput.answer,
+    }),
+  }),
+
+  // Custom evaluators can be user-defined RunEvaluator's
+  // or a compatible function
+  notUnsure,
+];
 ```
 
-For predefined evaluators passed under the `evaluators` key, the passed `formatEvaluatorInputs` formats the raw input and output from the chain and example correctly.
+For prebuilt LangChain evaluators, passing `formatEvaluatorInputs` function will format the raw input and output from the chain and example correctly.
 These will most often be strings.
 
 This is not required for custom evaluators, which can perform their own parsing of run inputs and outputs.
@@ -225,7 +231,13 @@ The results will be visible in the LangSmith app.
 ```typescript
 import { runOnDataset } from "langchain/smith";
 
-await runOnDataset(agentExecutor, datasetName, evaluators);
+await runOnDataset(agentExecutor, datasetName, {
+  evaluators,
+
+  // (Optional) Provide a name of the evaluator run to be 
+  // displayed in the LangSmith UI 
+  projectName: "Name of the evaluation run",
+});
 ```
 
 ```out

--- a/docs/core_docs/docs/guides/langsmith_evaluation.mdx
+++ b/docs/core_docs/docs/guides/langsmith_evaluation.mdx
@@ -234,8 +234,8 @@ import { runOnDataset } from "langchain/smith";
 await runOnDataset(agentExecutor, datasetName, {
   evaluators,
 
-  // (Optional) Provide a name of the evaluator run to be 
-  // displayed in the LangSmith UI 
+  // (Optional) Provide a name of the evaluator run to be
+  // displayed in the LangSmith UI
   projectName: "Name of the evaluation run",
 });
 ```

--- a/docs/core_docs/docs/guides/langsmith_evaluation.mdx
+++ b/docs/core_docs/docs/guides/langsmith_evaluation.mdx
@@ -194,15 +194,17 @@ const notUnsure = async ({
   };
 };
 
-const evaluators: RunEvalConfig["evaluators"] = [
-  // LangChain's built-in evaluators
-  LabeledCriteria("correctness"),
-  Criteria("conciseness"),
+const evaluators: RunEvalConfig = {
+  evaluators: [
+    // LangChain's built-in evaluators
+    LabeledCriteria("correctness"),
+    Criteria("conciseness"),
 
-  // Custom evaluators can be user-defined RunEvaluator's
-  // or a compatible function
-  notUnsure,
-];
+    // Custom evaluators can be user-defined RunEvaluator's
+    // or a compatible function
+    notUnsure,
+  ],
+};
 ```
 
 For predefined evaluators passed under the `evaluators` key, the passed `formatEvaluatorInputs` formats the raw input and output from the chain and example correctly.

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -64,6 +64,11 @@ export function isCustomEvaluator<
   return !isOffTheShelfEvaluator(evaluator);
 }
 
+export type RunEvaluatorConfig<
+  T extends keyof EvaluatorType = keyof EvaluatorType,
+  U extends RunEvaluator | RunEvaluatorLike = RunEvaluator | RunEvaluatorLike
+> = T | EvalConfig | U;
+
 /**
  * Configuration class for running evaluations on datasets.
  *
@@ -78,21 +83,11 @@ export type RunEvalConfig<
   U extends RunEvaluator | RunEvaluatorLike = RunEvaluator | RunEvaluatorLike
 > = {
   /**
-   * Custom evaluators to apply to a dataset run.
-   * Each evaluator is provided with a run trace containing the model
-   * outputs, as well as an "example" object representing a record
-   * in the dataset.
-   *
-   * @deprecated Use `evaluators` instead.
-   */
-  customEvaluators?: U[];
-
-  /**
-   * LangChain evaluators to apply to a dataset run.
+   * Evaluators to apply to a dataset run.
    * You can optionally specify these by name, or by
    * configuring them with an EvalConfig object.
    */
-  evaluators?: (T | EvalConfig | U)[];
+  evaluators?: RunEvaluatorConfig<T, U>[];
 
   /**
    * Convert the evaluation data into formats that can be used by the evaluator.
@@ -120,9 +115,14 @@ export type RunEvalConfig<
   formatEvaluatorInputs?: EvaluatorInputFormatter;
 
   /**
-   * The language model specification for evaluators that require one.
+   * Custom evaluators to apply to a dataset run.
+   * Each evaluator is provided with a run trace containing the model
+   * outputs, as well as an "example" object representing a record
+   * in the dataset.
+   *
+   * @deprecated Use `evaluators` instead.
    */
-  evalLlm?: string;
+  customEvaluators?: U[];
 };
 
 export interface EvalConfig extends LoadEvaluatorOptions {

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -240,7 +240,10 @@ export type CriteriaEvalChainConfig = Criteria;
 
 export function Criteria(
   criteria: CriteriaType,
-  config?: Omit<Partial<Criteria>, "evaluatorType">
+  config?: Pick<
+    Partial<LabeledCriteria>,
+    "formatEvaluatorInputs" | "llm" | "feedbackKey"
+  >
 ): EvalConfig {
   const formatEvaluatorInputs =
     config?.formatEvaluatorInputs ??
@@ -253,6 +256,7 @@ export function Criteria(
     evaluatorType: "criteria",
     criteria,
     feedbackKey: config?.feedbackKey ?? criteria,
+    llm: config?.llm,
     formatEvaluatorInputs,
   };
 }
@@ -303,7 +307,10 @@ export type LabeledCriteria = EvalConfig & {
 
 export function LabeledCriteria(
   criteria: CriteriaType,
-  config?: Omit<Partial<LabeledCriteria>, "evaluatorType">
+  config?: Pick<
+    Partial<LabeledCriteria>,
+    "formatEvaluatorInputs" | "llm" | "feedbackKey"
+  >
 ): LabeledCriteria {
   const formatEvaluatorInputs =
     config?.formatEvaluatorInputs ??
@@ -317,6 +324,7 @@ export function LabeledCriteria(
     evaluatorType: "labeled_criteria",
     criteria,
     feedbackKey: config?.feedbackKey ?? criteria,
+    llm: config?.llm,
     formatEvaluatorInputs,
   };
 }
@@ -330,20 +338,22 @@ export type EmbeddingDistance = EvalConfig &
   EmbeddingDistanceEvalChainInput & { evaluatorType: "embedding_distance" };
 
 export function EmbeddingDistance(
-  config: Omit<Partial<EmbeddingDistance>, "evaluatorType">
+  config?: Pick<
+    Partial<LabeledCriteria>,
+    "formatEvaluatorInputs" | "embedding" | "distanceMetric" | "feedbackKey"
+  >
 ): EmbeddingDistance {
   const formatEvaluatorInputs =
     config?.formatEvaluatorInputs ??
     ((payload) => ({
       prediction: getSingleStringifiedValue(payload.rawPrediction),
-      input: getSingleStringifiedValue(payload.rawInput),
       reference: getSingleStringifiedValue(payload.rawReferenceOutput),
     }));
 
   return {
     evaluatorType: "embedding_distance",
-    embedding: config.embedding,
-    distanceMetric: config.distanceMetric,
+    embedding: config?.embedding,
+    distanceMetric: config?.distanceMetric,
     feedbackKey: config?.feedbackKey ?? "embedding_distance",
     formatEvaluatorInputs,
   };

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -64,7 +64,7 @@ export function isCustomEvaluator<
   return !isOffTheShelfEvaluator(evaluator);
 }
 
-export type RunEvaluatorConfig<
+export type RunEvalType<
   T extends keyof EvaluatorType = keyof EvaluatorType,
   U extends RunEvaluator | RunEvaluatorLike = RunEvaluator | RunEvaluatorLike
 > = T | EvalConfig | U;
@@ -87,7 +87,7 @@ export type RunEvalConfig<
    * You can optionally specify these by name, or by
    * configuring them with an EvalConfig object.
    */
-  evaluators?: RunEvaluatorConfig<T, U>[];
+  evaluators?: RunEvalType<T, U>[];
 
   /**
    * Convert the evaluation data into formats that can be used by the evaluator.

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -68,7 +68,10 @@ export function isCustomEvaluator<
 }
 
 export type RunEvalType<
-  T extends keyof EvaluatorType = keyof EvaluatorType,
+  T extends keyof EvaluatorType =
+    | "criteria"
+    | "labeled_criteria"
+    | "embedding_distance",
   U extends RunEvaluator | RunEvaluatorLike = RunEvaluator | RunEvaluatorLike
 > = T | EvalConfig | U;
 
@@ -82,7 +85,10 @@ export type RunEvalType<
  * @typeparam U - The type of custom evaluators.
  */
 export type RunEvalConfig<
-  T extends keyof EvaluatorType = keyof EvaluatorType,
+  T extends keyof EvaluatorType =
+    | "criteria"
+    | "labeled_criteria"
+    | "embedding_distance",
   U extends RunEvaluator | RunEvaluatorLike = RunEvaluator | RunEvaluatorLike
 > = {
   /**
@@ -338,9 +344,10 @@ export type EmbeddingDistance = EvalConfig &
   EmbeddingDistanceEvalChainInput & { evaluatorType: "embedding_distance" };
 
 export function EmbeddingDistance(
+  distanceMetric: EmbeddingDistanceEvalChainInput["distanceMetric"],
   config?: Pick<
     Partial<LabeledCriteria>,
-    "formatEvaluatorInputs" | "embedding" | "distanceMetric" | "feedbackKey"
+    "formatEvaluatorInputs" | "embedding" | "feedbackKey"
   >
 ): EmbeddingDistance {
   const formatEvaluatorInputs =
@@ -353,7 +360,7 @@ export function EmbeddingDistance(
   return {
     evaluatorType: "embedding_distance",
     embedding: config?.embedding,
-    distanceMetric: config?.distanceMetric,
+    distanceMetric,
     feedbackKey: config?.feedbackKey ?? "embedding_distance",
     formatEvaluatorInputs,
   };

--- a/langchain/src/smith/config.ts
+++ b/langchain/src/smith/config.ts
@@ -2,7 +2,10 @@ import { BaseLanguageModel } from "@langchain/core/language_models/base";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { Example, Run } from "langsmith";
 import { EvaluationResult, RunEvaluator } from "langsmith/evaluation";
-import { Criteria as CriteriaType } from "../evaluation/index.js";
+import {
+  Criteria as CriteriaType,
+  type EmbeddingDistanceEvalChainInput,
+} from "../evaluation/index.js";
 import { LoadEvaluatorOptions } from "../evaluation/loader.js";
 import { EvaluatorType } from "../evaluation/types.js";
 
@@ -165,6 +168,31 @@ export interface EvalConfig extends LoadEvaluatorOptions {
   formatEvaluatorInputs: EvaluatorInputFormatter;
 }
 
+const isStringifiableValue = (
+  value: unknown
+): value is string | number | boolean | bigint =>
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean" ||
+  typeof value === "bigint";
+
+const getSingleStringifiedValue = (value: unknown) => {
+  if (isStringifiableValue(value)) {
+    return `${value}`;
+  }
+
+  if (typeof value === "object" && value != null && !Array.isArray(value)) {
+    const entries = Object.entries(value);
+
+    if (entries.length === 1 && isStringifiableValue(entries[0][1])) {
+      return `${entries[0][1]}`;
+    }
+  }
+
+  console.warn("Non-stringifiable value found when coercing", value);
+  return `${value}`;
+};
+
 /**
  * Configuration to load a "CriteriaEvalChain" evaluator,
  * which prompts an LLM to determine whether the model's
@@ -190,7 +218,7 @@ export interface EvalConfig extends LoadEvaluatorOptions {
  *   }]
  * };
  */
-export type CriteriaEvalChainConfig = EvalConfig & {
+export type Criteria = EvalConfig & {
   evaluatorType: "criteria";
 
   /**
@@ -202,17 +230,32 @@ export type CriteriaEvalChainConfig = EvalConfig & {
   criteria?: CriteriaType | Record<string, string>;
 
   /**
-   * The feedback (or metric) name to use for the logged
-   * evaluation results. If none provided, we default to
-   * the evaluationName.
-   */
-  feedbackKey?: string;
-
-  /**
-   * The language model to use as the evaluator.
+   * The language model to use as the evaluator, defaults to GPT-4
    */
   llm?: BaseLanguageModel;
 };
+
+// for compatibility reasons
+export type CriteriaEvalChainConfig = Criteria;
+
+export function Criteria(
+  criteria: CriteriaType,
+  config?: Omit<Partial<Criteria>, "evaluatorType">
+): EvalConfig {
+  const formatEvaluatorInputs =
+    config?.formatEvaluatorInputs ??
+    ((payload) => ({
+      prediction: getSingleStringifiedValue(payload.rawPrediction),
+      input: getSingleStringifiedValue(payload.rawInput),
+    }));
+
+  return {
+    evaluatorType: "criteria",
+    criteria,
+    feedbackKey: config?.feedbackKey ?? criteria,
+    formatEvaluatorInputs,
+  };
+}
 
 /**
  * Configuration to load a "LabeledCriteriaEvalChain" evaluator,
@@ -253,72 +296,15 @@ export type LabeledCriteria = EvalConfig & {
   criteria?: CriteriaType | Record<string, string>;
 
   /**
-   * The feedback (or metric) name to use for the logged
-   * evaluation results. If none provided, we default to
-   * the evaluationName.
-   */
-  feedbackKey?: string;
-
-  /**
-   * The language model to use as the evaluator.
+   * The language model to use as the evaluator, defaults to GPT-4
    */
   llm?: BaseLanguageModel;
 };
 
-const isStringifiableValue = (
-  value: unknown
-): value is string | number | boolean | bigint =>
-  typeof value === "string" ||
-  typeof value === "number" ||
-  typeof value === "boolean" ||
-  typeof value === "bigint";
-
-const getSingleStringifiedValue = (value: unknown) => {
-  if (isStringifiableValue(value)) {
-    return `${value}`;
-  }
-
-  if (typeof value === "object" && value != null && !Array.isArray(value)) {
-    const entries = Object.entries(value);
-
-    if (entries.length === 1 && isStringifiableValue(entries[0][1])) {
-      return `${entries[0][1]}`;
-    }
-  }
-
-  console.warn("Non-stringifiable value found when coercing", value);
-  return `${value}`;
-};
-
-export function Criteria(
-  criteria: CriteriaType,
-  config?: {
-    formatEvaluatorInputs?: EvaluatorInputFormatter;
-    feedbackKey?: string;
-  }
-) {
-  const formatEvaluatorInputs =
-    config?.formatEvaluatorInputs ??
-    ((payload) => ({
-      prediction: getSingleStringifiedValue(payload.rawPrediction),
-      input: getSingleStringifiedValue(payload.rawInput),
-    }));
-
-  return {
-    evaluatorType: "criteria",
-    criteria,
-    feedbackKey: config?.feedbackKey ?? criteria,
-    formatEvaluatorInputs,
-  } satisfies EvalConfig;
-}
-
 export function LabeledCriteria(
   criteria: CriteriaType,
-  config?: {
-    formatEvaluatorInputs?: EvaluatorInputFormatter;
-    feedbackKey?: string;
-  }
-) {
+  config?: Omit<Partial<LabeledCriteria>, "evaluatorType">
+): LabeledCriteria {
   const formatEvaluatorInputs =
     config?.formatEvaluatorInputs ??
     ((payload) => ({
@@ -332,5 +318,33 @@ export function LabeledCriteria(
     criteria,
     feedbackKey: config?.feedbackKey ?? criteria,
     formatEvaluatorInputs,
-  } satisfies EvalConfig;
+  };
+}
+
+/**
+ * Configuration to load a "EmbeddingDistanceEvalChain" evaluator,
+ * which embeds distances to score semantic difference between
+ * a prediction and reference.
+ */
+export type EmbeddingDistance = EvalConfig &
+  EmbeddingDistanceEvalChainInput & { evaluatorType: "embedding_distance" };
+
+export function EmbeddingDistance(
+  config: Omit<Partial<EmbeddingDistance>, "evaluatorType">
+): EmbeddingDistance {
+  const formatEvaluatorInputs =
+    config?.formatEvaluatorInputs ??
+    ((payload) => ({
+      prediction: getSingleStringifiedValue(payload.rawPrediction),
+      input: getSingleStringifiedValue(payload.rawInput),
+      reference: getSingleStringifiedValue(payload.rawReferenceOutput),
+    }));
+
+  return {
+    evaluatorType: "embedding_distance",
+    embedding: config.embedding,
+    distanceMetric: config.distanceMetric,
+    feedbackKey: config?.feedbackKey ?? "embedding_distance",
+    formatEvaluatorInputs,
+  };
 }

--- a/langchain/src/smith/runner_utils.ts
+++ b/langchain/src/smith/runner_utils.ts
@@ -691,18 +691,18 @@ const getExamplesInputs = (
 export async function runOnDataset(
   chainOrFactory: ChainOrFactory,
   datasetName: string,
-  options: RunOnDatasetParams
+  options?: RunOnDatasetParams
 ) {
   const {
     projectName,
     projectMetadata,
     client,
     maxConcurrency,
-  }: RunOnDatasetParams = options;
+  }: RunOnDatasetParams = options ?? {};
 
   const evaluationConfig =
-    options.evaluationConfig ??
-    (options.evaluators != null
+    options?.evaluationConfig ??
+    (options?.evaluators != null
       ? {
           evaluators: options.evaluators,
           formatEvaluatorInputs: options.formatEvaluatorInputs,

--- a/langchain/src/smith/runner_utils.ts
+++ b/langchain/src/smith/runner_utils.ts
@@ -326,17 +326,17 @@ class PreparedRunEvaluator implements RunEvaluator {
     const evalConfig = typeof config === "string" ? ({} as EvalConfig) : config;
     const evaluator = await loadEvaluator(evaluatorType, evalConfig);
     const feedbackKey = evalConfig?.feedbackKey ?? evaluator?.evaluationName;
-    if (!feedbackKey) {
-      throw new Error(
-        `Evaluator of type ${evaluatorType} must have an evaluationName` +
-          ` or feedbackKey. Please manually provide a feedbackKey in the EvalConfig.`
-      );
-    }
     if (!isLLMStringEvaluator(evaluator)) {
       throw new Error(
         `Evaluator of type ${evaluatorType} not yet supported. ` +
           "Please use a string evaluator, or implement your " +
           "evaluation logic as a custom evaluator."
+      );
+    }
+    if (!feedbackKey) {
+      throw new Error(
+        `Evaluator of type ${evaluatorType} must have an evaluationName` +
+          ` or feedbackKey. Please manually provide a feedbackKey in the EvalConfig.`
       );
     }
     return new PreparedRunEvaluator(
@@ -392,7 +392,7 @@ class LoadedEvalConfig {
   constructor(public evaluators: (RunEvaluator | DynamicRunEvaluator)[]) {}
 
   static async fromRunEvalConfig(
-    config: RunEvalConfig
+    config: RunEvalConfig<keyof EvaluatorType>
   ): Promise<LoadedEvalConfig> {
     // Custom evaluators are applied "as-is"
     const customEvaluators = (


### PR DESCRIPTION
1. Getting rid of the list of eval types as last arg syntax, smaller API surface
2. Added more strict type constraints on which evaluators we do support
3. Add EmbeddingDistance() config factory
4. Introduce a subclass of RunTree, which uses LangChain Callback Manager to handle weird cases with LS batching and proper order
5. Fix stringification of errors for other non-chain callbacks