### PR TITLE
Update PrismaVectorStore Similiarity Search to pass filters consistently

### DIFF
--- a/libs/langchain-community/src/vectorstores/prisma.ts
+++ b/libs/langchain-community/src/vectorstores/prisma.ts
@@ -324,7 +324,7 @@ export class PrismaVectorStore<
   async similaritySearch(
     query: string,
     k = 4,
-    _filter: this["FilterType"] | undefined = undefined,
+    _filter?: TFilterModel,
     _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
   ): Promise<Document<SimilarityModel<TModel, TSelectModel>>[]> {
     const results = await this.similaritySearchVectorWithScore(

--- a/libs/langchain-community/src/vectorstores/prisma.ts
+++ b/libs/langchain-community/src/vectorstores/prisma.ts
@@ -324,12 +324,13 @@ export class PrismaVectorStore<
   async similaritySearch(
     query: string,
     k = 4,
-    _filter: this["FilterType"] | undefined = undefined, // not used. here to make the interface compatible with the other stores
+    _filter: this["FilterType"] | undefined = undefined,
     _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
   ): Promise<Document<SimilarityModel<TModel, TSelectModel>>[]> {
     const results = await this.similaritySearchVectorWithScore(
       await this.embeddings.embedQuery(query),
-      k
+      k,
+      _filter
     );
 
     return results.map((result) => result[0]);


### PR DESCRIPTION
**Changes**
- Updated the type of `_filter` in PrismaVectorStore's `similaritySearch` method to match the other SimilaritySearch methods.
- `_filter` is now passed into the inner function.

**Comments**
Even through digging through the git blame/commit history, I couldn't find a good reason given as to why the _filter parameter shouldn't be passed into the inner function. This may have been an oversight.

After applying this change, I can now apply filters to `.similaritySearch`, i.e `await vectorStore.similaritySearch("hello world", 3, { userId: { equals: 1 } } )`

Fixes #4521 
