### PR TITLE
mistral[minor]: integrating Mistral LLM with AgentExecutor

### DIFF
--- a/libs/langchain-mistralai/package.json
+++ b/libs/langchain-mistralai/package.json
@@ -45,6 +45,7 @@
     "zod-to-json-schema": "^3.22.4"
   },
   "devDependencies": {
+    "langchain": "workspace:^",
     "@jest/globals": "^29.5.0",
     "@langchain/scripts": "~0.0",
     "@swc/core": "^1.3.90",

--- a/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.int.test.ts
@@ -1,6 +1,13 @@
 import { test } from "@jest/globals";
-import { ChatPromptTemplate } from "@langchain/core/prompts";
-import { StructuredTool } from "@langchain/core/tools";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  MessagesPlaceholder,
+  SystemMessagePromptTemplate,
+} from "@langchain/core/prompts";
+import { AgentExecutor, createOpenAIToolsAgent } from "langchain/agents";
+import { BaseChatModel } from "langchain/chat_models/base";
+import { DynamicStructuredTool, StructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
 import { AIMessage, BaseMessage } from "@langchain/core/messages";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -561,6 +568,54 @@ describe("withStructuredOutput", () => {
           raw.additional_kwargs.tool_calls?.[0].function.arguments ?? ""
         )
     ).toBe(true);
+  });
+
+  test("Model is compatible with OpenAI tools agent and Agent Executor", async () => {
+    const llm: BaseChatModel = new ChatMistralAI({
+      temperature: 0,
+      modelName: "mistral-large-latest",
+    });
+
+    const systemMessage = SystemMessagePromptTemplate.fromTemplate(
+      "You are an agent capable of retrieving current weather information."
+    );
+    const humanMessage = HumanMessagePromptTemplate.fromTemplate("{input}");
+    const agentScratchpad = new MessagesPlaceholder("agent_scratchpad");
+
+    const prompt = ChatPromptTemplate.fromMessages([
+      systemMessage,
+      humanMessage,
+      agentScratchpad,
+    ]);
+
+    const currentWeatherTool = new DynamicStructuredTool({
+      name: "get_current_weather",
+      description: "Get the current weather in a given location",
+      schema: z.object({
+        location: z
+          .string()
+          .describe("The city and state, e.g. San Francisco, CA"),
+      }),
+      func: async () => Promise.resolve("28 °C"),
+    });
+
+    const agent = await createOpenAIToolsAgent({
+      llm,
+      tools: [currentWeatherTool],
+      prompt,
+    });
+
+    const agentExecutor = new AgentExecutor({
+      agent,
+      tools: [currentWeatherTool],
+    });
+
+    const input = "What's the weather like in Paris?";
+    const { output } = await agentExecutor.invoke({ input });
+
+    console.log(output);
+    expect(output).toBeDefined();
+    expect(output).toContain("The current temperature in Paris is 28 °C");
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9598,6 +9598,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
+    langchain: "workspace:^"
     prettier: ^2.8.3
     release-it: ^15.10.1
     rollup: ^4.5.2
@@ -26338,7 +26339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"langchain@workspace:*, langchain@workspace:langchain":
+"langchain@workspace:*, langchain@workspace:^, langchain@workspace:langchain":
   version: 0.0.0-use.local
   resolution: "langchain@workspace:langchain"
   dependencies:


### PR DESCRIPTION
### Enhancing LangChain.js with Mistral Model Compatibility

This PR aims to adjust the `ChatMistralAI` class to ensure its compatibility with the `createOpenAIToolsAgent` interface, thereby enabling the use of Mistral models, specifically `mistral-large-latest` and `mistral-small-latest`, within the execution agent that utilizes tool calling in the manner of OpenAI. This modification aligns with the API specifications of Mistral for the mentioned models, making them compatible with the same implementations as those of recent OpenAI models, such as `gpt-4-0125-preview` and `gpt-3.5-turbo-0125`, as mentioned here: [LangChain Agents Documentation](https://api.js.langchain.com/functions/langchain_agents.createOpenAIToolsAgent.html).

The extended compatibility allows for the seamless integration of Mistral's capabilities within agents, using the `createOpenAIToolsAgent` method to create an agent. This method supports tool calling in the OpenAI style, making Mistral models suitable for use in agent scenarios similarly to OpenAI's GPT-3.5 and GPT-4 models.

References:
- Mistral API specification for `mistral-large-latest`: [Mistral Documentation](https://docs.mistral.ai/api/#operation/createChatCompletion)
- OpenAI API specifications for GPT-3.5 and GPT-4: [OpenAI Documentation](https://platform.openai.com/docs/api-reference/chat/create)

**Compatible Models with Tools:**
- ~~open-mistral-7b (aka mistral-tiny-2312)~~
- ~~open-mistral-8x7b (aka mistral-small-2312)~~
- **mistral-small-latest (aka mistral-small-2402)**
- ~~mistral-medium-latest (aka mistral-medium-2312)~~
- **mistral-large-latest (aka mistral-large-2402)**

Note: Models not listed as bold are not supported with tools implementation.
