### PR TITLE
Add missing a comma to FirestoreChatMessageHistory example

### DIFF
--- a/docs/core_docs/docs/integrations/chat_memory/firestore.mdx
+++ b/docs/core_docs/docs/integrations/chat_memory/firestore.mdx
@@ -36,7 +36,7 @@ import admin from "firebase-admin";
 
 const messageHistory = new FirestoreChatMessageHistory({
   collections: ["chats"],
-  docs: ["user-id"]
+  docs: ["user-id"],
   sessionId: "user-id",
   userId: "a@example.com",
   config: {


### PR DESCRIPTION
In the example, the `FirestoreChatMessageHistory` configuration object has a missing comma after `docs: ["user-id"]`

This commit updates the config example. 

```
const messageHistory = new FirestoreChatMessageHistory({
  collections: ["chats"],
  docs: ["user-id"],
  sessionId: "user-id",
  userId: "a@example.com",
  config: {
    projectId: "YOUR-PROJECT-ID",
    credential: admin.credential.cert({
      projectId: "YOUR-PROJECT-ID",
      privateKey:
        "-----BEGIN PRIVATE KEY-----\nCHANGE-ME\n-----END PRIVATE KEY-----\n",
      clientEmail: "CHANGE-ME@CHANGE-ME-TOO.iam.gserviceaccount.com",
    }),
  },
});
```

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
