### PR TITLE
langchain[patch]: fix:pass runManager to DocumentCompressor in MultiQueryRetriever

### DIFF
--- a/langchain/src/retrievers/multi_query.ts
+++ b/langchain/src/retrievers/multi_query.ts
@@ -196,7 +196,8 @@ export class MultiQueryRetriever extends BaseRetriever {
     if (this.documentCompressor && uniqueDocuments.length) {
       outputDocs = await this.documentCompressor.compressDocuments(
         uniqueDocuments,
-        question
+        question,
+        runManager?.getChild()
       );
       if (this.documentCompressorFilteringFn) {
         outputDocs = this.documentCompressorFilteringFn(outputDocs);


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

The MultiQueryRetriever can accept an instance of DocumentCompressor, but when executing compression - it will not pass the run manager and effectively, any chains executed inside DocumentCompressor will not get callbacks executed. 

This PR fixes this issue.
