### PR TITLE
core[patch]: Fixed "Bad control character in string literal"

### DIFF
--- a/langchain-core/src/output_parsers/structured.ts
+++ b/langchain-core/src/output_parsers/structured.ts
@@ -104,7 +104,13 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
       const json = text.includes("```")
         ? text.trim().split(/```(?:json)?/)[1]
         : text.trim();
-      return await this.schema.parseAsync(JSON.parse(json));
+      
+      const escapedJson = json.replace(/"([^"\\]*(\\.[^"\\]*)*)"/g, (_match, capturedGroup) => {
+        const escapedInsideQuotes = capturedGroup.replace(/\n/g, '\\n');
+        return `"${escapedInsideQuotes}"`;
+      }).replace(/\n/g, '');
+      
+      return await this.schema.parseAsync(JSON.parse(escapedJson));
     } catch (e) {
       throw new OutputParserException(
         `Failed to parse. Text: "${text}". Error: ${e}`,


### PR DESCRIPTION
The error "Bad control character in string literal" occurs when calling JSON.parse(json). This typically happens because the JSON string contains control characters that are not allowed, such as newline characters. Any control characters in the JSON string should be escaped before parsing it using JSON.parse().

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
