### PR TITLE
redis[patch]: Adds a connection pool to RedisChatHistory

### DIFF
--- a/libs/langchain-redis/src/chat_histories.ts
+++ b/libs/langchain-redis/src/chat_histories.ts
@@ -1,5 +1,4 @@
 import {
-  createClient,
   RedisClientOptions,
   RedisClientType,
   RedisModules,
@@ -12,6 +11,7 @@ import {
   mapChatMessagesToStoredMessages,
   mapStoredMessagesToChatMessages,
 } from "@langchain/core/messages";
+import { pool } from "./connections.js";
 
 /**
  * Type for the input to the `RedisChatMessageHistory` constructor.
@@ -68,7 +68,7 @@ export class RedisChatMessageHistory extends BaseListChatMessageHistory {
     super(fields);
 
     const { sessionId, sessionTTL, config, client } = fields;
-    this.client = (client ?? createClient(config ?? {})) as RedisClientType<
+    this.client = (client ?? pool.getClient(config)) as RedisClientType<
       RedisModules,
       RedisFunctions,
       RedisScripts

--- a/libs/langchain-redis/src/connections.ts
+++ b/libs/langchain-redis/src/connections.ts
@@ -1,0 +1,14 @@
+import { createClient, RedisClientOptions } from "redis";
+
+// A minimalistic connection pool to avoid creating multiple connections
+class RedisConnectionPool {
+  clients = new Map();
+
+  getClient(config: RedisClientOptions = {}) {
+    if (!this.clients.has(config))
+      this.clients.set(config, createClient(config));
+    return this.clients.get(config);
+  }
+}
+
+export const pool = new RedisConnectionPool();


### PR DESCRIPTION
This is a premature optimization after having reviewed the code.

When supplied with a config instead of a client instance, a new connection will be opened each time a history is loaded.

Instead, we can reuse opened clients by keeping them in a "pool".

This PR affects the proposed change.