### PR TITLE
scripts[minor]:Some symbols have empty declarations

### DIFF
--- a/libs/langchain-scripts/src/migrations/0_1.ts
+++ b/libs/langchain-scripts/src/migrations/0_1.ts
@@ -39,12 +39,10 @@ async function getEntrypointsFromFile(
     const exportedSymbolsMap = newFile.getExportedDeclarations();
     const exportedSymbols = Array.from(exportedSymbolsMap.entries())
       .filter(([_, declarations]) => declarations.length > 0)
-      .map(
-      ([symbol, declarations]) => ({
+      .map(([symbol, declarations]) => ({
         kind: declarations[0].getKind(),
         symbol,
-      })
-    );
+      }));
     return {
       entrypoint: key,
       exportedSymbols,

--- a/libs/langchain-scripts/src/migrations/0_1.ts
+++ b/libs/langchain-scripts/src/migrations/0_1.ts
@@ -37,7 +37,9 @@ async function getEntrypointsFromFile(
       path.join(packagePath, "src", `${value}.ts`)
     );
     const exportedSymbolsMap = newFile.getExportedDeclarations();
-    const exportedSymbols = Array.from(exportedSymbolsMap.entries()).map(
+    const exportedSymbols = Array.from(exportedSymbolsMap.entries())
+      .filter(([_, declarations]) => declarations.length > 0)
+      .map(
       ([symbol, declarations]) => ({
         kind: declarations[0].getKind(),
         symbol,


### PR DESCRIPTION
# Issue

- Migration script (updateEntrypointsFrom0_0_xTo0_1_x from @langchain/scripts/migrations) fails with the error below


```
TypeError: Cannot read properties of undefined (reading 'getKind')
    at file:///Users/tomoima525/workspace/knot/noxx-hiring-cdk/node_modules/.pnpm/@langchain+scripts@0.0.10/node_modules/@langchain/scripts/dist/migrations/0_1.js:21:39
    at Array.map (<anonymous>)
    at file:///Users/tomoima525/workspace/knot/noxx-hiring-cdk/node_modules/.pnpm/@langchain+scripts@0.0.10/node_modules/@langchain/scripts/dist/migrations/0_1.js:18:74
    at Array.flatMap (<anonymous>)
    at getEntrypointsFromFile (file:///Users/tomoima525/workspace/knot/noxx-hiring-cdk/node_modules/.pnpm/@langchain+scripts@0.0.10/node_modules/@langchain/scripts/dist/migrations/0_1.js:12:48)
    at async updateEntrypointsFrom0_0_xTo0_1_x (file:///Users/tomoima525/workspace/knot/noxx-hiring-cdk/node_modules/.pnpm/@langchain+scripts@0.0.10/node_modules/@langchain/scripts/dist/migrations/0_1.js:93:61)
    at async main (file:///Users/tomoima525/workspace/knot/noxx-hiring-cdk/scripts/langchain-migration/index.mts:11:3)
```

# Cause

- Some symbols do not have exported declarations. For example, `SafeSearchType` that was introduced in https://github.com/langchain-ai/langchainjs/pull/4943 

# Fix

- Check if declaration exists, and filter out.

# Test

- Confirmed that migration script worked as expected in https://github.com/knot-inc/LLM-Recruiter-Agents/pull/18

# Twitter
https://x.com/tomoima525