### PR TITLE
anthropic[patch]: Apply the new format for transferring the "usage" attribute in the "m…

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -288,9 +288,9 @@ export class ChatAnthropicMessages<
         yield new ChatGenerationChunk({
           message: new AIMessageChunk({
             content: "",
-            additional_kwargs: { 
+            additional_kwargs: {
               ...data.delta,
-              usage: data.usage
+              usage: data.usage,
             },
           }),
           text: "",

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -295,8 +295,7 @@ export class ChatAnthropicMessages<
           text: "",
         });
         if (data?.usage !== undefined) {
-          usageData.output_tokens =
-            usageData.output_tokens + data.usage.output_tokens;
+          usageData.output_tokens += data.usage.output_tokens;
         }
       } else if (data.type === "content_block_delta") {
         const content = data.delta?.text;

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -288,7 +288,10 @@ export class ChatAnthropicMessages<
         yield new ChatGenerationChunk({
           message: new AIMessageChunk({
             content: "",
-            additional_kwargs: { ...data.delta },
+            additional_kwargs: { 
+              ...data.delta,
+              usage: data.usage
+            },
           }),
           text: "",
         });


### PR DESCRIPTION
…essage_delta" event of the "anthropic" provider.

Apparently, anthropic has moved "usage" out of "delta", placing them now on the same level. Here is the current view of the event.

event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}         }
