### PR TITLE
feat(langchain-community): Allow custom model endpoints to be used with GoogleVertexAI LLM class

### DIFF
--- a/libs/langchain-community/src/types/googlevertexai-types.ts
+++ b/libs/langchain-community/src/types/googlevertexai-types.ts
@@ -14,6 +14,22 @@ export interface GoogleVertexAIConnectionParams<AuthOptions>
 
   /** The version of the API functions. Part of the path. */
   apiVersion?: string;
+
+  /**
+   * Whether you are planning to connect to a public VertexAI model
+   *
+   * In case you are connecting to a default model, that was published by Google
+   * and lives under the /publishers/google/models/:model path in Google Cloud
+   * you should use "true" (default behaviour)
+   *
+   * If you are planning on connecting to a model that lives under a custom endpoint
+   * which will be the case whenever you are fine-tuning your model for example
+   * then you should use "false", which will make sure the "/publishers/google/models/:model"
+   * is not being included when building the connection URL.
+   *
+   * @see GoogleVertexAILLMConnection.buildUrl
+   * */
+  useGooglePublishedModel?: boolean
 }
 
 export interface GoogleVertexAIModelParams {

--- a/libs/langchain-community/src/utils/googlevertexai-connection.ts
+++ b/libs/langchain-community/src/utils/googlevertexai-connection.ts
@@ -189,6 +189,8 @@ export class GoogleVertexAILLMConnection<
 
   client: GoogleAbstractedClient;
 
+  connectsToGooglePublishedModel: boolean
+
   constructor(
     fields: GoogleVertexAIBaseLLMInput<AuthOptions> | undefined,
     caller: AsyncCaller,
@@ -198,13 +200,16 @@ export class GoogleVertexAILLMConnection<
     super(fields, caller, client, streaming);
     this.client = client;
     this.model = fields?.model ?? this.model;
+
+    this.connectsToGooglePublishedModel = fields?.useGooglePublishedModel ?? true
   }
 
   async buildUrl(): Promise<string> {
     const projectId = await this.client.getProjectId();
     const method = this.streaming ? "serverStreamingPredict" : "predict";
-    const url = `https://${this.endpoint}/v1/projects/${projectId}/locations/${this.location}/publishers/google/models/${this.model}:${method}`;
-    return url;
+    const vendorPath = this.connectsToGooglePublishedModel ? "/publishers/google/models" : "";
+
+    return `https://${this.endpoint}/v1/projects/${projectId}/locations/${this.location}${vendorPath}/${this.model}:${method}`;
   }
 
   formatStreamingData(

--- a/libs/langchain-community/src/utils/tests/googlevertexai-connection.test.ts
+++ b/libs/langchain-community/src/utils/tests/googlevertexai-connection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { AsyncCaller } from "@langchain/core/utils/async_caller";
+import { GoogleVertexAILLMConnection } from "../googlevertexai-connection.js";
+
+describe("GoogleVertexAILLMConnection", () => {
+  it("should correctly build the url when useGooglePublishedModel param is not provided", async () => {
+    const connection = new GoogleVertexAILLMConnection(
+      {
+        model: 'text-bison'
+      },
+      new AsyncCaller( {}),
+      {
+        request: jest.fn(),
+        getProjectId: async () => "fake_project_id"
+      },
+      false
+    )
+
+    const streamingConnection = new GoogleVertexAILLMConnection(
+      {
+        model: 'text-bison'
+      },
+      new AsyncCaller( {}),
+      {
+        request: jest.fn(),
+        getProjectId: async () => "fake_project_id"
+      },
+      true
+    )
+
+    const url = await connection.buildUrl()
+    const streamedUrl = await streamingConnection.buildUrl()
+
+    expect(url).toBe('https://us-central1-aiplatform.googleapis.com/v1/projects/fake_project_id/locations/us-central1/publishers/google/models/text-bison:predict')
+    expect(streamedUrl).toBe('https://us-central1-aiplatform.googleapis.com/v1/projects/fake_project_id/locations/us-central1/publishers/google/models/text-bison:serverStreamingPredict')
+  })
+
+  it("should not contain publishers/google/models prefix when useGooglePublishedModel is false", async () => {
+    const connection = new GoogleVertexAILLMConnection(
+      {
+        endpoint: 'us-central1-aiplatform.googleapis.com',
+        model: 'endpoints/99999999', // the nines here are the endpoint ID
+        useGooglePublishedModel: false
+      },
+      new AsyncCaller( {}),
+      {
+        request: jest.fn(),
+        getProjectId: async () => "fake_project_id"
+      },
+      false
+    )
+
+    const streamingConnection = new GoogleVertexAILLMConnection(
+      {
+        endpoint: 'us-central1-aiplatform.googleapis.com',
+        model: 'endpoints/99999999', // the nines here are the endpoint ID
+        useGooglePublishedModel: false
+      },
+      new AsyncCaller( {}),
+      {
+        request: jest.fn(),
+        getProjectId: async () => "fake_project_id"
+      },
+      true
+    )
+
+    const url = await connection.buildUrl()
+    const streamedUrl = await streamingConnection.buildUrl()
+
+    expect(url).toBe('https://us-central1-aiplatform.googleapis.com/v1/projects/fake_project_id/locations/us-central1/endpoints/99999999:predict')
+    expect(streamedUrl).toBe('https://us-central1-aiplatform.googleapis.com/v1/projects/fake_project_id/locations/us-central1/endpoints/99999999:serverStreamingPredict')
+  })
+})


### PR DESCRIPTION
### Description

According to my research it currently is not possible to use the `GoogleVertexAI` class with a fine-tuned model, that was fine tuned on the Google Cloud VertexAI platform. 

For fine-tuned models, Google creates their own endpoints which have exactly the same APIs used by their own published models. 

To solve this issue in one of my projects, I had to extend from the `GoogleVertexAI` as a base-class and override the function used to build urls (GoogleVertexAILLMConnection.buildUrl).

I don't believe that approach is good in the long run, so I decided to create this PR. 

I have spent some time thinking how would I fix this if I was one of the LangChain maintainers, but couldn't come up with anything "smart", so I opted for the "make work" approach here. 

This might not be a perfect solution, but it might make it easier for engineers to build things while a better alternative appears. 
