### PR TITLE
community[patch]: ElasticVectorSearch - fix error when no bulk operations 

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -193,7 +193,8 @@ export class ElasticVectorSearch extends VectorStore {
         _index: this.indexName,
       },
     }));
-    await this.client.bulk({ refresh: true, operations });
+    if (operations.length > 0)
+      await this.client.bulk({ refresh: true, operations });
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes bug in discussion # ([discussion](https://github.com/langchain-ai/langchain/discussions/19396))

Description is in the attached issue/discussion. Basically, it was observed on `incremental` cleanup when calling the `index(...)` function a crash when trying to delete an empty list of elements. The deletion in Elastic is done by a `POST _bulk` request, which expects a non-emtpy list of operations. When there is no elements to delete, the list of operations is empty, hence the error. Easy to replicate straight in the Elastic Console (i.e. http://localhost:5601/app/dev_tools#/console) by writing just `POST _bulk`. 