### PR TITLE
Fix undefined prompt variable when loading a non-templated image message part

### DIFF
--- a/langchain-core/src/prompts/chat.ts
+++ b/langchain-core/src/prompts/chat.ts
@@ -486,7 +486,7 @@ class _StringImageMessagePromptTemplate<
             item.type === "variable" ? [item.name] : []
           );
 
-          if (variables) {
+          if ((variables?.length ?? 0) > 0) {
             if (variables.length > 1) {
               throw new Error(
                 `Only one format variable allowed per image template.\nGot: ${variables}\nFrom: ${imgTemplate}`


### PR DESCRIPTION
The following code will produce `input_variables: [undefined]`

```
const template = ChatPromptTemplate.fromMessages([
  HumanMessagePromptTemplate.fromTemplate([{ image_url: "url" }]),
]);
```
