### PR TITLE
Fix code example for agents in quickstart document

### DIFF
--- a/docs/core_docs/docs/get_started/quickstart.mdx
+++ b/docs/core_docs/docs/get_started/quickstart.mdx
@@ -597,7 +597,7 @@ import { createOpenAIFunctionsAgent, AgentExecutor } from "langchain/agents";
 // Get the prompt to use - you can modify this!
 // If you want to see the prompt in full, you can at:
 // https://smith.langchain.com/hub/hwchase17/openai-functions-agent
-const agentPrompt = await pull<ChatPromptTemplate>(
+const agentPrompt = await pull(
   "hwchase17/openai-functions-agent"
 );
 


### PR DESCRIPTION
The following was returning `false`:

```
await pull<ChatPromptTemplate>(
  "hwchase17/openai-functions-agent"
);
```

So `createOpenAIFunctionsAgent()` would fail with:

```
file:///home/gus/repos/langchain-quickstart/node_modules/langchain/dist/agents/openai_functions/index.js:218
    if (!prompt.inputVariables.includes("agent_scratchpad")) {
                               ^

TypeError: Cannot read properties of undefined (reading 'includes')
    at createOpenAIFunctionsAgent (file:///home/gus/repos/langchain-quickstart/node_modules/langchain/dist/agents/openai_functions/index.js:218:32)
    at file:///home/gus/repos/langchain-quickstart/index.js:44:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
