### PR TITLE
community[patch]: fix Azure AI search delete and improve documentation 

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
@@ -38,7 +38,7 @@ Note that semantic ranking capabilities is only available in the Basic and highe
 
 You can read more about using semantic ranking performance with hybrid search in [this blog post](https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/azure-cognitive-search-outperforming-vector-search-with-hybrid/ba-p/3929167).
 
-## Example
+## Example: index docs, vector search and LLM integration
 
 Below is an example that indexes documents from a file in Azure AI Search, runs a hybrid search query, and finally uses a chain to answer a question in natural language based on the retrieved documents.
 

--- a/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
@@ -33,10 +33,10 @@ Hybrid search is a feature that combines the strengths of full text search and v
 
 You can read more about hybrid search and how it may improve your search results in the [official documentation](https://learn.microsoft.com/azure/search/hybrid-search-overview).
 
-In some scenarios like retrieval-augmented generation, you may want to enable **semantic ranking** in addition to hybrid search to improve the relevance of the search results. You can enable semantic ranking by setting the `search.type` property to `AzureAISearchQueryType.SemanticHybrid` when creating the vector store.
-Note that semantic ranking capabilities is only available in the Basic and higher pricing tier, and subject to [regional availability](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=search).
+In some scenarios like retrieval-augmented generation (RAG), you may want to enable **semantic ranking** in addition to hybrid search to improve the relevance of the search results. You can enable semantic ranking by setting the `search.type` property to `AzureAISearchQueryType.SemanticHybrid` when creating the vector store.
+Note that semantic ranking capabilities are only available in the Basic and higher pricing tiers, and subject to [regional availability](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=search).
 
-You can read more about using semantic ranking performance with hybrid search in [this blog post](https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/azure-cognitive-search-outperforming-vector-search-with-hybrid/ba-p/3929167).
+You can read more about the performance of using semantic ranking with hybrid search in [this blog post](https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/azure-cognitive-search-outperforming-vector-search-with-hybrid/ba-p/3929167).
 
 ## Example: index docs, vector search and LLM integration
 

--- a/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_aisearch.mdx
@@ -27,7 +27,18 @@ import EnvVars from "@examples/indexes/vector_stores/azure_aisearch/.env.example
 
 <CodeBlock language="text">{EnvVars}</CodeBlock>
 
-## Example: index docs, vector search and LLM integration
+## About hybrid search
+
+Hybrid search is a feature that combines the strengths of full text search and vector search to provide the best ranking performance. It's enabled by default in Azure AI Search vector stores, but you can select a different search query type by setting the `search.type` property when creating the vector store.
+
+You can read more about hybrid search and how it may improve your search results in the [official documentation](https://learn.microsoft.com/azure/search/hybrid-search-overview).
+
+In some scenarios like retrieval-augmented generation, you may want to enable **semantic ranking** in addition to hybrid search to improve the relevance of the search results. You can enable semantic ranking by setting the `search.type` property to `AzureAISearchQueryType.SemanticHybrid` when creating the vector store.
+Note that semantic ranking capabilities is only available in the Basic and higher pricing tier, and subject to [regional availability](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=search).
+
+You can read more about using semantic ranking performance with hybrid search in [this blog post](https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/azure-cognitive-search-outperforming-vector-search-with-hybrid/ba-p/3929167).
+
+## Example
 
 Below is an example that indexes documents from a file in Azure AI Search, runs a hybrid search query, and finally uses a chain to answer a question in natural language based on the retrieved documents.
 

--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -369,7 +369,8 @@ export class AzureAISearchVectorStore extends VectorStore {
     k = 4,
     filter: this["FilterType"] | undefined = undefined
   ): Promise<[Document, number][]> {
-    const searchType = this.options.type ?? AzureAISearchQueryType.SimilarityHybrid;
+    const searchType =
+      this.options.type ?? AzureAISearchQueryType.SimilarityHybrid;
 
     if (searchType === AzureAISearchQueryType.Similarity) {
       return this.similaritySearchVectorWithScore(

--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -358,7 +358,7 @@ export class AzureAISearchVectorStore extends VectorStore {
 
   /**
    * Performs a similarity search using query type specified in configuration.
-   * If the query type is not specified, it defaults to similarity search.
+   * If the query type is not specified, it defaults to similarity hybrid search.
    * @param query Query text for the similarity search.
    * @param k=4 Number of nearest neighbors to return.
    * @param filter Optional filter options for the documents.
@@ -369,7 +369,7 @@ export class AzureAISearchVectorStore extends VectorStore {
     k = 4,
     filter: this["FilterType"] | undefined = undefined
   ): Promise<[Document, number][]> {
-    const searchType = this.options.type ?? AzureAISearchQueryType.Similarity;
+    const searchType = this.options.type ?? AzureAISearchQueryType.SimilarityHybrid;
 
     if (searchType === AzureAISearchQueryType.Similarity) {
       return this.similaritySearchVectorWithScore(

--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -192,6 +192,9 @@ export class AzureAISearchVectorStore extends VectorStore {
         `Azure AI Search delete requires either "ids" or "filter" to be set in the params object`
       );
     }
+
+    await this.initPromise;
+
     if (params.ids) {
       await this.deleteById(params.ids);
     }
@@ -251,8 +254,6 @@ export class AzureAISearchVectorStore extends VectorStore {
    * @returns A promise that resolves when the documents have been removed.
    */
   private async deleteById(ids: string | string[]): Promise<IndexingResult[]> {
-    await this.initPromise;
-
     const docsIds = Array.isArray(ids) ? ids : [ids];
     const docs: { id: string }[] = docsIds.map((id) => ({ id }));
 


### PR DESCRIPTION
This PRs includes the following changes:
- Fix missing `await initPromise` when doing a delete with filter, causing race conditions
- Set default search mode to hybrid to improve search results relevance
- Add documentation on hybrid search and semantic ranking