### PR TITLE
google-common [patch], google-* [tests]: Fix streaming false

### DIFF
--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -254,8 +254,7 @@ export abstract class AbstractGoogleLLMConnection<
   AuthOptions
 > {
   async buildUrlMethodGemini(): Promise<string> {
-    // Vertex AI only handles streamedGenerateContent
-    return "streamGenerateContent";
+    return this.streaming ? "streamGenerateContent" : "generateContent";
   }
 
   async buildUrlMethod(): Promise<string> {

--- a/libs/langchain-google-gauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-gauth/src/tests/chat_models.int.test.ts
@@ -8,7 +8,7 @@ import {
   BaseMessageChunk,
   BaseMessageLike,
   HumanMessage,
-  MessageContentComplex,
+  // MessageContentComplex,
   SystemMessage,
   ToolMessage,
 } from "@langchain/core/messages";
@@ -31,12 +31,22 @@ describe("GAuth Chat", () => {
 
       const aiMessage = res as AIMessageChunk;
       expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
+
+      /*
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
-
       const content = aiMessage.content[0] as MessageContentComplex;
-      expect(typeof content).toBe("string");
-      expect(content).toBe("2");
+      expect(content).toHaveProperty("type");
+      expect(content.type).toEqual("text");
+
+      const textContent = content as MessageContentText;
+      expect(textContent.text).toBeDefined();
+      expect(textContent.text).toEqual("2");
+      */
     } catch (e) {
       console.error(e);
       throw e;

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -131,24 +131,24 @@ describe("GAuth Chat", () => {
 
     const calculatorSchema = z.object({
       operation: z
-        .enum(['add', 'subtract', 'multiply', 'divide'])
-        .describe('The type of operation to execute'),
-      number1: z.number().describe('The first number to operate on.'),
-      number2: z.number().describe('The second number to operate on.'),
+        .enum(["add", "subtract", "multiply", "divide"])
+        .describe("The type of operation to execute"),
+      number1: z.number().describe("The first number to operate on."),
+      number2: z.number().describe("The second number to operate on."),
     });
 
     const model = new ChatVertexAI({
       temperature: 0.7,
-      model: 'gemini-1.0-pro',
+      model: "gemini-1.0-pro",
       callbacks: [handler],
     }).withStructuredOutput(calculatorSchema);
 
-    const response = await model.invoke('What is 1628253239 times 81623836?');
+    const response = await model.invoke("What is 1628253239 times 81623836?");
     expect(response).toHaveProperty("operation");
     expect(response.operation).toEqual("multiply");
     expect(response).toHaveProperty("number1");
     expect(response.number1).toEqual(1628253239);
     expect(response).toHaveProperty("number2");
     expect(response.number2).toEqual(81623836);
-  })
+  });
 });

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -1,4 +1,6 @@
 import { test } from "@jest/globals";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from "zod";
 import { BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import { ChatPromptValue } from "@langchain/core/prompt_values";
 import {
@@ -7,10 +9,11 @@ import {
   BaseMessage,
   BaseMessageChunk,
   HumanMessage,
-  MessageContentComplex,
-  MessageContentText,
+  // MessageContentComplex,
+  // MessageContentText,
   SystemMessage,
 } from "@langchain/core/messages";
+import { ConsoleCallbackHandler } from "@langchain/core/tracers/console";
 import { ChatVertexAI } from "../chat_models.js";
 import { VertexAI } from "../llms.js";
 
@@ -29,9 +32,14 @@ describe("GAuth Chat", () => {
 
       const aiMessage = res as AIMessageChunk;
       expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
+
+      /*
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
-
       const content = aiMessage.content[0] as MessageContentComplex;
       expect(content).toHaveProperty("type");
       expect(content.type).toEqual("text");
@@ -39,6 +47,7 @@ describe("GAuth Chat", () => {
       const textContent = content as MessageContentText;
       expect(textContent.text).toBeDefined();
       expect(textContent.text).toEqual("2");
+      */
     } catch (e) {
       console.error(e);
       throw e;
@@ -62,6 +71,12 @@ describe("GAuth Chat", () => {
 
       const aiMessage = res as AIMessageChunk;
       expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(["H", "T"]).toContainEqual(text);
+
+      /*
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
 
@@ -72,6 +87,7 @@ describe("GAuth Chat", () => {
       const textContent = content as MessageContentText;
       expect(textContent.text).toBeDefined();
       expect(["H", "T"]).toContainEqual(textContent.text);
+      */
     } catch (e) {
       console.error(e);
       throw e;
@@ -109,4 +125,30 @@ describe("GAuth Chat", () => {
       throw e;
     }
   });
+
+  test("structuredOutput", async () => {
+    const handler = new ConsoleCallbackHandler();
+
+    const calculatorSchema = z.object({
+      operation: z
+        .enum(['add', 'subtract', 'multiply', 'divide'])
+        .describe('The type of operation to execute'),
+      number1: z.number().describe('The first number to operate on.'),
+      number2: z.number().describe('The second number to operate on.'),
+    });
+
+    const model = new ChatVertexAI({
+      temperature: 0.7,
+      model: 'gemini-1.0-pro',
+      callbacks: [handler],
+    }).withStructuredOutput(calculatorSchema);
+
+    const response = await model.invoke('What is 1628253239 times 81623836?');
+    expect(response).toHaveProperty("operation");
+    expect(response.operation).toEqual("multiply");
+    expect(response).toHaveProperty("number1");
+    expect(response.number1).toEqual(1628253239);
+    expect(response).toHaveProperty("number2");
+    expect(response.number2).toEqual(81623836);
+  })
 });

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -6,8 +6,8 @@ import {
   BaseMessageChunk,
   BaseMessageLike,
   HumanMessage,
-  MessageContentComplex,
-  MessageContentText,
+  // MessageContentComplex,
+  // MessageContentText,
   SystemMessage,
   ToolMessage,
 } from "@langchain/core/messages";
@@ -253,9 +253,14 @@ describe("Google Webauth Chat", () => {
 
       const aiMessage = res as AIMessageChunk;
       expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
+
+      /*
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
-
       const content = aiMessage.content[0] as MessageContentComplex;
       expect(content).toHaveProperty("type");
       expect(content.type).toEqual("text");
@@ -263,6 +268,7 @@ describe("Google Webauth Chat", () => {
       const textContent = content as MessageContentText;
       expect(textContent.text).toBeDefined();
       expect(textContent.text).toEqual("2");
+      */
     } catch (e) {
       console.error(e);
       throw e;
@@ -286,6 +292,12 @@ describe("Google Webauth Chat", () => {
 
       const aiMessage = res as AIMessageChunk;
       expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(["H", "T"]).toContainEqual(text);
+
+      /*
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
 
@@ -296,6 +308,7 @@ describe("Google Webauth Chat", () => {
       const textContent = content as MessageContentText;
       expect(textContent.text).toBeDefined();
       expect(["H", "T"]).toContainEqual(textContent.text);
+      */
     } catch (e) {
       console.error(e);
       throw e;
@@ -361,8 +374,6 @@ describe("Google Webauth Chat", () => {
     });
     const result = await model.invoke("Run a test on the cobalt project");
     expect(result).toHaveProperty("content");
-    expect(Array.isArray(result.content)).toBeTruthy();
-    expect(result.content).toHaveLength(0);
     const args = result?.lc_kwargs?.additional_kwargs;
     expect(args).toBeDefined();
     expect(args).toHaveProperty("tool_calls");


### PR DESCRIPTION
Fixes #5475 

Not sure where or how, but it looks like we weren't aggregating streamed responses when streaming was false.
Since Vertex AI now supports non-streaming mode, it wasn't necessary anymore anyway. (It used to be.) So updated `AbstractGoogleLLMConnection.buildUrlMethodGemini()` to use the `streaming` setting.

Some of the tests were also failing because they were expecting structured, and not string, responses. No idea when that changed either, but adjusted the tests to handle.

