### PR TITLE
anthropic[patch]: Run formatting

### DIFF
--- a/libs/langchain-anthropic/src/load/import_map.ts
+++ b/libs/langchain-anthropic/src/load/import_map.ts
@@ -2,5 +2,3 @@
 
 export * as index from "../index.js";
 export * as experimental from "../experimental/index.js";
-
-


### PR DESCRIPTION
Missing formatting. Build script seems to be adding extra newlines