### PR TITLE
community[patch]: Fix issue with inserting documents in Milvus with autoId enabled

### DIFF
--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -276,9 +276,12 @@ export class Milvus extends VectorStore {
     if (this.partitionName !== undefined) {
       params.partition_name = this.partitionName;
     }
-    const insertResp = await this.client.upsert(params);
+    const insertResp = this.autoId
+      ? await this.client.insert(params)
+      : await this.client.upsert(params);
+
     if (insertResp.status.error_code !== ErrorCode.SUCCESS) {
-      throw new Error(`Error upserting data: ${JSON.stringify(insertResp)}`);
+      throw new Error(`Error ${this.autoId ? 'inserting' : 'upserting'} data: ${JSON.stringify(insertResp)}`);
     }
     await this.client.flushSync({ collection_names: [this.collectionName] });
   }

--- a/libs/langchain-community/src/vectorstores/milvus.ts
+++ b/libs/langchain-community/src/vectorstores/milvus.ts
@@ -281,7 +281,11 @@ export class Milvus extends VectorStore {
       : await this.client.upsert(params);
 
     if (insertResp.status.error_code !== ErrorCode.SUCCESS) {
-      throw new Error(`Error ${this.autoId ? 'inserting' : 'upserting'} data: ${JSON.stringify(insertResp)}`);
+      throw new Error(
+        `Error ${
+          this.autoId ? "inserting" : "upserting"
+        } data: ${JSON.stringify(insertResp)}`
+      );
     }
     await this.client.flushSync({ collection_names: [this.collectionName] });
   }

--- a/libs/langchain-community/src/vectorstores/tests/milvus.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/milvus.int.test.ts
@@ -1,8 +1,8 @@
 import { test, expect, afterAll, beforeAll } from "@jest/globals";
 import { ErrorCode, MilvusClient } from "@zilliz/milvus2-sdk-node";
 import { OpenAIEmbeddings } from "@langchain/openai";
-import { Milvus } from "../milvus.js";
 import { Document } from "@langchain/core/documents";
+import { Milvus } from "../milvus.js";
 
 let collectionName: string;
 let embeddings: OpenAIEmbeddings;
@@ -64,7 +64,7 @@ Harmonic Labyrinth of the dreaded Majotaur?`,
     { id: 5, other: objA },
   ]);
 
-  const resultThree = await milvus.similaritySearch(query, 1, "id == \"1\"");
+  const resultThree = await milvus.similaritySearch(query, 1, 'id == "1"');
   const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
   expect(resultThreeMetadatas).toEqual([{ id: 1, other: objB }]);
 });
@@ -114,7 +114,7 @@ Harmonic Labyrinth of the dreaded Majotaur?`,
     { id: 5, other: objA },
   ]);
 
-  const resultThree = await milvus.similaritySearch(query, 1, "id == \"1\"");
+  const resultThree = await milvus.similaritySearch(query, 1, 'id == "1"');
   const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
   expect(resultThreeMetadatas).toEqual([{ id: 1, other: objB }]);
 });
@@ -143,7 +143,7 @@ test.skip("Test Milvus.fromExistingCollection", async () => {
   expect(resultTwoMetadatas[1].id).toEqual(4);
   expect(resultTwoMetadatas[2].id).toEqual(5);
 
-  const resultThree = await milvus.similaritySearch(query, 1, "id == \"1\"");
+  const resultThree = await milvus.similaritySearch(query, 1, 'id == "1"');
   const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
   expect(resultThreeMetadatas.length).toBe(1);
   expect(resultThreeMetadatas[0].id).toEqual(1);
@@ -205,24 +205,25 @@ test.skip("Test Milvus.deleteData with ids", async () => {
 
 test.skip("Test Milvus.addDocuments with auto ID", async () => {
   const vectorstore = new Milvus(embeddings, {
-    collectionName: `test_collection_${Math.random().toString(36).substring(7)}`,
+    collectionName: `test_collection_${Math.random()
+      .toString(36)
+      .substring(7)}`,
     clientConfig: {
       address: MILVUS_ADDRESS,
       token: MILVUS_TOKEN,
-    }
-});
+    },
+  });
 
   await vectorstore.addDocuments([
     new Document({
-       pageContent: 'test',
-       metadata: { test: 'a' }
-     })
+      pageContent: "test",
+      metadata: { test: "a" },
+    }),
   ]);
 
   const result = await vectorstore.similaritySearch("test", 1);
   const resultMetadatas = result.map(({ metadata }) => metadata);
   expect(resultMetadatas.length).toBe(1);
-
 });
 
 afterAll(async () => {


### PR DESCRIPTION
Summary:
- Fixed issue with inserting into Milvus with `autoId` enabled 
- When `autoId` is enabled, the `insert` method is used
- When `autoId` is not enabled, the `upsert` method is used
- Added test from issue

Fixes #5813 
