### PR TITLE
docs: ✏️ should pass string into a AIMessage / BaseMessage class

### DIFF
--- a/docs/core_docs/docs/use_cases/chatbots/quickstart.mdx
+++ b/docs/core_docs/docs/use_cases/chatbots/quickstart.mdx
@@ -183,7 +183,7 @@ AIMessage {
 ```
 
 ```ts
-await demoEphemeralChatMessageHistory.addMessage(responseMessage);
+await demoEphemeralChatMessageHistory.addMessage(new AIMessage(responseMessage));
 
 await demoEphemeralChatMessageHistory.addMessage(
   new HumanMessage("What did you just say?")


### PR DESCRIPTION
Was trying to set up this QuickStart chatbot but faced some lint error. The return type of chain.invoke is a Promise<string>, but the input of demoEphemeralChatMessageHistory.addMessage() is of type BaseMessage. Thus we need to pass it into the constructor / class of AIMessage, appropriate in this context.

Also I'm getting a weird response from the bot. If i console.log() the response from the chat.invoke() statement, I get a back-and-forth conversation instead of a single AIMessage(). Is this expected behaviour?

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
