### PR TITLE
Ideas for `PromptTemplate` composition and type safety improvements

### DIFF
--- a/langchain-core/src/prompts/prompt.ts
+++ b/langchain-core/src/prompts/prompt.ts
@@ -13,7 +13,11 @@ import {
   type TemplateFormat,
 } from "./template.js";
 import type { SerializedPromptTemplate } from "./serde.js";
-import type { InputValues, PartialValues } from "../utils/types/index.js";
+import type {
+  InputValues,
+  InputValues_FSTRING,
+  PartialValues,
+} from "../utils/types/index.js";
 import { MessageContent } from "../messages/index.js";
 
 /**
@@ -183,7 +187,7 @@ export class PromptTemplate<
    */
   static fromTemplate<
     // eslint-disable-next-line @typescript-eslint/ban-types
-    RunInput extends InputValues = Symbol,
+    RunInput extends InputValues = InputValues_FSTRING,
     T extends string = string
   >(
     template: T,
@@ -203,7 +207,7 @@ export class PromptTemplate<
     });
     return new PromptTemplate<
       // eslint-disable-next-line @typescript-eslint/ban-types
-      RunInput extends Symbol ? ParamsFromFString<T> : RunInput
+      RunInput extends InputValues_FSTRING ? ParamsFromFString<T> : RunInput
     >({
       // Rely on extracted types
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/langchain-core/src/prompts/tests/chat.test.ts
+++ b/langchain-core/src/prompts/tests/chat.test.ts
@@ -568,3 +568,29 @@ test("Multi-modal, multi part chat prompt works with instances of BaseMessage", 
   });
   expect(messages).toMatchSnapshot();
 });
+
+test("fromTypedMessages combines message input types", () => {
+  const x = new SystemMessagePromptTemplate<{ x: string }>({
+    prompt: PromptTemplate.fromTemplate(""),
+  });
+  const y = new SystemMessagePromptTemplate<{ y: string }>({
+    prompt: PromptTemplate.fromTemplate(""),
+  });
+
+  const xy = ChatPromptTemplate.fromTypedMessages([x, y]);
+  ((test: ChatPromptTemplate<{ x: string; y: string }>) => test)(xy);
+});
+
+test("_StringImageMessagePromptTemplate infers RunInput from child prompt", () => {
+  const x = new SystemMessagePromptTemplate({
+    prompt: PromptTemplate.fromTemplate<{ x: number; y: boolean }>(""),
+  });
+
+  ((test: SystemMessagePromptTemplate<{ x: number; y: boolean }>) => test)(x);
+
+  // @ts-expect-error - nope
+  ((test: SystemMessagePromptTemplate<{ x: number; z: number }>) => test)(x);
+
+  // @ts-expect-error - nope
+  ((test: SystemMessagePromptTemplate<{ x: string; y: string }>) => test)(x);
+});

--- a/langchain-core/src/utils/types/index.ts
+++ b/langchain-core/src/utils/types/index.ts
@@ -7,7 +7,9 @@ export * from "./is_zod_schema.js";
 export type StringWithAutocomplete<T> = T | (string & Record<never, never>);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InputValues<K extends string = string> = Record<K, any>;
+export type InputValues<K extends string = string, V = any> = Record<K, V>;
+
+export type InputValues_FSTRING = InputValues & { __FSTRING: true };
 
 export type PartialValues<K extends string = string> = Record<
   K,

--- a/langchain/src/experimental/prompts/custom_format.ts
+++ b/langchain/src/experimental/prompts/custom_format.ts
@@ -6,6 +6,8 @@ import {
   TypedPromptInputValues,
 } from "@langchain/core/prompts";
 
+export type InputValues_FSTRING = InputValues & { __FSTRING: true }; 
+
 export type CustomFormatPromptTemplateInput<RunInput extends InputValues> =
   Omit<PromptTemplateInput<RunInput, string>, "templateFormat"> & {
     customParser: (template: string) => ParsedFStringNode[];
@@ -74,7 +76,7 @@ export class CustomFormatPromptTemplate<
       }
     }
     // eslint-disable-next-line @typescript-eslint/ban-types
-    return new this<RunInput extends Symbol ? never : RunInput>({
+    return new this<RunInput extends InputValues_FSTRING ? never : RunInput>({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       inputVariables: [...names] as any[],
       template,


### PR DESCRIPTION
This is a draft PR of some core improvements to typing of prompt templates. @functorism and I went down a rabbit hole trying to make prompt template input types inferred.

# Background
I was trying to improve type safety when composing multiple prompts. For example I wanted to do something like:
```ts
const a = PromptTemplate.fromTemplate('hello {a}'); // infers RunInput to { a: string }
const b = HandlebarsPromptTemplate.fromTemplate<{ b: number }>('hello {{b}}'); // explicitly sets RunInput to { b: number }

const composable = ComposablePromptTemplate.compose<{ c: string }>(HandlebarsPromptTemplate)`
    ${a}
    ${b}
    hello {{c}}
`;

// format type is an object of shape `{ a: string; b: number; c: string }`
const formatted = await composable.format({ a: 'America', b: 'Belgium', c: 'Croatia' }); 
```

Together w @functorism we created a class `ComposablePromptTemplate` that does this inference, which I'll gladly share later. Here's a simplifed version that paints the picture:
```ts
const composeTemplateString = <T>() => <Prompts extends PromptTemplate<unknown>[]>(
  strings: TemplateStringsArray,
  ...prompts: Prompts
): StringWithType<T & ObjectTupleIntersection<{}, { [K in keyof Prompts]: Prompts[K] extends PromptTemplate<infer T> ? T : never }>> => {
  return strings.map((str, i) => str + prompts[i].toString()).join('') as any;
}
```

# Problem
The problem that I run into when using `ComposablePromptTemplate` is that `ChatPromptTemplate` and `SystemPromptTemplate` don't propagate inferred type parameters correctly. This has already been acknowledged in this issue for example: https://github.com/langchain-ai/langchainjs/issues/4155

# Core parts of this PR
1. `ChatPromptTemplate.fromTypedMessages` is a new better typed version of `ChatPromptTemplate.fromMessages` that infers the ChatPromptTemplate RunInput based on the combined type of the messages' RunInputs. We couldn't update the existing `fromMessages` function without breaking current usage, and therefore added this as a new function.
1. `new {System/Human/AI}PromptTemplate(prompt)` infers RunInput type from the child prompt
1. We got very confused about TS errors related to `RunInput` defaulting to `Symbol` in `PromptTemplate`, which is used to infer if the PromptTemplate's type should be inferred using fstring generics or the explicit type, and tried to make that more explicit using `InputValues_FSTRING`. This is a vague suggestion and it might make sense for e.g. @jacoblee93 and @functorism to chat and share thoughts on typings

# Disclaimer
Do note, this is very much a showcase PR. E.g. `InputValues_FSTRING` should probably _not_ be in the file it's currently in.