### PR TITLE
redis[patch]: Escape additional metadata characters for RedisSearch metadata filtering usage

### DIFF
--- a/libs/langchain-redis/src/tests/vectorstores.test.ts
+++ b/libs/langchain-redis/src/tests/vectorstores.test.ts
@@ -55,7 +55,7 @@ test("RedisVectorStore with external keys", async () => {
   expect(client.hSet).toHaveBeenCalledWith("id1", {
     content_vector: Buffer.from(new Float32Array([0.1, 0.2, 0.3, 0.4]).buffer),
     content: "hello",
-    metadata: JSON.stringify({ a: 1, b: { nested: [1, { a: 4 }] } }),
+    metadata: `{\\\"a\\\"\\:1,\\\"b\\\"\\:{\\\"nested\\\"\\:[1,{\\\"a\\\"\\:4}]}}`,
   });
 
   const results = await store.similaritySearch("goodbye", 1);

--- a/libs/langchain-redis/src/tests/vectorstores.test.ts
+++ b/libs/langchain-redis/src/tests/vectorstores.test.ts
@@ -55,7 +55,7 @@ test("RedisVectorStore with external keys", async () => {
   expect(client.hSet).toHaveBeenCalledWith("id1", {
     content_vector: Buffer.from(new Float32Array([0.1, 0.2, 0.3, 0.4]).buffer),
     content: "hello",
-    metadata: `{\\\"a\\\"\\:1,\\\"b\\\"\\:{\\\"nested\\\"\\:[1,{\\\"a\\\"\\:4}]}}`,
+    metadata: `{\\"a\\"\\:1,\\"b\\"\\:{\\"nested\\"\\:[1,{\\"a\\"\\:4}]}}`,
   });
 
   const results = await store.similaritySearch("goodbye", 1);

--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -442,9 +442,9 @@ export class RedisVectorStore extends VectorStore {
   }
 
   /**
-   * Escapes all '-' characters.
-   * RediSearch considers '-' as a negative operator, hence we need
-   * to escape it
+   * Escapes all '-', ':', and '"' characters.
+   * RediSearch considers these all as special characters, so we need
+   * to escape them
    * @see https://redis.io/docs/stack/search/reference/query_syntax
    *
    * @param str
@@ -455,7 +455,7 @@ export class RedisVectorStore extends VectorStore {
   }
 
   /**
-   * Unescapes all '-' characters, returning the original string
+   * Unescapes all '-', ':', and '"' characters, returning the original string
    *
    * @param str
    * @returns

--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -451,7 +451,10 @@ export class RedisVectorStore extends VectorStore {
    * @returns
    */
   private escapeSpecialChars(str: string) {
-    return str.replaceAll("-", "\\-").replaceAll(":", "\\:").replaceAll(`"`, `\\"`);
+    return str
+      .replaceAll("-", "\\-")
+      .replaceAll(":", "\\:")
+      .replaceAll(`"`, `\\"`);
   }
 
   /**
@@ -461,7 +464,10 @@ export class RedisVectorStore extends VectorStore {
    * @returns
    */
   private unEscapeSpecialChars(str: string) {
-    return str.replaceAll("\\-", "-").replaceAll("\\:", ":").replaceAll(`\\"`, `"`);
+    return str
+      .replaceAll("\\-", "-")
+      .replaceAll("\\:", ":")
+      .replaceAll(`\\"`, `"`);
   }
 
   /**

--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -451,7 +451,7 @@ export class RedisVectorStore extends VectorStore {
    * @returns
    */
   private escapeSpecialChars(str: string) {
-    return str.replaceAll("-", "\\-");
+    return str.replaceAll("-", "\\-").replaceAll(":", "\\:").replaceAll(`"`, `\\"`);
   }
 
   /**
@@ -461,7 +461,7 @@ export class RedisVectorStore extends VectorStore {
    * @returns
    */
   private unEscapeSpecialChars(str: string) {
-    return str.replaceAll("\\-", "-");
+    return str.replaceAll("\\-", "-").replaceAll("\\:", ":").replaceAll(`\\"`, `"`);
   }
 
   /**


### PR DESCRIPTION
The `:` and `"` characters found in the stringified JSON are special characters in redisSearch queries, so we need to escape them in the stringified metadata if we want to be able to search the entire JSON object.

This enables key/value sub-string searches of the stringified metadata object for filtering purposes.