### PR TITLE
implement dynamic prompt template and benchmark

### DIFF
--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -44,6 +44,7 @@
     "decamelize": "1.2.0",
     "js-tiktoken": "^1.0.8",
     "langsmith": "~0.1.7",
+    "lodash.template": "^4.5.0",
     "ml-distance": "^4.0.0",
     "p-queue": "^6.6.2",
     "p-retry": "4",
@@ -56,6 +57,7 @@
     "@langchain/scripts": "~0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
+    "@types/lodash.template": "^4",
     "dpdm": "^3.12.0",
     "eslint": "^8.33.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -70,6 +72,7 @@
     "prettier": "^2.8.3",
     "release-it": "^15.10.1",
     "rimraf": "^5.0.1",
+    "tinybench": "^2.6.0",
     "turbo": "latest",
     "typescript": "~5.1.6",
     "web-streams-polyfill": "^3.3.3"

--- a/langchain-core/src/prompts/benchmark.ts
+++ b/langchain-core/src/prompts/benchmark.ts
@@ -1,0 +1,89 @@
+import { Bench } from 'tinybench';
+import { PromptTemplate } from './prompt.js';
+import { DynamicPromptTemplate } from './dynamic.js';
+
+// (async () => {
+
+//   const promptTemplate = `
+//   Simple: {simple}
+//   Nested:
+//   - {nested.a}
+//   - {nested.b}`;
+
+//   const nativePromptFormatted = await nativePrompt.format({
+//     simple: 'simple',
+//     nested: { a: '1', b: '2' },
+//     'nested.a': 'A',
+//     'nested.b': 'B',
+//   });
+//   console.log(nativePromptFormatted);
+
+//   const dynamicPromptFormatted = await dynamicPrompt.format({
+//     simple: 'simple',
+//     nested: { a: '1', b: '2' },
+//     'nested.a': 'A',
+//     'nested.b': 'B',
+//   });
+//   console.log(dynamicPromptFormatted);
+// })();
+
+
+
+type SimpleInput = { foo: string; bar: string };
+const simpleInput: SimpleInput = { foo: 'foo', bar: 'bar' };
+const simplePromptTemplate = `{foo}{bar}`;
+
+const simpleNativePrompt = PromptTemplate.fromTemplate<SimpleInput>(simplePromptTemplate);
+const simpleDynamicPrompt = DynamicPromptTemplate.fromTemplate<SimpleInput>(simplePromptTemplate);
+
+type ComplexInput = Record<string, string>;
+const complexInput: Record<string, string> = Array(100)
+	.map((_, i) => ({ [`key${i}`]: `value${i}` }))
+	.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+const complexPromptTemplate = Object.entries(complexInput)
+	.map(([key, value]) => `${key}: {${key}}`)
+	.join(`\n`);
+
+const complexNativePrompt = PromptTemplate.fromTemplate<ComplexInput>(complexPromptTemplate);
+const complexDynamicPrompt = DynamicPromptTemplate.fromTemplate<ComplexInput>(complexPromptTemplate);
+
+
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+	const bench = new Bench({ time: 1000 });
+	// simple prompts
+	bench
+		.add('DynamicPromptTemplate: simple', async () => {
+			await simpleDynamicPrompt.format(simpleInput);
+		})
+		.add('PromptTemplate: simple', async () => {
+			await simpleNativePrompt.format(simpleInput);
+		});
+
+	await bench.warmup();
+	await bench.run();
+
+	console.log("Simple prompts:")
+	console.table(bench.table());
+})();
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+	const bench = new Bench({ time: 1000 });
+	// complex prompts
+	bench
+		.add('DynamicPromptTemplate: complex', async () => {
+			await complexDynamicPrompt.format(complexInput);
+		})
+		.add('PromptTemplate: complex', async () => {
+			await complexNativePrompt.format(complexInput);
+		});
+
+	await bench.warmup();
+	await bench.run();
+
+	console.log("Complex prompts:")
+	console.table(bench.table());
+})();

--- a/langchain-core/src/prompts/benchmark.ts
+++ b/langchain-core/src/prompts/benchmark.ts
@@ -1,33 +1,25 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { Bench } from 'tinybench';
 import { PromptTemplate } from './prompt.js';
 import { DynamicPromptTemplate } from './dynamic.js';
 
-// (async () => {
+type NestedInput = {
+	foo: {
+		bar: {
+			baz: string;
+		};
+	};
+};
 
-//   const promptTemplate = `
-//   Simple: {simple}
-//   Nested:
-//   - {nested.a}
-//   - {nested.b}`;
+const nestedDynamicPrompt = DynamicPromptTemplate.fromTemplate<NestedInput>(`{foo.bar.baz}`);
 
-//   const nativePromptFormatted = await nativePrompt.format({
-//     simple: 'simple',
-//     nested: { a: '1', b: '2' },
-//     'nested.a': 'A',
-//     'nested.b': 'B',
-//   });
-//   console.log(nativePromptFormatted);
-
-//   const dynamicPromptFormatted = await dynamicPrompt.format({
-//     simple: 'simple',
-//     nested: { a: '1', b: '2' },
-//     'nested.a': 'A',
-//     'nested.b': 'B',
-//   });
-//   console.log(dynamicPromptFormatted);
-// })();
-
-
+const formatted = nestedDynamicPrompt.format({
+	foo: {
+		bar: {
+			baz: 'baz',
+		},
+	},
+});
 
 type SimpleInput = { foo: string; bar: string };
 const simpleInput: SimpleInput = { foo: 'foo', bar: 'bar' };
@@ -48,13 +40,11 @@ const complexPromptTemplate = Object.entries(complexInput)
 const complexNativePrompt = PromptTemplate.fromTemplate<ComplexInput>(complexPromptTemplate);
 const complexDynamicPrompt = DynamicPromptTemplate.fromTemplate<ComplexInput>(complexPromptTemplate);
 
-
-
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
-	const bench = new Bench({ time: 1000 });
+	const simple = new Bench({ time: 1000 });
 	// simple prompts
-	bench
+	simple
 		.add('DynamicPromptTemplate: simple', async () => {
 			await simpleDynamicPrompt.format(simpleInput);
 		})
@@ -62,18 +52,15 @@ const complexDynamicPrompt = DynamicPromptTemplate.fromTemplate<ComplexInput>(co
 			await simpleNativePrompt.format(simpleInput);
 		});
 
-	await bench.warmup();
-	await bench.run();
+	await simple.warmup();
+	await simple.run();
 
 	console.log("Simple prompts:")
-	console.table(bench.table());
-})();
+	console.table(simple.table());
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-(async () => {
-	const bench = new Bench({ time: 1000 });
+	const complex = new Bench({ time: 1000 });
 	// complex prompts
-	bench
+	complex
 		.add('DynamicPromptTemplate: complex', async () => {
 			await complexDynamicPrompt.format(complexInput);
 		})
@@ -81,9 +68,10 @@ const complexDynamicPrompt = DynamicPromptTemplate.fromTemplate<ComplexInput>(co
 			await complexNativePrompt.format(complexInput);
 		});
 
-	await bench.warmup();
-	await bench.run();
+	await complex.warmup();
+	await complex.run();
 
 	console.log("Complex prompts:")
-	console.table(bench.table());
+	console.table(complex.table());
 })();
+

--- a/langchain-core/src/prompts/dynamic.ts
+++ b/langchain-core/src/prompts/dynamic.ts
@@ -1,0 +1,47 @@
+import type { TemplateExecutor } from "lodash";
+import type { InputValues, PartialValues } from "../utils/types.js";
+import { BaseStringPromptTemplate } from "./string.js";
+import template from "lodash.template";
+import { BasePromptTemplate, TypedPromptInputValues } from "./base.js";
+import { StringPromptValueInterface } from "../prompt_values.js";
+
+export class DynamicPromptTemplate<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	RunInput extends InputValues = any
+> extends BaseStringPromptTemplate<RunInput> {
+	static lc_name() {
+		return 'DynamicPromptTemplate';
+	}
+
+	_getPromptType(): 'prompt' {
+		return 'prompt';
+	}
+
+	templateFn: TemplateExecutor;
+
+	constructor(templateString: string) {
+		super({ inputVariables: [] });
+
+		this.templateFn = template(templateString, { interpolate: /\{([\s\S]+?)\}/g });
+	}
+
+	static fromTemplate<
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		RunInput extends InputValues = any
+	>(templateString: string) {
+		return new DynamicPromptTemplate<RunInput>(templateString);
+	}
+
+	partial(values: PartialValues): Promise<BasePromptTemplate<
+		RunInput,
+		StringPromptValueInterface,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		any
+	>> {
+		throw new Error('Method not implemented.');
+	}
+
+	format(values: TypedPromptInputValues<RunInput>): Promise<string> {
+		return Promise.resolve(this.templateFn(values));
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9314,6 +9314,7 @@ __metadata:
     "@langchain/scripts": ~0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
+    "@types/lodash.template": ^4
     ansi-styles: ^5.0.0
     camelcase: 6
     decamelize: 1.2.0
@@ -9329,6 +9330,7 @@ __metadata:
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.8
     langsmith: ~0.1.7
+    lodash.template: ^4.5.0
     ml-distance: ^4.0.0
     ml-matrix: ^6.10.4
     p-queue: ^6.6.2
@@ -9336,6 +9338,7 @@ __metadata:
     prettier: ^2.8.3
     release-it: ^15.10.1
     rimraf: ^5.0.1
+    tinybench: ^2.6.0
     turbo: latest
     typescript: ~5.1.6
     uuid: ^9.0.0
@@ -14261,6 +14264,22 @@ __metadata:
   version: 3.0.2
   resolution: "@types/linkify-it@npm:3.0.2"
   checksum: dff8f10fafb885422474e456596f12d518ec4cdd6c33cca7a08e7c86b912d301ed91cf5a7613e148c45a12600dc9ab3d85ad16d5b48dc1aaeda151a68f16b536
+  languageName: node
+  linkType: hard
+
+"@types/lodash.template@npm:^4":
+  version: 4.5.3
+  resolution: "@types/lodash.template@npm:4.5.3"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 7c9d32b8d81959c8131223da191d2dd55d8ddfd4f0997bf18565b65cb6ba3b8087d39f458071031494b23f5dac857b9cbdba00df8b32c2d8178e89478b0b44ee
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.17.0
+  resolution: "@types/lodash@npm:4.17.0"
+  checksum: 3f98c0b67a93994cbc3403d4fa9dbaf52b0b6bb7f07a764d73875c2dcd5ef91222621bd5bcf8eee7b417a74d175c2f7191b9f595f8603956fd06f0674c0cba93
   languageName: node
   linkType: hard
 
@@ -26481,6 +26500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash._reinterpolate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lodash._reinterpolate@npm:3.0.0"
+  checksum: 06d2d5f33169604fa5e9f27b6067ed9fb85d51a84202a656901e5ffb63b426781a601508466f039c720af111b0c685d12f1a5c14ff8df5d5f27e491e562784b2
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -26611,6 +26637,25 @@ __metadata:
   version: 4.1.1
   resolution: "lodash.snakecase@npm:4.1.1"
   checksum: 1685ed3e83dda6eae5a4dcaee161a51cd210aabb3e1c09c57150e7dd8feda19e4ca0d27d0631eabe8d0f4eaa51e376da64e8c018ae5415417c5890d42feb72a8
+  languageName: node
+  linkType: hard
+
+"lodash.template@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.template@npm:4.5.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+    lodash.templatesettings: ^4.0.0
+  checksum: ca64e5f07b6646c9d3dbc0fe3aaa995cb227c4918abd1cef7a9024cd9c924f2fa389a0ec4296aa6634667e029bc81d4bbdb8efbfde11df76d66085e6c529b450
+  languageName: node
+  linkType: hard
+
+"lodash.templatesettings@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "lodash.templatesettings@npm:4.2.0"
+  dependencies:
+    lodash._reinterpolate: ^3.0.0
+  checksum: 863e025478b092997e11a04e9d9e735875eeff1ffcd6c61742aa8272e3c2cddc89ce795eb9726c4e74cef5991f722897ff37df7738a125895f23fc7d12a7bb59
   languageName: node
   linkType: hard
 
@@ -33648,6 +33693,13 @@ __metadata:
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
+  languageName: node
+  linkType: hard
+
+"tinybench@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "tinybench@npm:2.6.0"
+  checksum: a621ac66ac17ec5da7e9ac10b3c27040e58c3cd843ccedd8e1e3fab5702d6337b80d02b7bfbf420ab5f029dcb7895657fb80ce21181896e170fa4e6d2c2eebc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

This PR is still work in progress!

I have noticed that the performance of the prompts could be significantly improved by leveraging something like Lodash's [`template()`](https://lodash.com/docs/4.17.15#template) function. This function compiles the prompt template string into a javascript source code at instatiation. That means alls placeholders like `{foo}` are actual javascrupt variables which get interpolated by the nodejs engine.

I assembeld a short benchmark comparing a simple prompt with two placeholders and a complex prompt with 100 placeholders:

```sh
zirkelc@Chris-MBP langchainjs % tsx langchain-core/src/prompts/benchmark.ts
Simple prompts:
┌─────────┬─────────────────────────────────┬─────────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name                       │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼─────────────────────────────────┼─────────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'DynamicPromptTemplate: simple' │ '1,640,575' │ 609.5420955809827  │ '±0.93%' │ 1640576 │
│ 1       │ 'PromptTemplate: simple'        │ '761,489'   │ 1313.2150907825624 │ '±4.56%' │ 762757  │
└─────────┴─────────────────────────────────┴─────────────┴────────────────────┴──────────┴─────────┘

Complex prompts:
┌─────────┬──────────────────────────────────┬─────────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name                        │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────────────────────────┼─────────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'DynamicPromptTemplate: complex' │ '3,748,000' │ 266.80892961438684 │ '±3.67%' │ 3748001 │
│ 1       │ 'PromptTemplate: complex'        │ '1,626,574' │ 614.7888380257064  │ '±1.07%' │ 1626576 │
└─────────┴──────────────────────────────────┴─────────────┴────────────────────┴──────────┴─────────┘
```

As you can see in the results, the `DynamicPromptTemplate` is more than twice as fast as the `PromptTemplate`. 
To run the benchmark, I have used the typescript nodejs runner `tsx` (installed globally) and ran it from the root of the project: `tsx langchain-core/src/prompts/benchmark.ts`

Another advantage of using a template engine is that you have support for nested placeholders (see https://github.com/langchain-ai/langchainjs/discussions/4462):

```ts
type NestedInput = {
    foo: {
        bar: {
            baz: string;
        };
    };
};

const nestedDynamicPrompt = DynamicPromptTemplate.fromTemplate<NestedInput>(`{foo.bar.baz}`);

const formatted = nestedDynamicPrompt.format({
    foo: {
        bar: {
            baz: 'baz',
        },
    },
});
```

Prompts supporting nested variables would remove a lot of unnecessary `RunnableMap` that just exist to unpack an object into the primitive variables which are used as placeholders in a prompt template.

Let me know if you guys are interested in bringing this into LangChain. 