### PR TITLE
docs[patch]: fix monorepo typo

### DIFF
--- a/docs/core_docs/docs/contributing/repo_structure.mdx
+++ b/docs/core_docs/docs/contributing/repo_structure.mdx
@@ -7,7 +7,7 @@ sidebar_position: 0.5
 If you plan on contributing to LangChain code or documentation, it can be useful
 to understand the high level structure of the repository.
 
-LangChain is organized as a [monorep](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.
+LangChain is organized as a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.
 
 Here's the structure visualized as a tree:
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
fix monorepo typo. `monorep` -> `monorepo`