### PR TITLE
langchain[patch]: SelfQueryRetriever - fallback to similarity search

### DIFF
--- a/langchain/src/retrievers/self_query/index.ts
+++ b/langchain/src/retrievers/self_query/index.ts
@@ -123,16 +123,12 @@ export class SelfQueryRetriever<T extends VectorStore>
       myQuery = generatedQuery;
     }
 
-    if (!filter) {
-      return [];
-    } else {
-      return this.vectorStore.similaritySearch(
-        myQuery,
-        this.searchParams?.k,
-        filter,
-        runManager?.getChild("vectorstore")
-      );
-    }
+    return this.vectorStore.similaritySearch(
+      myQuery,
+      this.searchParams?.k,
+      filter,
+      runManager?.getChild("vectorstore")
+    );
   }
 
   /**


### PR DESCRIPTION
If there are no metadata filters (NO_FILTER), instead of explicitly returning [], it should fallback to a similarity search

This also matches the python implementation