### PR TITLE
community[patch]: Add support for inner product and Euclidean distance to `PGVector`

### DIFF
--- a/examples/src/indexes/vector_stores/pgvector_vectorstore/pgvector.ts
+++ b/examples/src/indexes/vector_stores/pgvector_vectorstore/pgvector.ts
@@ -1,5 +1,8 @@
 import { OpenAIEmbeddings } from "@langchain/openai";
-import { PGVectorStore } from "@langchain/community/vectorstores/pgvector";
+import {
+  DistanceStrategy,
+  PGVectorStore,
+} from "@langchain/community/vectorstores/pgvector";
 import { PoolConfig } from "pg";
 
 // First, follow set-up instructions at
@@ -21,6 +24,8 @@ const config = {
     contentColumnName: "content",
     metadataColumnName: "metadata",
   },
+  // supported distance strategies: cosine (default), innerProduct, or euclidean
+  distanceStrategy: "cosine" as DistanceStrategy,
 };
 
 const pgvectorStore = await PGVectorStore.initialize(

--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -509,13 +509,8 @@ export class PGVectorStore extends VectorStore {
       ? `WHERE ${whereClauses.join(" AND ")}`
       : "";
 
-    const operatorString =
-      this.extensionSchemaName !== null
-        ? `OPERATOR(${this.extensionSchemaName}.${this.computedOperatorString})`
-        : this.computedOperatorString;
-
     const queryString = `
-      SELECT *, "${this.vectorColumnName}" ${operatorString} $1 as "_distance"
+      SELECT *, "${this.vectorColumnName}" ${this.computedOperatorString} $1 as "_distance"
       FROM ${this.computedTableName}
       ${whereClause}
       ORDER BY "_distance" ASC

--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -6,7 +6,7 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 type Metadata = Record<string, unknown>;
 
-type SupportedVectorTypes = "cosine" | "innerProduct" | "euclidean";
+export type DistanceStrategy = "cosine" | "innerProduct" | "euclidean";
 
 /**
  * Interface that defines the arguments required to create a
@@ -37,7 +37,7 @@ export interface PGVectorStoreArgs {
    */
   chunkSize?: number;
   ids?: string[];
-  vectorType?: SupportedVectorTypes;
+  distanceStrategy?: DistanceStrategy;
 }
 
 /**
@@ -79,7 +79,7 @@ export class PGVectorStore extends VectorStore {
 
   chunkSize = 500;
 
-  vectorType?: SupportedVectorTypes = "cosine";
+  distanceStrategy?: DistanceStrategy = "cosine";
 
   _vectorstoreType(): string {
     return "pgvector";
@@ -112,7 +112,7 @@ export class PGVectorStore extends VectorStore {
     const pool = config.pool ?? new pg.Pool(config.postgresConnectionOptions);
     this.pool = pool;
     this.chunkSize = config.chunkSize ?? 500;
-    this.vectorType = config.vectorType ?? this.vectorType;
+    this.distanceStrategy = config.distanceStrategy ?? this.distanceStrategy;
 
     this._verbose =
       getEnvironmentVariable("LANGCHAIN_VERBOSE") === "true" ??
@@ -133,7 +133,7 @@ export class PGVectorStore extends VectorStore {
 
   get computedOperatorString() {
     let operator: string;
-    switch (this.vectorType) {
+    switch (this.distanceStrategy) {
       case "cosine":
         operator = "<=>";
         break;
@@ -144,7 +144,7 @@ export class PGVectorStore extends VectorStore {
         operator = "<->";
         break;
       default:
-        throw new Error(`Unknown search type: ${this.vectorType}`);
+        throw new Error(`Unknown distance strategy: ${this.distanceStrategy}`);
     }
 
     return this.extensionSchemaName !== null

--- a/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
@@ -222,29 +222,29 @@ describe("PGVectorStore", () => {
 
   test("PGvector supports different vector types", async () => {
     // verify by asserting different pgvector operators based on vector type
-    pgvectorVectorStore.vectorType = "cosine";
+    pgvectorVectorStore.distanceStrategy = "cosine";
     expect(pgvectorVectorStore.computedOperatorString).toEqual("<=>");
 
-    pgvectorVectorStore.vectorType = "innerProduct";
+    pgvectorVectorStore.distanceStrategy = "innerProduct";
     expect(pgvectorVectorStore.computedOperatorString).toEqual("<#>");
 
-    pgvectorVectorStore.vectorType = "euclidean";
+    pgvectorVectorStore.distanceStrategy = "euclidean";
     expect(pgvectorVectorStore.computedOperatorString).toEqual("<->");
 
     // verify with extensionSchemaName
-    pgvectorVectorStore.vectorType = "cosine";
+    pgvectorVectorStore.distanceStrategy = "cosine";
     pgvectorVectorStore.extensionSchemaName = "schema1";
     expect(pgvectorVectorStore.computedOperatorString).toEqual(
       "OPERATOR(schema1.<=>)"
     );
 
-    pgvectorVectorStore.vectorType = "innerProduct";
+    pgvectorVectorStore.distanceStrategy = "innerProduct";
     pgvectorVectorStore.extensionSchemaName = "schema2";
     expect(pgvectorVectorStore.computedOperatorString).toEqual(
       "OPERATOR(schema2.<#>)"
     );
 
-    pgvectorVectorStore.vectorType = "euclidean";
+    pgvectorVectorStore.distanceStrategy = "euclidean";
     pgvectorVectorStore.extensionSchemaName = "schema3";
     expect(pgvectorVectorStore.computedOperatorString).toEqual(
       "OPERATOR(schema3.<->)"

--- a/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
@@ -219,6 +219,31 @@ describe("PGVectorStore", () => {
       throw e;
     }
   });
+
+  test("PGvector supports different vector types", async () => {
+    // verify by asserting different pgvector operators based on vector type
+    pgvectorVectorStore.vectorType = "cosine";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("<=>");
+
+    pgvectorVectorStore.vectorType = "innerProduct";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("<#>");
+
+    pgvectorVectorStore.vectorType = "euclidean";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("<->");
+
+    // verify with extensionSchemaName
+    pgvectorVectorStore.vectorType = "cosine";
+    pgvectorVectorStore.extensionSchemaName = "schema1";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema1.<=>)");
+
+    pgvectorVectorStore.vectorType = "innerProduct";
+    pgvectorVectorStore.extensionSchemaName = "schema2";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema2.<#>)");
+
+    pgvectorVectorStore.vectorType = "euclidean";
+    pgvectorVectorStore.extensionSchemaName = "schema3";
+    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema3.<->)");
+  });
 });
 
 describe.skip("PGVectorStore with collection", () => {

--- a/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/pgvector/pgvector.int.test.ts
@@ -234,15 +234,21 @@ describe("PGVectorStore", () => {
     // verify with extensionSchemaName
     pgvectorVectorStore.vectorType = "cosine";
     pgvectorVectorStore.extensionSchemaName = "schema1";
-    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema1.<=>)");
+    expect(pgvectorVectorStore.computedOperatorString).toEqual(
+      "OPERATOR(schema1.<=>)"
+    );
 
     pgvectorVectorStore.vectorType = "innerProduct";
     pgvectorVectorStore.extensionSchemaName = "schema2";
-    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema2.<#>)");
+    expect(pgvectorVectorStore.computedOperatorString).toEqual(
+      "OPERATOR(schema2.<#>)"
+    );
 
     pgvectorVectorStore.vectorType = "euclidean";
     pgvectorVectorStore.extensionSchemaName = "schema3";
-    expect(pgvectorVectorStore.computedOperatorString).toEqual("OPERATOR(schema3.<->)");
+    expect(pgvectorVectorStore.computedOperatorString).toEqual(
+      "OPERATOR(schema3.<->)"
+    );
   });
 });
 


### PR DESCRIPTION
### Summary
Add support for inner product and Euclidean distance to `PGVector`. The implementation is modeled after the `CassandraStore` implementation.

### To Do
- [ ] Figure out how to run `PGVector` tests.
- [x] Update [LangChain's PGVector documentation](https://js.langchain.com/docs/integrations/vectorstores/pgvector) to indicate that different vector types are supported.

### Future
1. I can probably make this change in the Python library as well.

### References
1. [PGVector Vector Operators](https://github.com/pgvector/pgvector/?tab=readme-ov-file#vector-operators)
2. [Discord thread](https://discord.com/channels/1038097195422978059/1076182741374214285/1217854243017588816)