### PR TITLE
community[patch]: Fix typo in modelName options of `BaiduQianfanEmbeddings`

### DIFF
--- a/libs/langchain-community/src/embeddings/baidu_qianfan.ts
+++ b/libs/langchain-community/src/embeddings/baidu_qianfan.ts
@@ -4,7 +4,7 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 export interface BaiduQianfanEmbeddingsParams extends EmbeddingsParams {
   /** Model name to use */
-  modelName: "embedding-v1" | "bge_large_zh" | "bge-large-en" | "tao-8k";
+  modelName: "embedding-v1" | "bge_large_zh" | "bge_large_en" | "tao-8k";
 
   /**
    * Timeout to use when making requests to BaiduQianfan.


### PR DESCRIPTION
model name `bge-large-en` should be `bge_large_en` like `bge_large_zh`

at line 188 in the same file： `https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/embeddings/${this.modelName}?access_token=${this.accessToken}`

`${this.modelName}` directly used in the URL

![image](https://github.com/langchain-ai/langchainjs/assets/56373128/f5f16cc8-cb1c-4e46-bb65-ce37689edbd3)
URL for the image：`https://cloud.baidu.com/doc/WENXINWORKSHOP/s/mllz05nzk`
