### PR TITLE
docs[patch]: replace wrong interface API reference link

### DIFF
--- a/docs/core_docs/docs/tutorials/rag.ipynb
+++ b/docs/core_docs/docs/tutorials/rag.ipynb
@@ -422,9 +422,9 @@
       "source": [
         "### Go deeper\n",
         "\n",
-        "`TextSplitter`: Object that splits a list of `Document`s into smaller chunks. Subclass of `DocumentTransformers`. - Explore `Context-aware splitters`, which keep the location (“context”) of each split in the original `Document`: - [Markdown files](/docs/how_to/code_splitter/#markdown) - [Code](/docs/how_to/code_splitter/) (15+ langs) - [Interface](https://v02.api.js.langchain.com/classes/langchain_text_splitter.TextSplitter.html): API reference for the base interface.\n",
+        "`TextSplitter`: Object that splits a list of `Document`s into smaller chunks. Subclass of `DocumentTransformers`. - Explore `Context-aware splitters`, which keep the location (“context”) of each split in the original `Document`: - [Markdown files](/docs/how_to/code_splitter/#markdown) - [Code](/docs/how_to/code_splitter/) (15+ langs) - [Interface](https://v02.api.js.langchain.com/classes/langchain_textsplitters.TextSplitter.html): API reference for the base interface.\n",
         "\n",
-        "`DocumentTransformer`: Object that performs a transformation on a list of `Document`s. - Docs: Detailed documentation on how to use `DocumentTransformer`s - [Integrations](/docs/integrations/document_transformers) - [Interface](https://v02.api.js.langchain.com/modules/langchain_schema_document.html#BaseDocumentTransformer): API reference for the base interface."
+        "`DocumentTransformer`: Object that performs a transformation on a list of `Document`s. - Docs: Detailed documentation on how to use `DocumentTransformer`s - [Integrations](/docs/integrations/document_transformers) - [Interface](https://v02.api.js.langchain.com/classes/langchain_core_documents.BaseDocumentTransformer.html): API reference for the base interface."
       ]
     },
     {


### PR DESCRIPTION
Found out that has wrong  API reference link on `rag.ipynb`

- https://js.langchain.com/v0.2/docs/tutorials/rag#go-deeper-1

please check here Interface external link above. 

[AS-IS]

- https://v02.api.js.langchain.com/classes/langchain_text_splitter.TextSplitter.html

- https://v02.api.js.langchain.com/modules/langchain_schema_document.html#BaseDocumentTransformer

[TO-BE]

- https://v02.api.js.langchain.com/classes/langchain_textsplitters.TextSplitter.html

- https://v02.api.js.langchain.com/classes/langchain_core_documents.BaseDocumentTransformer.html