### PR TITLE
Adds BedrockCohereEmbeddings class + tests

### DIFF
--- a/libs/langchain-community/src/embeddings/bedrock.ts
+++ b/libs/langchain-community/src/embeddings/bedrock.ts
@@ -122,7 +122,7 @@ export class BedrockEmbeddings
    * @param document Document for which to generate an embedding.
    * @returns Promise that resolves to an embedding for the input document.
    */
-  embedQuery(document: string): Promise<number[]> {
+  async embedQuery(document: string): Promise<number[]> {
     return this.caller.callWithOptions(
       {},
       this._embedText.bind(this),

--- a/libs/langchain-community/src/embeddings/bedrock_cohere.ts
+++ b/libs/langchain-community/src/embeddings/bedrock_cohere.ts
@@ -1,0 +1,95 @@
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { Embeddings } from "@langchain/core/embeddings";
+import { BedrockEmbeddingsParams } from "./bedrock.js";
+
+export class BedrockCohereEmbeddings
+  extends Embeddings
+  implements BedrockEmbeddingsParams
+{
+  model: string;
+
+  client: BedrockRuntimeClient;
+
+  batchSize = 512;
+
+  constructor(fields?: BedrockEmbeddingsParams) {
+    super(fields ?? {});
+
+    this.model = fields?.model ?? "cohere.embed-english-v3";
+
+    this.client =
+      fields?.client ??
+      new BedrockRuntimeClient({
+        region: fields?.region,
+        credentials: fields?.credentials,
+      });
+  }
+
+  /**
+   * Embeds an array of documents using the Bedrock model.
+   * @param documents The array of documents to be embedded.
+   * @param inputType The input type for the embedding process.
+   * @returns A promise that resolves to a 2D array of embeddings.
+   * @throws If an error occurs while embedding documents with Bedrock.
+   */
+  protected async _embedDocuments(
+    documents: string[],
+    inputType: string
+  ): Promise<number[][]> {
+    return this.caller.call(async () => {
+      try {
+        const res = await this.client.send(
+          new InvokeModelCommand({
+            modelId: this.model,
+            body: JSON.stringify({
+              texts: documents.map((doc) => doc.replace(/\n+/g, " ")),
+              input_type: inputType,
+            }),
+            contentType: "application/json",
+            accept: "application/json",
+          })
+        );
+
+        const body = new TextDecoder().decode(res.body);
+        return JSON.parse(body).embeddings;
+      } catch (e) {
+        console.error({
+          error: e,
+        });
+        if (e instanceof Error) {
+          throw new Error(
+            `An error occurred while embedding documents with Bedrock: ${e.message}`
+          );
+        }
+
+        throw new Error(
+          "An error occurred while embedding documents with Bedrock"
+        );
+      }
+    });
+  }
+
+  /**
+   * Method that takes a document as input and returns a promise that
+   * resolves to an embedding for the document.
+   * @param document Document for which to generate an embedding.
+   * @returns Promise that resolves to an embedding for the input document.
+   */
+  async embedQuery(document: string): Promise<number[]> {
+    return this._embedDocuments([document], "search_query").then(
+      (embeddings) => embeddings[0]
+    );
+  }
+
+  /**
+   * Method to generate embeddings for an array of texts.
+   * @param documents Array of texts for which to generate embeddings.
+   * @returns Promise that resolves to a 2D array of embeddings for each input document.
+   */
+  async embedDocuments(documents: string[]): Promise<number[][]> {
+    return this._embedDocuments(documents, "search_document");
+  }
+}

--- a/libs/langchain-community/src/embeddings/tests/bedrock_cohere.int.test.ts
+++ b/libs/langchain-community/src/embeddings/tests/bedrock_cohere.int.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-process-env */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { expect, test } from "@jest/globals";
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
+
+import { HNSWLib } from "../../vectorstores/hnswlib.js";
+import { BedrockCohereEmbeddings } from "../bedrock_cohere.js";
+
+const getClient = () => {
+  if (
+    !process.env.BEDROCK_AWS_REGION ||
+    !process.env.BEDROCK_AWS_ACCESS_KEY_ID ||
+    !process.env.BEDROCK_AWS_SECRET_ACCESS_KEY
+  ) {
+    throw new Error("Missing environment variables for AWS");
+  }
+
+  const client = new BedrockRuntimeClient({
+    region: process.env.BEDROCK_AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY,
+    },
+  });
+
+  return client;
+};
+
+test("Test BedrockCohereEmbeddings.embedQuery", async () => {
+  const client = getClient();
+  const embeddings = new BedrockCohereEmbeddings({
+    maxRetries: 1,
+    client,
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  // console.log(res);
+  expect(typeof res[0]).toBe("number");
+});
+
+test("Test BedrockCohereEmbeddings.embedDocuments with passed region and credentials", async () => {
+  const client = getClient();
+  const embeddings = new BedrockCohereEmbeddings({
+    maxRetries: 1,
+    client,
+  });
+  const res = await embeddings.embedDocuments([
+    "Hello world",
+    "Bye bye",
+    "we need",
+    "at least",
+    "six documents",
+    "to test pagination",
+  ]);
+  // console.log(res);
+  expect(res).toHaveLength(6);
+  res.forEach((r) => {
+    expect(typeof r[0]).toBe("number");
+  });
+});
+
+test("Test BedrockCohereEmbeddings end to end with HNSWLib", async () => {
+  const client = getClient();
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }],
+    new BedrockCohereEmbeddings({
+      maxRetries: 1,
+      client,
+    })
+  );
+  expect(vectorStore.index?.getCurrentCount()).toBe(3);
+
+  const resultOne = await vectorStore.similaritySearch("hello world", 1);
+  const resultOneMetadatas = resultOne.map(({ metadata }) => metadata);
+  expect(resultOneMetadatas).toEqual([{ id: 2 }]);
+
+  const resultTwo = await vectorStore.similaritySearch("hello world", 2);
+  const resultTwoMetadatas = resultTwo.map(({ metadata }) => metadata);
+  expect(resultTwoMetadatas).toEqual([{ id: 2 }, { id: 3 }]);
+
+  const resultThree = await vectorStore.similaritySearch("hello world", 3);
+  const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
+  expect(resultThreeMetadatas).toEqual([{ id: 2 }, { id: 3 }, { id: 1 }]);
+});


### PR DESCRIPTION
- Adds BedrockCohereEmbeddings class and associated tests, adds async keyword to BedrockEmbeddings.embedQuery function - Code credits to @ BrianErikson (Most of the application code comes from their thread [here](https://github.com/langchain-ai/langchainjs/issues/3315#issuecomment-1821857715)). Some notes about the chosen design.
  - Consciously chose not to add conditions (to support Cohere embeddings) within the BedrockEmbeddings class to avoid making it brittle and unreadable.
  - Avoided extending the `BedrockEmbeddings` class in the `BedrockCohereEmbeddings` class since it'll have access to the protected `_embedText` function, which has no meaning in the context of the `BedrockCohereEmbeddings` class
- Adds missing async keyword BedrockEmbeddings.embedQuery function

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
