### PR TITLE
groq[minor]: Fix Readme example

### DIFF
--- a/libs/langchain-groq/README.md
+++ b/libs/langchain-groq/README.md
@@ -28,7 +28,7 @@ const model = new ChatGroq({
 
 const message = new HumanMessage("What color is the sky?");
 
-const res = await chat.invoke([message]);
+const res = await model.invoke([message]);
 ```
 
 ## Development


### PR DESCRIPTION
Fixes the example in the Groq readme.  It refers to an undefined variable.
