### PR TITLE
community[patch]: AstraDB: add option to skip create collection call

### DIFF
--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -88,7 +88,9 @@ export class AstraDBVectorStore extends VectorStore {
     this.caller = new AsyncCaller(callerArgs);
     this.skipCollectionProvisioning = skipCollectionProvisioning ?? false;
     if (this.skipCollectionProvisioning && this.collectionOptions) {
-      throw new Error("If 'skipCollectionProvisioning' has been set to true, 'collectionOptions' must not be defined");
+      throw new Error(
+        "If 'skipCollectionProvisioning' has been set to true, 'collectionOptions' must not be defined"
+      );
     }
   }
 
@@ -102,7 +104,7 @@ export class AstraDBVectorStore extends VectorStore {
     if (!this.skipCollectionProvisioning) {
       await this.astraDBClient.createCollection(
         this.collectionName,
-        this.collectionOptions,
+        this.collectionOptions
       );
     }
     this.collection = await this.astraDBClient.collection(this.collectionName);
@@ -119,7 +121,7 @@ export class AstraDBVectorStore extends VectorStore {
   async addVectors(
     vectors: number[][],
     documents: Document[],
-    options?: string[],
+    options?: string[]
   ) {
     if (!this.collection) {
       throw new Error("Must connect to a collection before adding vectors");
@@ -134,7 +136,7 @@ export class AstraDBVectorStore extends VectorStore {
 
     const chunkedDocs = chunkArray(docs, this.batchSize);
     const batchCalls = chunkedDocs.map((chunk) =>
-      this.caller.call(async () => this.collection?.insertMany(chunk)),
+      this.caller.call(async () => this.collection?.insertMany(chunk))
     );
 
     await Promise.all(batchCalls);
@@ -155,7 +157,7 @@ export class AstraDBVectorStore extends VectorStore {
     return this.addVectors(
       await this.embeddings.embedDocuments(documents.map((d) => d.pageContent)),
       documents,
-      options,
+      options
     );
   }
 
@@ -189,7 +191,7 @@ export class AstraDBVectorStore extends VectorStore {
   async similaritySearchVectorWithScore(
     query: number[],
     k: number,
-    filter?: CollectionFilter,
+    filter?: CollectionFilter
   ): Promise<[Document, number][]> {
     if (!this.collection) {
       throw new Error("Must connect to a collection before adding vectors");
@@ -235,7 +237,7 @@ export class AstraDBVectorStore extends VectorStore {
    */
   async maxMarginalRelevanceSearch(
     query: string,
-    options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>,
+    options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>
   ): Promise<Document[]> {
     if (!this.collection) {
       throw new Error("Must connect to a collection before adding vectors");
@@ -251,14 +253,14 @@ export class AstraDBVectorStore extends VectorStore {
 
     const results = (await cursor.toArray()) ?? [];
     const embeddingList: number[][] = results.map(
-      (row) => row.$vector as number[],
+      (row) => row.$vector as number[]
     );
 
     const mmrIndexes = maximalMarginalRelevance(
       queryEmbedding,
       embeddingList,
       options.lambda,
-      options.k,
+      options.k
     );
 
     const topMmrMatches = mmrIndexes.map((idx) => results[idx]);
@@ -291,7 +293,7 @@ export class AstraDBVectorStore extends VectorStore {
     texts: string[],
     metadatas: object[] | object,
     embeddings: EmbeddingsInterface,
-    dbConfig: AstraLibArgs,
+    dbConfig: AstraLibArgs
   ): Promise<AstraDBVectorStore> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -316,7 +318,7 @@ export class AstraDBVectorStore extends VectorStore {
   static async fromDocuments(
     docs: Document[],
     embeddings: EmbeddingsInterface,
-    dbConfig: AstraLibArgs,
+    dbConfig: AstraLibArgs
   ): Promise<AstraDBVectorStore> {
     const instance = new this(embeddings, dbConfig);
     await instance.initialize();
@@ -334,7 +336,7 @@ export class AstraDBVectorStore extends VectorStore {
    */
   static async fromExistingIndex(
     embeddings: EmbeddingsInterface,
-    dbConfig: AstraLibArgs,
+    dbConfig: AstraLibArgs
   ): Promise<AstraDBVectorStore> {
     const instance = new this(embeddings, dbConfig);
 

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -165,4 +165,33 @@ describe.skip("AstraDBVectorStore", () => {
       );
     }
   }, 60000);
+
+  test("skipCollectionProvisioning", async () => {
+    let store = new AstraDBVectorStore(new FakeEmbeddings(), {
+      ...astraConfig,
+      skipCollectionProvisioning: true,
+      collectionOptions: undefined,
+    });
+    await store.initialize();
+    try {
+      await store.similaritySearch("test");
+      fail("Should have thrown error");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      expect(e.message).toContain("'default_keyspace.langchain_test'");
+    }
+    store = new AstraDBVectorStore(new FakeEmbeddings(), {
+      ...astraConfig,
+      skipCollectionProvisioning: false,
+      collectionOptions: {
+        checkExists: false,
+        vector: {
+          dimension: 4,
+          metric: "cosine",
+        },
+      },
+    });
+    await store.initialize();
+    await store.similaritySearch("test");
+  });
 });


### PR DESCRIPTION
While using AstraDB there are cases whereas the collection already exists and you don't want to store to try to initialize it. For example, you might have read only permission and trying to create the collection will give you 403

Add boolean flag `skipCollectionProvisioning` to just assume the collection is already there with the correct settings.