### PR TITLE
Add mistral as supported provider for AWS Bedrock

### DIFF
--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -353,7 +353,10 @@ export class BedrockChat extends BaseChatModel implements BaseBedrockInput {
       this.endpointHost ?? `${service}.${this.region}.amazonaws.com`;
 
     const bedrockMethod =
-      provider === "anthropic" || provider === "cohere" || provider === "meta"
+      provider === "anthropic" ||
+      provider === "cohere" ||
+      provider === "meta" ||
+      provider === "mistral"
         ? "invoke-with-response-stream"
         : "invoke";
 
@@ -374,7 +377,8 @@ export class BedrockChat extends BaseChatModel implements BaseBedrockInput {
     if (
       provider === "anthropic" ||
       provider === "cohere" ||
-      provider === "meta"
+      provider === "meta" ||
+      provider === "mistral"
     ) {
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();

--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -171,7 +171,14 @@ export class BedrockChat extends BaseChatModel implements BaseBedrockInput {
     super(fields ?? {});
 
     this.model = fields?.model ?? this.model;
-    const allowedModels = ["ai21", "anthropic", "amazon", "cohere", "meta"];
+    const allowedModels = [
+      "ai21",
+      "anthropic",
+      "amazon",
+      "cohere",
+      "meta",
+      "mistral",
+    ];
     if (!allowedModels.includes(this.model.split(".")[0])) {
       throw new Error(
         `Unknown model: '${this.model}', only these are supported: ${allowedModels}`

--- a/libs/langchain-community/src/chat_models/tests/chatbedrock.int.test.ts
+++ b/libs/langchain-community/src/chat_models/tests/chatbedrock.int.test.ts
@@ -21,21 +21,21 @@ import { BedrockChat } from "../bedrock/web.js";
 void testChatModel(
   "Test Bedrock chat model: Claude-v2",
   "us-east-1",
-  "anthropic.claude-v2",
+  "mistral.mistral-7b-instruct-v0:2",
   "What is your name?"
 );
 
 void testChatStreamingModel(
   "Test Bedrock chat model streaming: Claude-v2",
   "us-east-1",
-  "anthropic.claude-v2",
+  "mistral.mistral-7b-instruct-v0:2",
   "What is your name and something about yourself?"
 );
 
 void testChatHandleLLMNewToken(
   "Test Bedrock chat model HandleLLMNewToken: Claude-v2",
   "us-east-1",
-  "anthropic.claude-v2",
+  "mistral.mistral-7b-instruct-v0:2",
   "What is your name and something about yourself?"
 );
 

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -248,7 +248,10 @@ export class Bedrock extends LLM implements BaseBedrockInput {
   ): AsyncGenerator<GenerationChunk> {
     const provider = this.model.split(".")[0];
     const bedrockMethod =
-      provider === "anthropic" || provider === "cohere" || provider === "meta"
+      provider === "anthropic" ||
+      rovider === "cohere" ||
+      provider === "meta" ||
+      provider === "mistral"
         ? "invoke-with-response-stream"
         : "invoke";
 
@@ -274,7 +277,8 @@ export class Bedrock extends LLM implements BaseBedrockInput {
     if (
       provider === "anthropic" ||
       provider === "cohere" ||
-      provider === "meta"
+      provider === "meta" ||
+      provider === "mistral"
     ) {
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -249,7 +249,7 @@ export class Bedrock extends LLM implements BaseBedrockInput {
     const provider = this.model.split(".")[0];
     const bedrockMethod =
       provider === "anthropic" ||
-      rovider === "cohere" ||
+      provider === "cohere" ||
       provider === "meta" ||
       provider === "mistral"
         ? "invoke-with-response-stream"

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -84,7 +84,14 @@ export class Bedrock extends LLM implements BaseBedrockInput {
     super(fields ?? {});
 
     this.model = fields?.model ?? this.model;
-    const allowedModels = ["ai21", "anthropic", "amazon", "cohere", "meta"];
+    const allowedModels = [
+      "ai21",
+      "anthropic",
+      "amazon",
+      "cohere",
+      "meta",
+      "mistral",
+    ];
     if (!allowedModels.includes(this.model.split(".")[0])) {
       throw new Error(
         `Unknown model: '${this.model}', only these are supported: ${allowedModels}`

--- a/libs/langchain-community/src/utils/bedrock.ts
+++ b/libs/langchain-community/src/utils/bedrock.ts
@@ -190,6 +190,11 @@ export class BedrockLLMInputOutputAdapter {
       if (bedrockMethod === "invoke-with-response-stream") {
         inputBody.stream = true;
       }
+    } else if (provider === "mistral") {
+      inputBody.prompt = prompt;
+      inputBody.max_tokens = maxTokens;
+      inputBody.temperature = temperature;
+      inputBody.stop = stopSequences;
     }
     return { ...inputBody, ...modelKwargs };
   }
@@ -239,6 +244,8 @@ export class BedrockLLMInputOutputAdapter {
       return responseBody?.generations?.[0]?.text ?? responseBody?.text ?? "";
     } else if (provider === "meta") {
       return responseBody.generation;
+    } else if (provider === "mistral") {
+      return responseBody?.outputs?.[0]?.text;
     }
 
     // I haven't been able to get a response with more than one result in it.
@@ -257,7 +264,7 @@ export class BedrockLLMInputOutputAdapter {
       } else if (
         (responseBody.type === "content_block_delta" &&
           responseBody.delta?.type === "text_delta",
-        typeof responseBody.delta?.text === "string")
+          typeof responseBody.delta?.text === "string")
       ) {
         return new ChatGenerationChunk({
           message: new AIMessageChunk({

--- a/libs/langchain-community/src/utils/bedrock.ts
+++ b/libs/langchain-community/src/utils/bedrock.ts
@@ -262,9 +262,9 @@ export class BedrockLLMInputOutputAdapter {
       if (responseBody.type === "message_start") {
         return parseMessage(responseBody.message, true);
       } else if (
-        (responseBody.type === "content_block_delta" &&
-          responseBody.delta?.type === "text_delta",
-          typeof responseBody.delta?.text === "string")
+        responseBody.type === "content_block_delta" &&
+        responseBody.delta?.type === "text_delta" &&
+        typeof responseBody.delta?.text === "string"
       ) {
         return new ChatGenerationChunk({
           message: new AIMessageChunk({


### PR DESCRIPTION
Mistral is now supported in AWS Bedrock. 

```
$ aws bedrock list-foundation-models --region us-east-1 --query 'modelSummaries[*].modelId' | grep mistral
    "mistral.mistral-7b-instruct-v0:2",
    "mistral.mixtral-8x7b-instruct-v0:1"
$
```

Langchain has a duplicated list of valid models. I'd argue that they both can be removed. Langchain doesn't need to validate the models before passing them on to Bedrock.