### PR TITLE
core[minor]: Allow injection of AsyncLocalStorage

### DIFF
--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -90,6 +90,10 @@ retrievers.cjs
 retrievers.js
 retrievers.d.ts
 retrievers.d.cts
+singletons.cjs
+singletons.js
+singletons.d.ts
+singletons.d.cts
 stores.cjs
 stores.js
 stores.d.ts

--- a/langchain-core/langchain.config.js
+++ b/langchain-core/langchain.config.js
@@ -35,6 +35,7 @@ export const config = {
     runnables: "runnables/index",
     "runnables/remote": "runnables/remote",
     retrievers: "retrievers",
+    singletons: "singletons/index",
     stores: "stores",
     tools: "tools",
     "tracers/base": "tracers/base",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -298,6 +298,15 @@
       "import": "./retrievers.js",
       "require": "./retrievers.cjs"
     },
+    "./singletons": {
+      "types": {
+        "import": "./singletons.d.ts",
+        "require": "./singletons.d.cts",
+        "default": "./singletons.d.ts"
+      },
+      "import": "./singletons.js",
+      "require": "./singletons.cjs"
+    },
     "./stores": {
       "types": {
         "import": "./stores.d.ts",
@@ -601,6 +610,10 @@
     "retrievers.js",
     "retrievers.d.ts",
     "retrievers.d.cts",
+    "singletons.cjs",
+    "singletons.js",
+    "singletons.d.ts",
+    "singletons.d.cts",
     "stores.cjs",
     "stores.js",
     "stores.d.ts",

--- a/langchain-core/src/runnables/config.ts
+++ b/langchain-core/src/runnables/config.ts
@@ -3,6 +3,7 @@ import {
   CallbackManager,
   ensureHandler,
 } from "../callbacks/manager.js";
+import { AsyncLocalStorageProviderSingleton } from "../singletons/index.js";
 
 export const DEFAULT_RECURSION_LIMIT = 25;
 
@@ -120,25 +121,27 @@ const PRIMITIVES = new Set(["string", "number", "boolean"]);
 export function ensureConfig<CallOptions extends RunnableConfig>(
   config?: CallOptions
 ): CallOptions {
-  let empty = {
+  const loadedConfig =
+    config ?? AsyncLocalStorageProviderSingleton.getInstance().getStore();
+  let empty: RunnableConfig = {
     tags: [],
     metadata: {},
     callbacks: undefined,
     recursionLimit: 25,
-  } as RunnableConfig;
-  if (config) {
-    empty = { ...empty, ...config };
+  };
+  if (loadedConfig) {
+    empty = { ...empty, ...loadedConfig };
   }
-  if (config?.configurable) {
-    for (const key of Object.keys(config.configurable)) {
+  if (loadedConfig?.configurable) {
+    for (const key of Object.keys(loadedConfig.configurable)) {
       if (
-        PRIMITIVES.has(typeof config.configurable[key]) &&
+        PRIMITIVES.has(typeof loadedConfig.configurable[key]) &&
         !empty.metadata?.[key]
       ) {
         if (!empty.metadata) {
           empty.metadata = {};
         }
-        empty.metadata[key] = config.configurable[key];
+        empty.metadata[key] = loadedConfig.configurable[key];
       }
     }
   }

--- a/langchain-core/src/runnables/index.ts
+++ b/langchain-core/src/runnables/index.ts
@@ -22,6 +22,7 @@ export {
   type RunnableConfig,
   getCallbackManagerForConfig,
   patchConfig,
+  ensureConfig,
 } from "./config.js";
 export { RunnablePassthrough } from "./passthrough.js";
 export { type RouterInput, RouterRunnable } from "./router.js";

--- a/langchain-core/src/runnables/passthrough.ts
+++ b/langchain-core/src/runnables/passthrough.ts
@@ -5,7 +5,7 @@ import {
   RunnableMap,
   RunnableMapLike,
 } from "./base.js";
-import type { RunnableConfig } from "./config.js";
+import { ensureConfig, type RunnableConfig } from "./config.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RunnablePassthroughFunc<RunInput = any> =
@@ -65,14 +65,15 @@ export class RunnablePassthrough<RunInput> extends Runnable<
     input: RunInput,
     options?: Partial<RunnableConfig>
   ): Promise<RunInput> {
+    const config = ensureConfig(options);
     if (this.func) {
-      await this.func(input, options);
+      await this.func(input, config);
     }
 
     return this._callWithConfig(
       (input: RunInput) => Promise.resolve(input),
       input,
-      options
+      config
     );
   }
 
@@ -80,13 +81,14 @@ export class RunnablePassthrough<RunInput> extends Runnable<
     generator: AsyncGenerator<RunInput>,
     options: Partial<RunnableConfig>
   ): AsyncGenerator<RunInput> {
+    const config = ensureConfig(options);
     let finalOutput: RunInput | undefined;
     let finalOutputSupported = true;
 
     for await (const chunk of this._transformStreamWithConfig(
       generator,
       (input: AsyncGenerator<RunInput>) => input,
-      options
+      config
     )) {
       yield chunk;
       if (finalOutputSupported) {
@@ -105,7 +107,7 @@ export class RunnablePassthrough<RunInput> extends Runnable<
     }
 
     if (this.func && finalOutput !== undefined) {
-      await this.func(finalOutput, options);
+      await this.func(finalOutput, config);
     }
   }
 

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -16,17 +16,16 @@ export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
   }
 }
 
-class AsyncLocalStorageProvider<
-  T extends new (...args: any[]) => AsyncLocalStorageInterface
-> {
-  private asyncLocalStorageClass: T = MockAsyncLocalStorage as T;
+class AsyncLocalStorageProvider {
+  private asyncLocalStorage: AsyncLocalStorageInterface =
+    new MockAsyncLocalStorage();
 
-  getClass(): T {
-    return this.asyncLocalStorageClass;
+  getInstance(): AsyncLocalStorageInterface {
+    return this.asyncLocalStorage;
   }
 
-  setClass(newClass: T) {
-    this.asyncLocalStorageClass = newClass;
+  setInstance(instance: AsyncLocalStorageInterface) {
+    this.asyncLocalStorage = instance;
   }
 }
 

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -20,12 +20,17 @@ class AsyncLocalStorageProvider {
   private asyncLocalStorage: AsyncLocalStorageInterface =
     new MockAsyncLocalStorage();
 
+  private hasBeenInitialized = false;
+
   getInstance(): AsyncLocalStorageInterface {
     return this.asyncLocalStorage;
   }
 
-  setInstance(instance: AsyncLocalStorageInterface) {
-    this.asyncLocalStorage = instance;
+  initializeGlobalInstance(instance: AsyncLocalStorageInterface) {
+    if (!this.hasBeenInitialized) {
+      this.hasBeenInitialized = true;
+      this.asyncLocalStorage = instance;
+    }
   }
 }
 

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface AsyncLocalStorageInterface {
+  getStore: () => any | undefined;
+
+  run: (store: any, callback: () => any) => any;
+}
+
+export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
+  getStore(): any {
+    return undefined;
+  }
+
+  run(_store: any, callback: () => any): any {
+    callback();
+  }
+}
+
+class AsyncLocalStorageProvider<
+  T extends new (...args: any[]) => AsyncLocalStorageInterface
+> {
+  private asyncLocalStorageClass: T = MockAsyncLocalStorage as T;
+
+  getClass(): T {
+    return this.asyncLocalStorageClass;
+  }
+
+  setClass(newClass: T) {
+    this.asyncLocalStorageClass = newClass;
+  }
+}
+
+const AsyncLocalStorageProviderSingleton = new AsyncLocalStorageProvider();
+
+export { AsyncLocalStorageProviderSingleton };

--- a/langchain-core/src/singletons/tests/async_local_storage.test.ts
+++ b/langchain-core/src/singletons/tests/async_local_storage.test.ts
@@ -32,4 +32,63 @@ test("Config should be automatically populated after setting global async local 
     }
   );
   expect(res2?.tags).toEqual(["tester"]);
+
+  const stream = await outer.stream(
+    { hi2: true },
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["stream_tester"],
+    }
+  );
+  const chunks = [];
+  for await (const chunk of stream) {
+    console.log(chunk);
+    chunks.push(chunk);
+  }
+  expect(chunks.length).toEqual(1);
+  expect(chunks[0]).toEqual(
+    expect.objectContaining({
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["stream_tester"],
+    })
+  );
+
+  const outer2 = RunnableLambda.from(async () => inner);
+  const res3 = await outer2.invoke(
+    {},
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["test_recursive"],
+    }
+  );
+  expect(res3?.tags).toEqual(["test_recursive"]);
+  const stream2 = await outer2.stream(
+    {},
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["stream_test_recursive"],
+    }
+  );
+  const chunks2 = [];
+  for await (const chunk of stream2) {
+    console.log(chunk);
+    chunks2.push(chunk);
+  }
+  expect(chunks2.length).toEqual(1);
+  expect(chunks2[0]).toEqual(
+    expect.objectContaining({
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["stream_test_recursive"],
+    })
+  );
 });

--- a/langchain-core/src/singletons/tests/async_local_storage.test.ts
+++ b/langchain-core/src/singletons/tests/async_local_storage.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@jest/globals";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { AsyncLocalStorageProviderSingleton } from "../index.js";
+import { RunnableLambda } from "../../runnables/base.js";
+
+test("Config should be automatically populated after setting global async local storage", async () => {
+  const inner = RunnableLambda.from((_, config) => {
+    return config;
+  });
+  const outer = RunnableLambda.from(async (input) => {
+    const res = await inner.invoke(input);
+    return res;
+  });
+  const res1 = await outer.invoke(
+    { hi: true },
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["tester"],
+    }
+  );
+  expect(res1?.tags).toEqual([]);
+  AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+    new AsyncLocalStorage()
+  );
+  const res2 = await outer.invoke(
+    { hi: true },
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["tester"],
+    }
+  );
+  expect(res2?.tags).toEqual(["tester"]);
+});

--- a/langchain-core/src/singletons/tests/async_local_storage.test.ts
+++ b/langchain-core/src/singletons/tests/async_local_storage.test.ts
@@ -4,9 +4,7 @@ import { AsyncLocalStorageProviderSingleton } from "../index.js";
 import { RunnableLambda } from "../../runnables/base.js";
 
 test("Config should be automatically populated after setting global async local storage", async () => {
-  const inner = RunnableLambda.from((_, config) => {
-    return config;
-  });
+  const inner = RunnableLambda.from((_, config) => config);
   const outer = RunnableLambda.from(async (input) => {
     const res = await inner.invoke(input);
     return res;

--- a/langchain-core/src/singletons/tests/async_local_storage.test.ts
+++ b/langchain-core/src/singletons/tests/async_local_storage.test.ts
@@ -91,4 +91,23 @@ test("Config should be automatically populated after setting global async local 
       tags: ["stream_test_recursive"],
     })
   );
+
+  const inner2 = RunnableLambda.from((_, config) => config).withConfig({
+    runName: "inner_test_run",
+  });
+  const outer3 = RunnableLambda.from(async (input) => {
+    const res = await inner2.invoke(input);
+    return res;
+  });
+
+  const res4 = await outer3.invoke(
+    { hi: true },
+    {
+      configurable: {
+        sampleKey: "sampleValue",
+      },
+      tags: ["tester_with_config"],
+    }
+  );
+  expect(res4?.tags).toEqual(["tester_with_config"]);
 });

--- a/langchain-core/src/tools.ts
+++ b/langchain-core/src/tools.ts
@@ -9,7 +9,7 @@ import {
   BaseLangChain,
   type BaseLangChainParams,
 } from "./language_models/base.js";
-import type { RunnableConfig } from "./runnables/config.js";
+import { ensureConfig, type RunnableConfig } from "./runnables/config.js";
 import type { RunnableInterface } from "./runnables/base.js";
 
 /**
@@ -101,7 +101,7 @@ export abstract class StructuredTool<
     input: (z.output<T> extends string ? string : never) | z.input<T>,
     config?: RunnableConfig
   ): Promise<string> {
-    return this.call(input, config);
+    return this.call(input, ensureConfig(config));
   }
 
   /**


### PR DESCRIPTION
`AsyncLocalStorage` a very useful API that is available in many environments but not all. We want to allow projects like LangGraph to take advantage of its convenience at the cost of supporting only a subset of environments.

The idea would be (before instantiating any `RunnableLambda`):

```ts
import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
import { AsyncLocalStorage } from "node:async_hooks";

AsyncLocalStorageProviderSingleton.setClass(AsyncLocalStorage);
```

This PR also allows nested `RunnableLambdas` to automatically fetch config from the next level up, enabling more convenient tracing.

@nfcampos @bracesproul @dqbd 