### PR TITLE
partners[minor]: Throw error if tool_choice is supplied but not supported

### DIFF
--- a/libs/langchain-cohere/src/chat_models.ts
+++ b/libs/langchain-cohere/src/chat_models.ts
@@ -347,7 +347,9 @@ export class ChatCohere<
 
   invocationParams(options: this["ParsedCallOptions"]) {
     if (options.tool_choice) {
-      throw new Error("'tool_choice' call option is not supported by ChatCohere.")
+      throw new Error(
+        "'tool_choice' call option is not supported by ChatCohere."
+      );
     }
 
     const params = {

--- a/libs/langchain-cohere/src/chat_models.ts
+++ b/libs/langchain-cohere/src/chat_models.ts
@@ -14,7 +14,6 @@ import {
   BaseLanguageModelInput,
   ToolDefinition,
   isOpenAITool,
-  type BaseLanguageModelCallOptions,
 } from "@langchain/core/language_models/base";
 import { isStructuredTool } from "@langchain/core/utils/function_calling";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
@@ -22,6 +21,7 @@ import {
   type BaseChatModelParams,
   BaseChatModel,
   LangSmithParams,
+  BaseChatModelCallOptions,
 } from "@langchain/core/language_models/chat_models";
 import {
   ChatGeneration,
@@ -84,7 +84,7 @@ interface TokenUsage {
 }
 
 export interface ChatCohereCallOptions
-  extends BaseLanguageModelCallOptions,
+  extends BaseChatModelCallOptions,
     Partial<Omit<Cohere.ChatRequest, "message" | "tools">>,
     Partial<Omit<Cohere.ChatStreamRequest, "message" | "tools">>,
     Pick<ChatCohereInput, "streamUsage"> {
@@ -346,6 +346,10 @@ export class ChatCohere<
   }
 
   invocationParams(options: this["ParsedCallOptions"]) {
+    if (options.tool_choice) {
+      throw new Error("'tool_choice' call option is not supported by ChatCohere.")
+    }
+
     const params = {
       model: this.model,
       preamble: options.preamble,

--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -379,7 +379,9 @@ export class BedrockChat
 
   override invocationParams(options?: this["ParsedCallOptions"]) {
     if (options?.tool_choice) {
-      throw new Error("'tool_choice' call option is not supported by BedrockChat.")
+      throw new Error(
+        "'tool_choice' call option is not supported by BedrockChat."
+      );
     }
 
     const callOptionTools = formatTools(options?.tools ?? []);

--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -378,6 +378,10 @@ export class BedrockChat
   }
 
   override invocationParams(options?: this["ParsedCallOptions"]) {
+    if (options?.tool_choice) {
+      throw new Error("'tool_choice' call option is not supported by BedrockChat.")
+    }
+
     const callOptionTools = formatTools(options?.tools ?? []);
     return {
       tools: [...(this._anthropicTools ?? []), ...callOptionTools],

--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -340,7 +340,9 @@ export abstract class ChatGoogleBase<AuthOptions>
    */
   override invocationParams(options?: this["ParsedCallOptions"]) {
     if (options?.tool_choice) {
-      throw new Error(`'tool_choice' call option is not supported by ${this.getName()}.`);
+      throw new Error(
+        `'tool_choice' call option is not supported by ${this.getName()}.`
+      );
     }
 
     return copyAIModelParams(this, options);

--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -339,6 +339,10 @@ export abstract class ChatGoogleBase<AuthOptions>
    * Get the parameters used to invoke the model
    */
   override invocationParams(options?: this["ParsedCallOptions"]) {
+    if (options?.tool_choice) {
+      throw new Error(`'tool_choice' call option is not supported by ${this.getName()}.`);
+    }
+
     return copyAIModelParams(this, options);
   }
 

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -1,7 +1,7 @@
 import type { BaseLLMParams } from "@langchain/core/language_models/llms";
-import { BaseLanguageModelCallOptions } from "@langchain/core/language_models/base";
 import { StructuredToolInterface } from "@langchain/core/tools";
 import type { JsonStream } from "./utils/stream.js";
+import type { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
 
 /**
  * Parameters needed to setup the client connection.
@@ -120,7 +120,7 @@ export interface GoogleAIBaseLLMInput<AuthOptions>
     GoogleAISafetyParams {}
 
 export interface GoogleAIBaseLanguageModelCallOptions
-  extends BaseLanguageModelCallOptions,
+  extends BaseChatModelCallOptions,
     GoogleAIModelRequestParams,
     GoogleAISafetyParams {
   /**

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -1,7 +1,7 @@
 import type { BaseLLMParams } from "@langchain/core/language_models/llms";
 import { StructuredToolInterface } from "@langchain/core/tools";
-import type { JsonStream } from "./utils/stream.js";
 import type { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
+import type { JsonStream } from "./utils/stream.js";
 
 /**
  * Parameters needed to setup the client connection.

--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -365,7 +365,9 @@ export class ChatGoogleGenerativeAI
     options?: this["ParsedCallOptions"]
   ): Omit<GenerateContentRequest, "contents"> {
     if (options?.tool_choice) {
-      throw new Error("'tool_choice' call option is not supported by ChatGoogleGenerativeAI.")
+      throw new Error(
+        "'tool_choice' call option is not supported by ChatGoogleGenerativeAI."
+      );
     }
 
     const tools = options?.tools as

--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -18,12 +18,12 @@ import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import {
   BaseChatModel,
-  LangSmithParams,
+  type BaseChatModelCallOptions,
+  type LangSmithParams,
   type BaseChatModelParams,
 } from "@langchain/core/language_models/chat_models";
 import { NewTokenIndices } from "@langchain/core/callbacks/base";
 import {
-  BaseLanguageModelCallOptions,
   BaseLanguageModelInput,
   StructuredOutputMethodOptions,
   ToolDefinition,
@@ -59,7 +59,7 @@ export type BaseMessageExamplePair = {
 };
 
 export interface GoogleGenerativeAIChatCallOptions
-  extends BaseLanguageModelCallOptions {
+  extends BaseChatModelCallOptions {
   tools?:
     | StructuredToolInterface[]
     | GoogleGenerativeAIFunctionDeclarationsTool[];
@@ -364,6 +364,10 @@ export class ChatGoogleGenerativeAI
   invocationParams(
     options?: this["ParsedCallOptions"]
   ): Omit<GenerateContentRequest, "contents"> {
+    if (options?.tool_choice) {
+      throw new Error("'tool_choice' call option is not supported by ChatGoogleGenerativeAI.")
+    }
+
     const tools = options?.tools as
       | GoogleGenerativeAIFunctionDeclarationsTool[]
       | StructuredToolInterface[]


### PR DESCRIPTION
Throw an error if `tool_choice` is passed to a model which does not support it. Updated instances where call options interface extended `BaseLanguageModelCallOptions` instead of `BaseChatModelCallOptions`