### PR TITLE
community[patch]: Allow must_not filter in Elasticsearch VectorStore

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -165,7 +165,7 @@ export class ElasticVectorSearch extends VectorStore {
       knn: {
         field: "embedding",
         query_vector: query,
-        filter: this.buildMetadataTerms(filter),
+        filter: { bool: this.buildMetadataTerms(filter) },
         k,
         num_candidates: this.candidates,
       },
@@ -313,9 +313,11 @@ export class ElasticVectorSearch extends VectorStore {
   private buildMetadataTerms(
     filter?: ElasticFilter
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): { [operator: string]: { [field: string]: any } }[] {
-    if (filter == null) return [];
-    const result = [];
+  ): {
+    must: { [operator: string]: { [field: string]: any } }[];
+    must_not: { [operator: string]: { [field: string]: any } }[];
+  } {
+    if (filter == null) return { must: [], must_not: [] };
     const filters = Array.isArray(filter)
       ? filter
       : Object.entries(filter).map(([key, value]) => ({
@@ -323,22 +325,32 @@ export class ElasticVectorSearch extends VectorStore {
           field: key,
           value,
         }));
+
+    const must = [];
+    const must_not = [];
     for (const condition of filters) {
+      const metadataField = `metadata.${condition.field}`;
       if (condition.operator === "exists") {
-        result.push({
+        must.push({
           [condition.operator]: {
-            field: `metadata.${condition.field}`,
+            field: metadataField,
+          },
+        });
+      } else if (condition.operator === "exclude") {
+        must_not.push({
+          terms: {
+            [metadataField]: condition.value,
           },
         });
       } else {
-        result.push({
+        must.push({
           [condition.operator]: {
-            [`metadata.${condition.field}`]: condition.value,
+            [metadataField]: condition.value,
           },
         });
       }
     }
-    return result;
+    return { must, must_not };
   }
 
   /**

--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -310,11 +310,10 @@ export class ElasticVectorSearch extends VectorStore {
     await this.client.indices.create(request);
   }
 
-  private buildMetadataTerms(
-    filter?: ElasticFilter
+  private buildMetadataTerms(filter?: ElasticFilter): {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): {
     must: { [operator: string]: { [field: string]: any } }[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     must_not: { [operator: string]: { [field: string]: any } }[];
   } {
     if (filter == null) return { must: [], must_not: [] };


### PR DESCRIPTION
For our project we needed to exclude some ids of certain entities when searching the VectorStore.
As the current implementation doesn't support the must_not filter yet, I've added it as an "exclude" operator to be flexible and populate the must_not filter accordingly.