### PR TITLE
Adds default maxRetries to 6 as per documentation

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -437,14 +437,9 @@ export class ChatOpenAI<
       fields?.configuration?.organization ??
       getEnvironmentVariable("OPENAI_ORGANIZATION");
 
-<<<<<<< Updated upstream
+    this.maxRetries = fields?.configuration?.maxRetries ?? 6;
     this.modelName = fields?.model ?? fields?.modelName ?? this.model;
     this.model = this.modelName;
-=======
-    // OpenAi ClientOptions interface defaults to 2
-    this.maxRetries = fields?.configuration?.maxRetries ?? 6;
-    this.modelName = fields?.modelName ?? this.modelName;
->>>>>>> Stashed changes
     this.modelKwargs = fields?.modelKwargs ?? {};
     this.timeout = fields?.timeout;
 
@@ -921,7 +916,8 @@ export class ChatOpenAI<
       const params = {
         ...this.clientConfig,
         baseURL: endpoint,
-        timeout: this.timeout
+        timeout: this.timeout,
+        maxRetries: 0,// 0 to avoid using the default SDK retry policy. We retry using the more generalized AsyncCaller
       };
       if (!params.baseURL) {
         delete params.baseURL;

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -366,6 +366,8 @@ export class ChatOpenAI<
 
   maxTokens?: number;
 
+  maxRetries?: number;
+
   logprobs?: boolean;
 
   topLogprobs?: number;
@@ -435,8 +437,14 @@ export class ChatOpenAI<
       fields?.configuration?.organization ??
       getEnvironmentVariable("OPENAI_ORGANIZATION");
 
+<<<<<<< Updated upstream
     this.modelName = fields?.model ?? fields?.modelName ?? this.model;
     this.model = this.modelName;
+=======
+    // OpenAi ClientOptions interface defaults to 2
+    this.maxRetries = fields?.configuration?.maxRetries ?? 6;
+    this.modelName = fields?.modelName ?? this.modelName;
+>>>>>>> Stashed changes
     this.modelKwargs = fields?.modelKwargs ?? {};
     this.timeout = fields?.timeout;
 
@@ -480,6 +488,7 @@ export class ChatOpenAI<
         configuration?.baseOptions?.params ??
         fields?.configuration?.baseOptions?.params,
       ...configuration,
+      maxRetries: this.maxRetries,
       ...fields?.configuration,
     };
   }
@@ -912,8 +921,7 @@ export class ChatOpenAI<
       const params = {
         ...this.clientConfig,
         baseURL: endpoint,
-        timeout: this.timeout,
-        maxRetries: 0,
+        timeout: this.timeout
       };
       if (!params.baseURL) {
         delete params.baseURL;

--- a/libs/langchain-openai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models.int.test.ts
@@ -231,6 +231,15 @@ test("Test OpenAI with timeout in call options and node adapter", async () => {
   ).rejects.toThrow();
 }, 5000);
 
+test("Test OpenAI with maxRetries in call options and node adapter", async () => {
+  const model = new ChatOpenAI({ maxTokens: 5, maxRetries: 2 });
+  await expect(() =>
+    model.invoke([new HumanMessage("Print hello world")], {
+      options: { timeout: 10 },
+    })
+  ).rejects.toThrow();
+}, 5000);
+
 test("Test OpenAI with signal in call options", async () => {
   const model = new ChatOpenAI({ maxTokens: 5 });
   const controller = new AbortController();


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #5061

This PR adds default value for `maxRetries` to `6` as per this [documentation](https://js.langchain.com/docs/modules/model_io/chat/dealing_with_api_errors). 