### PR TITLE
docs[patch]: Update installation instructions with missing packages in redis docs

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/redis.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/redis.mdx
@@ -29,7 +29,7 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/openai @langchain/community @langchain/redis
+npm install @langchain/openai @langchain/core @langchain/redis langchain
 ```
 
 ## Index docs

--- a/docs/core_docs/docs/integrations/vectorstores/redis.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/redis.mdx
@@ -29,7 +29,7 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/openai @langchain/community
+npm install @langchain/openai @langchain/community @langchain/redis
 ```
 
 ## Index docs


### PR DESCRIPTION
Added missing dependency installation in docs for Redis VectorStore

pnpm add @langchain/openai @langchain/community -> 

pnpm add @langchain/openai @langchain/community @langchain/redis