### PR TITLE
Send document.metadata to AzureAISearch in addVectors()

### DIFF
--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -314,6 +314,7 @@ export class AzureAISearchVectorStore extends VectorStore {
       metadata: {
         source: doc.metadata?.source,
         attributes: doc.metadata?.attributes ?? [],
+        ...doc.metadata,
       },
     }));
 


### PR DESCRIPTION
Fixes the issue with `document.metadata` not being sent to Azure AI Search when using `AzureAISearchVectorStore.fromDocuments()`. 
`AzureAISearchVectorStore.fromDocuments()` accepts `Document[]` as argument which has a parameter `document.metadata`, but internally this value is not passed to `AzureAISearchVectorStore.addVectors()` and it could be confusing to the users. 