### PR TITLE
Fix: Handle Escaped Curly Braces in parseFString Function

### DIFF
--- a/langchain-core/src/prompts/template.ts
+++ b/langchain-core/src/prompts/template.ts
@@ -21,13 +21,25 @@ export const parseFString = (template: string): ParsedFStringNode[] => {
   const chars = template.split("");
   const nodes: ParsedFStringNode[] = [];
 
-  const nextBracket = (bracket: "}" | "{" | "{}", start: number) => {
+  const nextBracket = (bracket, start) => {
     for (let i = start; i < chars.length; i += 1) {
       if (bracket.includes(chars[i])) {
-        return i;
+        // Before returning the index of the bracket, check if it is escaped.
+        if (chars[i] === "}" && i > 0 && chars[i-1] === "\\") {
+          // Check if the backslash is escaped (even number of backslashes means it's not escaping the bracket)
+          let backslashCount = 0;
+          for (let j = i - 1; j >= 0 && chars[j] === "\\"; j--) {
+            backslashCount++;
+          }
+          if (backslashCount % 2 === 0) {
+            return i; 
+          }
+        } else {
+            return i; 
+        }
       }
     }
-    return -1;
+    return -1; 
   };
 
   let i = 0;
@@ -43,7 +55,7 @@ export const parseFString = (template: string): ParsedFStringNode[] => {
       nodes.push({ type: "literal", text: "}" });
       i += 2;
     } else if (chars[i] === "{") {
-      const j = nextBracket("}", i);
+      const j = nextBracket("}", i + 1);
       if (j < 0) {
         throw new Error("Unclosed '{' in template.");
       }


### PR DESCRIPTION
Summary:

I've experienced and fixed an issue in the parseFString function where escaped curly braces (\}) caused an erroneous "Single '}' in template." error, disrupting the parsing of templates containing literal curly braces.
I was experiencing this specifically when I was including code as part of templates, even when I manually escaped the curly braces

There is likely a way to have code in a template to avoid this problem (Please help if someone knows), but I imagine this fix could still help some people

Fix Details:

The update modifies the nextBracket function to distinguish between escaped and unescaped closing braces, allowing for accurate parsing of templates. This ensures that escaped braces are treated as literals, preventing unnecessary errors and improving the function's handling of complex string scenarios.
Impact:

This change enhances the robustness of the parseFString function, making it more adaptable to various templates and resolving a key bug affecting users working with escaped characters in their strings.