### PR TITLE
aws[minor]: Add support for tool result statuses via raw_output

### DIFF
--- a/docs/core_docs/docs/integrations/chat/bedrock_converse.mdx
+++ b/docs/core_docs/docs/integrations/chat/bedrock_converse.mdx
@@ -75,3 +75,27 @@ import WSOExample from "@examples/models/chat/integration_bedrock_wso_converse.t
 :::tip
 See the LangSmith trace [here](https://smith.langchain.com/public/982940c4-5f96-4168-80c9-99102c3e073a/r)
 :::
+
+### Tool result status
+
+:::note
+This feature is only available in `@langchain/aws` version 0.0.2 and above.
+:::
+
+The Bedrock Converse tool calling API allows for passing a `status` field in the tool result.
+This can be one of `"success"`, or `"error"` to indicate the status of the tool call.
+This can be helpful when building complex tool calling agents/graphs, where you want the agent/graph to handle errors gracefully.
+
+With LangChain, you can pass the `status` field to the Bedrock Converse API via the `raw_output` field on `ToolMessage`.
+
+Below is an example showing how this can work in practice:
+
+import ErrorStatusTool from "@examples/models/chat/integration_bedrock_converse_err_status.ts";
+
+<CodeBlock language="typescript">{ErrorStatusTool}</CodeBlock>
+
+We can see the model handled the error exactly as we intended, with it calling the `error_handler_tool` after it received a tool result with a status of `"error"`!
+
+:::tip
+See the LangSmith trace [here](https://smith.langchain.com/public/8794ac4d-dd17-4bf7-8334-6022e3a6af56/r)
+:::

--- a/examples/src/models/chat/integration_bedrock_converse_err_status.ts
+++ b/examples/src/models/chat/integration_bedrock_converse_err_status.ts
@@ -1,0 +1,103 @@
+import { ChatBedrockConverse } from "@langchain/aws";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const model = new ChatBedrockConverse({
+  model: "anthropic.claude-3-sonnet-20240229-v1:0",
+  region: "us-east-1",
+  credentials: {
+    accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
+  },
+});
+
+// Define two tools. The `weather_tool`, which will have already been called
+// and the result will be an error. Next, the `error_handler_tool` will be
+// provided to the model to handle the error.
+
+const weatherTool = tool(
+  (_) => {
+    return ""; // no-op, we won't actually invoke the tools in this example
+  },
+  {
+    name: "weather_tool",
+    description: "Fetches the weather for a given location.",
+    schema: z.object({
+      location: z.string().describe("The location to fetch the weather for."),
+    }),
+  }
+);
+const errorHandlerTool = tool(
+  (_) => {
+    return ""; // no-op, we won't actually invoke the tools in this example
+  },
+  {
+    name: "error_handler_tool",
+    description: "A tool which handles any errors in the conversation.",
+    schema: z.object({
+      errorMessage: z.string().describe("The error message to handle."),
+    }),
+  }
+);
+
+// Define an array of messages to simulate a conversation history.
+// Ensure the `ToolMessage` has a status if "error" to indicate to
+// the model that an error occurred.
+const messageHistory = [
+  new SystemMessage(`You are a helpful AI agent.`),
+  new HumanMessage("What's the weather like in New York, NY?"),
+  new AIMessage({
+    content: "",
+    tool_calls: [
+      {
+        name: "weather_tool",
+        args: {
+          location: "New York, NY",
+        },
+        id: "tool_call_1",
+      },
+    ],
+  }),
+  new ToolMessage({
+    content: "An error occurred while trying to fetch the weather.",
+    tool_call_id: "tool_call_1",
+    raw_output: {
+      status: "error",
+    },
+  }),
+];
+
+// Bind both tools to the model.
+const modelWithTools = model.bindTools([weatherTool, errorHandlerTool]);
+
+const res = await modelWithTools.invoke(messageHistory);
+console.log(JSON.stringify(res, null, 2));
+
+/*
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "It seems there was an issue fetching the weather for New York, NY. Let me try handling the error:"
+    }
+  ],
+  "tool_calls": [
+    {
+      "id": "tooluse__pIOAIE6QUy8g6gAo_YyqA",
+      "name": "error_handler_tool",
+      "args": {
+        "errorMessage": "An error occurred while trying to fetch the weather."
+      }
+    }
+  ],
+  "response_metadata": { ... },
+  "usage_metadata": { ... },
+  "id": "53eb9f1c-b874-4c9a-a476-d1c77c0bea77",
+}
+*/

--- a/libs/langchain-aws/src/chat_models.ts
+++ b/libs/langchain-aws/src/chat_models.ts
@@ -179,23 +179,6 @@ export class ChatBedrockConverse
     return "ChatBedrockConverse";
   }
 
-  /**
-   * Replace with any secrets this class passes to `super`.
-   * See {@link ../../langchain-cohere/src/chat_model.ts} for
-   * an example.
-   */
-  get lc_secrets(): { [key: string]: string } | undefined {
-    return {
-      apiKey: "API_KEY_NAME",
-    };
-  }
-
-  get lc_aliases(): { [key: string]: string } | undefined {
-    return {
-      apiKey: "API_KEY_NAME",
-    };
-  }
-
   model = "anthropic.claude-3-haiku-20240307-v1:0";
 
   streaming = false;

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -169,6 +169,15 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
         }
       } else if (msg._getType() === "tool") {
         const castMsg = msg as ToolMessage;
+        let status: "error" | "success" | undefined;
+        if (
+          castMsg.raw_output &&
+          typeof castMsg.raw_output === "object" &&
+          "status" in castMsg.raw_output &&
+          ["error", "success"].includes(castMsg.raw_output.status as string)
+        ) {
+          status = castMsg.raw_output.status as "error" | "success";
+        }
         if (typeof castMsg.content === "string") {
           return {
             // Tool use messages are always from the user
@@ -182,6 +191,7 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
                       text: castMsg.content,
                     },
                   ],
+                  status,
                 },
               },
             ],
@@ -199,6 +209,7 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
                       json: castMsg.content,
                     },
                   ],
+                  status,
                 },
               },
             ],


### PR DESCRIPTION
todo:
- [ ] cut new core release so `raw_output` on `ToolMessage` is avail
- [ ] Bump min core version in aws package