### PR TITLE
fix: npm to yarn command conversion

### DIFF
--- a/docs/core_docs/docs/use_cases/sql/quickstart.mdx
+++ b/docs/core_docs/docs/use_cases/sql/quickstart.mdx
@@ -34,7 +34,7 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-yarn add langchain @langchain/community @langchain/openai
+npm install langchain @langchain/community @langchain/openai
 ```
 
 We default to OpenAI models in this guide.


### PR DESCRIPTION
The commands for npm and pnpm were broken in [this page](https://js.langchain.com/docs/use_cases/chatbots/quickstart). 

The PR will fix this issue and will show relevant commands depending on selected package manager
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.
https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
