### PR TITLE
docs: fix code snippet in retrievers/vectorstore article

### DIFF
--- a/docs/core_docs/docs/modules/data_connection/retrievers/vectorstore.mdx
+++ b/docs/core_docs/docs/modules/data_connection/retrievers/vectorstore.mdx
@@ -36,7 +36,7 @@ const docs = await textSplitter.createDocuments([text]);
 const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
 
 // Initialize a retriever wrapper around the vector store
-const vectorStoreRetriever = vectorStore.asRetriever();
+const retriever = vectorStore.asRetriever();
 
 const docs = await retriever.getRelevantDocuments(
   "what did he say about ketanji brown jackson"


### PR DESCRIPTION
This update fixes the variable name in a code snippet located at https://js.langchain.com/docs/modules/data_connection/retrievers/vectorstore.