### PR TITLE
community[patch]: Neo4j will no longer return undefined

### DIFF
--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -113,7 +113,7 @@ export class Neo4jGraph {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params: Record<string, any> = {},
     routing: RoutingControl = neo4j.routing.WRITE
-  ): Promise<RecordShape[] | undefined> {
+  ): Promise<RecordShape[]> {
     const result = await this.driver.executeQuery<RecordShape>(query, params, {
       database: this.database,
       routing,
@@ -152,15 +152,15 @@ export class Neo4jGraph {
     `;
 
     // Assuming query method is defined and returns a Promise
-    const nodeProperties: NodeType[] | undefined = (
+    const nodeProperties = (
       await this.query<{ output: NodeType }>(nodePropertiesQuery)
     )?.map((el) => el.output);
 
-    const relationshipsProperties: RelType[] | undefined = (
+    const relationshipsProperties = (
       await this.query<{ output: RelType }>(relPropertiesQuery)
     )?.map((el) => el.output);
 
-    const relationships: PathType[] | undefined = (
+    const relationships: PathType[] = (
       await this.query<{ output: PathType }>(relQuery)
     )?.map((el) => el.output);
 


### PR DESCRIPTION
The `Neo4jGraph.query()` method would return `undefined` if an error was thrown at query time.  This is no longer the case, so the method will either throw or return an empty array if no records are returned.