### PR TITLE
docs: disable contextual search

### DIFF
--- a/docs/core_docs/docusaurus.config.js
+++ b/docs/core_docs/docusaurus.config.js
@@ -290,7 +290,7 @@ const config = {
 
         indexName: "js-langchain-0.2",
 
-        contextualSearch: true,
+        contextualSearch: false,
       },
     }),
 


### PR DESCRIPTION
Fixes search on the 0.2 index