### PR TITLE
community[patch]: add neo4j-graph generics, don't swallow query execution errors

### DIFF
--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -148,7 +148,7 @@
     "lunary": "^0.6.11",
     "mongodb": "^5.2.0",
     "mysql2": "^3.3.3",
-    "neo4j-driver": "^5.16.0",
+    "neo4j-driver": "^5.17.0",
     "node-llama-cpp": "2.7.3",
     "pg": "^8.11.0",
     "pg-copy-streams": "^6.0.5",

--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -108,11 +108,15 @@ export class Neo4jGraph {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async query<RecordShape extends Record<string, any> = Record<string, any>>(query: string, params: Record<string, any> = {}, routing: RoutingControl = neo4j.routing.WRITE): Promise<RecordShape[] | undefined> {
+  async query<RecordShape extends Record<string, any> = Record<string, any>>(
+    query: string,
+    params: Record<string, any> = {},
+    routing: RoutingControl = neo4j.routing.WRITE
+  ): Promise<RecordShape[] | undefined> {
     const result = await this.driver.executeQuery<RecordShape>(query, params, {
       database: this.database,
       routing,
-      transactionConfig: { timeout: this.timeoutMs,  },
+      transactionConfig: { timeout: this.timeoutMs },
     });
     return toObjects<RecordShape>(result.records);
   }
@@ -208,7 +212,9 @@ export class Neo4jGraph {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function toObjects<RecordShape extends Record<string, any> = Record<string, any>>(records: neo4j.Record<RecordShape>): RecordShape[] {
+function toObjects<
+  RecordShape extends Record<string, any> = Record<string, any>
+>(records: neo4j.Record<RecordShape>): RecordShape[] {
   return records.map((record) => {
     const rObj = record.toObject();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -1,4 +1,4 @@
-import neo4j, { Neo4jError } from "neo4j-driver";
+import neo4j, { Neo4jError, RoutingControl } from "neo4j-driver";
 
 interface Neo4jGraphConfig {
   url: string;
@@ -108,25 +108,13 @@ export class Neo4jGraph {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async query(query: string, params: any = {}): Promise<any[] | undefined> {
-    try {
-      const result = await this.driver.executeQuery(query, params, {
-        database: this.database,
-        transactionConfig: { timeout: this.timeoutMs },
-      });
-      return toObjects(result.records);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if (
-        // eslint-disable-next-line
-        error instanceof Neo4jError &&
-        error.code === "Neo.ClientError.Procedure.ProcedureNotFound"
-      ) {
-        throw new Error("Procedure not found in Neo4j.");
-      }
-    }
-    /** @TODO Propagate error instead of returning undefined */
-    return undefined;
+  async query<RecordShape extends Record<string, any> = Record<string, any>>(query: string, params: Record<string, any> = {}, routing: RoutingControl = neo4j.routing.WRITE): Promise<RecordShape[] | undefined> {
+    const result = await this.driver.executeQuery<RecordShape>(query, params, {
+      database: this.database,
+      routing,
+      transactionConfig: { timeout: this.timeoutMs,  },
+    });
+    return toObjects<RecordShape>(result.records);
   }
 
   async verifyConnectivity() {
@@ -160,16 +148,16 @@ export class Neo4jGraph {
 
     // Assuming query method is defined and returns a Promise
     const nodeProperties: NodeType[] | undefined = (
-      await this.query(nodePropertiesQuery)
-    )?.map((el: { output: NodeType }) => el.output);
+      await this.query<{ output: NodeType }>(nodePropertiesQuery)
+    )?.map((el) => el.output);
 
     const relationshipsProperties: RelType[] | undefined = (
-      await this.query(relPropertiesQuery)
-    )?.map((el: { output: RelType }) => el.output);
+      await this.query<{ output: RelType }>(relPropertiesQuery)
+    )?.map((el) => el.output);
 
     const relationships: PathType[] | undefined = (
-      await this.query(relQuery)
-    )?.map((el: { output: PathType }) => el.output);
+      await this.query<{ output: PathType }>(relQuery)
+    )?.map((el) => el.output);
 
     // Structured schema similar to Python's dictionary comprehension
     this.structuredSchema = {
@@ -219,18 +207,17 @@ export class Neo4jGraph {
   }
 }
 
-function toObjects(records: neo4j.Record[]) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const recordValues: Record<string, any>[] = records.map((record) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toObjects<RecordShape extends Record<string, any> = Record<string, any>>(records: neo4j.Record<RecordShape>): RecordShape[] {
+  return records.map((record) => {
     const rObj = record.toObject();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const out: { [key: string]: any } = {};
-    Object.keys(rObj).forEach((key) => {
+    const out: Partial<RecordShape> = {};
+    Object.keys(rObj).forEach((key: keyof RecordShape) => {
       out[key] = itemIntToString(rObj[key]);
     });
-    return out;
+    return out as RecordShape;
   });
-  return recordValues;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -1,4 +1,4 @@
-import neo4j, { Neo4jError, RoutingControl } from "neo4j-driver";
+import neo4j, { RoutingControl } from "neo4j-driver";
 
 interface Neo4jGraphConfig {
   url: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9065,7 +9065,7 @@ __metadata:
     lunary: ^0.6.11
     mongodb: ^5.2.0
     mysql2: ^3.3.3
-    neo4j-driver: ^5.16.0
+    neo4j-driver: ^5.17.0
     node-llama-cpp: 2.7.3
     pg: ^8.11.0
     pg-copy-streams: ^6.0.5
@@ -27660,32 +27660,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo4j-driver-bolt-connection@npm:5.16.0":
-  version: 5.16.0
-  resolution: "neo4j-driver-bolt-connection@npm:5.16.0"
+"neo4j-driver-bolt-connection@npm:5.17.0":
+  version: 5.17.0
+  resolution: "neo4j-driver-bolt-connection@npm:5.17.0"
   dependencies:
     buffer: ^6.0.3
-    neo4j-driver-core: 5.16.0
+    neo4j-driver-core: 5.17.0
     string_decoder: ^1.3.0
-  checksum: ddf5337fba3bd31b5909c1ab351d57df3b51d971786ba262d53ba38e89c4204d78cf7401527814e0ea6541dea26d21b54627e17fed4b9e78e2ee31f46b3deaf3
+  checksum: 778b7df9e6bc0bb29da98cea3b7dbd0407b652466c13d0fb657c7a4d8f11f99ba2704cc3d0a29b43edc298431a65be93ead834c30a57872df6518c0fe25d4834
   languageName: node
   linkType: hard
 
-"neo4j-driver-core@npm:5.16.0":
-  version: 5.16.0
-  resolution: "neo4j-driver-core@npm:5.16.0"
-  checksum: 58c33ea0121bdbd4d541c1967998fae1b07a092a8b83438c78567dd008f79ab3401a97824c9ccb721bb25c9ff65485521bb0a1b33fa75e3464a5b6324e65d593
+"neo4j-driver-core@npm:5.17.0":
+  version: 5.17.0
+  resolution: "neo4j-driver-core@npm:5.17.0"
+  checksum: b441ba5349878934755c29bde7aac8ce5d8c23c403473902c15009cd8a4d727d0693529828721168de35a4bf43e7dff8cfd6e8c334cc8d37ac2385bc6d150086
   languageName: node
   linkType: hard
 
-"neo4j-driver@npm:^5.16.0":
-  version: 5.16.0
-  resolution: "neo4j-driver@npm:5.16.0"
+"neo4j-driver@npm:^5.17.0":
+  version: 5.17.0
+  resolution: "neo4j-driver@npm:5.17.0"
   dependencies:
-    neo4j-driver-bolt-connection: 5.16.0
-    neo4j-driver-core: 5.16.0
+    neo4j-driver-bolt-connection: 5.17.0
+    neo4j-driver-core: 5.17.0
     rxjs: ^7.8.1
-  checksum: ac6beea48043a379149132514fbabcd8ce2604c2e8237fdd60729244834a9ce45f5379aa6ca4fb93f008beaed9c3c4414e7087cd5b9d1e9c3397715fb74aa9e3
+  checksum: 655c5a8279e74a7c2e6085ea152ba2c83fd0dcd4c9badd40f14eb32d2da5fbc39881a730682de77c5a0bdb8b607cf240b3730263d902bfb0bc163fcc76e91257
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Added routing mode to allow the app to specify whether the query is routed to the leader or cluster - (defaults to `WRITE` for backwards compatibility)
* Modified `Neo4jGraph.query()` to accept generics for cleaner code
* Stopped `.query() from swallowing errors - a source of much personal confusion & frustration
* Bumped `neo4j-driver` version

Although the routing method defaults to Write, this isn't best practice.  Especially, if you consider the security note in the comments.  If possible, this should default to `READ`.