### PR TITLE
all[minor]: Add ability to disable console logs in tests

### DIFF
--- a/libs/create-langchain-integration/template/scripts/jest-setup-after-env.js
+++ b/libs/create-langchain-integration/template/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-anthropic/scripts/jest-setup-after-env.js
+++ b/libs/langchain-anthropic/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-aws/scripts/jest-setup-after-env.js
+++ b/libs/langchain-aws/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-azure-dynamic-sessions/scripts/jest-setup-after-env.js
+++ b/libs/langchain-azure-dynamic-sessions/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-azure-openai/scripts/jest-setup-after-env.js
+++ b/libs/langchain-azure-openai/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-baidu-qianfan/scripts/jest-setup-after-env.js
+++ b/libs/langchain-baidu-qianfan/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-cloudflare/scripts/jest-setup-after-env.js
+++ b/libs/langchain-cloudflare/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-cohere/scripts/jest-setup-after-env.js
+++ b/libs/langchain-cohere/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-community/scripts/jest-setup-after-env.js
+++ b/libs/langchain-community/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-exa/scripts/jest-setup-after-env.js
+++ b/libs/langchain-exa/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-google-genai/scripts/jest-setup-after-env.js
+++ b/libs/langchain-google-genai/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-groq/scripts/jest-setup-after-env.js
+++ b/libs/langchain-groq/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-mistralai/scripts/jest-setup-after-env.js
+++ b/libs/langchain-mistralai/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-mixedbread-ai/scripts/jest-setup-after-env.js
+++ b/libs/langchain-mixedbread-ai/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-mongodb/scripts/jest-setup-after-env.js
+++ b/libs/langchain-mongodb/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-nomic/scripts/jest-setup-after-env.js
+++ b/libs/langchain-nomic/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-pinecone/scripts/jest-setup-after-env.js
+++ b/libs/langchain-pinecone/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-qdrant/scripts/jest-setup-after-env.js
+++ b/libs/langchain-qdrant/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-redis/scripts/jest-setup-after-env.js
+++ b/libs/langchain-redis/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-standard-tests/scripts/jest-setup-after-env.js
+++ b/libs/langchain-standard-tests/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-textsplitters/scripts/jest-setup-after-env.js
+++ b/libs/langchain-textsplitters/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}

--- a/libs/langchain-weaviate/scripts/jest-setup-after-env.js
+++ b/libs/langchain-weaviate/scripts/jest-setup-after-env.js
@@ -1,3 +1,9 @@
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
+import { afterAll, jest } from "@jest/globals";
 
 afterAll(awaitAllCallbacks);
+
+// Allow console.log to be disabled in tests
+if (process.env.DISABLE_CONSOLE_LOGS === "true") {
+  console.log = jest.fn();
+}


### PR DESCRIPTION
there's far too many console logs in our tests... this makes it difficult to diagnose failures in ci and similar. This PR allows for setting an env var (`DISABLE_CONSOLE_LOGS`) which will prevent `console.log` calls from actually logging anything.