### PR TITLE
langchain[patch],docs[patch]: Remove unnecessary `await` from `SelfQueryRetriever.fromLLM` calls

### DIFF
--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/chroma-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/chroma-self-query.mdx
@@ -21,7 +21,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/hnswlib-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/hnswlib-self-query.mdx
@@ -21,7 +21,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/index.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/index.mdx
@@ -45,7 +45,7 @@ with or as a fallback to the generated query. For example, if you wanted to ensu
 you could initialize the above retriever as follows:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/memory-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/memory-self-query.mdx
@@ -21,7 +21,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/pinecone-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/pinecone-self-query.mdx
@@ -21,7 +21,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/supabase-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/supabase-self-query.mdx
@@ -23,7 +23,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/vectara-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/vectara-self-query.mdx
@@ -25,7 +25,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/docs/core_docs/docs/modules/data_connection/retrievers/self_query/weaviate-self-query.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/self_query/weaviate-self-query.mdx
@@ -27,7 +27,7 @@ You can also initialize the retriever with default search parameters that apply 
 addition to the generated query:
 
 ```typescript
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/chroma_self_query.ts
+++ b/examples/src/retrievers/chroma_self_query.ts
@@ -89,7 +89,7 @@ const documentContents = "Brief summary of a movie";
 const vectorStore = await Chroma.fromDocuments(docs, embeddings, {
   collectionName: "a-movie-collection",
 });
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/hnswlib_self_query.ts
+++ b/examples/src/retrievers/hnswlib_self_query.ts
@@ -87,7 +87,7 @@ const embeddings = new OpenAIEmbeddings();
 const llm = new OpenAI();
 const documentContents = "Brief summary of a movie";
 const vectorStore = await HNSWLib.fromDocuments(docs, embeddings);
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/memory_self_query.ts
+++ b/examples/src/retrievers/memory_self_query.ts
@@ -87,7 +87,7 @@ const embeddings = new OpenAIEmbeddings();
 const llm = new OpenAI();
 const documentContents = "Brief summary of a movie";
 const vectorStore = await MemoryVectorStore.fromDocuments(docs, embeddings);
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/pinecone_self_query.ts
+++ b/examples/src/retrievers/pinecone_self_query.ts
@@ -104,7 +104,7 @@ const documentContents = "Brief summary of a movie";
 const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
   pineconeIndex: index,
 });
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/supabase_self_query.ts
+++ b/examples/src/retrievers/supabase_self_query.ts
@@ -100,7 +100,7 @@ const client = createClient(
 const vectorStore = await SupabaseVectorStore.fromDocuments(docs, embeddings, {
   client,
 });
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/vectara_self_query.ts
+++ b/examples/src/retrievers/vectara_self_query.ts
@@ -102,7 +102,7 @@ const vectorStore = await VectaraStore.fromDocuments(
 const llm = new OpenAI();
 const documentContents = "Brief summary of a movie";
 
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/examples/src/retrievers/weaviate_self_query.ts
+++ b/examples/src/retrievers/weaviate_self_query.ts
@@ -103,7 +103,7 @@ const vectorStore = await WeaviateStore.fromDocuments(docs, embeddings, {
   textKey: "text",
   metadataKeys: ["year", "director", "rating", "genre"],
 });
-const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+const selfQueryRetriever = SelfQueryRetriever.fromLLM({
   llm,
   vectorStore,
   documentContents,

--- a/langchain/src/retrievers/self_query/index.ts
+++ b/langchain/src/retrievers/self_query/index.ts
@@ -41,7 +41,7 @@ export interface SelfQueryRetrieverArgs<T extends VectorStore>
  * implements the SelfQueryRetrieverArgs interface.
  * @example
  * ```typescript
- * const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+ * const selfQueryRetriever = SelfQueryRetriever.fromLLM({
  *   llm: new ChatOpenAI(),
  *   vectorStore: await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings()),
  *   documentContents: "Brief summary of a movie",

--- a/langchain/src/retrievers/self_query/pinecone.ts
+++ b/langchain/src/retrievers/self_query/pinecone.ts
@@ -10,7 +10,7 @@ import { BasicTranslator } from "./base.js";
  * queries and compare results.
  * @example
  * ```typescript
- * const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+ * const selfQueryRetriever = SelfQueryRetriever.fromLLM({
  *   llm: new ChatOpenAI(),
  *   vectorStore: new PineconeStore(),
  *   documentContents: "Brief summary of a movie",

--- a/langchain/src/retrievers/self_query/tests/chroma_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/chroma_self_query.int.test.ts
@@ -78,7 +78,7 @@ test.skip("Chroma Store Self Query Retriever Test", async () => {
   const vectorStore = await Chroma.fromDocuments(docs, embeddings, {
     collectionName: "a-movie-collection",
   });
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,

--- a/langchain/src/retrievers/self_query/tests/hnswlib_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/hnswlib_self_query.int.test.ts
@@ -79,7 +79,7 @@ test("HNSWLib Store Self Query Retriever Test", async () => {
   });
   const documentContents = "Brief summary of a movie";
   const vectorStore = await HNSWLib.fromDocuments(docs, embeddings);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -174,7 +174,7 @@ test("HNSWLib shouldn't throw an error if a filter can't be generated, but shoul
   });
   const documentContents = "Brief summary of a movie";
   const vectorStore = await HNSWLib.fromDocuments(docs, embeddings);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,

--- a/langchain/src/retrievers/self_query/tests/memory_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/memory_self_query.int.test.ts
@@ -78,7 +78,7 @@ test("Memory Vector Store Self Query Retriever Test", async () => {
   });
   const documentContents = "Brief summary of a movie";
   const vectorStore = await MemoryVectorStore.fromDocuments(docs, embeddings);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -208,7 +208,7 @@ test("Memory Vector Store Self Query Retriever Test With Default Filter Or Merge
   });
   const documentContents = "Brief summary of a movie";
   const vectorStore = await MemoryVectorStore.fromDocuments(docs, embeddings);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -349,7 +349,7 @@ test("Memory Vector Store Self Query Retriever Test With Default Filter And Merg
   });
   const documentContents = "Brief summary of a movie";
   const vectorStore = await MemoryVectorStore.fromDocuments(docs, embeddings);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,

--- a/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/pinecone_self_query.int.test.ts
@@ -126,7 +126,7 @@ describe("Pinecone self query", () => {
     const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
       pineconeIndex: index,
     });
-    const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+    const selfQueryRetriever = SelfQueryRetriever.fromLLM({
       llm,
       vectorStore,
       documentContents,
@@ -276,7 +276,7 @@ describe("Pinecone self query", () => {
     const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
       pineconeIndex: index,
     });
-    const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+    const selfQueryRetriever = SelfQueryRetriever.fromLLM({
       llm,
       vectorStore,
       documentContents,
@@ -432,7 +432,7 @@ describe("Pinecone self query", () => {
     const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
       pineconeIndex: index,
     });
-    const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+    const selfQueryRetriever = SelfQueryRetriever.fromLLM({
       llm,
       vectorStore,
       documentContents,
@@ -588,7 +588,7 @@ describe("Pinecone self query", () => {
     const vectorStore = await PineconeStore.fromDocuments(docs, embeddings, {
       pineconeIndex: index,
     });
-    const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+    const selfQueryRetriever = SelfQueryRetriever.fromLLM({
       llm,
       vectorStore,
       documentContents,

--- a/langchain/src/retrievers/self_query/tests/supabase_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/supabase_self_query.int.test.ts
@@ -112,7 +112,7 @@ test("Supabase Store Self Query Retriever Test", async () => {
   // idempotency
   const opts = { ids: docs.map((_, idx) => idx) };
   await vectorStore.addDocuments(docs, opts);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -259,7 +259,7 @@ test("Supabase Store Self Query Retriever Test With Default Filter And Merge Ope
   // idempotency
   const opts = { ids: docs.map((_, idx) => idx) };
   await vectorStore.addDocuments(docs, opts);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -412,7 +412,7 @@ test("Supabase Store Self Query Retriever Test With Default Filter Or Merge Oper
   // idempotency
   const opts = { ids: docs.map((_, idx) => idx) };
   await vectorStore.addDocuments(docs, opts);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -567,7 +567,7 @@ test("Supabase Store Self Query Retriever Test With Default Filter And Merge Ope
   // idempotency
   const opts = { ids: docs.map((_, idx) => idx) };
   await vectorStore.addDocuments(docs, opts);
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,

--- a/langchain/src/retrievers/self_query/tests/vectara_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/vectara_self_query.int.test.ts
@@ -84,7 +84,7 @@ test.skip("Vectara Self Query Retriever Test", async () => {
   const llm = new OpenAI();
   const documentContents = "Brief summary of a movie";
 
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,

--- a/langchain/src/retrievers/self_query/tests/weaviate_self_query.int.test.ts
+++ b/langchain/src/retrievers/self_query/tests/weaviate_self_query.int.test.ts
@@ -97,7 +97,7 @@ test.skip("Weaviate Self Query Retriever Test", async () => {
     textKey: "text",
     metadataKeys: ["year", "director", "rating", "genre"],
   });
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -239,7 +239,7 @@ test.skip("Weaviate Vector Store Self Query Retriever Test With Default Filter O
     metadataKeys: ["year", "director", "rating", "genre", "type"],
   });
 
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,
@@ -386,7 +386,7 @@ test.skip("Weaviate Vector Store Self Query Retriever Test With Default Filter A
     metadataKeys: ["year", "director", "rating", "genre", "type"],
   });
 
-  const selfQueryRetriever = await SelfQueryRetriever.fromLLM({
+  const selfQueryRetriever = SelfQueryRetriever.fromLLM({
     llm,
     vectorStore,
     documentContents,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes https://github.com/langchain-ai/langchainjs/discussions/5096
