### PR TITLE
community[minor]: Support configurable index creation for Milvus

### DIFF
--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -7,7 +7,7 @@ import {
   FieldType,
   ClientConfig,
   InsertReq,
-  keyValueObj
+  keyValueObj,
 } from "@zilliz/milvus2-sdk-node";
 
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
@@ -31,12 +31,12 @@ export interface MilvusLibArgs {
   textFieldMaxLength?: number;
   clientConfig?: ClientConfig;
   autoId?: boolean;
-  indexCreateOptions?: IndexCreateOptions
+  indexCreateOptions?: IndexCreateOptions;
 }
 
 export interface IndexCreateOptions {
-  index_type: IndexType,
-  metric_type: MetricType,
+  index_type: IndexType;
+  metric_type: MetricType;
   params?: keyValueObj;
 }
 
@@ -163,7 +163,9 @@ export class Milvus extends VectorStore {
         index_type: indexCreateOptions.index_type,
         params: JSON.stringify(indexCreateOptions.params),
       };
-      this.indexSearchParams = JSON.stringify(this.indexParams[indexCreateOptions.index_type].params);
+      this.indexSearchParams = JSON.stringify(
+        this.indexParams[indexCreateOptions.index_type].params
+      );
     }
 
     // combine args clientConfig and env variables

--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -7,6 +7,7 @@ import {
   FieldType,
   ClientConfig,
   InsertReq,
+  keyValueObj
 } from "@zilliz/milvus2-sdk-node";
 
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
@@ -30,7 +31,16 @@ export interface MilvusLibArgs {
   textFieldMaxLength?: number;
   clientConfig?: ClientConfig;
   autoId?: boolean;
+  indexCreateOptions?: IndexCreateOptions
 }
+
+interface IndexCreateOptions {
+  index_type: IndexType,
+  metric_type: MetricType,
+  params?: keyValueObj;
+}
+
+type MetricType = "L2" | "IP" | "COSINE";
 
 /**
  * Type representing the type of index used in the Milvus database.
@@ -144,6 +154,17 @@ export class Milvus extends VectorStore {
       password = "",
       ssl,
     } = args.clientConfig || {};
+
+    // index create params
+    const { indexCreateOptions } = args;
+    if (indexCreateOptions) {
+      this.indexCreateParams = {
+        metric_type: indexCreateOptions.metric_type,
+        index_type: indexCreateOptions.index_type,
+        params: JSON.stringify(indexCreateOptions.params),
+      };
+      this.indexSearchParams = JSON.stringify(this.indexParams[indexCreateOptions.index_type].params);
+    }
 
     // combine args clientConfig and env variables
     const clientConfig: ClientConfig = {

--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -34,13 +34,13 @@ export interface MilvusLibArgs {
   indexCreateOptions?: IndexCreateOptions
 }
 
-interface IndexCreateOptions {
+export interface IndexCreateOptions {
   index_type: IndexType,
   metric_type: MetricType,
   params?: keyValueObj;
 }
 
-type MetricType = "L2" | "IP" | "COSINE";
+export type MetricType = "L2" | "IP" | "COSINE";
 
 /**
  * Type representing the type of index used in the Milvus database.


### PR DESCRIPTION
# Summary

- Add configurable parameters for index creation,  So we can configure the index using index_type and metric_type.