### PR TITLE
add neon postgres as a vector store

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/neon.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/neon.mdx
@@ -1,0 +1,55 @@
+# Neon Postgres
+
+Neon is a fully managed serverless PostgreSQL database. It separates storage and compute to offer
+features such as instant branching and automatic scaling.
+
+With the `pgvector` extension, Neon provides a vector store that can be used with LangChain.js to store and query embeddings.
+
+## Setup
+
+### Select a Neon project
+
+If you do not have a Neon account, sign up for one at [Neon](https://neon.tech). After logging into the Neon Console, proceed
+to the [Projects](https://console.neon.tech/app/projects) section and select an existing project or create a new one.
+
+Your Neon project comes with a ready-to-use Postgres database named `neondb` that you can use to store embeddings. Navigate to
+the Connection Details section to find your database connection string. It should look similar to this:
+
+```text
+postgres://alex:AbC123dEf@ep-cool-darkness-123456.us-east-2.aws.neon.tech/dbname?sslmode=require
+```
+
+Keep your connection string handy for later use.
+
+### Application code
+
+To work with Neon Postgres, you need to install the `@neondatabase/serverless` package which provides a JavaScript/TypeScript
+driver to connect to the database.
+
+```bash npm2yarn
+npm install @neondatabase/serverless
+```
+
+import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
+
+<IntegrationInstallTooltip></IntegrationInstallTooltip>
+
+```bash npm2yarn
+npm install @langchain/community
+```
+
+To initialize a `NeonPostgres` vectorstore, you need to provide your Neon database connection string. You can use the connection string
+we fetched above directly, or store it as an environment variable and use it in your code.
+
+```typescript
+const vectorStore = await NeonPostgres.initialize(embeddings, {
+  connectionString: NEON_POSTGRES_CONNECTION_STRING,
+});
+```
+
+## Usage
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/indexes/vector_stores/neon/example.ts";
+
+<CodeBlock language="typescript">{Example}</CodeBlock>

--- a/examples/src/indexes/vector_stores/neon/example.ts
+++ b/examples/src/indexes/vector_stores/neon/example.ts
@@ -1,0 +1,92 @@
+import { OpenAIEmbeddings } from "@langchain/openai";
+import { NeonPostgres } from "@langchain/community/vectorstores/neon";
+
+// Initialize an embeddings instance
+const embeddings = new OpenAIEmbeddings({
+  apiKey: process.env.OPENAI_API_KEY,
+  dimensions: 256,
+  model: "text-embedding-3-small",
+});
+
+// Initialize a NeonPostgres instance to store embedding vectors
+const vectorStore = await NeonPostgres.initialize(embeddings, {
+  connectionString: process.env.DATABASE_URL as string,
+});
+
+// You can add documents to the store, strings in the `pageContent` field will be embedded
+// and stored in the database
+const documents = [
+  { pageContent: "Hello world", metadata: { topic: "greeting" } },
+  { pageContent: "Bye bye", metadata: { topic: "greeting" } },
+  {
+    pageContent: "Mitochondria is the powerhouse of the cell",
+    metadata: { topic: "science" },
+  },
+];
+const idsInserted = await vectorStore.addDocuments(documents);
+
+// You can now query the store for similar documents to the input query
+const resultOne = await vectorStore.similaritySearch("hola", 1);
+console.log(resultOne);
+/*
+[
+  Document {
+    pageContent: 'Hello world',
+    metadata: { topic: 'greeting' }
+  }
+]
+*/
+
+// You can also filter by metadata
+const resultTwo = await vectorStore.similaritySearch("Irrelevant query", 2, {
+  topic: "science",
+});
+console.log(resultTwo);
+/*
+[
+  Document {
+    pageContent: 'Mitochondria is the powerhouse of the cell',
+    metadata: { topic: 'science' }
+  }
+]
+*/
+
+// Metadata filtering with IN-filters works as well
+const resultsThree = await vectorStore.similaritySearch("Irrelevant query", 2, {
+  topic: { in: ["greeting"] },
+});
+console.log(resultsThree);
+/*
+[
+  Document { pageContent: 'Bye bye', metadata: { topic: 'greeting' } },
+  Document {
+    pageContent: 'Hello world',
+    metadata: { topic: 'greeting' }
+  }
+]
+*/
+
+// Upserting is supported as well
+await vectorStore.addDocuments(
+  [
+    {
+      pageContent: "ATP is the powerhouse of the cell",
+      metadata: { topic: "science" },
+    },
+  ],
+  { ids: [idsInserted[2]] }
+);
+
+const resultsFour = await vectorStore.similaritySearch(
+  "powerhouse of the cell",
+  1
+);
+console.log(resultsFour);
+/*
+[
+  Document {
+    pageContent: 'ATP is the powerhouse of the cell',
+    metadata: { topic: 'science' }
+  }
+]
+*/

--- a/libs/langchain-community/.gitignore
+++ b/libs/langchain-community/.gitignore
@@ -374,6 +374,10 @@ vectorstores/neo4j_vector.cjs
 vectorstores/neo4j_vector.js
 vectorstores/neo4j_vector.d.ts
 vectorstores/neo4j_vector.d.cts
+vectorstores/neon.cjs
+vectorstores/neon.js
+vectorstores/neon.d.ts
+vectorstores/neon.d.cts
 vectorstores/opensearch.cjs
 vectorstores/opensearch.js
 vectorstores/opensearch.d.ts

--- a/libs/langchain-community/langchain.config.js
+++ b/libs/langchain-community/langchain.config.js
@@ -125,6 +125,7 @@ export const config = {
     "vectorstores/mongodb_atlas": "vectorstores/mongodb_atlas",
     "vectorstores/myscale": "vectorstores/myscale",
     "vectorstores/neo4j_vector": "vectorstores/neo4j_vector",
+    "vectorstores/neon": "vectorstores/neon",
     "vectorstores/opensearch": "vectorstores/opensearch",
     "vectorstores/pgvector": "vectorstores/pgvector",
     "vectorstores/pinecone": "vectorstores/pinecone",
@@ -233,7 +234,8 @@ export const config = {
     "util/convex": "utils/convex",
     "utils/event_source_parse": "utils/event_source_parse",
     "utils/cassandra": "utils/cassandra",
-    "experimental/graph_transformers/llm": "experimental/graph_transformers/llm",
+    "experimental/graph_transformers/llm":
+      "experimental/graph_transformers/llm",
   },
   requiresOptionalDependency: [
     "tools/aws_sfn",
@@ -296,6 +298,7 @@ export const config = {
     "vectorstores/mongodb_atlas",
     "vectorstores/myscale",
     "vectorstores/neo4j_vector",
+    "vectorstores/neon",
     "vectorstores/opensearch",
     "vectorstores/pgvector",
     "vectorstores/pinecone",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -76,6 +76,7 @@
     "@jest/globals": "^29.5.0",
     "@langchain/scripts": "~0.0",
     "@mozilla/readability": "^0.4.4",
+    "@neondatabase/serverless": "^0.9.1",
     "@opensearch-project/opensearch": "^2.2.0",
     "@pinecone-database/pinecone": "^1.1.0",
     "@planetscale/database": "^1.8.0",
@@ -204,6 +205,7 @@
     "@gradientai/nodejs-sdk": "^1.2.0",
     "@huggingface/inference": "^2.6.4",
     "@mozilla/readability": "*",
+    "@neondatabase/serverless": "*",
     "@opensearch-project/opensearch": "*",
     "@pinecone-database/pinecone": "*",
     "@planetscale/database": "^1.8.0",
@@ -339,6 +341,9 @@
       "optional": true
     },
     "@mozilla/readability": {
+      "optional": true
+    },
+    "@neondatabase/serverless": {
       "optional": true
     },
     "@opensearch-project/opensearch": {
@@ -1398,6 +1403,15 @@
       },
       "import": "./vectorstores/neo4j_vector.js",
       "require": "./vectorstores/neo4j_vector.cjs"
+    },
+    "./vectorstores/neon": {
+      "types": {
+        "import": "./vectorstores/neon.d.ts",
+        "require": "./vectorstores/neon.d.cts",
+        "default": "./vectorstores/neon.d.ts"
+      },
+      "import": "./vectorstores/neon.js",
+      "require": "./vectorstores/neon.cjs"
     },
     "./vectorstores/opensearch": {
       "types": {
@@ -2652,6 +2666,10 @@
     "vectorstores/neo4j_vector.js",
     "vectorstores/neo4j_vector.d.ts",
     "vectorstores/neo4j_vector.d.cts",
+    "vectorstores/neon.cjs",
+    "vectorstores/neon.js",
+    "vectorstores/neon.d.ts",
+    "vectorstores/neon.d.cts",
     "vectorstores/opensearch.cjs",
     "vectorstores/opensearch.js",
     "vectorstores/opensearch.d.ts",

--- a/libs/langchain-community/src/vectorstores/neon.ts
+++ b/libs/langchain-community/src/vectorstores/neon.ts
@@ -1,0 +1,357 @@
+import { neon } from "@neondatabase/serverless";
+import type { EmbeddingsInterface } from "@langchain/core/embeddings";
+import { VectorStore } from "@langchain/core/vectorstores";
+import { Document } from "@langchain/core/documents";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+
+type Metadata = Record<string, string | number | Record<"in", string[]>>;
+
+/**
+ * Interface that defines the arguments required to create a
+ * `NeonPostgres` instance. It includes Postgres connection options,
+ * table name, filter, and verbosity level.
+ */
+export interface NeonPostgresArgs {
+  connectionString: string;
+  tableName?: string;
+  columns?: {
+    idColumnName?: string;
+    vectorColumnName?: string;
+    contentColumnName?: string;
+    metadataColumnName?: string;
+  };
+  filter?: Metadata;
+  verbose?: boolean;
+}
+
+/**
+ * Class that provides an interface to a Neon Postgres database. It
+ * extends the `VectorStore` base class and implements methods for adding
+ * documents and vectors, performing similarity searches, and ensuring the
+ * existence of a table in the database.
+ */
+export class NeonPostgres extends VectorStore {
+  declare FilterType: Metadata;
+
+  tableName: string;
+
+  idColumnName: string;
+
+  vectorColumnName: string;
+
+  contentColumnName: string;
+
+  metadataColumnName: string;
+
+  filter?: Metadata;
+
+  _verbose?: boolean;
+
+  neonConnectionString: string;
+
+  _vectorstoreType(): string {
+    return "neon-postgres";
+  }
+
+  constructor(embeddings: EmbeddingsInterface, config: NeonPostgresArgs) {
+    super(embeddings, config);
+    this._verbose =
+      getEnvironmentVariable("LANGCHAIN_VERBOSE") === "true" ??
+      !!config.verbose;
+
+    this.neonConnectionString = config.connectionString;
+    this.tableName = config.tableName ?? "vectorstore_documents";
+    this.filter = config.filter;
+
+    this.vectorColumnName = config.columns?.vectorColumnName ?? "embedding";
+    this.contentColumnName = config.columns?.contentColumnName ?? "text";
+    this.idColumnName = config.columns?.idColumnName ?? "id";
+    this.metadataColumnName = config.columns?.metadataColumnName ?? "metadata";
+  }
+
+  /**
+   * Static method to create a new `NeonPostgres` instance from a
+   * connection. It creates a table if one does not exist.
+   *
+   * @param embeddings - Embeddings instance.
+   * @param fields - `NeonPostgresArgs` instance.
+   * @returns A new instance of `NeonPostgres`.
+   */
+  static async initialize(
+    embeddings: EmbeddingsInterface,
+    config: NeonPostgresArgs
+  ): Promise<NeonPostgres> {
+    const neonVectorStore = new NeonPostgres(embeddings, config);
+    await neonVectorStore.ensureTableInDatabase();
+    return neonVectorStore;
+  }
+
+  /**
+   * Constructs the SQL query for inserting rows into the specified table.
+   *
+   * @param rows - The rows of data to be inserted, consisting of values and records.
+   * @param chunkIndex - The starting index for generating query placeholders based on chunk positioning.
+   * @returns The complete SQL INSERT INTO query string.
+   */
+  protected async runInsertQuery(
+    rows: (string | Record<string, any>)[][],
+    useIdColumn: boolean
+  ) {
+    const placeholders = rows.map((row, index) => {
+      const base = index * row.length;
+      return `(${row.map((_, j) => `$${base + 1 + j}`)})`;
+    });
+    const queryString = `
+    INSERT INTO ${this.tableName} (
+        ${useIdColumn ? `${this.idColumnName},` : ""}
+        ${this.contentColumnName}, 
+        ${this.vectorColumnName}, 
+        ${this.metadataColumnName}
+    ) VALUES ${placeholders.join(", ")}
+    ON CONFLICT (${this.idColumnName}) 
+    DO UPDATE 
+    SET 
+        ${this.contentColumnName} = EXCLUDED.${this.contentColumnName},
+        ${this.vectorColumnName} = EXCLUDED.${this.vectorColumnName},
+        ${this.metadataColumnName} = EXCLUDED.${this.metadataColumnName}
+    RETURNING ${this.idColumnName}
+    `;
+
+    const flatValues = rows.flat();
+    const sql = neon(this.neonConnectionString);
+    return await sql(queryString, flatValues);
+  }
+
+  /**
+   * Method to add vectors to the vector store. It converts the vectors into
+   * rows and inserts them into the database.
+   *
+   * @param vectors - Array of vectors.
+   * @param documents - Array of `Document` instances.
+   * @param options - Optional arguments for adding documents
+   * @returns Promise that resolves when the vectors have been added.
+   */
+  async addVectors(
+    vectors: number[][],
+    documents: Document[],
+    options?: { ids?: string[] }
+  ): Promise<string[]> {
+    if (options?.ids !== undefined && options?.ids.length !== vectors.length) {
+      throw new Error(
+        `If provided, the length of "ids" must be the same as the number of vectors.`
+      );
+    }
+
+    const rows = vectors.map((embedding, idx) => {
+      const embeddingString = `[${embedding.join(",")}]`;
+      const row = [
+        documents[idx].pageContent,
+        embeddingString,
+        documents[idx].metadata,
+      ];
+      if (options?.ids) {
+        return [options.ids[idx], ...row];
+      }
+      return row;
+    });
+
+    const chunkSize = 500;
+    const ids = [];
+    for (let i = 0; i < rows.length; i += chunkSize) {
+      const chunk = rows.slice(i, i + chunkSize);
+      try {
+        const result = await this.runInsertQuery(
+          chunk,
+          options?.ids !== undefined
+        );
+        ids.push(...result.map((row) => row[this.idColumnName]));
+      } catch (e) {
+        console.error(e);
+        throw new Error(`Error inserting: ${(e as Error).message}`);
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Method to perform a similarity search in the vector store. It returns
+   * the `k` most similar documents to the query vector, along with their
+   * similarity scores.
+   *
+   * @param query - Query vector.
+   * @param k - Number of most similar documents to return.
+   * @param filter - Optional filter to apply to the search.
+   * @returns Promise that resolves with an array of tuples, each containing a `Document` and its similarity score.
+   */
+  async similaritySearchVectorWithScore(
+    query: number[],
+    k: number,
+    filter?: this["FilterType"]
+  ): Promise<[Document, number][]> {
+    const embeddingString = `[${query.join(",")}]`;
+    const _filter: this["FilterType"] = filter ?? {};
+
+    const whereClauses = [];
+    const parameters = [embeddingString, k];
+    let paramCount = parameters.length;
+
+    // The vector to query with, and the num of results are the first
+    // two parameters. The rest of the parameters are the filter values
+    for (const [key, value] of Object.entries(_filter)) {
+      if (typeof value === "object" && value !== null) {
+        const currentParamCount = paramCount;
+        const placeholders = value.in
+          .map((_, index) => `$${currentParamCount + index + 1}`)
+          .join(",");
+        whereClauses.push(
+          `${this.metadataColumnName}->>'${key}' IN (${placeholders})`
+        );
+        parameters.push(...value.in);
+        paramCount += value.in.length;
+      } else {
+        paramCount += 1;
+        whereClauses.push(
+          `${this.metadataColumnName}->>'${key}' = $${paramCount}`
+        );
+        parameters.push(value);
+      }
+    }
+
+    const whereClause = whereClauses.length
+      ? `WHERE ${whereClauses.join(" AND ")}`
+      : "";
+    const queryString = `
+      SELECT *, ${this.vectorColumnName} <=> $1 as "_distance"
+      FROM ${this.tableName}
+      ${whereClause}
+      ORDER BY "_distance" ASC
+      LIMIT $2;`;
+
+    const sql = neon(this.neonConnectionString);
+    const documents = await sql(queryString, parameters);
+
+    const results = [] as [Document, number][];
+    for (const doc of documents) {
+      if (doc._distance != null && doc[this.contentColumnName] != null) {
+        const document = new Document({
+          pageContent: doc[this.contentColumnName],
+          metadata: doc[this.metadataColumnName],
+        });
+        results.push([document, doc._distance]);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Method to add documents to the vector store. It converts the documents into
+   * vectors, and adds them to the store.
+   *
+   * @param documents - Array of `Document` instances.
+   * @param options - Optional arguments for adding documents
+   * @returns Promise that resolves when the documents have been added.
+   */
+  async addDocuments(
+    documents: Document[],
+    options?: { ids?: string[] }
+  ): Promise<string[]> {
+    const texts = documents.map(({ pageContent }) => pageContent);
+    return this.addVectors(
+      await this.embeddings.embedDocuments(texts),
+      documents,
+      options
+    );
+  }
+
+  /**
+   * Method to delete documents from the vector store. It deletes the
+   * documents that match the provided ids.
+   *
+   * @param ids - Array of document ids.
+   * @param deleteAll - Boolean to delete all documents.
+   * @returns Promise that resolves when the documents have been deleted.
+   */
+  async delete(params: { ids?: string[]; deleteAll?: boolean }): Promise<void> {
+    const sql = neon(this.neonConnectionString);
+
+    if (params.ids !== undefined) {
+      await sql(
+        `DELETE FROM ${this.tableName} 
+        WHERE ${this.idColumnName} 
+        IN (${params.ids.map((_, idx) => `$${idx + 1}`)})`,
+        params.ids
+      );
+    } else if (params.deleteAll) {
+      await sql(`TRUNCATE TABLE ${this.tableName}`);
+    }
+  }
+
+  /**
+   * Method to ensure the existence of the table to store vectors in
+   * the database. It creates the table if it does not already exist.
+   *
+   * @returns Promise that resolves when the table has been ensured.
+   */
+  async ensureTableInDatabase(): Promise<void> {
+    const sql = neon(this.neonConnectionString);
+
+    await sql(`CREATE EXTENSION IF NOT EXISTS vector;`);
+    await sql(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
+    await sql(`
+      CREATE TABLE IF NOT EXISTS ${this.tableName} (
+        ${this.idColumnName} uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+        ${this.contentColumnName} text,
+        ${this.metadataColumnName} jsonb,
+        ${this.vectorColumnName} vector
+      );
+    `);
+  }
+
+  /**
+   * Static method to create a new `NeonPostgres` instance from an
+   * array of texts and their metadata. It converts the texts into
+   * `Document` instances and adds them to the store.
+   *
+   * @param texts - Array of texts.
+   * @param metadatas - Array of metadata objects or a single metadata object.
+   * @param embeddings - Embeddings instance.
+   * @param dbConfig - `NeonPostgresArgs` instance.
+   * @returns Promise that resolves with a new instance of `NeonPostgresArgs`.
+   */
+  static async fromTexts(
+    texts: string[],
+    metadatas: object[] | object,
+    embeddings: EmbeddingsInterface,
+    dbConfig: NeonPostgresArgs
+  ): Promise<NeonPostgres> {
+    const docs = [];
+    for (let i = 0; i < texts.length; i += 1) {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
+      const newDoc = new Document({
+        pageContent: texts[i],
+        metadata,
+      });
+      docs.push(newDoc);
+    }
+    return this.fromDocuments(docs, embeddings, dbConfig);
+  }
+
+  /**
+   * Static method to create a new `NeonPostgres` instance from an
+   * array of `Document` instances. It adds the documents to the store.
+   *
+   * @param docs - Array of `Document` instances.
+   * @param embeddings - Embeddings instance.
+   * @param dbConfig - `NeonPostgreseArgs` instance.
+   * @returns Promise that resolves with a new instance of `NeonPostgres`.
+   */
+  static async fromDocuments(
+    docs: Document[],
+    embeddings: EmbeddingsInterface,
+    dbConfig: NeonPostgresArgs
+  ): Promise<NeonPostgres> {
+    const instance = await this.initialize(embeddings, dbConfig);
+    await instance.addDocuments(docs);
+    return instance;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8961,6 +8961,7 @@ __metadata:
     "@langchain/openai": ~0.0.28
     "@langchain/scripts": ~0.0
     "@mozilla/readability": ^0.4.4
+    "@neondatabase/serverless": ^0.9.1
     "@opensearch-project/opensearch": ^2.2.0
     "@pinecone-database/pinecone": ^1.1.0
     "@planetscale/database": ^1.8.0
@@ -9094,6 +9095,7 @@ __metadata:
     "@gradientai/nodejs-sdk": ^1.2.0
     "@huggingface/inference": ^2.6.4
     "@mozilla/readability": "*"
+    "@neondatabase/serverless": "*"
     "@opensearch-project/opensearch": "*"
     "@pinecone-database/pinecone": "*"
     "@planetscale/database": ^1.8.0
@@ -9207,6 +9209,8 @@ __metadata:
     "@huggingface/inference":
       optional: true
     "@mozilla/readability":
+      optional: true
+    "@neondatabase/serverless":
       optional: true
     "@opensearch-project/opensearch":
       optional: true
@@ -10125,6 +10129,15 @@ __metadata:
   dependencies:
     "@types/pg": 8.6.6
   checksum: 25b81ba6b37e0ac56a746a1219de6107dd74d6f2d093bc23dc33b6fb8f33d00f80cb37eb0648afacd32ab0020b20c1809e3ec6e5c34d23fa21ae5b76d6041332
+  languageName: node
+  linkType: hard
+
+"@neondatabase/serverless@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@neondatabase/serverless@npm:0.9.1"
+  dependencies:
+    "@types/pg": 8.6.6
+  checksum: b74b30386006d80d02d9d70bbfd7b25be4265ca731e6d716b7ee7801524489b10411969ef2ece03cc858e558c24ae32ecb11fa151bded1218f3dec0ffdd0e26d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds Neon Postgres (backed by the pgvector extension) as a vector store. The code mostly follows the vercel-postgres integration but uses the Neon database serverless driver (https://github.com/neondatabase/serverless), which is quicker for one-shot queries. 

(I write technical content for Neon)