### PR TITLE
core[patch]: Set global async local storage instance

### DIFF
--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -20,12 +20,15 @@ const mockAsyncLocalStorage = new MockAsyncLocalStorage();
 
 class AsyncLocalStorageProvider {
   getInstance(): AsyncLocalStorageInterface {
-    return (globalThis as any).__lc_async_local_storage ?? mockAsyncLocalStorage;
+    return (
+      (globalThis as any).__lc_tracing_async_local_storage ??
+      mockAsyncLocalStorage
+    );
   }
 
   initializeGlobalInstance(instance: AsyncLocalStorageInterface) {
-    if ((globalThis as any).__lc_async_local_storage === undefined) {
-      (globalThis as any).__lc_async_local_storage = instance;
+    if ((globalThis as any).__lc_tracing_async_local_storage === undefined) {
+      (globalThis as any).__lc_tracing_async_local_storage = instance;
     }
   }
 }

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -20,12 +20,12 @@ const mockAsyncLocalStorage = new MockAsyncLocalStorage();
 
 class AsyncLocalStorageProvider {
   getInstance(): AsyncLocalStorageInterface {
-    return (globalThis as any).__lc_local_storage ?? mockAsyncLocalStorage;
+    return (globalThis as any).__lc_async_local_storage ?? mockAsyncLocalStorage;
   }
 
   initializeGlobalInstance(instance: AsyncLocalStorageInterface) {
-    if ((globalThis as any).__lc_local_storage === undefined) {
-      (globalThis as any).__lc_local_storage = instance;
+    if ((globalThis as any).__lc_async_local_storage === undefined) {
+      (globalThis as any).__lc_async_local_storage = instance;
     }
   }
 }

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -16,20 +16,16 @@ export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
   }
 }
 
+const mockAsyncLocalStorage = new MockAsyncLocalStorage();
+
 class AsyncLocalStorageProvider {
-  private asyncLocalStorage: AsyncLocalStorageInterface =
-    new MockAsyncLocalStorage();
-
-  private hasBeenInitialized = false;
-
   getInstance(): AsyncLocalStorageInterface {
-    return this.asyncLocalStorage;
+    return (globalThis as any).__lc_local_storage ?? mockAsyncLocalStorage;
   }
 
   initializeGlobalInstance(instance: AsyncLocalStorageInterface) {
-    if (!this.hasBeenInitialized) {
-      this.hasBeenInitialized = true;
-      this.asyncLocalStorage = instance;
+    if ((globalThis as any).__lc_local_storage === undefined) {
+      (globalThis as any).__lc_local_storage = instance;
     }
   }
 }


### PR DESCRIPTION
Sets `AsyncLocalStorage` on `globalThis` instead of encapsulating it in a singleton.

This enables a few things:

- Removes some of the need for a reverse peer dependency from LangSmith -> core
- If multiple instances of core get installed (e.g. if someone doesn't set `resolutions` and the package manager makes bad decisions), tracing will still use a single instance.

@dqbd @nfcampos 