### PR TITLE
docs[patch]: Fix import path in typesense doc

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/typesense.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/typesense.mdx
@@ -9,14 +9,17 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/openai
+npm install @langchain/openai @langchain/community
 ```
 
 ```typescript
-import { Typesense, TypesenseConfig } from "langchain/vectorstores/typesense";
+import {
+  Typesense,
+  TypesenseConfig,
+} from "@lanchain/community/vectorstores/typesense";
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { Client } from "typesense";
-import { Document } from "langchain/document";
+import { Document } from "@langchain/core/documents";
 
 const vectorTypesenseClient = new Client({
   nodes: [


### PR DESCRIPTION
closes #6105