### PR TITLE
community[patch]: Change neo4j verify connectivity method

### DIFF
--- a/libs/langchain-community/src/graphs/neo4j_graph.ts
+++ b/libs/langchain-community/src/graphs/neo4j_graph.ts
@@ -323,7 +323,7 @@ export class Neo4jGraph {
   }
 
   async verifyConnectivity() {
-    await this.driver.verifyAuthentication();
+    await this.driver.getServerInfo();
   }
 
   async refreshSchema() {


### PR DESCRIPTION
This method allows that also neo4j 4.x is supported