### PR TITLE
community[minor]: Add DuckDuckGoSearch tool

### DIFF
--- a/docs/core_docs/docs/integrations/tools/duckduckgo_search.mdx
+++ b/docs/core_docs/docs/integrations/tools/duckduckgo_search.mdx
@@ -1,0 +1,47 @@
+---
+hide_table_of_contents: true
+---
+
+import CodeBlock from "@theme/CodeBlock";
+
+# DuckDuckGoSearch
+
+DuckDuckGoSearch offers a privacy-focused search API designed for LLM Agents. It provides seamless integration with a wide range of data sources, prioritizing user privacy and relevant search results.
+
+## Setup
+
+Install the `@langchain/community` package, along with the `duck-duck-scrape` dependency:
+
+import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
+
+<IntegrationInstallTooltip></IntegrationInstallTooltip>
+
+```bash npm2yarn
+npm install @langchain/community
+```
+
+```bash npm2yarn
+npm install duck-duck-scrape
+```
+
+## Usage
+
+You can call `.invoke` on `DuckDuckGoSearch` to search for a query:
+
+import SimpleQueryExample from "@examples/tools/duckduckgo_search_simple.ts";
+
+<CodeBlock language="typescript">{SimpleQueryExample}</CodeBlock>
+
+:::tip
+See the LangSmith trace [here](https://smith.langchain.com/public/c352faaf-e617-4779-a943-96f963dc19a5/r)
+:::
+
+### With an agent
+
+import ToolExample from "@examples/tools/duckduckgo_search_agent.ts";
+
+<CodeBlock language="typescript">{ToolExample}</CodeBlock>
+
+:::tip
+See the LangSmith trace for the Agent example [here](https://smith.langchain.com/public/48f84a32-4fb5-4863-a8cd-324abebfce91/r)
+:::

--- a/examples/package.json
+++ b/examples/package.json
@@ -69,6 +69,7 @@
     "convex": "^1.3.1",
     "couchbase": "^4.3.0",
     "date-fns": "^3.3.1",
+    "duck-duck-scrape": "^2.2.5",
     "exa-js": "^1.0.12",
     "faiss-node": "^0.5.1",
     "firebase-admin": "^12.0.0",

--- a/examples/src/tools/duckduckgo_search_agent.ts
+++ b/examples/src/tools/duckduckgo_search_agent.ts
@@ -1,0 +1,40 @@
+import { DuckDuckGoSearch } from "@langchain/community/tools/duckduckgo_search";
+import { ChatOpenAI } from "@langchain/openai";
+import type { ChatPromptTemplate } from "@langchain/core/prompts";
+
+import { pull } from "langchain/hub";
+import { AgentExecutor, createOpenAIFunctionsAgent } from "langchain/agents";
+
+// Define the tools the agent will have access to.
+const tools = [new DuckDuckGoSearch({ maxResults: 1 })];
+
+// Get the prompt to use - you can modify this!
+// If you want to see the prompt in full, you can at:
+// https://smith.langchain.com/hub/hwchase17/openai-functions-agent
+const prompt = await pull<ChatPromptTemplate>(
+  "hwchase17/openai-functions-agent"
+);
+const llm = new ChatOpenAI({
+  modelName: "gpt-4-turbo-preview",
+  temperature: 0,
+});
+const agent = await createOpenAIFunctionsAgent({
+  llm,
+  tools,
+  prompt,
+});
+const agentExecutor = new AgentExecutor({
+  agent,
+  tools,
+});
+const result = await agentExecutor.invoke({
+  input: "What is Anthropic's estimated revenue for 2024?",
+});
+
+console.log(result);
+/*
+{
+  input: "What is Anthropic's estimated revenue for 2024?",
+  output: 'Anthropic has projected that it will generate more than $850 million in annualized revenue by the end of 2024. For more details, you can refer to the [Reuters article](https://www.reuters.com/technology/anthropic-forecasts-more-than-850-mln-annualized-revenue-rate-by-2024-end-report-2023-12-26/).'
+}
+*/

--- a/examples/src/tools/duckduckgo_search_simple.ts
+++ b/examples/src/tools/duckduckgo_search_simple.ts
@@ -1,0 +1,18 @@
+import { DuckDuckGoSearch } from "@langchain/community/tools/duckduckgo_search";
+
+// Instantiate the DuckDuckGoSearch tool.
+const tool = new DuckDuckGoSearch({ maxResults: 1 });
+
+// Get the results of a query by calling .invoke on the tool.
+const result = await tool.invoke(
+  "What is Anthropic's estimated revenue for 2024?"
+);
+
+console.log(result);
+/*
+[{
+  "title": "Anthropic forecasts more than $850 mln in annualized revenue rate by ...",
+  "link": "https://www.reuters.com/technology/anthropic-forecasts-more-than-850-mln-annualized-revenue-rate-by-2024-end-report-2023-12-26/",
+  "snippet": "Dec 26 (Reuters) - Artificial intelligence startup <b>Anthropic</b> has projected it will generate more than $850 million in annualized <b>revenue</b> by the end of <b>2024</b>, the Information reported on Tuesday ..."
+}]
+*/

--- a/libs/langchain-community/.gitignore
+++ b/libs/langchain-community/.gitignore
@@ -26,6 +26,10 @@ tools/brave_search.cjs
 tools/brave_search.js
 tools/brave_search.d.ts
 tools/brave_search.d.cts
+tools/duckduckgo_search.cjs
+tools/duckduckgo_search.js
+tools/duckduckgo_search.d.ts
+tools/duckduckgo_search.d.cts
 tools/calculator.cjs
 tools/calculator.js
 tools/calculator.d.ts

--- a/libs/langchain-community/langchain.config.js
+++ b/libs/langchain-community/langchain.config.js
@@ -18,6 +18,7 @@ export const config = {
     "convex/values",
     "@rockset/client/dist/codegen/api.js",
     "discord.js",
+    "duck-duck-scrape",
     "mysql2/promise",
     "web-auth-library/google",
     "firebase-admin/app",
@@ -33,6 +34,7 @@ export const config = {
     "tools/aws_sfn": "tools/aws_sfn",
     "tools/bingserpapi": "tools/bingserpapi",
     "tools/brave_search": "tools/brave_search",
+    "tools/duckduckgo_search": "tools/duckduckgo_search",
     "tools/calculator": "tools/calculator",
     "tools/connery": "tools/connery",
     "tools/dadjokeapi": "tools/dadjokeapi",
@@ -231,6 +233,7 @@ export const config = {
   requiresOptionalDependency: [
     "tools/aws_sfn",
     "tools/aws_lambda",
+    "tools/duckduckgo_search",
     "tools/discord",
     "tools/gmail",
     "tools/google_calendar",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -131,6 +131,7 @@
     "dotenv": "^16.0.3",
     "dpdm": "^3.12.0",
     "dria": "^0.0.3",
+    "duck-duck-scrape": "^2.2.5",
     "eslint": "^8.33.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.6.0",
@@ -237,6 +238,7 @@
     "couchbase": "^4.3.0",
     "discord.js": "^14.14.1",
     "dria": "^0.0.3",
+    "duck-duck-scrape": "^2.2.5",
     "faiss-node": "^0.5.1",
     "firebase-admin": "^11.9.0 || ^12.0.0",
     "google-auth-library": "^8.9.0",
@@ -445,6 +447,9 @@
     "dria": {
       "optional": true
     },
+    "duck-duck-scrape": {
+      "optional": true
+    },
     "faiss-node": {
       "optional": true
     },
@@ -608,6 +613,15 @@
       },
       "import": "./tools/brave_search.js",
       "require": "./tools/brave_search.cjs"
+    },
+    "./tools/duckduckgo_search": {
+      "types": {
+        "import": "./tools/duckduckgo_search.d.ts",
+        "require": "./tools/duckduckgo_search.d.cts",
+        "default": "./tools/duckduckgo_search.d.ts"
+      },
+      "import": "./tools/duckduckgo_search.js",
+      "require": "./tools/duckduckgo_search.cjs"
     },
     "./tools/calculator": {
       "types": {
@@ -2243,6 +2257,10 @@
     "tools/brave_search.js",
     "tools/brave_search.d.ts",
     "tools/brave_search.d.cts",
+    "tools/duckduckgo_search.cjs",
+    "tools/duckduckgo_search.js",
+    "tools/duckduckgo_search.d.ts",
+    "tools/duckduckgo_search.d.cts",
     "tools/calculator.cjs",
     "tools/calculator.js",
     "tools/calculator.d.ts",

--- a/libs/langchain-community/src/tools/duckduckgo_search.ts
+++ b/libs/langchain-community/src/tools/duckduckgo_search.ts
@@ -1,0 +1,73 @@
+import { Tool } from "@langchain/core/tools";
+import { search, SearchOptions } from "duck-duck-scrape";
+
+/**
+ * Class for interacting with the DuckDuckGoSearch engine
+ * It extends the base Tool class and implements the _call method to
+ * perform the retrieve operation.
+ *
+ */
+
+export {
+  SafeSearchType,
+  SearchOptions,
+  SearchTimeType,
+} from "duck-duck-scrape";
+
+export interface DuckDuckGoSearchParameters {
+  /**
+   * The search options for the search using the SearchOptions interface
+   * from the duck-duck-scrape package.
+   * */
+
+  searchOptions?: SearchOptions;
+  /**
+   * @default 10
+   * The maximum number of results to return from the search. 
+   * Limiting to 10 to avoid context overload.
+   * */
+  maxResults?: number;
+}
+
+const DEFAULT_MAX_RESULTS = 10;
+
+export class DuckDuckGoSearch extends Tool {
+  private searchOptions?: SearchOptions;
+
+  private maxResults?: number;
+
+  constructor(params? : DuckDuckGoSearchParameters) {
+    super();
+    if (params) {
+      const { searchOptions, maxResults } = params;
+
+      this.searchOptions = searchOptions;
+      this.maxResults = maxResults || DEFAULT_MAX_RESULTS;
+    } else {
+      this.maxResults = DEFAULT_MAX_RESULTS;
+    }
+  }
+
+  static lc_name() {
+    return "DuckDuckGoSearch";
+  }
+
+  name = "duckduckgo-search";
+
+  description =
+    "a search engine. useful for when you need to answer questions about current events. input should be a search query.";
+
+  async _call(input: string): Promise<string> {
+    const { results } = await search(input, this.searchOptions);
+
+    return JSON.stringify(
+      results
+        .map((result) => ({
+          title: result.title,
+          link: result.url,
+          snippet: result.description,
+        }))
+        .slice(0, this.maxResults)
+    );
+  }
+}

--- a/libs/langchain-community/src/tools/duckduckgo_search.ts
+++ b/libs/langchain-community/src/tools/duckduckgo_search.ts
@@ -1,12 +1,5 @@
-import { Tool } from "@langchain/core/tools";
+import { Tool, ToolParams } from "@langchain/core/tools";
 import { search, SearchOptions } from "duck-duck-scrape";
-
-/**
- * Class for interacting with the DuckDuckGoSearch engine
- * It extends the base Tool class and implements the _call method to
- * perform the retrieve operation.
- *
- */
 
 export {
   SafeSearchType,
@@ -14,38 +7,37 @@ export {
   SearchTimeType,
 } from "duck-duck-scrape";
 
-export interface DuckDuckGoSearchParameters {
+export interface DuckDuckGoSearchParameters extends ToolParams {
   /**
    * The search options for the search using the SearchOptions interface
    * from the duck-duck-scrape package.
-   * */
-
+   */
   searchOptions?: SearchOptions;
   /**
-   * @default 10
-   * The maximum number of results to return from the search. 
+   * The maximum number of results to return from the search.
    * Limiting to 10 to avoid context overload.
-   * */
+   * @default 10
+   */
   maxResults?: number;
 }
 
 const DEFAULT_MAX_RESULTS = 10;
 
+/**
+ * Class for interacting with the DuckDuckGo search engine
+ * It extends the base Tool class to perform retrieval.
+ */
 export class DuckDuckGoSearch extends Tool {
   private searchOptions?: SearchOptions;
 
-  private maxResults?: number;
+  private maxResults = DEFAULT_MAX_RESULTS;
 
-  constructor(params? : DuckDuckGoSearchParameters) {
-    super();
-    if (params) {
-      const { searchOptions, maxResults } = params;
+  constructor(params?: DuckDuckGoSearchParameters) {
+    super(params ?? {});
 
-      this.searchOptions = searchOptions;
-      this.maxResults = maxResults || DEFAULT_MAX_RESULTS;
-    } else {
-      this.maxResults = DEFAULT_MAX_RESULTS;
-    }
+    const { searchOptions, maxResults } = params ?? {};
+    this.searchOptions = searchOptions;
+    this.maxResults = maxResults || this.maxResults;
   }
 
   static lc_name() {
@@ -55,7 +47,7 @@ export class DuckDuckGoSearch extends Tool {
   name = "duckduckgo-search";
 
   description =
-    "a search engine. useful for when you need to answer questions about current events. input should be a search query.";
+    "A search engine. Useful for when you need to answer questions about current events. Input should be a search query.";
 
   async _call(input: string): Promise<string> {
     const { results } = await search(input, this.searchOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9023,6 +9023,7 @@ __metadata:
     dotenv: ^16.0.3
     dpdm: ^3.12.0
     dria: ^0.0.3
+    duck-duck-scrape: ^2.2.5
     eslint: ^8.33.0
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-prettier: ^8.6.0
@@ -9133,6 +9134,7 @@ __metadata:
     couchbase: ^4.3.0
     discord.js: ^14.14.1
     dria: ^0.0.3
+    duck-duck-scrape: ^2.2.5
     faiss-node: ^0.5.1
     firebase-admin: ^11.9.0 || ^12.0.0
     google-auth-library: ^8.9.0
@@ -9281,6 +9283,8 @@ __metadata:
     discord.js:
       optional: true
     dria:
+      optional: true
+    duck-duck-scrape:
       optional: true
     faiss-node:
       optional: true
@@ -20148,6 +20152,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duck-duck-scrape@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "duck-duck-scrape@npm:2.2.5"
+  dependencies:
+    html-entities: ^2.3.3
+    needle: ^3.2.0
+  checksum: a7a01e39b8ceab8f2858c596b8f13563786179f89b28411eff7f37dd2baddec6a68220732bdf369922782a20af97466578893c576ad56fefbdd896abfad63c9f
+  languageName: node
+  linkType: hard
+
 "duck@npm:^0.1.12":
   version: 0.1.12
   resolution: "duck@npm:0.1.12"
@@ -23838,6 +23852,13 @@ __metadata:
   version: 2.4.0
   resolution: "html-entities@npm:2.4.0"
   checksum: 25bea32642ce9ebd0eedc4d24381883ecb0335ccb8ac26379a0958b9b16652fdbaa725d70207ce54a51db24103436a698a8e454397d3ba8ad81460224751f1dc
+  languageName: node
+  linkType: hard
+
+"html-entities@npm:^2.3.3":
+  version: 2.5.2
+  resolution: "html-entities@npm:2.5.2"
+  checksum: b23f4a07d33d49ade1994069af4e13d31650e3fb62621e92ae10ecdf01d1a98065c78fd20fdc92b4c7881612210b37c275f2c9fba9777650ab0d6f2ceb3b99b6
   languageName: node
   linkType: hard
 
@@ -28365,6 +28386,18 @@ __metadata:
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
   checksum: 23ad088b08f898fc9b53011d7bb78ec48e79de7627e01ab5518e806033861bef68d5b0cd0e2205c2f36690ac9571ff6bcb05eb777ced2eeda8d4ac5b44592c3d
+  languageName: node
+  linkType: hard
+
+"needle@npm:^3.2.0":
+  version: 3.3.1
+  resolution: "needle@npm:3.3.1"
+  dependencies:
+    iconv-lite: ^0.6.3
+    sax: ^1.2.4
+  bin:
+    needle: bin/needle
+  checksum: ed4864d7ee85f1037ac803154868bf7151fa59399c1e55e5d93ca26a9d16e1c8ccbe9552d846ce7e2519b4bce1de3e81a501f0dc33244e02902e27cf5a9bc11d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21683,6 +21683,7 @@ __metadata:
     couchbase: ^4.3.0
     date-fns: ^3.3.1
     dotenv: ^16.0.3
+    duck-duck-scrape: ^2.2.5
     eslint: ^8.33.0
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-prettier: ^8.6.0


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

# Context:

Here is another try to add the DuckDuckGo as a community search tool. 
Duplicate of - [one](https://github.com/langchain-ai/langchainjs/pull/1184)  that unfortunately still stays in Open state that was reviewed by @dqbd 

I am open to any comments and suggestions for this merge request. I value your time and am willing to make the necessary changes to expedite its acceptance into the main branch as I consider these tools a valuable addition to the TS version of the community toolset. 

Thank you for the opportunity to contribute to the project!

# Change description:

DuckDuckGo tool that uses the existing mature under the hood.
Tools take the same options as the library it uses, plus the possibility to limit the max number of return results, as I experience that the initial amount might overload the context buffer with less relevant results from the end of the list

The DuckDuckGo tool inherits all options from the [underlying](https://www.npmjs.com/package/duck-duck-scrape) library, adding a feature to limit the maximum number of results returned. This addresses the possible issue of context overload by filtering out less relevant search results typically found at the end of the list.
