### PR TITLE
core[minor]: StringOutputParser and text BaseMessage contents

### DIFF
--- a/langchain-core/src/output_parsers/base.ts
+++ b/langchain-core/src/output_parsers/base.ts
@@ -48,13 +48,15 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
     return this.parseResult(generations, callbacks);
   }
 
-  _baseMessageToString(message: BaseMessage): string {
+  protected _baseMessageToString(message: BaseMessage): string {
     return typeof message.content === "string"
       ? message.content
       : this._baseMessageContentToString(message.content);
   }
 
-  _baseMessageContentToString(content: MessageContentComplex[]): string {
+  protected _baseMessageContentToString(
+    content: MessageContentComplex[]
+  ): string {
     return JSON.stringify(content);
   }
 

--- a/langchain-core/src/output_parsers/base.ts
+++ b/langchain-core/src/output_parsers/base.ts
@@ -1,7 +1,7 @@
 import { Runnable } from "../runnables/index.js";
 import type { RunnableConfig } from "../runnables/config.js";
 import type { BasePromptValueInterface } from "../prompt_values.js";
-import type { BaseMessage } from "../messages/index.js";
+import type { BaseMessage, MessageContentComplex } from "../messages/index.js";
 import type { Callbacks } from "../callbacks/manager.js";
 import type { Generation, ChatGeneration } from "../outputs.js";
 
@@ -48,6 +48,16 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
     return this.parseResult(generations, callbacks);
   }
 
+  _baseMessageToString(message: BaseMessage): string {
+    return typeof message.content === "string"
+      ? message.content
+      : this._baseMessageContentToString(message.content);
+  }
+
+  _baseMessageContentToString(content: MessageContentComplex[]): string {
+    return JSON.stringify(content);
+  }
+
   /**
    * Calls the parser with a given input and optional configuration options.
    * If the input is a string, it creates a generation with the input as
@@ -75,10 +85,7 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
           this.parseResult([
             {
               message: input,
-              text:
-                typeof input.content === "string"
-                  ? input.content
-                  : JSON.stringify(input.content),
+              text: this._baseMessageToString(input),
             },
           ]),
         input,

--- a/langchain-core/src/output_parsers/string.ts
+++ b/langchain-core/src/output_parsers/string.ts
@@ -65,7 +65,9 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
       case "image_url":
         return this._imageUrlContentToString(content);
       default:
-        return "";
+        throw new Error(
+          `Cannot coerce "${(content as any).type}" message part into a string.`
+        );
     }
   }
 

--- a/langchain-core/src/output_parsers/string.ts
+++ b/langchain-core/src/output_parsers/string.ts
@@ -1,4 +1,9 @@
 import { BaseTransformOutputParser } from "./transform.js";
+import {
+  MessageContentComplex,
+  MessageContentImageUrl,
+  MessageContentText,
+} from "../messages/index.js";
 
 /**
  * OutputParser that parses LLMResult into the top likely string.
@@ -41,5 +46,32 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
 
   getFormatInstructions(): string {
     return "";
+  }
+
+  _textContentToString(content: MessageContentText): string {
+    return content.text;
+  }
+
+  _imageUrlContentToString(_content: MessageContentImageUrl): string {
+    return "";
+  }
+
+  _messageContentComplexToString(content: MessageContentComplex): string {
+    switch (content.type) {
+      case "text":
+        return this._textContentToString(content);
+      case "image_url":
+        return this._imageUrlContentToString(content);
+      default:
+        return "";
+    }
+  }
+
+  _baseMessageContentToString(content: MessageContentComplex[]): string {
+    return content.reduce(
+      (acc: string, item: MessageContentComplex) =>
+        acc + this._messageContentComplexToString(item),
+      ""
+    );
   }
 }

--- a/langchain-core/src/output_parsers/string.ts
+++ b/langchain-core/src/output_parsers/string.ts
@@ -68,6 +68,7 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
         return this._imageUrlContentToString(content);
       default:
         throw new Error(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           `Cannot coerce "${(content as any).type}" message part into a string.`
         );
     }

--- a/langchain-core/src/output_parsers/string.ts
+++ b/langchain-core/src/output_parsers/string.ts
@@ -53,7 +53,9 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
   }
 
   _imageUrlContentToString(_content: MessageContentImageUrl): string {
-    return "";
+    throw new Error(
+      `Cannot coerce a multimodal "image_url" message part into a string.`
+    );
   }
 
   _messageContentComplexToString(content: MessageContentComplex): string {

--- a/langchain-core/src/output_parsers/string.ts
+++ b/langchain-core/src/output_parsers/string.ts
@@ -48,17 +48,19 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
     return "";
   }
 
-  _textContentToString(content: MessageContentText): string {
+  protected _textContentToString(content: MessageContentText): string {
     return content.text;
   }
 
-  _imageUrlContentToString(_content: MessageContentImageUrl): string {
+  protected _imageUrlContentToString(_content: MessageContentImageUrl): string {
     throw new Error(
       `Cannot coerce a multimodal "image_url" message part into a string.`
     );
   }
 
-  _messageContentComplexToString(content: MessageContentComplex): string {
+  protected _messageContentComplexToString(
+    content: MessageContentComplex
+  ): string {
     switch (content.type) {
       case "text":
         return this._textContentToString(content);
@@ -71,7 +73,9 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
     }
   }
 
-  _baseMessageContentToString(content: MessageContentComplex[]): string {
+  protected _baseMessageContentToString(
+    content: MessageContentComplex[]
+  ): string {
     return content.reduce(
       (acc: string, item: MessageContentComplex) =>
         acc + this._messageContentComplexToString(item),

--- a/langchain-core/src/output_parsers/tests/string.test.ts
+++ b/langchain-core/src/output_parsers/tests/string.test.ts
@@ -55,7 +55,7 @@ describe("StringOutputParser", () => {
     expect(result).toEqual("hellothere");
   });
 
-  test("BaseMessage complex text and image type", async () => {
+  test("BaseMessage complex text and image type fails", async () => {
     const parser = new StringOutputParser();
     const content: MessageContentComplex[] = [
       {
@@ -70,30 +70,8 @@ describe("StringOutputParser", () => {
     const msg: BaseMessage = new AIMessage({
       content,
     });
-    const result = await parser.invoke(msg);
-    expect(result).toEqual("hello");
-  });
-
-  test("BaseMessage multiple complex text and image type", async () => {
-    const parser = new StringOutputParser();
-    const content: MessageContentComplex[] = [
-      {
-        type: "text",
-        text: "hello",
-      },
-      {
-        type: "image_url",
-        image_url: "https://example.com/example.png",
-      },
-      {
-        type: "text",
-        text: "there",
-      },
-    ];
-    const msg: BaseMessage = new AIMessage({
-      content,
-    });
-    const result = await parser.invoke(msg);
-    expect(result).toEqual("hellothere");
+    await expect(async () => {
+      await parser.invoke(msg);
+    }).rejects.toThrowError();
   });
 });

--- a/langchain-core/src/output_parsers/tests/string.test.ts
+++ b/langchain-core/src/output_parsers/tests/string.test.ts
@@ -1,0 +1,99 @@
+import { describe } from "@jest/globals";
+import { StringOutputParser } from "../string.js";
+import {
+  AIMessage,
+  BaseMessage,
+  MessageContentComplex,
+} from "../../messages/index.js";
+
+describe("StringOutputParser", () => {
+  test("string input", async () => {
+    const msg: string = "hello";
+    const parser = new StringOutputParser();
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hello");
+  });
+
+  test("BaseMessage string content", async () => {
+    const msg: BaseMessage = new AIMessage({ content: "hello" });
+    const parser = new StringOutputParser();
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hello");
+  });
+
+  test("BaseMessage complex text type", async () => {
+    const parser = new StringOutputParser();
+    const content: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "hello",
+      },
+    ];
+    const msg: BaseMessage = new AIMessage({
+      content,
+    });
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hello");
+  });
+
+  test("BaseMessage multiple complex text type", async () => {
+    const parser = new StringOutputParser();
+    const content: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "hello",
+      },
+      {
+        type: "text",
+        text: "there",
+      },
+    ];
+    const msg: BaseMessage = new AIMessage({
+      content,
+    });
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hellothere");
+  });
+
+  test("BaseMessage complex text and image type", async () => {
+    const parser = new StringOutputParser();
+    const content: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "hello",
+      },
+      {
+        type: "image_url",
+        image_url: "https://example.com/example.png",
+      },
+    ];
+    const msg: BaseMessage = new AIMessage({
+      content,
+    });
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hello");
+  });
+
+  test("BaseMessage multiple complex text and image type", async () => {
+    const parser = new StringOutputParser();
+    const content: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "hello",
+      },
+      {
+        type: "image_url",
+        image_url: "https://example.com/example.png",
+      },
+      {
+        type: "text",
+        text: "there",
+      },
+    ];
+    const msg: BaseMessage = new AIMessage({
+      content,
+    });
+    const result = await parser.invoke(msg);
+    expect(result).toEqual("hellothere");
+  });
+});

--- a/langchain-core/src/output_parsers/transform.ts
+++ b/langchain-core/src/output_parsers/transform.ts
@@ -29,10 +29,7 @@ export abstract class BaseTransformOutputParser<
         yield this.parseResult([
           {
             message: chunk,
-            text:
-              typeof chunk.content === "string"
-                ? chunk.content
-                : JSON.stringify(chunk.content),
+            text: this._baseMessageToString(chunk),
           },
         ]);
       }


### PR DESCRIPTION
Added a number of methods to `BaseLLMOutputParser` and call from `invoke()` to allow subclasses to override the string representation of a `BaseMessage`. Take advantage of this as part of `StringOutputParser` to make sure any text types are represented as human-readable strings.

Fixes #4695 
