### PR TITLE
docs[patch]: Docs update: update cloudflare_vectorize.mdx

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/cloudflare_vectorize.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/cloudflare_vectorize.mdx
@@ -50,7 +50,7 @@ If running locally, be sure to run wrangler as `npx wrangler dev --remote`!
 
 ```toml
 name = "langchain-test"
-main = "worker.js"
+main = "worker.ts"
 compatibility_date = "2024-01-10"
 
 [[vectorize]]


### PR DESCRIPTION
Incorrect file extension type, causing the example to be unexecutable.