### PR TITLE
langchain[patch]: Add Possibility to use Contextual chunk headers in Parent Document Retriever

### DIFF
--- a/docs/core_docs/docs/modules/data_connection/retrievers/parent-document-retriever.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/parent-document-retriever.mdx
@@ -47,4 +47,6 @@ Consider a scenario where you want to store collection of documents in a vector 
 
 Tagging each document with metadata is a solution if you know what to filter against, but you may not know ahead of time exactly what kind of queries your vector store will be expected to handle. Including additional contextual information directly in each chunk in the form of headers can help deal with arbitrary queries.
 
+This is particularly important if you have several fine-grained child chunks that need to be correctly retrieved from the vector store.
+
 <CodeBlock language="typescript">{ExampleWithChunkHeader}</CodeBlock>

--- a/docs/core_docs/docs/modules/data_connection/retrievers/parent-document-retriever.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/parent-document-retriever.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/retrievers/parent_document_retriever.ts";
 import ExampleWithScoreThreshold from "@examples/retrievers/parent_document_retriever_score_threshold.ts";
+import ExampleWithChunkHeader from "@examples/retrievers/parent_document_retriever_chunk_header.ts";
 
 # Parent Document Retriever
 
@@ -39,3 +40,11 @@ This can be helpful when you're not sure how many documents you want (or if you 
 Note: if a retriever is passed, `ParentDocumentRetriever` will default to use it for retrieving small chunks, as well as adding documents via the `addDocuments` method.
 
 <CodeBlock language="typescript">{ExampleWithScoreThreshold}</CodeBlock>
+
+## With Contextual chunk headers
+
+Consider a scenario where you want to store collection of documents in a vector store and perform Q&A tasks on them. Simply splitting documents with overlapping text may not provide sufficient context for LLMs to determine if multiple chunks are referencing the same information, or how to resolve information from contradictory sources.
+
+Tagging each document with metadata is a solution if you know what to filter against, but you may not know ahead of time exactly what kind of queries your vector store will be expected to handle. Including additional contextual information directly in each chunk in the form of headers can help deal with arbitrary queries.
+
+<CodeBlock language="typescript">{ExampleWithChunkHeader}</CodeBlock>

--- a/examples/src/retrievers/parent_document_retriever_chunk_header.ts
+++ b/examples/src/retrievers/parent_document_retriever_chunk_header.ts
@@ -9,18 +9,29 @@ import { ScoreThresholdRetriever } from "langchain/retrievers/score_threshold";
 
 const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1500 });
 
+const jimChunkHeader = `DOC NAME: Jim Interview\\n---\\n`;
 const jimDocs = await splitter.createDocuments(
   [`My favorite color is blue.`],
   [{
-    chunkHeader: `DOC NAME: Jim Interview\\n---\\n`
-  }]
+    chunkHeader: jimChunkHeader
+  }],
+  {
+    chunkHeader: jimChunkHeader,
+    appendChunkOverlapHeader: true,
+  }
 );
 
+
+const pamChunkHeader = `DOC NAME: Pam Interview\\n---\\n`;
 const pamDocs = await splitter.createDocuments(
   [`My favorite color is red.`],
   [{
-    chunkHeader: `DOC NAME: Pam Interview\\n---\\n`
-  }]
+    chunkHeader: pamChunkHeader
+  }],
+  {
+    chunkHeader: pamChunkHeader,
+    appendChunkOverlapHeader: true,
+  }
 );
 
 const vectorstore = await HNSWLib.fromDocuments([], new OpenAIEmbeddings());
@@ -52,7 +63,7 @@ console.log(retrievedDocs);
 /*
   [
     Document {
-      pageContent: 'My favorite color is red.'
+      pageContent: 'DOC NAME: Pam Interview\n---\n My favorite color is red.'
     },
   ]
 */

--- a/examples/src/retrievers/parent_document_retriever_chunk_header.ts
+++ b/examples/src/retrievers/parent_document_retriever_chunk_header.ts
@@ -13,22 +13,25 @@ const jimChunkHeader = `DOC NAME: Jim Interview\\n---\\n`;
 const jimDocs = await splitter.createDocuments(
   [`My favorite color is blue.`],
   [{
+    // header for child docs
     chunkHeader: jimChunkHeader
   }],
   {
+    // header for parent doc
     chunkHeader: jimChunkHeader,
     appendChunkOverlapHeader: true,
   }
 );
 
-
 const pamChunkHeader = `DOC NAME: Pam Interview\\n---\\n`;
 const pamDocs = await splitter.createDocuments(
   [`My favorite color is red.`],
   [{
+    // header for child docs
     chunkHeader: pamChunkHeader
   }],
   {
+    // header for parent doc
     chunkHeader: pamChunkHeader,
     appendChunkOverlapHeader: true,
   }
@@ -46,7 +49,7 @@ const retriever = new ParentDocumentRetriever({
 });
 const documents = [].concat(jimDocs, pamDocs);
 
-// We pass additional option `chunkHeader` that will add metadata chunk header to documents
+// We pass additional option `chunkHeader` that will add metadata chunk header to child documents
 await retriever.addDocuments(documents, { chunkHeader: true });
 // Documents added to vector store have this, search friendly format
 /*
@@ -56,9 +59,11 @@ await retriever.addDocuments(documents, { chunkHeader: true });
   ]
 */
 
+// this will search child documents in vector store with the help of chunk header
 const retrievedDocs = await retriever.getRelevantDocuments("What is Pam's favorite color?");
 
-// Retrieved chunk is the larger parent chunk
+// Retrieved chunk is the larger parent chunk. We also added chunk header there so LLM can use it to provide correct
+// answer
 console.log(retrievedDocs);
 /*
   [

--- a/examples/src/retrievers/parent_document_retriever_chunk_header.ts
+++ b/examples/src/retrievers/parent_document_retriever_chunk_header.ts
@@ -3,9 +3,6 @@ import { HNSWLib } from "langchain/vectorstores/hnswlib";
 import { InMemoryStore } from "langchain/storage/in_memory";
 import { ParentDocumentRetriever } from "langchain/retrievers/parent_document";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
-import { TextLoader } from "langchain/document_loaders/fs/text";
-import { ScoreThresholdRetriever } from "langchain/retrievers/score_threshold";
-
 
 const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1500 });
 

--- a/examples/src/retrievers/parent_document_retriever_chunk_header.ts
+++ b/examples/src/retrievers/parent_document_retriever_chunk_header.ts
@@ -1,0 +1,58 @@
+import { OpenAIEmbeddings } from "@langchain/openai";
+import { HNSWLib } from "langchain/vectorstores/hnswlib";
+import { InMemoryStore } from "langchain/storage/in_memory";
+import { ParentDocumentRetriever } from "langchain/retrievers/parent_document";
+import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { TextLoader } from "langchain/document_loaders/fs/text";
+import { ScoreThresholdRetriever } from "langchain/retrievers/score_threshold";
+
+
+const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1500 });
+
+const jimDocs = await splitter.createDocuments(
+  [`My favorite color is blue.`],
+  [{
+    chunkHeader: `DOC NAME: Jim Interview\\n---\\n`
+  }]
+);
+
+const pamDocs = await splitter.createDocuments(
+  [`My favorite color is red.`],
+  [{
+    chunkHeader: `DOC NAME: Pam Interview\\n---\\n`
+  }]
+);
+
+const vectorstore = await HNSWLib.fromDocuments([], new OpenAIEmbeddings());
+const docstore = new InMemoryStore();
+
+const retriever = new ParentDocumentRetriever({
+  vectorstore,
+  docstore,
+  childSplitter: new RecursiveCharacterTextSplitter({ chunkSize: 150 }),
+  childK: 50,
+  parentK: 5
+});
+const documents = [].concat(jimDocs, pamDocs);
+
+// We pass additional option `chunkHeader` that will add metadata chunk header to documents
+await retriever.addDocuments(documents, { chunkHeader: true });
+// Documents added to vector store have this, search friendly format
+/*
+  [
+    Document { pageContent: 'DOC NAME: Jim Interview\n---\n My favorite color is blue.' },
+    Document { pageContent: 'DOC NAME: Pam Interview\n---\n My favorite color is red.' },
+  ]
+*/
+
+const retrievedDocs = await retriever.getRelevantDocuments("What is Pam's favorite color?");
+
+// Retrieved chunk is the larger parent chunk
+console.log(retrievedDocs);
+/*
+  [
+    Document {
+      pageContent: 'My favorite color is red.'
+    },
+  ]
+*/

--- a/examples/src/retrievers/parent_document_retriever_chunk_header.ts
+++ b/examples/src/retrievers/parent_document_retriever_chunk_header.ts
@@ -6,33 +6,17 @@ import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 
 const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1500 });
 
-const jimChunkHeader = `DOC NAME: Jim Interview\\n---\\n`;
-const jimDocs = await splitter.createDocuments(
-  [`My favorite color is blue.`],
-  [{
-    // header for child docs
-    chunkHeader: jimChunkHeader
-  }],
-  {
-    // header for parent doc
-    chunkHeader: jimChunkHeader,
-    appendChunkOverlapHeader: true,
-  }
-);
+const jimDocs = await splitter.createDocuments([`My favorite color is blue.`]);
+const jimChunkHeaderOptions = {
+  chunkHeader: "DOC NAME: Jim Interview\n---\n",
+  appendChunkOverlapHeader: true,
+};
 
-const pamChunkHeader = `DOC NAME: Pam Interview\\n---\\n`;
-const pamDocs = await splitter.createDocuments(
-  [`My favorite color is red.`],
-  [{
-    // header for child docs
-    chunkHeader: pamChunkHeader
-  }],
-  {
-    // header for parent doc
-    chunkHeader: pamChunkHeader,
-    appendChunkOverlapHeader: true,
-  }
-);
+const pamDocs = await splitter.createDocuments([`My favorite color is red.`]);
+const pamChunkHeaderOptions = {
+  chunkHeader: "DOC NAME: Pam Interview\n---\n",
+  appendChunkOverlapHeader: true,
+};
 
 const vectorstore = await HNSWLib.fromDocuments([], new OpenAIEmbeddings());
 const docstore = new InMemoryStore();
@@ -42,12 +26,17 @@ const retriever = new ParentDocumentRetriever({
   docstore,
   childSplitter: new RecursiveCharacterTextSplitter({ chunkSize: 150 }),
   childK: 50,
-  parentK: 5
+  parentK: 5,
 });
-const documents = [].concat(jimDocs, pamDocs);
 
 // We pass additional option `chunkHeader` that will add metadata chunk header to child documents
-await retriever.addDocuments(documents, { chunkHeader: true });
+await retriever.addDocuments(jimDocs, {
+  chunkHeaderOptions: jimChunkHeaderOptions,
+});
+await retriever.addDocuments(pamDocs, {
+  chunkHeaderOptions: pamChunkHeaderOptions,
+});
+
 // Documents added to vector store have this, search friendly format
 /*
   [
@@ -57,7 +46,9 @@ await retriever.addDocuments(documents, { chunkHeader: true });
 */
 
 // this will search child documents in vector store with the help of chunk header
-const retrievedDocs = await retriever.getRelevantDocuments("What is Pam's favorite color?");
+const retrievedDocs = await retriever.getRelevantDocuments(
+  "What is Pam's favorite color?"
+);
 
 // Retrieved chunk is the larger parent chunk. We also added chunk header there so LLM can use it to provide correct
 // answer
@@ -65,7 +56,7 @@ console.log(retrievedDocs);
 /*
   [
     Document {
-      pageContent: 'DOC NAME: Pam Interview\n---\n My favorite color is red.'
+      pageContent: 'My favorite color is red.'
     },
   ]
 */

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -5,7 +5,10 @@ import {
   type VectorStoreRetrieverInterface,
 } from "@langchain/core/vectorstores";
 import { Document } from "@langchain/core/documents";
-import { TextSplitter } from "../text_splitter.js";
+import {
+  TextSplitter,
+  TextSplitterChunkHeaderOptions,
+} from "../text_splitter.js";
 import {
   MultiVectorRetriever,
   type MultiVectorRetrieverInput,
@@ -126,18 +129,17 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
    * This can be false if and only if `ids` are provided. You may want
    *   to set this to False if the documents are already in the docstore
    *   and you don't want to re-add them.
-   * @param config.chunkHeader Boolean of whether to add chunk header to docs to ease
-   * searching in vector store
+   * @param config.chunkHeaderOptions Object with options for adding Contextual chunk headers
    */
   async addDocuments(
     docs: Document[],
     config?: {
       ids?: string[];
       addToDocstore?: boolean;
-      chunkHeader?: boolean;
+      chunkHeaderOptions?: TextSplitterChunkHeaderOptions;
     }
   ): Promise<void> {
-    const { ids, addToDocstore = true, chunkHeader = false } = config ?? {};
+    const { ids, addToDocstore = true, chunkHeaderOptions = {} } = config ?? {};
     const parentDocs = this.parentSplitter
       ? await this.parentSplitter.splitDocuments(docs)
       : docs;
@@ -162,11 +164,10 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
     for (let i = 0; i < parentDocs.length; i += 1) {
       const parentDoc = parentDocs[i];
       const parentDocId = parentDocIds[i];
-      const chunkHeaderOptions = chunkHeader && parentDoc?.metadata?.chunkHeader ? {
-        chunkHeader: parentDoc.metadata.chunkHeader,
-        appendChunkOverlapHeader: true,
-      } : {};
-      const subDocs = await this.childSplitter.splitDocuments([parentDoc], chunkHeaderOptions);
+      const subDocs = await this.childSplitter.splitDocuments(
+        [parentDoc],
+        chunkHeaderOptions
+      );
       const taggedSubDocs = subDocs.map(
         (subDoc: Document) =>
           new Document({

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -136,10 +136,10 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
     config?: {
       ids?: string[];
       addToDocstore?: boolean;
-      chunkHeaderOptions?: TextSplitterChunkHeaderOptions;
+      childDocChunkHeaderOptions?: TextSplitterChunkHeaderOptions;
     }
   ): Promise<void> {
-    const { ids, addToDocstore = true, chunkHeaderOptions = {} } = config ?? {};
+    const { ids, addToDocstore = true, childDocChunkHeaderOptions = {} } = config ?? {};
     const parentDocs = this.parentSplitter
       ? await this.parentSplitter.splitDocuments(docs)
       : docs;
@@ -166,7 +166,7 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
       const parentDocId = parentDocIds[i];
       const subDocs = await this.childSplitter.splitDocuments(
         [parentDoc],
-        chunkHeaderOptions
+        childDocChunkHeaderOptions
       );
       const taggedSubDocs = subDocs.map(
         (subDoc: Document) =>

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -139,7 +139,11 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
       childDocChunkHeaderOptions?: TextSplitterChunkHeaderOptions;
     }
   ): Promise<void> {
-    const { ids, addToDocstore = true, childDocChunkHeaderOptions = {} } = config ?? {};
+    const {
+      ids,
+      addToDocstore = true,
+      childDocChunkHeaderOptions = {},
+    } = config ?? {};
     const parentDocs = this.parentSplitter
       ? await this.parentSplitter.splitDocuments(docs)
       : docs;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Add possibility to use Contextual chunk headers in Parent Document Retriever.

This is particularly important if you have several fine-grained child chunks that need to be correctly retrieved from the vector store.
