### PR TITLE
community[patch]: fix data.usage error because Moonshot sometimes does not return

### DIFF
--- a/libs/langchain-community/src/chat_models/moonshot.ts
+++ b/libs/langchain-community/src/chat_models/moonshot.ts
@@ -355,7 +355,7 @@ export class ChatMoonshot extends BaseChatModel implements ChatMoonshotParams {
       prompt_tokens = 0,
       completion_tokens = 0,
       total_tokens = 0,
-    } = data.usage;
+    } = data.usage ?? {};
 
     const { text } = data.output;
 


### PR DESCRIPTION
Moonshot does not return `data.usage` when `stream` is `true`. So we need to add a default value to avoid errors.