### PR TITLE
feat(community): Add schema support for `ensureTableInDatabase` in typeorm vectorstore.

### DIFF
--- a/libs/langchain-community/src/vectorstores/typeorm.ts
+++ b/libs/langchain-community/src/vectorstores/typeorm.ts
@@ -13,6 +13,7 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
 export interface TypeORMVectorStoreArgs {
   postgresConnectionOptions: DataSourceOptions;
   tableName?: string;
+  schemaName?: string;
   filter?: Metadata;
   verbose?: boolean;
 }
@@ -38,6 +39,8 @@ export class TypeORMVectorStore extends VectorStore {
 
   tableName: string;
 
+  schemaName: string;
+
   documentEntity: EntitySchema;
 
   filter?: Metadata;
@@ -56,6 +59,7 @@ export class TypeORMVectorStore extends VectorStore {
   ) {
     super(embeddings, fields);
     this.tableName = fields.tableName || defaultDocumentTableName;
+    this.schemaName = fields.schemaName || "public";
     this.filter = fields.filter;
 
     const TypeORMDocumentEntity = new EntitySchema<TypeORMVectorStoreDocument>({
@@ -219,7 +223,7 @@ export class TypeORMVectorStore extends VectorStore {
     );
 
     await this.appDataSource.query(`
-      CREATE TABLE IF NOT EXISTS ${this.tableName} (
+      CREATE TABLE IF NOT EXISTS ${this.schemaName}.${this.tableName} (
         "id" uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
         "pageContent" text,
         metadata jsonb,

--- a/libs/langchain-community/src/vectorstores/typeorm.ts
+++ b/libs/langchain-community/src/vectorstores/typeorm.ts
@@ -27,6 +27,7 @@ export class TypeORMVectorStoreDocument extends Document {
 }
 
 const defaultDocumentTableName = "documents";
+const defaultSchemaName = "public";
 
 /**
  * Class that provides an interface to a Postgres vector database. It
@@ -59,7 +60,7 @@ export class TypeORMVectorStore extends VectorStore {
   ) {
     super(embeddings, fields);
     this.tableName = fields.tableName || defaultDocumentTableName;
-    this.schemaName = fields.schemaName || "public";
+    this.schemaName = fields.schemaName || defaultSchemaName;
     this.filter = fields.filter;
 
     const TypeORMDocumentEntity = new EntitySchema<TypeORMVectorStoreDocument>({


### PR DESCRIPTION
Added schema name to override it when needed.

It's backward-compatible and should not break existing functionality. 

Fixes https://github.com/langchain-ai/langchainjs/issues/4503
