### PR TITLE
openai[minor]: Force tool usage through tool_choice

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -953,7 +953,12 @@ export class ChatOpenAI<
               },
             },
           ],
-          tool_choice: "auto",
+          tool_choice: {
+            type: "function" as const,
+            function: {
+              name,
+            }
+          },
         } as Partial<CallOptions>);
         outputParser = new JsonOutputKeyToolsParser<RunOutput>({
           returnSingle: true,
@@ -971,7 +976,12 @@ export class ChatOpenAI<
               },
             },
           ],
-          tool_choice: "auto",
+          tool_choice: {
+            type: "function" as const,
+            function: {
+              name,
+            }
+          },
         } as Partial<CallOptions>);
         outputParser = new JsonOutputKeyToolsParser<RunOutput>({
           returnSingle: true,

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -957,7 +957,7 @@ export class ChatOpenAI<
             type: "function" as const,
             function: {
               name,
-            }
+            },
           },
         } as Partial<CallOptions>);
         outputParser = new JsonOutputKeyToolsParser<RunOutput>({
@@ -980,7 +980,7 @@ export class ChatOpenAI<
             type: "function" as const,
             function: {
               name,
-            }
+            },
           },
         } as Partial<CallOptions>);
         outputParser = new JsonOutputKeyToolsParser<RunOutput>({


### PR DESCRIPTION
Turns out setting `tool_choice: "auto"` does not always guarantee tool usage, and is different between models.

This will force then model to use the provided tool.