### PR TITLE
community[patch]: unstructured loader support extractImageBlockType option

### DIFF
--- a/libs/langchain-community/src/document_loaders/fs/unstructured.ts
+++ b/libs/langchain-community/src/document_loaders/fs/unstructured.ts
@@ -113,6 +113,7 @@ export type UnstructuredLoaderOptions = {
   combineUnderNChars?: number;
   newAfterNChars?: number;
   maxCharacters?: number;
+  extractImageBlockTypes?: string[];
 };
 
 export type UnstructuredDirectoryLoaderOptions = UnstructuredLoaderOptions & {
@@ -178,6 +179,8 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
   private maxCharacters?: number;
 
+  private extractImageBlockTypes?: string[];
+
   constructor(
     filepathOrBufferOptions: string | UnstructuredMemoryLoaderOptions,
     unstructuredOptions: UnstructuredLoaderOptions | string = {}
@@ -221,6 +224,7 @@ export class UnstructuredLoader extends BaseDocumentLoader {
       this.combineUnderNChars = options.combineUnderNChars;
       this.newAfterNChars = options.newAfterNChars;
       this.maxCharacters = options.maxCharacters;
+      this.extractImageBlockTypes = options.extractImageBlockTypes;
     }
   }
 
@@ -286,6 +290,13 @@ export class UnstructuredLoader extends BaseDocumentLoader {
     }
     if (this.maxCharacters !== undefined) {
       formData.append("max_characters", String(this.maxCharacters));
+    }
+
+    if (this.extractImageBlockTypes !== undefined) {
+      formData.append(
+        "extract_image_block_types",
+        JSON.stringify(this.extractImageBlockTypes)
+      );
     }
 
     const headers = {

--- a/libs/langchain-community/src/document_loaders/tests/unstructured.int.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/unstructured.int.test.ts
@@ -71,9 +71,26 @@ test.skip("Test Unstructured base loader with fast strategy", async () => {
 
   const loader = new UnstructuredLoader(filePath, options);
   const docs = await loader.load();
-
   expect(docs.length).toBeGreaterThan(10);
   expect(typeof docs[0].pageContent).toBe("string");
+});
+
+test.skip("Test Unstructured base loader with extractImageBlockTypes", async () => {
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/1706.03762.pdf"
+  );
+
+  const options = {
+    apiKey: process.env.UNSTRUCTURED_API_KEY!,
+    extractImageBlockTypes: ["image"],
+  };
+
+  const loader = new UnstructuredLoader(filePath, options);
+  const docs = await loader.load();
+
+  expect(docs.length).toBeGreaterThan(10);
+  expect(docs.some((item) => item?.metadata?.category === "image")).toBe(true);
 });
 
 test.skip("Test Unstructured directory loader", async () => {


### PR DESCRIPTION
Fixes #5942 