### PR TITLE
Fix PostgresRecordManager table being created with name 'undefined'

### DIFF
--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -29,8 +29,8 @@ export class PostgresRecordManager implements RecordManagerInterface {
     this.pool = pool || new pg.Pool(postgresConnectionOptions);
     this.tableName = tableName || "upsertion_records";
     this.finalTableName = config.schema
-      ? `"${config.schema}"."${tableName}"`
-      : `"${tableName}"`;
+      ? `"${config.schema}"."${this.tableName}"`
+      : `"${this.tableName}"`;
   }
 
   async createSchema(): Promise<void> {


### PR DESCRIPTION
The final table name is computed from the table name that is passed in the config which is an optional field. When no table name is explicitly passed, the final table name becomes `undefined`. This PR fixes the bug by using the correct `tableName` property, which is initialized with a fallback value.

Note: This is technically breaking for anyone who started using the api after the schema support was added.

Fixes #5795 
