### PR TITLE
mongodb[minor]: add, implement delete method

### DIFF
--- a/libs/langchain-mongodb/src/vectorstores.ts
+++ b/libs/langchain-mongodb/src/vectorstores.ts
@@ -4,6 +4,7 @@ import {
   VectorStore,
 } from "@langchain/core/vectorstores";
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
+import { chunkArray } from "@langchain/core/utils/chunk_array";
 import { Document } from "@langchain/core/documents";
 import { maximalMarginalRelevance } from "@langchain/core/utils/math";
 import {
@@ -262,14 +263,12 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
    *
    * @returns - A promise that resolves when all documents deleted
    */
-  async delete(params: { ids: any[] }): Promise<void> { // eslint-disable-line @typescript-eslint/no-explicit-any
-    const splice = <T>(l: T[], c: number): T[][] =>
-      l.length < c ? [l] : [l.splice(0, c), ...splice<T>(l, c)];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async delete(params: { ids: any[] }): Promise<void> {
     const CHUNK_SIZE = 50;
-    const chunkIds: any[][] = splice(params.ids, CHUNK_SIZE); // eslint-disable-line @typescript-eslint/no-explicit-any
-
+    const chunkIds: any[][] = chunkArray(params.ids, CHUNK_SIZE); // eslint-disable-line @typescript-eslint/no-explicit-any
     for (const chunk of chunkIds)
-      await this.collection.deleteMany({ _id: { $in: chunk }});
+      await this.collection.deleteMany({ _id: { $in: chunk } });
   }
 
   /**

--- a/libs/langchain-mongodb/src/vectorstores.ts
+++ b/libs/langchain-mongodb/src/vectorstores.ts
@@ -1,4 +1,4 @@
-import type { Collection, Document as MongoDBDocument } from "mongodb";
+import { type Collection, type Document as MongoDBDocument } from "mongodb";
 import {
   MaxMarginalRelevanceSearchOptions,
   VectorStore,
@@ -254,6 +254,22 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       }
       return doc;
     });
+  }
+
+  /**
+   * Delete documents from the collection
+   * @param ids - An array of document IDs to be deleted from the collection.
+   *
+   * @returns - A promise that resolves when all documents deleted
+   */
+  async delete(params: { ids: any[] }): Promise<void> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const splice = <T>(l: T[], c: number): T[][] =>
+      l.length < c ? [l] : [l.splice(0, c), ...splice<T>(l, c)];
+    const CHUNK_SIZE = 50;
+    const chunkIds: any[][] = splice(params.ids, CHUNK_SIZE); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    for (const chunk of chunkIds)
+      await this.collection.deleteMany({ _id: { $in: chunk }});
   }
 
   /**


### PR DESCRIPTION
Method `delete` was missing in `MongoDBAtlasVectorSearch` class and it's needed if `incremental` _indexing_ strategy is used.

Be aware of the `// eslint-disable-line @typescript-eslint/no-explicit-any` as the `$in` operator needs explicitly an `ObjectID` type (as discussed [here](https://www.mongodb.com/community/forums/t/cant-use-string-ids-with-typescript/262793)) instead allowing an _union type_ `string | ObjectId`. The ids coming in are `uuid v4` ids, which don't match `ObjectID` type but it works just fine as a mongodb `_id`.