### PR TITLE
community[patch]: fix astra initialize error

### DIFF
--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -88,16 +88,10 @@ export class AstraDBVectorStore extends VectorStore {
    * @returns Promise that resolves if connected to the collection.
    */
   async initialize(): Promise<void> {
-    try {
-      await this.astraDBClient.createCollection(
+    await this.astraDBClient.createCollection(
         this.collectionName,
         this.collectionOptions
-      );
-    } catch (error) {
-      console.debug(
-        `Collection already exists, connecting to ${this.collectionName}`
-      );
-    }
+    );
     this.collection = await this.astraDBClient.collection(this.collectionName);
     console.debug("Connected to Astra DB collection");
   }

--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -89,8 +89,8 @@ export class AstraDBVectorStore extends VectorStore {
    */
   async initialize(): Promise<void> {
     await this.astraDBClient.createCollection(
-        this.collectionName,
-        this.collectionOptions
+      this.collectionName,
+      this.collectionOptions
     );
     this.collection = await this.astraDBClient.collection(this.collectionName);
     console.debug("Connected to Astra DB collection");

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -5,6 +5,7 @@ import { faker } from "@faker-js/faker";
 import { Document } from "@langchain/core/documents";
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { AstraDBVectorStore, AstraLibArgs } from "../astradb.js";
+import { FakeEmbeddings } from "closevector-common/dist/fake.js";
 
 describe.skip("AstraDBVectorStore", () => {
   const clientConfig = {
@@ -133,4 +134,25 @@ describe.skip("AstraDBVectorStore", () => {
       "AstraDB is built on Apache Cassandra"
     );
   });
+
+  test("collection exists", async () => {
+    let store = new AstraDBVectorStore(new FakeEmbeddings(), astraConfig)
+    await store.initialize()
+    await store.initialize()
+    try {
+      store = new AstraDBVectorStore(new FakeEmbeddings(), {
+        ...astraConfig,
+        collectionOptions: {
+          vector: {
+            dimension: 8,
+            metric: "cosine",
+          },
+        }
+      })
+      await store.initialize()
+      fail("Should have thrown error")
+    } catch (e: any) {
+      expect(e.message).toContain("already exists with different 'vector'")
+    }
+  }, 60000);
 });

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -4,8 +4,8 @@ import { AstraDB } from "@datastax/astra-db-ts";
 import { faker } from "@faker-js/faker";
 import { Document } from "@langchain/core/documents";
 import { OpenAIEmbeddings } from "@langchain/openai";
-import { AstraDBVectorStore, AstraLibArgs } from "../astradb.js";
 import { FakeEmbeddings } from "closevector-common/dist/fake.js";
+import { AstraDBVectorStore, AstraLibArgs } from "../astradb.js";
 
 describe.skip("AstraDBVectorStore", () => {
   const clientConfig = {

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -136,9 +136,9 @@ describe.skip("AstraDBVectorStore", () => {
   });
 
   test("collection exists", async () => {
-    let store = new AstraDBVectorStore(new FakeEmbeddings(), astraConfig)
-    await store.initialize()
-    await store.initialize()
+    let store = new AstraDBVectorStore(new FakeEmbeddings(), astraConfig);
+    await store.initialize();
+    await store.initialize();
     try {
       store = new AstraDBVectorStore(new FakeEmbeddings(), {
         ...astraConfig,
@@ -147,12 +147,12 @@ describe.skip("AstraDBVectorStore", () => {
             dimension: 8,
             metric: "cosine",
           },
-        }
-      })
-      await store.initialize()
-      fail("Should have thrown error")
+        },
+      });
+      await store.initialize();
+      fail("Should have thrown error");
     } catch (e: any) {
-      expect(e.message).toContain("already exists with different 'vector'")
+      expect(e.message).toContain("already exists with different 'vector'");
     }
   }, 60000);
 });


### PR DESCRIPTION
Currently in the `AstraDBVectorStore#initialize` method if there is an error while creating the collection, the error is suppressed, assuming the collection already exists. This is wrong because:
- if the collection already exists with the same options, the Astra Data API won't return errors
- In case of auth, network or server errors, the user can't really see the errors and no error is raised 