### PR TITLE
Fix broken `Table of contents` links on `Q&A with RAG` page

### DIFF
--- a/docs/core_docs/docs/use_cases/question_answering/index.mdx
+++ b/docs/core_docs/docs/use_cases/question_answering/index.mdx
@@ -48,10 +48,11 @@ The most common full sequence from raw data to answer looks like:
 
 ## Table of contents
 
-- [Quickstart](/docs/use_cases/question_answering/): We recommend starting here. Many of the following guides assume you fully understand the architecture shown in the Quickstart.
-- [Returning sources](/docs/use_cases/question_answering/): How to return the source documents used in a particular generation.
-- [Streaming](/docs/use_cases/question_answering/): How to stream final answers as well as intermediate steps.
-- [Adding chat history](/docs/use_cases/question_answering/): How to add chat history to a Q&A app.
+- [Quickstart](/docs/use_cases/question_answering/quickstart): We recommend starting here. Many of the following guides assume you fully understand the architecture shown in the Quickstart.
+- [Returning sources](/docs/use_cases/question_answering/sources): How to return the source documents used in a particular generation.
+- [Citations](/docs/use_cases/question_answering/citations): How to cite which parts of the source documents are referenced in a particular generation.
+- [Streaming](/docs/use_cases/question_answering/streaming): How to stream final answers as well as intermediate steps.
+- [Adding chat history](/docs/use_cases/question_answering/chat_history): How to add chat history to a Q&A app.
 - [Per-user retrieval](/docs/use_cases/question_answering/): How to do retrieval when each user has their own private data.
-- [Using agents](/docs/use_cases/question_answering/): How to use agents for Q&A.
-- [Using local models](/docs/use_cases/question_answering/): How to use local models for Q&A.
+- [Using agents](/docs/use_cases/question_answering/conversational_retrieval_agents): How to use agents for Q&A.
+- [Using local models](/docs/use_cases/question_answering/local_retrieval_qa): How to use local models for Q&A.


### PR DESCRIPTION
### Summary
Fix broken [Table of contents](https://js.langchain.com/docs/use_cases/question_answering/#table-of-contents) links on the [Q&A with RAG](https://js.langchain.com/docs/use_cases/question_answering/) page. Also added a new link for the [Citations](https://js.langchain.com/docs/use_cases/question_answering/citations) page.

Side note: I don't know where the page is for the `Per-user retrieval` link. I can update this if someone points me to the right page.