### PR TITLE
docs[patch]: fix(docs): correct typos in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ good code into the codebase.
 
 ### 🏭 Release process
 
-As of now, LangChain has an ad hoc release process: releases are cut with high frequency via by
+As of now, LangChain has an ad hoc release process: releases are cut with high frequency by
 a developer and published to [npm](https://www.npmjs.com/package/langchain).
 
 LangChain follows the [semver](https://semver.org/) versioning standard. However, as pre-1.0 software,

--- a/docs/core_docs/docs/modules/memory/index.mdx
+++ b/docs/core_docs/docs/modules/memory/index.mdx
@@ -14,7 +14,7 @@ which allows it to do things like maintain information about entities and their 
 We call this ability to store information about past interactions "memory". LangChain provides utilities for
 adding memory to a system. These utilities can be used by themselves or incorporated seamlessly into a chain.
 
-Most of memory-related functionality in LangChain is marked as beta. This is for two reasons:
+Most memory-related functionality in LangChain is marked as beta. This is for two reasons:
 
 1. Most functionality (with some exceptions, see below) is not production ready.
 2. Most functionality (with some exceptions, see below) works with Legacy chains, not the newer LCEL syntax.


### PR DESCRIPTION
Resolves two minor typos in documentation.
