### PR TITLE
core[patch]: Export `mergeConfigs()`

### DIFF
--- a/langchain-core/src/runnables/index.ts
+++ b/langchain-core/src/runnables/index.ts
@@ -26,6 +26,7 @@ export {
   getCallbackManagerForConfig,
   patchConfig,
   ensureConfig,
+  mergeConfigs,
 } from "./config.js";
 export { RunnablePassthrough } from "./passthrough.js";
 export { type RouterInput, RouterRunnable } from "./router.js";


### PR DESCRIPTION
This matches the Python implementation and is needed to implement `RunnableCallable` in LangGraphJS.

Python implementation of `RunnableCallable`: https://github.com/langchain-ai/langgraph/blob/main/langgraph/utils.py#L5