### PR TITLE
core: Avoid out-of-order runs by appending numeric execution order to…

### DIFF
--- a/langchain-core/src/tracers/base.ts
+++ b/langchain-core/src/tracers/base.ts
@@ -47,10 +47,16 @@ function stripNonAlphanumeric(input: string) {
   return input.replace(/[-:.]/g, "");
 }
 
-function convertToDottedOrderFormat(epoch: number, runId: string) {
+function convertToDottedOrderFormat(
+  epoch: number,
+  runId: string,
+  executionOrder: number
+) {
+  const paddedOrder = executionOrder.toFixed(0).slice(0, 3).padStart(3, "0");
   return (
-    stripNonAlphanumeric(`${new Date(epoch).toISOString().slice(0, -1)}000Z`) +
-    runId
+    stripNonAlphanumeric(
+      `${new Date(epoch).toISOString().slice(0, -1)}${paddedOrder}Z`
+    ) + runId
   );
 }
 
@@ -87,7 +93,8 @@ export abstract class BaseTracer extends BaseCallbackHandler {
   protected async _startTrace(run: Run) {
     const currentDottedOrder = convertToDottedOrderFormat(
       run.start_time,
-      run.id
+      run.id,
+      run.execution_order
     );
     const storedRun = { ...run };
     if (storedRun.parent_run_id !== undefined) {

--- a/langchain-core/src/tracers/tests/tracer.test.ts
+++ b/langchain-core/src/tracers/tests/tracer.test.ts
@@ -48,7 +48,7 @@ test("Test LLMRun", async () => {
     child_runs: [],
     extra: {},
     tags: [],
-    dotted_order: `20210503T000000000000Z${runId}`,
+    dotted_order: `20210503T000000000001Z${runId}`,
     trace_id: runId,
   };
   expect(run).toEqual(compareRun);
@@ -70,7 +70,7 @@ test("Test Chat Model Run", async () => {
     {
       "child_execution_order": 1,
       "child_runs": [],
-      "dotted_order": "20210503T000000000000Z${runId}",
+      "dotted_order": "20210503T000000000001Z${runId}",
       "end_time": 1620000000000,
       "events": [
         {
@@ -162,7 +162,7 @@ test("Test Chain Run", async () => {
     child_runs: [],
     extra: {},
     tags: [],
-    dotted_order: `20210503T000000000000Z${runId}`,
+    dotted_order: `20210503T000000000001Z${runId}`,
     trace_id: runId,
   };
   await tracer.handleChainStart(serialized, { foo: "bar" }, runId);
@@ -199,7 +199,7 @@ test("Test Tool Run", async () => {
     child_runs: [],
     extra: {},
     tags: [],
-    dotted_order: `20210503T000000000000Z${runId}`,
+    dotted_order: `20210503T000000000001Z${runId}`,
     trace_id: runId,
   };
   await tracer.handleToolStart(serialized, "test", runId);
@@ -240,7 +240,7 @@ test("Test Retriever Run", async () => {
     child_runs: [],
     extra: {},
     tags: [],
-    dotted_order: `20210503T000000000000Z${runId}`,
+    dotted_order: `20210503T000000000001Z${runId}`,
     trace_id: runId,
   };
 
@@ -314,7 +314,7 @@ test("Test nested runs", async () => {
             child_runs: [],
             extra: {},
             tags: [],
-            dotted_order: `20210503T000000000000Z${chainRunId}.20210503T000000000000Z${toolRunId}.20210503T000000000000Z${llmRunId}`,
+            dotted_order: `20210503T000000000001Z${chainRunId}.20210503T000000000002Z${toolRunId}.20210503T000000000003Z${llmRunId}`,
             trace_id: chainRunId,
           },
         ],
@@ -338,7 +338,7 @@ test("Test nested runs", async () => {
         run_type: "tool",
         extra: {},
         tags: [],
-        dotted_order: `20210503T000000000000Z${chainRunId}.20210503T000000000000Z${toolRunId}`,
+        dotted_order: `20210503T000000000001Z${chainRunId}.20210503T000000000002Z${toolRunId}`,
         trace_id: chainRunId,
       },
       {
@@ -368,7 +368,7 @@ test("Test nested runs", async () => {
         child_runs: [],
         extra: {},
         tags: [],
-        dotted_order: `20210503T000000000000Z${chainRunId}.20210503T000000000000Z${llmRunId2}`,
+        dotted_order: `20210503T000000000001Z${chainRunId}.20210503T000000000004Z${llmRunId2}`,
         trace_id: chainRunId,
       },
     ],
@@ -399,7 +399,7 @@ test("Test nested runs", async () => {
     extra: {},
     tags: [],
     parent_run_id: undefined,
-    dotted_order: `20210503T000000000000Z${chainRunId}`,
+    dotted_order: `20210503T000000000001Z${chainRunId}`,
     trace_id: chainRunId,
   };
   expect(tracer.runs.length).toBe(1);


### PR DESCRIPTION
… ms precision timestamp in dotted order construction

This works around date constructor in js having only millisecond precision



