### PR TITLE
docs[minor]: Fix typo

### DIFF
--- a/docs/core_docs/docs/modules/agents/agent_types/openai_tools_agent.mdx
+++ b/docs/core_docs/docs/modules/agents/agent_types/openai_tools_agent.mdx
@@ -9,7 +9,7 @@ sidebar_position: 1
 OpenAI tool calling is new and only available on [OpenAI's latest models](https://platform.openai.com/docs/guides/function-calling).
 :::
 
-Certain OpenAI models have been finetuned to work with with tool calling. This is very similar but different from function calling, and thus requires a separate agent type.
+Certain OpenAI models have been finetuned to work with tool calling. This is very similar but different from function calling, and thus requires a separate agent type.
 
 While the goal of more reliably returning valid and useful function calls is the same as the functions agent, the ability to return multiple tools at once results in
 both fewer roundtrips for complex questions.


### PR DESCRIPTION
Fix typo at openai_tools_agent.mdx
