### PR TITLE
azure-openai[patch]: fix only first embedding generated when batching enabled

### DIFF
--- a/libs/langchain-azure-openai/src/embeddings.ts
+++ b/libs/langchain-azure-openai/src/embeddings.ts
@@ -135,18 +135,18 @@ export class AzureOpenAIEmbeddings
 
     const batchRequests = batches.map((batch) => this.getEmbeddings(batch));
     const embeddings = await Promise.all(batchRequests);
-
-    return embeddings;
+    return embeddings.flat(1);
   }
 
   async embedQuery(document: string): Promise<number[]> {
     const input = [
       this.stripNewLines ? document.replace(/\n/g, " ") : document,
     ];
-    return this.getEmbeddings(input);
+    const embeddings = await this.getEmbeddings(input);
+    return embeddings[0];
   }
 
-  private async getEmbeddings(input: string[]) {
+  private async getEmbeddings(input: string[]): Promise<number[][]> {
     const deploymentName = this.azureOpenAIApiDeploymentName || this.model;
 
     const res = await this.caller.call(() =>
@@ -159,6 +159,6 @@ export class AzureOpenAIEmbeddings
       })
     );
 
-    return res.data[0].embedding;
+    return res.data.map((data) => data.embedding);
   }
 }

--- a/libs/langchain-azure-openai/src/embeddings.ts
+++ b/libs/langchain-azure-openai/src/embeddings.ts
@@ -135,7 +135,7 @@ export class AzureOpenAIEmbeddings
 
     const batchRequests = batches.map((batch) => this.getEmbeddings(batch));
     const embeddings = await Promise.all(batchRequests);
-    return embeddings.flat(1);
+    return embeddings.flat();
   }
 
   async embedQuery(document: string): Promise<number[]> {
@@ -143,7 +143,7 @@ export class AzureOpenAIEmbeddings
       this.stripNewLines ? document.replace(/\n/g, " ") : document,
     ];
     const embeddings = await this.getEmbeddings(input);
-    return embeddings[0];
+    return embeddings.flat()
   }
 
   private async getEmbeddings(input: string[]): Promise<number[][]> {

--- a/libs/langchain-azure-openai/src/embeddings.ts
+++ b/libs/langchain-azure-openai/src/embeddings.ts
@@ -143,7 +143,7 @@ export class AzureOpenAIEmbeddings
       this.stripNewLines ? document.replace(/\n/g, " ") : document,
     ];
     const embeddings = await this.getEmbeddings(input);
-    return embeddings.flat()
+    return embeddings.flat();
   }
 
   private async getEmbeddings(input: string[]): Promise<number[][]> {

--- a/libs/langchain-azure-openai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-azure-openai/src/tests/embeddings.int.test.ts
@@ -18,6 +18,16 @@ test("Test OpenAIEmbeddings.embedDocuments", async () => {
   expect(typeof res[1][0]).toBe("number");
 });
 
+test("Test OpenAIEmbeddings.embedDocuments batching", async () => {
+  const embeddings = new AzureOpenAIEmbeddings({
+    batchSize: 16,
+  });
+  const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
+  expect(res).toHaveLength(2);
+  expect(typeof res[0][0]).toBe("number");
+  expect(typeof res[1][0]).toBe("number");
+});
+
 test("Test OpenAIEmbeddings concurrency", async () => {
   const embeddings = new AzureOpenAIEmbeddings({
     batchSize: 1,


### PR DESCRIPTION
When batching is enabled, only the first embedding for the batch was generated. This PR fixes that.
