### PR TITLE
mistralai[minor]: Fix throwing abort errors and add tests

### DIFF
--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -87,7 +87,8 @@ type MistralAIChatCompletionOptions = {
   responseFormat?: ResponseFormat;
 };
 
-interface MistralAICallOptions extends Omit<BaseLanguageModelCallOptions, "stop"> {
+interface MistralAICallOptions
+  extends Omit<BaseLanguageModelCallOptions, "stop"> {
   response_format?: {
     type: "text" | "json_object";
   };
@@ -528,7 +529,6 @@ export class ChatMistralAI<
         { chunk: generationChunk }
       );
     }
-
   }
 
   /** @ignore */

--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -412,11 +412,12 @@ export class ChatMistralAI<
       messages: mistralMessages,
     };
 
+    // Enable streaming for signal controller or timeout due
+    // to SDK limitations on canceling requests.
     const shouldStream = !!options.signal ?? !!options.timeout;
 
     // Handle streaming
     if (this.streaming || shouldStream) {
-      console.log("should stream!")
       const stream = this._streamResponseChunks(messages, options, runManager);
       const finalChunks: Record<number, ChatGenerationChunk> = {};
       for await (const chunk of stream) {

--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -87,7 +87,7 @@ type MistralAIChatCompletionOptions = {
   responseFormat?: ResponseFormat;
 };
 
-interface MistralAICallOptions extends BaseLanguageModelCallOptions {
+interface MistralAICallOptions extends Omit<BaseLanguageModelCallOptions, "stop"> {
   response_format?: {
     type: "text" | "json_object";
   };
@@ -491,6 +491,9 @@ export class ChatMistralAI<
 
     const streamIterable = await this.completionWithRetry(input, true);
     for await (const data of streamIterable) {
+      if (options.signal?.aborted) {
+        throw new Error("AbortError");
+      }
       const choice = data?.choices[0];
       if (!choice || !("delta" in choice)) {
         continue;
@@ -525,9 +528,7 @@ export class ChatMistralAI<
         { chunk: generationChunk }
       );
     }
-    if (options.signal?.aborted) {
-      throw new Error("AbortError");
-    }
+
   }
 
   /** @ignore */

--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -412,8 +412,11 @@ export class ChatMistralAI<
       messages: mistralMessages,
     };
 
+    const shouldStream = !!options.signal ?? !!options.timeout;
+
     // Handle streaming
-    if (this.streaming) {
+    if (this.streaming || shouldStream) {
+      console.log("should stream!")
       const stream = this._streamResponseChunks(messages, options, runManager);
       const finalChunks: Record<number, ChatGenerationChunk> = {};
       for await (const chunk of stream) {

--- a/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
@@ -568,18 +568,21 @@ describe("ChatMistralAI aborting", () => {
   test("ChatMistralAI can abort request", async () => {
     const controller = new AbortController();
     const model = new ChatMistralAI().bind({
-      signal: controller.signal
-    })
+      signal: controller.signal,
+    });
     const prompt = ChatPromptTemplate.fromMessages([
       ["system", "You're super good at counting!"],
-      ["human", "Count from 0-100, remember to say 'woof' after every even number!"]
+      [
+        "human",
+        "Count from 0-100, remember to say 'woof' after every even number!",
+      ],
     ]);
-  
+
     const stream = await prompt.pipe(model).stream({});
-  
+
     let finalRes = "";
     let iters = 0;
-  
+
     try {
       for await (const item of stream) {
         finalRes += item.content;
@@ -588,45 +591,52 @@ describe("ChatMistralAI aborting", () => {
         controller.abort();
       }
       // If the loop completes without error, fail the test
-      fail("Expected for-await loop to throw an error due to abort, but it did not.");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fail(
+        "Expected for-await loop to throw an error due to abort, but it did not."
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       // Check if the error is due to the abort action
       expect(error.message).toBe("AbortError");
     }
     expect(iters).toBe(1);
-  })
-  
+  });
+
   test("ChatMistralAI can timeout requests", async () => {
     const model = new ChatMistralAI().bind({
       timeout: 1000,
-    })
+    });
     const prompt = ChatPromptTemplate.fromMessages([
       ["system", "You're super good at counting!"],
-      ["human", "Count from 0-100, remember to say 'woof' after every even number!"]
+      [
+        "human",
+        "Count from 0-100, remember to say 'woof' after every even number!",
+      ],
     ]);
     let didError = false;
     let finalRes = "";
     let iters = 0;
-  
+
     try {
       // Stream is inside the for-await loop because sometimes
       // the abort will occur before the first stream event is emitted
       const stream = await prompt.pipe(model).stream({});
-  
+
       for await (const item of stream) {
         finalRes += item.content;
         console.log(finalRes);
         iters += 1;
       }
       // If the loop completes without error, fail the test
-      fail("Expected for-await loop to throw an error due to abort, but it did not.");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fail(
+        "Expected for-await loop to throw an error due to abort, but it did not."
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       didError = true;
       // Check if the error is due to the abort action
       expect(error.message).toBe("AbortError");
     }
     expect(didError).toBeTruthy();
-  })
+  });
 });

--- a/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
@@ -563,3 +563,70 @@ describe("withStructuredOutput", () => {
     ).toBe(true);
   });
 });
+
+describe("ChatMistralAI aborting", () => {
+  test("ChatMistralAI can abort request", async () => {
+    const controller = new AbortController();
+    const model = new ChatMistralAI().bind({
+      signal: controller.signal
+    })
+    const prompt = ChatPromptTemplate.fromMessages([
+      ["system", "You're super good at counting!"],
+      ["human", "Count from 0-100, remember to say 'woof' after every even number!"]
+    ]);
+  
+    const stream = await prompt.pipe(model).stream({});
+  
+    let finalRes = "";
+    let iters = 0;
+  
+    try {
+      for await (const item of stream) {
+        finalRes += item.content;
+        console.log(finalRes);
+        iters += 1;
+        controller.abort();
+      }
+      // If the loop completes without error, fail the test
+      fail("Expected for-await loop to throw an error due to abort, but it did not.");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      // Check if the error is due to the abort action
+      expect(error.message).toBe("AbortError");
+    }
+    expect(iters).toBe(1);
+  })
+  
+  test("ChatMistralAI can timeout requests", async () => {
+    const model = new ChatMistralAI().bind({
+      timeout: 1000,
+    })
+    const prompt = ChatPromptTemplate.fromMessages([
+      ["system", "You're super good at counting!"],
+      ["human", "Count from 0-100, remember to say 'woof' after every even number!"]
+    ]);
+    let didError = false;
+    let finalRes = "";
+    let iters = 0;
+  
+    try {
+      // Stream is inside the for-await loop because sometimes
+      // the abort will occur before the first stream event is emitted
+      const stream = await prompt.pipe(model).stream({});
+  
+      for await (const item of stream) {
+        finalRes += item.content;
+        console.log(finalRes);
+        iters += 1;
+      }
+      // If the loop completes without error, fail the test
+      fail("Expected for-await loop to throw an error due to abort, but it did not.");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      didError = true;
+      // Check if the error is due to the abort action
+      expect(error.message).toBe("AbortError");
+    }
+    expect(didError).toBeTruthy();
+  })
+});


### PR DESCRIPTION
Closes #4809

Changes:
- omit `stop` from the mistral call options, not supported via their sdk
- move the error thrown if abort controller is aborted to inside the `for-await` loop since their sdk doesn't support aborting natively
- if timeout or signal is passed, make the `generate` method stream instead so we can properly abort
- add tests