### PR TITLE
docs[patch]: Fix missing link to `Agents Quick Start`

### DIFF
--- a/docs/core_docs/docs/modules/agents/index.mdx
+++ b/docs/core_docs/docs/modules/agents/index.mdx
@@ -10,7 +10,7 @@ In chains, a sequence of actions is hardcoded (in code). In agents, a language m
 
 ## [Quick Start](/docs/modules/agents/quick_start)
 
-For a quick start to working with agents, please check out this getting started guide. This covers basics like initializing an agent, creating tools, and adding memory.
+For a quick start to working with agents, please check out [this getting started guide](/docs/modules/agents/quick_start). This covers basics like initializing an agent, creating tools, and adding memory.
 
 ## [Concepts](/docs/modules/agents/concepts)
 


### PR DESCRIPTION
[Python docs](https://python.langchain.com/docs/modules/agents/) have a link on `this getting started guide` which [JS docs](https://js.langchain.com/docs/modules/agents/) are missing