### PR TITLE
core[patch]: Update ai.ts

### DIFF
--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -71,7 +71,7 @@ export class AIMessage extends BaseMessage {
         );
       }
       try {
-        if (!(rawToolCalls == null)  && toolCalls === undefined) {
+        if (!(rawToolCalls == null) && toolCalls === undefined) {
           const [toolCalls, invalidToolCalls] =
             defaultToolCallParser(rawToolCalls);
           initParams.tool_calls = toolCalls ?? [];

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -57,7 +57,7 @@ export class AIMessage extends BaseMessage {
       const rawToolCalls = initParams.additional_kwargs?.tool_calls;
       const toolCalls = initParams.tool_calls;
       if (
-        rawToolCalls !== undefined &&
+        !(rawToolCalls == null) &&
         rawToolCalls.length > 0 &&
         (toolCalls === undefined || toolCalls.length === 0)
       ) {
@@ -71,7 +71,7 @@ export class AIMessage extends BaseMessage {
         );
       }
       try {
-        if (rawToolCalls !== undefined && toolCalls === undefined) {
+        if (!(rawToolCalls == null)  && toolCalls === undefined) {
           const [toolCalls, invalidToolCalls] =
             defaultToolCallParser(rawToolCalls);
           initParams.tool_calls = toolCalls ?? [];


### PR DESCRIPTION
In langchain-core/src/messages/ai.ts

The code currently only checks for undefined on rawToolCalls.  However, the provider (deep-infra in this case)  can return toolCalls=null, which passed the conditional but will then produce an error when rawToolCalls.length is accessed.

Changed the conditional to !(rawToolCalls == null) to address the issue, and verified that this fixed the issue.

Note that `rawToolCalls == null` is true if rawToolCalls is null OR undefined, thus handling both cases.