### PR TITLE
docs[patch]: Add missing "s" to end of word

### DIFF
--- a/docs/core_docs/docs/get_started/quickstart.mdx
+++ b/docs/core_docs/docs/get_started/quickstart.mdx
@@ -39,7 +39,7 @@ export LANGCHAIN_API_KEY="..."
 
 ## Building with LangChain
 
-LangChain enables building application that connect external sources of data and computation to LLMs.
+LangChain enables building applications that connect external sources of data and computation to LLMs.
 
 In this quickstart, we will walk through a few different ways of doing that:
 


### PR DESCRIPTION
I noticed a missing "s" at the end of "application" in the sentence where it looks to be meant to be plural. Thought I'd submit a quick PR to fix it.

Thanks!