### PR TITLE
fix(cohere): bump client version

### DIFF
--- a/libs/langchain-cohere/package.json
+++ b/libs/langchain-cohere/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@langchain/core": "~0.1",
-    "cohere-ai": "^7.6.2"
+    "cohere-ai": "^7.8.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/libs/langchain-cohere/src/chat_models.ts
+++ b/libs/langchain-cohere/src/chat_models.ts
@@ -150,13 +150,12 @@ export class ChatCohere<
   invocationParams(options: this["ParsedCallOptions"]) {
     const params = {
       model: this.model,
-      preambleOverride: options.preambleOverride,
+      preamble: options.preamble,
       conversationId: options.conversationId,
       promptTruncation: options.promptTruncation,
       connectors: options.connectors,
       searchQueriesOnly: options.searchQueriesOnly,
       documents: options.documents,
-      citationQuality: options.citationQuality,
       temperature: options.temperature ?? this.temperature,
     };
     // Filter undefined entries

--- a/libs/langchain-cohere/src/embeddings.ts
+++ b/libs/langchain-cohere/src/embeddings.ts
@@ -86,7 +86,8 @@ export class CohereEmbeddings
       this.embeddingWithRetry({
         model: this.model,
         texts: batch,
-        inputType: this.inputType,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        inputType: this.inputType as any,
       })
     );
 
@@ -118,7 +119,8 @@ export class CohereEmbeddings
     const { embeddings } = await this.embeddingWithRetry({
       model: this.model,
       texts: [text],
-      inputType: this.inputType,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inputType: this.inputType as any,
     });
     if ("float" in embeddings && embeddings.float) {
       return embeddings.float[0];

--- a/libs/langchain-cohere/src/llms.ts
+++ b/libs/langchain-cohere/src/llms.ts
@@ -113,7 +113,6 @@ export class Cohere extends LLM<CohereCallOptions> implements CohereInput {
       frequencyPenalty: options.frequencyPenalty,
       presencePenalty: options.presencePenalty,
       returnLikelihoods: options.returnLikelihoods,
-      logitBias: options.logitBias,
     };
     // Filter undefined entries
     return Object.fromEntries(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8899,7 +8899,7 @@ __metadata:
     "@tsconfig/recommended": ^1.0.3
     "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.12.0
-    cohere-ai: ^7.6.2
+    cohere-ai: ^7.8.0
     dotenv: ^16.3.1
     dpdm: ^3.12.0
     eslint: ^8.33.0
@@ -18176,16 +18176,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cohere-ai@npm:^7.6.2":
-  version: 7.6.2
-  resolution: "cohere-ai@npm:7.6.2"
+"cohere-ai@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "cohere-ai@npm:7.8.0"
   dependencies:
     form-data: 4.0.0
     js-base64: 3.7.2
     node-fetch: 2.7.0
     qs: 6.11.2
     url-join: 4.0.1
-  checksum: cf70c115ddc50162f9fa7df5d2d569417ab68000dc4ca1a93646c457b61f691fd91cf5f73d69fd225d8224c05c105f74d7ca5a7700e6c0f4b37df70aa3d4fb48
+  checksum: dc2f612fe209329542a45c0c600cc5eb65cce138f935e9a254c0a992000de28d298ed961acb9d58d19d84b26e981c6fa39f8ac29adb82f2ffe5495b11dc58766
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps the version of the cohere-ai ts client. It fixes an issue with the cohere-ai package running on aws lambda to where the fetch function is not defined in some node versions because of the default export, more info mentioned on the issue below.
twitter.  `https://twitter.com/Gr33nLight_`

Fixes https://github.com/cohere-ai/cohere-typescript/issues/136
