### PR TITLE
langchain[patch]: fix: make GithubRepoLoader robust against .gitmodules files w/o newline

### DIFF
--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -312,9 +312,10 @@ export class GithubRepoLoader
   private async parseGitmodules(
     gitmodulesContent: string
   ): Promise<SubmoduleInfo[]> {
+    let validGitmodulesContent = gitmodulesContent;
     // in case the .gitmodules file does not end with a newline, we add one to make the regex work
-    if (!gitmodulesContent.endsWith("\n")) {
-      gitmodulesContent += "\n";
+    if (!validGitmodulesContent.endsWith("\n")) {
+      validGitmodulesContent += "\n";
     }
     // catches the initial line of submodule entries
     const submodulePattern = /\[submodule "(.*?)"]\n((\s+.*?\s*=\s*.*?\n)*)/g;
@@ -322,7 +323,7 @@ export class GithubRepoLoader
     const keyValuePattern = /\s+(.*?)\s*=\s*(.*?)\s/g;
 
     const submoduleInfos = [];
-    for (const [, name, propertyLines] of gitmodulesContent.matchAll(
+    for (const [, name, propertyLines] of validGitmodulesContent.matchAll(
       submodulePattern
     )) {
       if (!name || !propertyLines) {

--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -312,6 +312,10 @@ export class GithubRepoLoader
   private async parseGitmodules(
     gitmodulesContent: string
   ): Promise<SubmoduleInfo[]> {
+    // in case the .gitmodules file does not end with a newline, we add one to make the regex work
+    if (!gitmodulesContent.endsWith("\n")) {
+      gitmodulesContent += "\n";
+    }
     // catches the initial line of submodule entries
     const submodulePattern = /\[submodule "(.*?)"]\n((\s+.*?\s*=\s*.*?\n)*)/g;
     // catches the properties of a submodule


### PR DESCRIPTION
Occasionally .gitmodules files are not ending with a newline character. Still the file is valid.
This PR fixes the issue with the given regex by adding the newline character for parsing, if not present. 