### PR TITLE
openai[minor]: Send token usage stats when streaming

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -586,11 +586,11 @@ export class ChatOpenAI<
       stream_options: {
         ...this.invocationParams(options).stream_options,
         include_usage: true,
-      }
+      },
     };
     let defaultRole: OpenAIRoleEnum | undefined;
     const streamIterable = await this.completionWithRetry(params, options);
-    let usage: OpenAIClient.Completions.CompletionUsage | undefined = undefined;
+    let usage: OpenAIClient.Completions.CompletionUsage | undefined;
     for await (const data of streamIterable) {
       const choice = data?.choices[0];
       if (data.usage) {
@@ -642,9 +642,12 @@ export class ChatOpenAI<
     }
     if (usage) {
       const generationChunk = new ChatGenerationChunk({
-        message: new AIMessageChunk({ content: "", response_metadata: {
-          usage,
-        } }),
+        message: new AIMessageChunk({
+          content: "",
+          response_metadata: {
+            usage,
+          },
+        }),
         text: "",
       });
       yield generationChunk;


### PR DESCRIPTION
```typescript
AIMessageChunk {
      content: '',
      additional_kwargs: {},
      response_metadata: {
        usage: { prompt_tokens: 11, completion_tokens: 3, total_tokens: 14 }
      },
      tool_calls: [],
      invalid_tool_calls: [],
      tool_call_chunks: []
}
```
token usage from OpenAI is only included in the final chunk, the example above is what that final chunk will look like from LC streaming

cc @ccurme