### PR TITLE
community[patch]: refactor: configurable payload keys in  Qdrant vectorstore

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/qdrant.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/qdrant.mdx
@@ -6,10 +6,6 @@ sidebar_class_name: node-only
 
 [Qdrant](https://qdrant.tech/) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage points - vectors with an additional payload.
 
-:::tip Compatibility
-Only available on Node.js.
-:::
-
 ## Setup
 
 1. Run a Qdrant instance with Docker on your computer by following the [Qdrant setup instructions](https://qdrant.tech/documentation/install/).


### PR DESCRIPTION
## Description

This PR intends to make the keys used to store documents and metadata in Qdrant configurable.

## Why?

Since LangchainPy uses differently named keys, the 2 are currently not interoperable.

The default values maintain backward compatibility.

## Related issues

Effort to resolve https://github.com/langchain-ai/langchainjs/issues/2408.