### PR TITLE
community[patch]: overriding similaritySearchWithScore in neo4j vector store to enable filtering

### DIFF
--- a/libs/langchain-community/src/vectorstores/neo4j_vector.ts
+++ b/libs/langchain-community/src/vectorstores/neo4j_vector.ts
@@ -637,7 +637,11 @@ export class Neo4jVectorStore extends VectorStore {
     return results.map((result) => result[0]);
   }
 
-  async similaritySearchWithScore(query: string, k = 4, params: Record<string, any> = {}): Promise<Document[]> {
+  async similaritySearchWithScore(
+    query: string,
+    k = 4,
+    params: Record<string, any> = {}
+  ): Promise<Document[]> {
     const embedding = await this.embeddings.embedQuery(query);
     return this.similaritySearchVectorWithScore(embedding, k, query, params);
   }

--- a/libs/langchain-community/src/vectorstores/neo4j_vector.ts
+++ b/libs/langchain-community/src/vectorstores/neo4j_vector.ts
@@ -637,6 +637,11 @@ export class Neo4jVectorStore extends VectorStore {
     return results.map((result) => result[0]);
   }
 
+  async similaritySearchWithScore(query: string, k = 4, params: Record<string, any> = {}): Promise<Document[]> {
+    const embedding = await this.embeddings.embedQuery(query);
+    return this.similaritySearchVectorWithScore(embedding, k, query, params);
+  }
+
   async similaritySearchVectorWithScore(
     vector: number[],
     k: number,

--- a/libs/langchain-community/src/vectorstores/neo4j_vector.ts
+++ b/libs/langchain-community/src/vectorstores/neo4j_vector.ts
@@ -641,7 +641,7 @@ export class Neo4jVectorStore extends VectorStore {
     query: string,
     k = 4,
     params: Record<string, any> = {}
-  ): Promise<Document[]> {
+  ): Promise<[Document, number][]> {
     const embedding = await this.embeddings.embedQuery(query);
     return this.similaritySearchVectorWithScore(embedding, k, query, params);
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #5594

Now we can emulate the `similaritySearch` function but also get back the score.
