### PR TITLE
community[patch]: allow to use postgres pool instance on PostgresRecordManager

### DIFF
--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -7,6 +7,7 @@ import {
 
 export type PostgresRecordManagerOptions = {
   postgresConnectionOptions: PoolConfig;
+  pool?: Pool;
   tableName?: string;
   schema?: string;
 };
@@ -23,9 +24,9 @@ export class PostgresRecordManager implements RecordManagerInterface {
   finalTableName: string;
 
   constructor(namespace: string, config: PostgresRecordManagerOptions) {
-    const { postgresConnectionOptions, tableName } = config;
+    const { postgresConnectionOptions, tableName, pool } = config;
     this.namespace = namespace;
-    this.pool = new pg.Pool(postgresConnectionOptions);
+    this.pool = pool || new pg.Pool(postgresConnectionOptions);
     this.tableName = tableName || "upsertion_records";
     this.finalTableName = config.schema
       ? `"${config.schema}"."${tableName}"`

--- a/libs/langchain-community/src/indexes/tests/postgres.int.test.ts
+++ b/libs/langchain-community/src/indexes/tests/postgres.int.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, jest } from "@jest/globals";
-import { PoolConfig } from "pg";
+import pg, { PoolConfig } from "pg";
 import {
   PostgresRecordManager,
   PostgresRecordManagerOptions,
@@ -34,6 +34,16 @@ describe.skip("PostgresRecordManager", () => {
 
   afterAll(async () => {
     await recordManager.end();
+  });
+
+  test("Test provided postgres pool instance", async () => {
+    const pool = new pg.Pool(config.postgresConnectionOptions);
+    const providedPoolRecordManager = new PostgresRecordManager("test", {
+      ...config,
+      pool,
+    });
+
+    expect(providedPoolRecordManager.pool).toBe(pool);
   });
 
   test("Test explicit schema definition", async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This is a proposal to support passing an instance of Pool when instantiating PostgresRecordManager. This would enable the reuse of an existing database connection pool.

```ts
import pg from "pg";

const pool = new pg.Pool(postgresConnectionOptions);

const providedPoolRecordManager = new PostgresRecordManager("test", {
  ...config,
  pool,
});
```

Fixes # (issue)
https://github.com/langchain-ai/langchainjs/discussions/5676