### PR TITLE
add support to set apiVersion in fields so more models can be supported

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -191,7 +191,7 @@ export class ChatGoogleGenerativeAI
 
   apiKey?: string;
 
-  apiVersion?: string = "v1";
+  apiVersion?: string = "v1"; // v1 or v1beta (has more more models)
 
   baseUrl?: string = "https://generativeai.googleapis.com";
 
@@ -277,7 +277,7 @@ export class ChatGoogleGenerativeAI
         },
       },
       {
-        apiVersion: this.apiVersion,
+        apiVersion: fields?.apiVersion ?? this.apiVersion,
         baseUrl: this.baseUrl,
       }
     );


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
add setting api version on google gen ai, so it can support v1 or v1beta which has more models available