### PR TITLE
[Docs] Fix wrong import paths at googlevertexai.mdx

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/googlevertexai.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/googlevertexai.mdx
@@ -63,10 +63,10 @@ initial testing, you will want to use something like a
 [GoogleCloudStorageDocstore](https://v02.api.js.langchain.com/classes/langchain_stores_doc_gcs.GoogleCloudStorageDocstore.html) to store it more permanently.
 
 ```typescript
-import { MatchingEngine } from "langchain/vectorstores/googlevertexai";
+import { MatchingEngine } from "@langchain/community/vectorstores/googlevertexai";
 import { Document } from "langchain/document";
 import { SyntheticEmbeddings } from "langchain/embeddings/fake";
-import { GoogleCloudStorageDocstore } from "langchain/stores/doc/gcs";
+import { GoogleCloudStorageDocstore } from "@langchain/community/stores/doc/gcs";
 
 const embeddings = new SyntheticEmbeddings({
   vectorSize: Number.parseInt(


### PR DESCRIPTION
Fix import paths: some components have been moved to a `@langchain/community` package