### PR TITLE
fix: incorrect text_type type declaration in Alibaba Tongyi Embeddings

### DIFF
--- a/libs/langchain-community/src/embeddings/alibaba_tongyi.ts
+++ b/libs/langchain-community/src/embeddings/alibaba_tongyi.ts
@@ -30,7 +30,7 @@ export interface AlibabaTongyiEmbeddingsParams extends EmbeddingsParams {
      * 	底库文本（document）类型, 聚类、分类等对称任务可以不用特殊指定，
      * 	采用系统默认值"document"即可
      */
-    text_type?: "text" | "document";
+    text_type?: "query" | "document";
   };
 }
 


### PR DESCRIPTION
corrects the type declaration for the `text_type` parameter in Alibaba Tongyi embeddings. The previous declaration incorrectly listed `text` as an option, which is not supported. The corrected declaration includes the intended options: `query` and `document` as shown in [official docs](https://help.aliyun.com/zh/dashscope/developer-reference/text-embedding-api-details) and comment above it.

Translation for the original comment: 
```js
/**
 * Value: query or document, default value is document
 * Description: After text is converted into vectors, it can be applied to downstream tasks such as retrieval, clustering, and classification.
 * For asymmetric tasks like retrieval, to achieve better retrieval effects, it is recommended to distinguish between query text (query) and
 * document text (document). For symmetric tasks like clustering and classification, there is no need to specify,
 * and the system's default value "document" can be used.
 */
```