### PR TITLE
openai[patch]: Fix integration tests

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -667,8 +667,7 @@ export class ChatOpenAI<
         generationInfo,
       });
       yield generationChunk;
-      // eslint-disable-next-line no-void
-      void runManager?.handleLLMNewToken(
+      await runManager?.handleLLMNewToken(
         generationChunk.text ?? "",
         newTokenIndices,
         undefined,

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -543,7 +543,10 @@ export class ChatOpenAI<
    * Get the parameters used to invoke the model
    */
   invocationParams(
-    options?: this["ParsedCallOptions"]
+    options?: this["ParsedCallOptions"],
+    extra?: {
+      streaming?: boolean
+    }
   ): Omit<OpenAIClient.Chat.ChatCompletionCreateParams, "messages"> {
     function isStructuredToolArray(
       tools?: unknown[]
@@ -558,7 +561,7 @@ export class ChatOpenAI<
     let streamOptionsConfig = {};
     if (options?.stream_options !== undefined) {
       streamOptionsConfig = { stream_options: options.stream_options };
-    } else if (this.streamUsage && this.streaming) {
+    } else if (this.streamUsage && (this.streaming || extra?.streaming)) {
       streamOptionsConfig = { stream_options: { include_usage: true } };
     }
     const params: Omit<
@@ -616,7 +619,9 @@ export class ChatOpenAI<
     const messagesMapped: OpenAICompletionParam[] =
       convertMessagesToOpenAIParams(messages);
     const params = {
-      ...this.invocationParams(options),
+      ...this.invocationParams(options, {
+        streaming: true,
+      }),
       messages: messagesMapped,
       stream: true as const,
     };

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -545,7 +545,7 @@ export class ChatOpenAI<
   invocationParams(
     options?: this["ParsedCallOptions"],
     extra?: {
-      streaming?: boolean
+      streaming?: boolean;
     }
   ): Omit<OpenAIClient.Chat.ChatCompletionCreateParams, "messages"> {
     function isStructuredToolArray(

--- a/libs/langchain-openai/src/tests/azure/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/azure/chat_models.int.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+
 import { test, jest, expect } from "@jest/globals";
 import {
   BaseMessage,
@@ -22,6 +24,9 @@ import {
   getBearerTokenProvider,
 } from "@azure/identity";
 import { AzureChatOpenAI } from "../../azure/chat_models.js";
+
+// Save the original value of the 'LANGCHAIN_CALLBACKS_BACKGROUND' environment variable
+const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
 
 test("Test Azure ChatOpenAI call method", async () => {
   const chat = new AzureChatOpenAI({
@@ -78,107 +83,147 @@ test("Test Azure ChatOpenAI Generate throws when one of the calls fails", async 
 });
 
 test("Test Azure ChatOpenAI tokenUsage", async () => {
-  let tokenUsage = {
-    completionTokens: 0,
-    promptTokens: 0,
-    totalTokens: 0,
-  };
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const model = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    maxTokens: 10,
-    callbackManager: CallbackManager.fromHandlers({
-      async handleLLMEnd(output: LLMResult) {
-        console.log(output);
-        tokenUsage = output.llmOutput?.tokenUsage;
-      },
-    }),
-  });
-  const message = new HumanMessage("Hello");
-  const res = await model.invoke([message]);
-  console.log({ res });
+  try {
+    let tokenUsage = {
+      completionTokens: 0,
+      promptTokens: 0,
+      totalTokens: 0,
+    };
 
-  expect(tokenUsage.promptTokens).toBeGreaterThan(0);
+    const model = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      maxTokens: 10,
+      callbackManager: CallbackManager.fromHandlers({
+        async handleLLMEnd(output: LLMResult) {
+          console.log(output);
+          tokenUsage = output.llmOutput?.tokenUsage;
+        },
+      }),
+    });
+    const message = new HumanMessage("Hello");
+    const res = await model.invoke([message]);
+    console.log({ res });
+
+    expect(tokenUsage.promptTokens).toBeGreaterThan(0);
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+  }
 });
 
 test("Test Azure ChatOpenAI tokenUsage with a batch", async () => {
-  let tokenUsage = {
-    completionTokens: 0,
-    promptTokens: 0,
-    totalTokens: 0,
-  };
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const model = new AzureChatOpenAI({
-    temperature: 0,
-    modelName: "gpt-3.5-turbo",
-    callbackManager: CallbackManager.fromHandlers({
-      async handleLLMEnd(output: LLMResult) {
-        tokenUsage = output.llmOutput?.tokenUsage;
-      },
-    }),
-  });
-  const res = await model.generate([
-    [new HumanMessage("Hello")],
-    [new HumanMessage("Hi")],
-  ]);
-  console.log(res);
+  try {
+    let tokenUsage = {
+      completionTokens: 0,
+      promptTokens: 0,
+      totalTokens: 0,
+    };
 
-  expect(tokenUsage.promptTokens).toBeGreaterThan(0);
+    const model = new AzureChatOpenAI({
+      temperature: 0,
+      modelName: "gpt-3.5-turbo",
+      callbackManager: CallbackManager.fromHandlers({
+        async handleLLMEnd(output: LLMResult) {
+          tokenUsage = output.llmOutput?.tokenUsage;
+        },
+      }),
+    });
+    const res = await model.generate([
+      [new HumanMessage("Hello")],
+      [new HumanMessage("Hi")],
+    ]);
+    console.log(res);
+
+    expect(tokenUsage.promptTokens).toBeGreaterThan(0);
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+  }
 });
 
 test("Test Azure ChatOpenAI in streaming mode", async () => {
-  let nrNewTokens = 0;
-  let streamedCompletion = "";
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const model = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: true,
-    maxTokens: 10,
-    callbacks: [
-      {
-        async handleLLMNewToken(token: string) {
-          nrNewTokens += 1;
-          streamedCompletion += token;
+  try {
+    let nrNewTokens = 0;
+    let streamedCompletion = "";
+
+    const model = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: true,
+      maxTokens: 10,
+      callbacks: [
+        {
+          async handleLLMNewToken(token: string) {
+            nrNewTokens += 1;
+            streamedCompletion += token;
+          },
         },
-      },
-    ],
-  });
-  const message = new HumanMessage("Hello!");
-  const result = await model.invoke([message]);
+      ],
+    });
+    const message = new HumanMessage("Hello!");
+    const result = await model.invoke([message]);
 
-  expect(nrNewTokens > 0).toBe(true);
-  expect(result.content).toBe(streamedCompletion);
+    expect(nrNewTokens > 0).toBe(true);
+    expect(result.content).toBe(streamedCompletion);
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+  }
 }, 10000);
 
 test("Test Azure ChatOpenAI in streaming mode with n > 1 and multiple prompts", async () => {
-  let nrNewTokens = 0;
-  const streamedCompletions = [
-    ["", ""],
-    ["", ""],
-  ];
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const model = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: true,
-    maxTokens: 10,
-    n: 2,
-    callbacks: [
-      {
-        async handleLLMNewToken(token: string, idx: NewTokenIndices) {
-          nrNewTokens += 1;
-          streamedCompletions[idx.prompt][idx.completion] += token;
+  try {
+    let nrNewTokens = 0;
+    const streamedCompletions = [
+      ["", ""],
+      ["", ""],
+    ];
+
+    const model = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: true,
+      maxTokens: 10,
+      n: 2,
+      callbacks: [
+        {
+          async handleLLMNewToken(token: string, idx: NewTokenIndices) {
+            nrNewTokens += 1;
+            streamedCompletions[idx.prompt][idx.completion] += token;
+          },
         },
-      },
-    ],
-  });
-  const message1 = new HumanMessage("Hello!");
-  const message2 = new HumanMessage("Bye!");
-  const result = await model.generate([[message1], [message2]]);
+      ],
+    });
+    const message1 = new HumanMessage("Hello!");
+    const message2 = new HumanMessage("Bye!");
+    const result = await model.generate([[message1], [message2]]);
 
-  expect(nrNewTokens > 0).toBe(true);
-  expect(result.generations.map((g) => g.map((gg) => gg.text))).toEqual(
-    streamedCompletions
-  );
+    expect(nrNewTokens > 0).toBe(true);
+    expect(result.generations.map((g) => g.map((gg) => gg.text))).toEqual(
+      streamedCompletions
+    );
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+  }
 }, 10000);
 
 test("Test Azure ChatOpenAI prompt value", async () => {
@@ -365,65 +410,75 @@ test("Test Azure ChatOpenAI stream method, timeout error thrown from SDK", async
 });
 
 test("Test Azure ChatOpenAI Function calling with streaming", async () => {
-  let finalResult: BaseMessage | undefined;
-  const modelForFunctionCalling = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    temperature: 0,
-    callbacks: [
-      {
-        handleLLMEnd(output: LLMResult) {
-          finalResult = (output.generations[0][0] as ChatGeneration).message;
-        },
-      },
-    ],
-  });
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const stream = await modelForFunctionCalling.stream(
-    "What is the weather in New York?",
-    {
-      functions: [
+  try {
+    let finalResult: BaseMessage | undefined;
+    const modelForFunctionCalling = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      temperature: 0,
+      callbacks: [
         {
-          name: "get_current_weather",
-          description: "Get the current weather in a given location",
-          parameters: {
-            type: "object",
-            properties: {
-              location: {
-                type: "string",
-                description: "The city and state, e.g. San Francisco, CA",
-              },
-              unit: { type: "string", enum: ["celsius", "fahrenheit"] },
-            },
-            required: ["location"],
+          handleLLMEnd(output: LLMResult) {
+            finalResult = (output.generations[0][0] as ChatGeneration).message;
           },
         },
       ],
-      function_call: {
-        name: "get_current_weather",
-      },
-    }
-  );
+    });
 
-  const chunks = [];
-  let streamedOutput;
-  for await (const chunk of stream) {
-    chunks.push(chunk);
-    if (!streamedOutput) {
-      streamedOutput = chunk;
-    } else if (chunk) {
-      streamedOutput = streamedOutput.concat(chunk);
+    const stream = await modelForFunctionCalling.stream(
+      "What is the weather in New York?",
+      {
+        functions: [
+          {
+            name: "get_current_weather",
+            description: "Get the current weather in a given location",
+            parameters: {
+              type: "object",
+              properties: {
+                location: {
+                  type: "string",
+                  description: "The city and state, e.g. San Francisco, CA",
+                },
+                unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+              },
+              required: ["location"],
+            },
+          },
+        ],
+        function_call: {
+          name: "get_current_weather",
+        },
+      }
+    );
+
+    const chunks = [];
+    let streamedOutput;
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+      if (!streamedOutput) {
+        streamedOutput = chunk;
+      } else if (chunk) {
+        streamedOutput = streamedOutput.concat(chunk);
+      }
     }
+
+    expect(finalResult).toEqual(streamedOutput);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(finalResult?.additional_kwargs?.function_call?.name).toBe(
+      "get_current_weather"
+    );
+    console.log(
+      JSON.parse(finalResult?.additional_kwargs?.function_call?.arguments ?? "")
+        .location
+    );
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
   }
-
-  expect(finalResult).toEqual(streamedOutput);
-  expect(chunks.length).toBeGreaterThan(1);
-  expect(finalResult?.additional_kwargs?.function_call?.name).toBe(
-    "get_current_weather"
-  );
-  console.log(
-    JSON.parse(finalResult?.additional_kwargs?.function_call?.arguments ?? "")
-      .location
-  );
 });
 
 test("Test Azure ChatOpenAI can cache generations", async () => {
@@ -633,172 +688,198 @@ test("Test Azure ChatOpenAI getNumTokensFromMessages gpt-4-0314 model for sample
 });
 
 test("Test Azure ChatOpenAI token usage reporting for streaming function calls", async () => {
-  let streamingTokenUsed = -1;
-  let nonStreamingTokenUsed = -1;
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const humanMessage = "What a beautiful day!";
-  const extractionFunctionSchema = {
-    name: "extractor",
-    description: "Extracts fields from the input.",
-    parameters: {
-      type: "object",
-      properties: {
-        tone: {
-          type: "string",
-          enum: ["positive", "negative"],
-          description: "The overall tone of the input",
+  try {
+    let streamingTokenUsed = -1;
+    let nonStreamingTokenUsed = -1;
+
+    const humanMessage = "What a beautiful day!";
+    const extractionFunctionSchema = {
+      name: "extractor",
+      description: "Extracts fields from the input.",
+      parameters: {
+        type: "object",
+        properties: {
+          tone: {
+            type: "string",
+            enum: ["positive", "negative"],
+            description: "The overall tone of the input",
+          },
+          word_count: {
+            type: "number",
+            description: "The number of words in the input",
+          },
+          chat_response: {
+            type: "string",
+            description: "A response to the human's input",
+          },
         },
-        word_count: {
-          type: "number",
-          description: "The number of words in the input",
-        },
-        chat_response: {
-          type: "string",
-          description: "A response to the human's input",
-        },
+        required: ["tone", "word_count", "chat_response"],
       },
-      required: ["tone", "word_count", "chat_response"],
-    },
-  };
+    };
 
-  const streamingModel = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: true,
-    maxRetries: 10,
-    maxConcurrency: 10,
-    temperature: 0,
-    topP: 0,
-    callbacks: [
-      {
-        handleLLMEnd: async (output) => {
-          streamingTokenUsed =
-            output.llmOutput?.estimatedTokenUsage?.totalTokens;
-          console.log("streaming usage", output.llmOutput?.estimatedTokenUsage);
+    const streamingModel = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: true,
+      maxRetries: 10,
+      maxConcurrency: 10,
+      temperature: 0,
+      topP: 0,
+      callbacks: [
+        {
+          handleLLMEnd: async (output) => {
+            streamingTokenUsed =
+              output.llmOutput?.estimatedTokenUsage?.totalTokens;
+            console.log(
+              "streaming usage",
+              output.llmOutput?.estimatedTokenUsage
+            );
+          },
+          handleLLMError: async (err) => {
+            console.error(err);
+          },
         },
-        handleLLMError: async (err) => {
-          console.error(err);
-        },
-      },
-    ],
-  }).bind({
-    seed: 42,
-    functions: [extractionFunctionSchema],
-    function_call: { name: "extractor" },
-  });
+      ],
+    }).bind({
+      seed: 42,
+      functions: [extractionFunctionSchema],
+      function_call: { name: "extractor" },
+    });
 
-  const nonStreamingModel = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: false,
-    maxRetries: 10,
-    maxConcurrency: 10,
-    temperature: 0,
-    topP: 0,
-    callbacks: [
-      {
-        handleLLMEnd: async (output) => {
-          nonStreamingTokenUsed = output.llmOutput?.tokenUsage?.totalTokens;
-          console.log("non-streaming usage", output.llmOutput?.tokenUsage);
+    const nonStreamingModel = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: false,
+      maxRetries: 10,
+      maxConcurrency: 10,
+      temperature: 0,
+      topP: 0,
+      callbacks: [
+        {
+          handleLLMEnd: async (output) => {
+            nonStreamingTokenUsed = output.llmOutput?.tokenUsage?.totalTokens;
+            console.log("non-streaming usage", output.llmOutput?.tokenUsage);
+          },
+          handleLLMError: async (err) => {
+            console.error(err);
+          },
         },
-        handleLLMError: async (err) => {
-          console.error(err);
-        },
-      },
-    ],
-  }).bind({
-    functions: [extractionFunctionSchema],
-    function_call: { name: "extractor" },
-  });
+      ],
+    }).bind({
+      functions: [extractionFunctionSchema],
+      function_call: { name: "extractor" },
+    });
 
-  const [nonStreamingResult, streamingResult] = await Promise.all([
-    nonStreamingModel.invoke([new HumanMessage(humanMessage)]),
-    streamingModel.invoke([new HumanMessage(humanMessage)]),
-  ]);
+    const [nonStreamingResult, streamingResult] = await Promise.all([
+      nonStreamingModel.invoke([new HumanMessage(humanMessage)]),
+      streamingModel.invoke([new HumanMessage(humanMessage)]),
+    ]);
 
-  if (
-    nonStreamingResult.additional_kwargs.function_call?.arguments &&
-    streamingResult.additional_kwargs.function_call?.arguments
-  ) {
-    console.log(
-      `Function Call: ${JSON.stringify(
-        nonStreamingResult.additional_kwargs.function_call
-      )}`
-    );
-    const nonStreamingArguments = JSON.stringify(
-      JSON.parse(nonStreamingResult.additional_kwargs.function_call.arguments)
-    );
-    const streamingArguments = JSON.stringify(
-      JSON.parse(streamingResult.additional_kwargs.function_call.arguments)
-    );
-    if (nonStreamingArguments === streamingArguments) {
-      expect(streamingTokenUsed).toEqual(nonStreamingTokenUsed);
+    if (
+      nonStreamingResult.additional_kwargs.function_call?.arguments &&
+      streamingResult.additional_kwargs.function_call?.arguments
+    ) {
+      console.log(
+        `Function Call: ${JSON.stringify(
+          nonStreamingResult.additional_kwargs.function_call
+        )}`
+      );
+      const nonStreamingArguments = JSON.stringify(
+        JSON.parse(nonStreamingResult.additional_kwargs.function_call.arguments)
+      );
+      const streamingArguments = JSON.stringify(
+        JSON.parse(streamingResult.additional_kwargs.function_call.arguments)
+      );
+      if (nonStreamingArguments === streamingArguments) {
+        expect(streamingTokenUsed).toEqual(nonStreamingTokenUsed);
+      }
     }
-  }
 
-  expect(streamingTokenUsed).toBeGreaterThan(-1);
+    expect(streamingTokenUsed).toBeGreaterThan(-1);
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+  }
 });
 
 test("Test Azure ChatOpenAI token usage reporting for streaming calls", async () => {
-  let streamingTokenUsed = -1;
-  let nonStreamingTokenUsed = -1;
-  const systemPrompt = "You are a helpful assistant";
-  const question = "What is the color of the night sky?";
+  // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
+  // after the test/llm call has already finished & returned. Set that environment variable to false
+  // to prevent that from happening.
+  process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
-  const streamingModel = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: true,
-    maxRetries: 10,
-    maxConcurrency: 10,
-    temperature: 0,
-    topP: 0,
-    callbacks: [
-      {
-        handleLLMEnd: async (output) => {
-          streamingTokenUsed =
-            output.llmOutput?.estimatedTokenUsage?.totalTokens;
-          console.log("streaming usage", output.llmOutput?.estimatedTokenUsage);
-        },
-        handleLLMError: async (err) => {
-          console.error(err);
-        },
-      },
-    ],
-  });
+  try {
+    let streamingTokenUsed = -1;
+    let nonStreamingTokenUsed = -1;
+    const systemPrompt = "You are a helpful assistant";
+    const question = "What is the color of the night sky?";
 
-  const nonStreamingModel = new AzureChatOpenAI({
-    modelName: "gpt-3.5-turbo",
-    streaming: false,
-    maxRetries: 10,
-    maxConcurrency: 10,
-    temperature: 0,
-    topP: 0,
-    callbacks: [
-      {
-        handleLLMEnd: async (output) => {
-          nonStreamingTokenUsed = output.llmOutput?.tokenUsage?.totalTokens;
-          console.log("non-streaming usage", output.llmOutput?.estimated);
+    const streamingModel = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: true,
+      maxRetries: 10,
+      maxConcurrency: 10,
+      temperature: 0,
+      topP: 0,
+      callbacks: [
+        {
+          handleLLMEnd: async (output) => {
+            streamingTokenUsed =
+              output.llmOutput?.estimatedTokenUsage?.totalTokens;
+            console.log(
+              "streaming usage",
+              output.llmOutput?.estimatedTokenUsage
+            );
+          },
+          handleLLMError: async (err) => {
+            console.error(err);
+          },
         },
-        handleLLMError: async (err) => {
-          console.error(err);
+      ],
+    });
+
+    const nonStreamingModel = new AzureChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      streaming: false,
+      maxRetries: 10,
+      maxConcurrency: 10,
+      temperature: 0,
+      topP: 0,
+      callbacks: [
+        {
+          handleLLMEnd: async (output) => {
+            nonStreamingTokenUsed = output.llmOutput?.tokenUsage?.totalTokens;
+            console.log("non-streaming usage", output.llmOutput?.estimated);
+          },
+          handleLLMError: async (err) => {
+            console.error(err);
+          },
         },
-      },
-    ],
-  });
+      ],
+    });
 
-  const [nonStreamingResult, streamingResult] = await Promise.all([
-    nonStreamingModel.generate([
-      [new SystemMessage(systemPrompt), new HumanMessage(question)],
-    ]),
-    streamingModel.generate([
-      [new SystemMessage(systemPrompt), new HumanMessage(question)],
-    ]),
-  ]);
+    const [nonStreamingResult, streamingResult] = await Promise.all([
+      nonStreamingModel.generate([
+        [new SystemMessage(systemPrompt), new HumanMessage(question)],
+      ]),
+      streamingModel.generate([
+        [new SystemMessage(systemPrompt), new HumanMessage(question)],
+      ]),
+    ]);
 
-  expect(streamingTokenUsed).toBeGreaterThan(-1);
-  if (
-    nonStreamingResult.generations[0][0].text ===
-    streamingResult.generations[0][0].text
-  ) {
-    expect(streamingTokenUsed).toEqual(nonStreamingTokenUsed);
+    expect(streamingTokenUsed).toBeGreaterThan(-1);
+    if (
+      nonStreamingResult.generations[0][0].text ===
+      streamingResult.generations[0][0].text
+    ) {
+      expect(streamingTokenUsed).toEqual(nonStreamingTokenUsed);
+    }
+  } finally {
+    // Reset the environment variable
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
   }
 });
 

--- a/libs/langchain-openai/src/tests/azure/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/azure/chat_models.int.test.ts
@@ -883,12 +883,22 @@ test("Test Azure ChatOpenAI token usage reporting for streaming calls", async ()
   }
 });
 
-test("Test Azure ChatOpenAI with bearer token provider", async () => {
-  const tenantId: string = getEnvironmentVariable("AZURE_TENANT_ID") ?? "";
-  const clientId: string = getEnvironmentVariable("AZURE_CLIENT_ID") ?? "";
-  const clientSecret: string =
-    getEnvironmentVariable("AZURE_CLIENT_SECRET") ?? "";
+// This test should be skipped if the required environment variables are not set
+// instead of failing the test.
+const tenantId: string = getEnvironmentVariable("AZURE_TENANT_ID") ?? "";
+const clientId: string = getEnvironmentVariable("AZURE_CLIENT_ID") ?? "";
+const clientSecret: string =
+  getEnvironmentVariable("AZURE_CLIENT_SECRET") ?? "";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let testFn: any = test;
+if (!tenantId || !clientId || !clientSecret) {
+  console.warn(`One or more required environment variables are not set.
+Skipping "Test Azure ChatOpenAI with bearer token provider".`);
+  testFn = test.skip;
+}
+
+testFn("Test Azure ChatOpenAI with bearer token provider", async () => {
   const credentials = new ClientSecretCredential(
     tenantId,
     clientId,

--- a/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
@@ -29,7 +29,14 @@ test("Test ChatOpenAI seed", async () => {
   const res = await chat.invoke([message]);
   console.log(JSON.stringify(res));
   const res2 = await chat.invoke([message]);
-  expect(res).toEqual(res2);
+  const resAsObject = { ...res };
+  const res2AsObject = { ...res2 };
+  delete resAsObject.id;
+  delete resAsObject.lc_kwargs.id;
+  delete res2AsObject.id;
+  delete res2AsObject.lc_kwargs.id;
+
+  expect(resAsObject).toEqual(res2AsObject);
 });
 
 test("Test ChatOpenAI tool calling", async () => {

--- a/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
@@ -17,7 +17,7 @@ test("Test ChatOpenAI JSON mode", async () => {
   console.log(JSON.stringify(res));
 });
 
-test.only("Test ChatOpenAI seed", async () => {
+test("Test ChatOpenAI seed", async () => {
   const chat = new ChatOpenAI({
     modelName: "gpt-3.5-turbo-1106",
     maxTokens: 128,

--- a/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models-extended.int.test.ts
@@ -17,7 +17,7 @@ test("Test ChatOpenAI JSON mode", async () => {
   console.log(JSON.stringify(res));
 });
 
-test("Test ChatOpenAI seed", async () => {
+test.only("Test ChatOpenAI seed", async () => {
   const chat = new ChatOpenAI({
     modelName: "gpt-3.5-turbo-1106",
     maxTokens: 128,
@@ -28,13 +28,18 @@ test("Test ChatOpenAI seed", async () => {
   const message = new HumanMessage("Say something random!");
   const res = await chat.invoke([message]);
   console.log(JSON.stringify(res));
+
   const res2 = await chat.invoke([message]);
-  const resAsObject = { ...res };
-  const res2AsObject = { ...res2 };
-  delete resAsObject.id;
-  delete resAsObject.lc_kwargs.id;
-  delete res2AsObject.id;
-  delete res2AsObject.lc_kwargs.id;
+  const resAsObject = {
+    ...res,
+    id: undefined,
+    lc_kwargs: { ...res.lc_kwargs, id: undefined },
+  };
+  const res2AsObject = {
+    ...res2,
+    id: undefined,
+    lc_kwargs: { ...res2.lc_kwargs, id: undefined },
+  };
 
   expect(resAsObject).toEqual(res2AsObject);
 });

--- a/libs/langchain-openai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models.int.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+
 import { test, jest, expect } from "@jest/globals";
 import {
   AIMessageChunk,
@@ -18,6 +20,9 @@ import { CallbackManager } from "@langchain/core/callbacks/manager";
 import { NewTokenIndices } from "@langchain/core/callbacks/base";
 import { InMemoryCache } from "@langchain/core/caches";
 import { ChatOpenAI } from "../chat_models.js";
+
+// Save the original value of the 'LANGCHAIN_CALLBACKS_BACKGROUND' environment variable
+const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
 
 test("Test ChatOpenAI Generate", async () => {
   const chat = new ChatOpenAI({
@@ -56,7 +61,6 @@ test("Test ChatOpenAI tokenUsage", async () => {
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {
@@ -89,7 +93,6 @@ test("Test ChatOpenAI tokenUsage with a batch", async () => {
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {
@@ -124,7 +127,6 @@ test("Test ChatOpenAI in streaming mode", async () => {
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {
@@ -160,7 +162,6 @@ test("Test ChatOpenAI in streaming mode with n > 1 and multiple prompts", async 
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {
@@ -441,7 +442,6 @@ test("Function calling with streaming", async () => {
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {
@@ -741,7 +741,6 @@ test("Test ChatOpenAI token usage reporting for streaming calls", async () => {
   // Running LangChain callbacks in the background will sometimes cause the callbackManager to execute
   // after the test/llm call has already finished & returned. Set that environment variable to false
   // to prevent that from happening.
-  const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
   process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
 
   try {

--- a/libs/langchain-openai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models.int.test.ts
@@ -52,7 +52,7 @@ test("Test ChatOpenAI Generate throws when one of the calls fails", async () => 
   ).rejects.toThrow();
 });
 
-test("Test ChatOpenAI tokenUsage", async () => {
+test.skip("Test ChatOpenAI tokenUsage", async () => {
   let tokenUsage = {
     completionTokens: 0,
     promptTokens: 0,
@@ -395,7 +395,7 @@ test("Test ChatOpenAI stream method, timeout error thrown from SDK", async () =>
   }).rejects.toThrow();
 });
 
-test("Function calling with streaming", async () => {
+test.skip("Function calling with streaming", async () => {
   let finalResult: BaseMessage | undefined;
   const modelForFunctionCalling = new ChatOpenAI({
     modelName: "gpt-3.5-turbo",
@@ -603,7 +603,7 @@ test("ChatOpenAI should not reuse cache if function call args have changed", asy
   updateSpy.mockRestore();
 });
 
-test("Test ChatOpenAI token usage reporting for streaming function calls", async () => {
+test.only("Test ChatOpenAI token usage reporting for streaming function calls", async () => {
   let streamingTokenUsed = -1;
   let nonStreamingTokenUsed = -1;
 
@@ -784,7 +784,7 @@ test("Finish reason is 'stop'", async () => {
   expect(finalResult?.response_metadata?.finish_reason).toBe("stop");
 });
 
-test("Streaming tokens can be found in usage_metadata field", async () => {
+test.skip("Streaming tokens can be found in usage_metadata field", async () => {
   const model = new ChatOpenAI();
   const response = await model.stream("Hello, how are you?");
   let finalResult: AIMessageChunk | undefined;


### PR DESCRIPTION
Tests which relied on callbacks are flaky if `LANGCHAIN_CALLBACKS_BACKGROUND` is set to `true`. This is due to those callback funcs not necessarily completing until after the parent fn (in this case a chat model) has resolved. To solve this, I wrapped those tests in a `try { ... } finally { ... }` and set `LANGCHAIN_CALLBACKS_BACKGROUND` to false at the start of the test, and inside the `finally` block I reset it to the original value.

I also updated the Azure test `Test Azure ChatOpenAI with bearer token provider` to first check if the required env vars are set. If they are, it runs the test as normal. If not, it marks the test as skipped. Ideally we remove this code once we get our hands on those vars 🙃