### PR TITLE
core[patch]: Fix handling custom run id in sequence streams

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -1590,12 +1590,14 @@ export class RunnableSequence<
     const runManager = await callbackManager_?.handleChainStart(
       this.toJSON(),
       _coerceToDict(input, "input"),
-      undefined,
+      options?.runId,
       undefined,
       undefined,
       undefined,
       options?.runName
     );
+    // eslint-disable-next-line no-param-reassign
+    delete options?.runId;
     const steps = [this.first, ...this.middle, this.last];
     let concatSupported = true;
     let finalOutput;

--- a/langchain-core/src/utils/testing/index.ts
+++ b/langchain-core/src/utils/testing/index.ts
@@ -219,22 +219,24 @@ export class FakeStreamingChatModel extends BaseChatModel {
     messages: BaseMessage[],
     _options: this["ParsedCallOptions"],
     _runManager?: CallbackManagerForLLMRun
-    ): Promise<ChatResult> {
+  ): Promise<ChatResult> {
     if (this.thrownErrorString) {
       throw new Error(this.thrownErrorString);
     }
 
     const content = this.responses?.[0].content ?? messages[0].content;
     const generation: ChatResult = {
-      generations: [{
-        text: "",
-        message: new AIMessage({
-          content,
-        })
-      }]
-    }
+      generations: [
+        {
+          text: "",
+          message: new AIMessage({
+            content,
+          }),
+        },
+      ],
+    };
 
-    return generation
+    return generation;
   }
 
   async *_streamResponseChunks(
@@ -253,7 +255,7 @@ export class FakeStreamingChatModel extends BaseChatModel {
           message: new AIMessageChunk({
             content,
           }),
-        })
+        });
       }
     } else {
       for (const _ of this.responses ?? messages) {
@@ -262,7 +264,7 @@ export class FakeStreamingChatModel extends BaseChatModel {
           message: new AIMessageChunk({
             content,
           }),
-        })
+        });
       }
     }
   }


### PR DESCRIPTION
When streaming a runnable sequence before, custom runId's were not properly handled and tracing would lose some items inside the sequence due to duplicate runIds

(also includes some missing formatting)