### PR TITLE
community[patch]: Add retrieval params to neo4j vector

### DIFF
--- a/libs/langchain-community/src/vectorstores/neo4j_vector.ts
+++ b/libs/langchain-community/src/vectorstores/neo4j_vector.ts
@@ -577,13 +577,18 @@ export class Neo4jVectorStore extends VectorStore {
     );
   }
 
-  async similaritySearch(query: string, k = 4): Promise<Document[]> {
+  async similaritySearch(
+    query: string,
+    k = 4,
+    params: Record<string, any> = {}
+  ): Promise<Document[]> {
     const embedding = await this.embeddings.embedQuery(query);
 
     const results = await this.similaritySearchVectorWithScore(
       embedding,
       k,
-      query
+      query,
+      params
     );
 
     return results.map((result) => result[0]);
@@ -592,7 +597,8 @@ export class Neo4jVectorStore extends VectorStore {
   async similaritySearchVectorWithScore(
     vector: number[],
     k: number,
-    query: string
+    query: string,
+    params: Record<string, any> = {}
   ): Promise<[Document, number][]> {
     const defaultRetrieval = `
     RETURN node.${this.textNodeProperty} AS text, score,
@@ -614,6 +620,7 @@ export class Neo4jVectorStore extends VectorStore {
       embedding: vector,
       keyword_index: this.keywordIndexName,
       query: removeLuceneChars(query),
+      ...params,
     };
     const results = await this.query(readQuery, parameters);
 

--- a/libs/langchain-community/src/vectorstores/tests/neo4j_vector.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/neo4j_vector.int.test.ts
@@ -45,7 +45,7 @@ async function dropVectorIndexes(store: Neo4jVectorStore) {
   }
 }
 
-test("Test fromTexts", async () => {
+test.skip("Test fromTexts", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -88,7 +88,7 @@ test("Test fromTexts", async () => {
   await neo4jVectorStore.close();
 });
 
-test("Test fromTexts Hybrid", async () => {
+test.skip("Test fromTexts Hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -132,7 +132,7 @@ test("Test fromTexts Hybrid", async () => {
   await neo4jVectorStore.close();
 });
 
-test("Test fromExistingIndex", async () => {
+test.skip("Test fromExistingIndex", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -184,7 +184,7 @@ test("Test fromExistingIndex", async () => {
   await existingIndex.close();
 });
 
-test("Test fromExistingIndex Hybrid", async () => {
+test.skip("Test fromExistingIndex Hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -240,7 +240,7 @@ test("Test fromExistingIndex Hybrid", async () => {
   await existingIndex.close();
 });
 
-test("Test retrievalQuery", async () => {
+test.skip("Test retrievalQuery", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -286,7 +286,7 @@ test("Test retrievalQuery", async () => {
   await neo4jVectorStore.close();
 });
 
-test("Test fromExistingGraph", async () => {
+test.skip("Test fromExistingGraph", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -347,7 +347,7 @@ test("Test fromExistingGraph", async () => {
   await existingGraph.close();
 });
 
-test("Test fromExistingGraph multiple properties", async () => {
+test.skip("Test fromExistingGraph multiple properties", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -408,7 +408,7 @@ test("Test fromExistingGraph multiple properties", async () => {
   await existingGraph.close();
 });
 
-test("Test fromExistingGraph multiple properties hybrid", async () => {
+test.skip("Test fromExistingGraph multiple properties hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -470,7 +470,7 @@ test("Test fromExistingGraph multiple properties hybrid", async () => {
   await existingGraph.close();
 });
 
-test("Test escape lucene characters", async () => {
+test.skip("Test escape lucene characters", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -517,7 +517,7 @@ test("Test escape lucene characters", async () => {
   await neo4jVectorStore.close();
 });
 
-test("Test multiple index", async () => {
+test.skip("Test multiple index", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -597,7 +597,7 @@ test("Test multiple index", async () => {
   await fooExistingIndex.close();
 });
 
-test("Test retrievalQuery with params", async () => {
+test.skip("Test retrievalQuery with params", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;

--- a/libs/langchain-community/src/vectorstores/tests/neo4j_vector.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/neo4j_vector.int.test.ts
@@ -45,7 +45,7 @@ async function dropVectorIndexes(store: Neo4jVectorStore) {
   }
 }
 
-test.skip("Test fromTexts", async () => {
+test("Test fromTexts", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -88,7 +88,7 @@ test.skip("Test fromTexts", async () => {
   await neo4jVectorStore.close();
 });
 
-test.skip("Test fromTexts Hybrid", async () => {
+test("Test fromTexts Hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -132,7 +132,7 @@ test.skip("Test fromTexts Hybrid", async () => {
   await neo4jVectorStore.close();
 });
 
-test.skip("Test fromExistingIndex", async () => {
+test("Test fromExistingIndex", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -184,7 +184,7 @@ test.skip("Test fromExistingIndex", async () => {
   await existingIndex.close();
 });
 
-test.skip("Test fromExistingIndex Hybrid", async () => {
+test("Test fromExistingIndex Hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -240,7 +240,7 @@ test.skip("Test fromExistingIndex Hybrid", async () => {
   await existingIndex.close();
 });
 
-test.skip("Test retrievalQuery", async () => {
+test("Test retrievalQuery", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -286,7 +286,7 @@ test.skip("Test retrievalQuery", async () => {
   await neo4jVectorStore.close();
 });
 
-test.skip("Test fromExistingGraph", async () => {
+test("Test fromExistingGraph", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -347,7 +347,7 @@ test.skip("Test fromExistingGraph", async () => {
   await existingGraph.close();
 });
 
-test.skip("Test fromExistingGraph multiple properties", async () => {
+test("Test fromExistingGraph multiple properties", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -408,7 +408,7 @@ test.skip("Test fromExistingGraph multiple properties", async () => {
   await existingGraph.close();
 });
 
-test.skip("Test fromExistingGraph multiple properties hybrid", async () => {
+test("Test fromExistingGraph multiple properties hybrid", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -470,7 +470,7 @@ test.skip("Test fromExistingGraph multiple properties hybrid", async () => {
   await existingGraph.close();
 });
 
-test.skip("Test escape lucene characters", async () => {
+test("Test escape lucene characters", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -517,7 +517,7 @@ test.skip("Test escape lucene characters", async () => {
   await neo4jVectorStore.close();
 });
 
-test.skip("Test multiple index", async () => {
+test("Test multiple index", async () => {
   const url = process.env.NEO4J_URI as string;
   const username = process.env.NEO4J_USERNAME as string;
   const password = process.env.NEO4J_PASSWORD as string;
@@ -595,4 +595,52 @@ test.skip("Test multiple index", async () => {
   await bar.close();
   await barExistingIndex.close();
   await fooExistingIndex.close();
+});
+
+test("Test retrievalQuery with params", async () => {
+  const url = process.env.NEO4J_URI as string;
+  const username = process.env.NEO4J_USERNAME as string;
+  const password = process.env.NEO4J_PASSWORD as string;
+
+  expect(url).toBeDefined();
+  expect(username).toBeDefined();
+  expect(password).toBeDefined();
+
+  const embeddings = new FakeEmbeddingsWithOsDimension();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const metadatas: any[] = [];
+
+  const neo4jVectorStore = await Neo4jVectorStore.fromTexts(
+    texts,
+    metadatas,
+    embeddings,
+    {
+      url,
+      username,
+      password,
+      indexName: "vector",
+      preDeleteCollection: true,
+      retrievalQuery: "RETURN $test AS text, score, {foo:$test1} AS metadata",
+    }
+  );
+
+  const output = await neo4jVectorStore.similaritySearch("foo", 2, {
+    test: "test",
+    test1: "test1",
+  });
+
+  const expectedResult = [
+    new Document({
+      pageContent: "test",
+      metadata: { foo: "test1" },
+    }),
+    new Document({
+      pageContent: "test",
+      metadata: { foo: "test1" },
+    }),
+  ];
+
+  expect(output).toStrictEqual(expectedResult);
+  await dropVectorIndexes(neo4jVectorStore);
+  await neo4jVectorStore.close();
 });


### PR DESCRIPTION
Sometimes, you want to use various parameters in the retrieval query of Neo4j Vector to personalize/customize results. Before, when there were only predefined chains, it didn't really make sense. Now that it's all about custom chains and LCEL, it is worth adding since users can inject any params they wish at query time. Isn't prone to SQL injection-type attacks since we use parameters and not concatenating strings.