### PR TITLE
docs[patch]: Add wrapping library metadata to MongoDB docs example

### DIFF
--- a/examples/src/memory/mongodb.ts
+++ b/examples/src/memory/mongodb.ts
@@ -4,7 +4,9 @@ import { ChatOpenAI } from "@langchain/openai";
 import { ConversationChain } from "langchain/chains";
 import { MongoDBChatMessageHistory } from "@langchain/mongodb";
 
-const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "", { driverInfo: { name: 'langchainjs' } });
+const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "", {
+  driverInfo: { name: "langchainjs" },
+});
 await client.connect();
 const collection = client.db("langchain").collection("memory");
 

--- a/examples/src/memory/mongodb.ts
+++ b/examples/src/memory/mongodb.ts
@@ -4,7 +4,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { ConversationChain } from "langchain/chains";
 import { MongoDBChatMessageHistory } from "@langchain/mongodb";
 
-const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "");
+const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "", { driverInfo: { name: 'langchainjs' } });
 await client.connect();
 const collection = client.db("langchain").collection("memory");
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

This PR adds logic similar to the implementation in Python added in https://github.com/langchain-ai/langchain/pull/13084. 

In JS, users instantiate `MongoClient`s and provide them to langchain instead of langchain instantiating the `MongoClient` for them.  As such, there's no way for langchain to add client metadata like the Python implementation does.  Additionally, there's no equivalent of `importlib.metadata` in Javascript that can return the version of a package.  So we'd like to just add this to the documentation example, so that when users use the code provided in the docs, they include the metadata as well.