### PR TITLE
fix(doc):  Firecrawl package issue

### DIFF
--- a/docs/core_docs/docs/integrations/document_loaders/web_loaders/firecrawl.mdx
+++ b/docs/core_docs/docs/integrations/document_loaders/web_loaders/firecrawl.mdx
@@ -28,7 +28,7 @@ import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/document_loaders/firecrawl.ts";
 
 ```bash npm2yarn
-npm install @mendableai/firecrawl-js
+npm install @mendable/firecrawl-js
 ```
 
 <CodeBlock language="typescript">{Example}</CodeBlock>


### PR DESCRIPTION
Replace the wrong firecrawl npm package with the correct one.
`npm install @mendableai/firecrawl-js (incorrect)`
`npm install @mendable/firecrawl-js (correct)`