### PR TITLE
docs: adding missing dependencies to RAG documentation

### DIFF
--- a/docs/core_docs/docs/expression_language/cookbook/retrieval.mdx
+++ b/docs/core_docs/docs/expression_language/cookbook/retrieval.mdx
@@ -27,9 +27,7 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/openai
-npm install @langchain/community
-npm install hnswlib-node
+npm install @langchain/openai @langchain/community hnswlib-node
 ```
 
 <CodeBlock language="typescript">{RetrieverExample}</CodeBlock>

--- a/docs/core_docs/docs/expression_language/cookbook/retrieval.mdx
+++ b/docs/core_docs/docs/expression_language/cookbook/retrieval.mdx
@@ -28,6 +28,8 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 
 ```bash npm2yarn
 npm install @langchain/openai
+npm install @langchain/community
+npm install hnswlib-node
 ```
 
 <CodeBlock language="typescript">{RetrieverExample}</CodeBlock>


### PR DESCRIPTION
The current docs indicate that `@langchain/openai` should be installed, there are actually a couple of other dependencies thar need to be installed in order to execute the example code.