### PR TITLE
Fix unclear S3Loader error message

### DIFF
--- a/langchain/src/document_loaders/web/s3.ts
+++ b/langchain/src/document_loaders/web/s3.ts
@@ -159,9 +159,9 @@ export class S3Loader extends BaseDocumentLoader {
       const docs = await unstructuredLoader.load();
 
       return docs;
-    } catch {
+    } catch (e: any) {
       throw new Error(
-        `Failed to load file ${filePath} using unstructured loader.`
+        `Failed to load file ${filePath} using unstructured loader: ${e.message}`
       );
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #5253 

The S3Loader return an unclear error message when trying to load an S3 object without a file type. This PR fixes that.
