### PR TITLE
langchain[patch]: Bug fix for ParentDocumentRetriever

### DIFF
--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -136,7 +136,7 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
   }
 
   async _storeDocuments(
-    parentDoc: Document,
+    parentDoc: Record<string, Document>,
     childDocs: Document[],
     addToDocstore: boolean
   ) {
@@ -210,7 +210,7 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
             metadata: { ...subDoc.metadata, [this.idKey]: parentDocId },
           })
       );
-      await this._storeDocuments(parentDoc, taggedSubDocs, addToDocstore);
+      await this._storeDocuments({ parentDocId: parentDoc }, taggedSubDocs, addToDocstore);
     }
   }
 }

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -211,7 +211,7 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
           })
       );
       await this._storeDocuments(
-        { parentDocId: parentDoc },
+        { [parentDocId]: parentDoc },
         taggedSubDocs,
         addToDocstore
       );

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -210,7 +210,11 @@ export class ParentDocumentRetriever extends MultiVectorRetriever {
             metadata: { ...subDoc.metadata, [this.idKey]: parentDocId },
           })
       );
-      await this._storeDocuments({ parentDocId: parentDoc }, taggedSubDocs, addToDocstore);
+      await this._storeDocuments(
+        { parentDocId: parentDoc },
+        taggedSubDocs,
+        addToDocstore
+      );
     }
   }
 }


### PR DESCRIPTION
Fix for bug introduced in https://github.com/langchain-ai/langchainjs/pull/5989 (sorry about this).

Fixes error: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined

@PetersClemens