### PR TITLE
bedrock[minor]: add support for metadata filtering

### DIFF
--- a/libs/langchain-community/src/retrievers/amazon_knowledge_base.ts
+++ b/libs/langchain-community/src/retrievers/amazon_knowledge_base.ts
@@ -2,6 +2,7 @@ import {
   RetrieveCommand,
   BedrockAgentRuntimeClient,
   BedrockAgentRuntimeClientConfig,
+  RetrievalFilter,
 } from "@aws-sdk/client-bedrock-agent-runtime";
 
 import { BaseRetriever } from "@langchain/core/retrievers";
@@ -78,7 +79,7 @@ export class AmazonKnowledgeBaseRetriever extends BaseRetriever {
     return res;
   }
 
-  async queryKnowledgeBase(query: string, topK: number) {
+  async queryKnowledgeBase(query: string, topK: number, filter?: RetrievalFilter) {
     const retrieveCommand = new RetrieveCommand({
       knowledgeBaseId: this.knowledgeBaseId,
       retrievalQuery: {
@@ -87,6 +88,7 @@ export class AmazonKnowledgeBaseRetriever extends BaseRetriever {
       retrievalConfiguration: {
         vectorSearchConfiguration: {
           numberOfResults: topK,
+          filter,
         },
       },
     });


### PR DESCRIPTION
Hey there! Bedrock supports filtering the documents that are searched for information by passing a RetrievalFilter object, and I wanted to be able to use this functionality with LangChain. 

I added the necessary parameters to the queryKnowledgeBase function to allow for filters to be optionally passed when querying a Bedrock Knowledge Base.
This PR needs some more work, as I have been unable to build/test the repository when following the contributing guidelines.

This is my first PR on a public repository, so any help would be appreciated!

Fixes #5600 
