### PR TITLE
community[patch]: ensure AstraDB createCollectionOptions are aligned with py version

### DIFF
--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -81,16 +81,7 @@ export class AstraDBVectorStore extends VectorStore {
     const dataAPIClient = new DataAPIClient(token, { caller: ["langchainjs"] });
     this.astraDBClient = dataAPIClient.db(endpoint, { namespace });
     this.collectionName = collection;
-    this.collectionOptions = collectionOptions;
-    if (
-      !this.collectionOptions ||
-      this.collectionOptions.checkExists === undefined
-    ) {
-      this.collectionOptions = {
-        checkExists: false,
-        ...(this.collectionOptions || {}),
-      };
-    }
+    this.collectionOptions = AstraDBVectorStore.applyCollectionOptionsDefaults(collectionOptions);
     this.idKey = idKey ?? "_id";
     this.contentKey = contentKey ?? "text";
     this.batchSize = batchSize && batchSize <= 20 ? batchSize : 20;
@@ -101,6 +92,19 @@ export class AstraDBVectorStore extends VectorStore {
         "If 'skipCollectionProvisioning' has been set to true, 'collectionOptions' must not be defined"
       );
     }
+  }
+
+  private static applyCollectionOptionsDefaults(fromUser?: CreateCollectionOptions<any>): CreateCollectionOptions<any> {
+    const copy: CreateCollectionOptions<any> = fromUser ? {...fromUser} : {};
+    if (copy.checkExists === undefined) {
+      copy.checkExists = false;
+    }
+    if (copy.indexing === undefined) {
+      // same default as langchain python AstraDBVectorStore.
+      // this enables to create the collection in python/ts and use it in ts/python with default options.
+      copy.indexing = {allow: ["metadata"]}
+    }
+    return copy
   }
 
   /**

--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -87,24 +87,27 @@ export class AstraDBVectorStore extends VectorStore {
       );
     }
     this.collectionName = collection;
-    this.collectionOptions = AstraDBVectorStore.applyCollectionOptionsDefaults(collectionOptions);
+    this.collectionOptions =
+      AstraDBVectorStore.applyCollectionOptionsDefaults(collectionOptions);
     this.idKey = idKey ?? "_id";
     this.contentKey = contentKey ?? "text";
     this.batchSize = batchSize && batchSize <= 20 ? batchSize : 20;
     this.caller = new AsyncCaller(callerArgs);
   }
 
-  private static applyCollectionOptionsDefaults(fromUser?: CreateCollectionOptions<any>): CreateCollectionOptions<any> {
-    const copy: CreateCollectionOptions<any> = fromUser ? {...fromUser} : {};
+  private static applyCollectionOptionsDefaults(
+    fromUser?: CreateCollectionOptions<any>
+  ): CreateCollectionOptions<any> {
+    const copy: CreateCollectionOptions<any> = fromUser ? { ...fromUser } : {};
     if (copy.checkExists === undefined) {
       copy.checkExists = false;
     }
     if (copy.indexing === undefined) {
       // same default as langchain python AstraDBVectorStore.
       // this enables to create the collection in python/ts and use it in ts/python with default options.
-      copy.indexing = {allow: ["metadata"]}
+      copy.indexing = { allow: ["metadata"] };
     }
-    return copy
+    return copy;
   }
 
   /**

--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -80,18 +80,18 @@ export class AstraDBVectorStore extends VectorStore {
     } = args;
     const dataAPIClient = new DataAPIClient(token, { caller: ["langchainjs"] });
     this.astraDBClient = dataAPIClient.db(endpoint, { namespace });
+    this.skipCollectionProvisioning = skipCollectionProvisioning ?? false;
+    if (this.skipCollectionProvisioning && collectionOptions) {
+      throw new Error(
+        "If 'skipCollectionProvisioning' has been set to true, 'collectionOptions' must not be defined"
+      );
+    }
     this.collectionName = collection;
     this.collectionOptions = AstraDBVectorStore.applyCollectionOptionsDefaults(collectionOptions);
     this.idKey = idKey ?? "_id";
     this.contentKey = contentKey ?? "text";
     this.batchSize = batchSize && batchSize <= 20 ? batchSize : 20;
     this.caller = new AsyncCaller(callerArgs);
-    this.skipCollectionProvisioning = skipCollectionProvisioning ?? false;
-    if (this.skipCollectionProvisioning && this.collectionOptions) {
-      throw new Error(
-        "If 'skipCollectionProvisioning' has been set to true, 'collectionOptions' must not be defined"
-      );
-    }
   }
 
   private static applyCollectionOptionsDefaults(fromUser?: CreateCollectionOptions<any>): CreateCollectionOptions<any> {


### PR DESCRIPTION
Same indexing default as python langchain.
Also fixes a rebase issue after https://github.com/langchain-ai/langchainjs/pull/5170 and https://github.com/langchain-ai/langchainjs/pull/5142