### PR TITLE
textsplitters[patch]: Bump dependency range for @langchain/textsplitters

### DIFF
--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -39,7 +39,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/core": ">0.1.0 <0.3.0",
+    "@langchain/core": ">0.2.0 <0.3.0",
     "js-tiktoken": "^1.0.12"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,7 +10252,7 @@ __metadata:
   resolution: "@langchain/textsplitters@workspace:libs/langchain-textsplitters"
   dependencies:
     "@jest/globals": ^29.5.0
-    "@langchain/core": ">0.1.0 <0.3.0"
+    "@langchain/core": ">0.2.0 <0.3.0"
     "@langchain/scripts": ~0.0.14
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29


### PR DESCRIPTION
Fixes #5682