### PR TITLE
docs[minor]: Hide prev/next buttons on how to and tutorials

### DIFF
--- a/docs/core_docs/src/theme/DocPaginator/index.js
+++ b/docs/core_docs/src/theme/DocPaginator/index.js
@@ -1,21 +1,17 @@
-import React from 'react';
-import DocPaginator from '@theme-original/DocPaginator';
+import React from "react";
+import DocPaginator from "@theme-original/DocPaginator";
 
-const BLACKLISTED_PATHS = ["/docs/how_to/", "/docs/tutorials/"]
+const BLACKLISTED_PATHS = ["/docs/how_to/", "/docs/tutorials/"];
 
 export default function DocPaginatorWrapper(props) {
   const [shouldHide, setShouldHide] = React.useState(false);
 
   React.useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === "undefined") return;
     const currentPath = window.location.pathname;
-    if (BLACKLISTED_PATHS.some(path => currentPath.includes(path))) {
+    if (BLACKLISTED_PATHS.some((path) => currentPath.includes(path))) {
       setShouldHide(true);
     }
-  }, [])
-  return (
-    <>
-      {shouldHide ? null : <DocPaginator {...props} />}
-    </>
-  );
+  }, []);
+  return <>{shouldHide ? null : <DocPaginator {...props} />}</>;
 }

--- a/docs/core_docs/src/theme/DocPaginator/index.js
+++ b/docs/core_docs/src/theme/DocPaginator/index.js
@@ -13,5 +13,10 @@ export default function DocPaginatorWrapper(props) {
       setShouldHide(true);
     }
   }, []);
-  return <>{shouldHide ? null : <DocPaginator {...props} />}</>;
+
+  if (!shouldHide) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <DocPaginator {...props} />;
+  }
+  return null;
 }

--- a/docs/core_docs/src/theme/DocPaginator/index.js
+++ b/docs/core_docs/src/theme/DocPaginator/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import DocPaginator from '@theme-original/DocPaginator';
+
+const BLACKLISTED_PATHS = ["/docs/how_to/", "/docs/tutorials/"]
+
+export default function DocPaginatorWrapper(props) {
+  const [shouldHide, setShouldHide] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const currentPath = window.location.pathname;
+    if (BLACKLISTED_PATHS.some(path => currentPath.includes(path))) {
+      setShouldHide(true);
+    }
+  }, [])
+  return (
+    <>
+      {shouldHide ? null : <DocPaginator {...props} />}
+    </>
+  );
+}


### PR DESCRIPTION
Only hide on how to's and tutorials. Other pages appear to work just fine