### PR TITLE
aws[major]: Add bedrock embeddings to aws package

### DIFF
--- a/docs/core_docs/docs/integrations/platforms/aws.mdx
+++ b/docs/core_docs/docs/integrations/platforms/aws.mdx
@@ -48,7 +48,7 @@ import {
 See a [usage example](/docs/integrations/text_embedding/bedrock).
 
 ```typescript
-import { BedrockEmbeddings } from "@langchain/community/embeddings/bedrock";
+import { BedrockEmbeddings } from "@langchain/aws";
 ```
 
 ## Document loaders

--- a/docs/core_docs/docs/integrations/text_embedding/bedrock.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/bedrock.mdx
@@ -6,27 +6,17 @@ hide_table_of_contents: true
 
 [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-service.html) is a fully managed service that makes base models from Amazon and third-party model providers accessible through an API.
 
-When this documentation was written, Bedrock supports one model for text embeddings, the Titan Embeddings G1 - Text model (amazon.titan-embed-text-v1). This model supports text retrieval, semantic similarity, and clustering. The maximum input text is 8K tokens and the maximum output vector length is 1536.
-
 ## Setup
 
-To use this embedding, please ensure you have the Bedrock runtime client installed in your project.
-
-```bash npm2yarn
-npm i @aws-sdk/client-bedrock-runtime@^3.422.0
-```
+To use this embedding, please ensure you have the LangChain AWS package installed.
 
 import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
 
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/community
+npm i @langchain/aws
 ```
-
-import UnifiedModelParamsTooltip from "@mdx_components/unified_model_params_tooltip.mdx";
-
-<UnifiedModelParamsTooltip></UnifiedModelParamsTooltip>
 
 ## Usage
 
@@ -44,7 +34,7 @@ You can pass in your own instance of the `BedrockRuntimeClient` if you want to c
 
 ```typescript
 import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
-import { BedrockEmbeddings } from "langchain/embeddings/bedrock";
+import { BedrockEmbeddings } from "@langchain/aws";
 
 const client = new BedrockRuntimeClient({
   region: "us-east-1",

--- a/examples/src/embeddings/bedrock.ts
+++ b/examples/src/embeddings/bedrock.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { BedrockEmbeddings } from "@langchain/community/embeddings/bedrock";
+import { BedrockEmbeddings } from "@langchain/aws";
 
 const embeddings = new BedrockEmbeddings({
   region: process.env.BEDROCK_AWS_REGION!,

--- a/libs/langchain-aws/package.json
+++ b/libs/langchain-aws/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
     "jest-environment-node": "^29.6.4",
+    "langchain": "workspace:*",
     "prettier": "^2.8.3",
     "release-it": "^15.10.1",
     "rollup": "^4.5.2",

--- a/libs/langchain-aws/src/embeddings.ts
+++ b/libs/langchain-aws/src/embeddings.ts
@@ -1,0 +1,142 @@
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
+import { CredentialType } from "./types.js";
+
+/**
+ * Interface that extends EmbeddingsParams and defines additional
+ * parameters specific to the BedrockEmbeddings class.
+ */
+export interface BedrockEmbeddingsParams extends EmbeddingsParams {
+  /**
+   * Model Name to use. Defaults to `amazon.titan-embed-text-v1` if not provided
+   *
+   */
+  model?: string;
+
+  /**
+   * A client provided by the user that allows them to customze any
+   * SDK configuration options.
+   */
+  client?: BedrockRuntimeClient;
+
+  region?: string;
+
+  credentials?: CredentialType;
+}
+
+/**
+ * Class that extends the Embeddings class and provides methods for
+ * generating embeddings using the Bedrock API.
+ * @example
+ * ```typescript
+ * const embeddings = new BedrockEmbeddings({
+ *   region: "your-aws-region",
+ *   credentials: {
+ *     accessKeyId: "your-access-key-id",
+ *     secretAccessKey: "your-secret-access-key",
+ *   },
+ *   model: "amazon.titan-embed-text-v1",
+ * });
+ *
+ * // Embed a query and log the result
+ * const res = await embeddings.embedQuery(
+ *   "What would be a good company name for a company that makes colorful socks?"
+ * );
+ * console.log({ res });
+ * ```
+ */
+export class BedrockEmbeddings
+  extends Embeddings
+  implements BedrockEmbeddingsParams
+{
+  model: string;
+
+  client: BedrockRuntimeClient;
+
+  batchSize = 512;
+
+  constructor(fields?: BedrockEmbeddingsParams) {
+    super(fields ?? {});
+
+    this.model = fields?.model ?? "amazon.titan-embed-text-v1";
+
+    this.client =
+      fields?.client ??
+      new BedrockRuntimeClient({
+        region: fields?.region,
+        credentials: fields?.credentials,
+      });
+  }
+
+  /**
+   * Protected method to make a request to the Bedrock API to generate
+   * embeddings. Handles the retry logic and returns the response from the
+   * API.
+   * @param request Request to send to the Bedrock API.
+   * @returns Promise that resolves to the response from the API.
+   */
+  protected async _embedText(text: string): Promise<number[]> {
+    return this.caller.call(async () => {
+      try {
+        // replace newlines, which can negatively affect performance.
+        const cleanedText = text.replace(/\n/g, " ");
+
+        const res = await this.client.send(
+          new InvokeModelCommand({
+            modelId: this.model,
+            body: JSON.stringify({
+              inputText: cleanedText,
+            }),
+            contentType: "application/json",
+            accept: "application/json",
+          })
+        );
+
+        const body = new TextDecoder().decode(res.body);
+        return JSON.parse(body).embedding;
+      } catch (e) {
+        console.error({
+          error: e,
+        });
+        // eslint-disable-next-line no-instanceof/no-instanceof
+        if (e instanceof Error) {
+          throw new Error(
+            `An error occurred while embedding documents with Bedrock: ${e.message}`
+          );
+        }
+
+        throw new Error(
+          "An error occurred while embedding documents with Bedrock"
+        );
+      }
+    });
+  }
+
+  /**
+   * Method that takes a document as input and returns a promise that
+   * resolves to an embedding for the document. It calls the _embedText
+   * method with the document as the input.
+   * @param document Document for which to generate an embedding.
+   * @returns Promise that resolves to an embedding for the input document.
+   */
+  embedQuery(document: string): Promise<number[]> {
+    return this.caller.callWithOptions(
+      {},
+      this._embedText.bind(this),
+      document
+    );
+  }
+
+  /**
+   * Method to generate embeddings for an array of texts. Calls _embedText
+   * method which batches and handles retry logic when calling the AWS Bedrock API.
+   * @param documents Array of texts for which to generate embeddings.
+   * @returns Promise that resolves to a 2D array of embeddings for each input document.
+   */
+  async embedDocuments(documents: string[]): Promise<number[][]> {
+    return Promise.all(documents.map((document) => this._embedText(document)));
+  }
+}

--- a/libs/langchain-aws/src/index.ts
+++ b/libs/langchain-aws/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./chat_models.js";
 export * from "./types.js";
+export * from "./embeddings.js";

--- a/libs/langchain-aws/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-aws/src/tests/embeddings.int.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-process-env */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { expect, test } from "@jest/globals";
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
+
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import { BedrockEmbeddings } from "../embeddings.js";
+
+const getClient = () => {
+  if (
+    !process.env.BEDROCK_AWS_REGION ||
+    !process.env.BEDROCK_AWS_ACCESS_KEY_ID ||
+    !process.env.BEDROCK_AWS_SECRET_ACCESS_KEY
+  ) {
+    throw new Error("Missing environment variables for AWS");
+  }
+
+  const client = new BedrockRuntimeClient({
+    region: process.env.BEDROCK_AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY,
+    },
+  });
+
+  return client;
+};
+
+test("Test BedrockEmbeddings.embedQuery", async () => {
+  const client = getClient();
+  const embeddings = new BedrockEmbeddings({
+    maxRetries: 1,
+    client,
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  // console.log(res);
+  expect(typeof res[0]).toBe("number");
+});
+
+test("Test BedrockEmbeddings.embedDocuments with passed region and credentials", async () => {
+  const client = getClient();
+  const embeddings = new BedrockEmbeddings({
+    maxRetries: 1,
+    client,
+  });
+  const res = await embeddings.embedDocuments([
+    "Hello world",
+    "Bye bye",
+    "we need",
+    "at least",
+    "six documents",
+    "to test pagination",
+  ]);
+  // console.log(res);
+  expect(res).toHaveLength(6);
+  res.forEach((r) => {
+    expect(typeof r[0]).toBe("number");
+  });
+});
+
+test("Test end to end with MemoryVectorStore", async () => {
+  const client = getClient();
+  const vectorStore = await MemoryVectorStore.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }],
+    new BedrockEmbeddings({
+      maxRetries: 1,
+      client,
+    })
+  );
+  expect(vectorStore.memoryVectors).toHaveLength(3);
+
+  const resultOne = await vectorStore.similaritySearch("hello world", 1);
+  const resultOneMetadatas = resultOne.map(({ metadata }) => metadata);
+  expect(resultOneMetadatas).toEqual([{ id: 2 }]);
+
+  const resultTwo = await vectorStore.similaritySearch("hello world", 2);
+  const resultTwoMetadatas = resultTwo.map(({ metadata }) => metadata);
+  expect(resultTwoMetadatas).toEqual([{ id: 2 }, { id: 3 }]);
+
+  const resultThree = await vectorStore.similaritySearch("hello world", 3);
+  const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
+  expect(resultThreeMetadatas).toEqual([{ id: 2 }, { id: 3 }, { id: 1 }]);
+});

--- a/libs/langchain-community/src/embeddings/bedrock.ts
+++ b/libs/langchain-community/src/embeddings/bedrock.ts
@@ -6,6 +6,8 @@ import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
 import type { CredentialType } from "../utils/bedrock/index.js";
 
 /**
+ * @deprecated The BedrockEmbeddings integration has been moved to the `@langchain/aws` package. Import from `@langchain/aws` instead.
+ * 
  * Interface that extends EmbeddingsParams and defines additional
  * parameters specific to the BedrockEmbeddings class.
  */
@@ -28,6 +30,8 @@ export interface BedrockEmbeddingsParams extends EmbeddingsParams {
 }
 
 /**
+ * @deprecated The BedrockEmbeddings integration has been moved to the `@langchain/aws` package. Import from `@langchain/aws` instead.
+ * 
  * Class that extends the Embeddings class and provides methods for
  * generating embeddings using the Bedrock API.
  * @example

--- a/libs/langchain-community/src/embeddings/bedrock.ts
+++ b/libs/langchain-community/src/embeddings/bedrock.ts
@@ -7,7 +7,7 @@ import type { CredentialType } from "../utils/bedrock/index.js";
 
 /**
  * @deprecated The BedrockEmbeddings integration has been moved to the `@langchain/aws` package. Import from `@langchain/aws` instead.
- * 
+ *
  * Interface that extends EmbeddingsParams and defines additional
  * parameters specific to the BedrockEmbeddings class.
  */
@@ -31,7 +31,7 @@ export interface BedrockEmbeddingsParams extends EmbeddingsParams {
 
 /**
  * @deprecated The BedrockEmbeddings integration has been moved to the `@langchain/aws` package. Import from `@langchain/aws` instead.
- * 
+ *
  * Class that extends the Embeddings class and provides methods for
  * generating embeddings using the Bedrock API.
  * @example

--- a/yarn.lock
+++ b/yarn.lock
@@ -10267,6 +10267,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
+    langchain: "workspace:*"
     prettier: ^2.8.3
     release-it: ^15.10.1
     rollup: ^4.5.2


### PR DESCRIPTION
Ported from community
Added `langchain` as workspace dev dep so I can access `MemoryVectorStore` in tests