### PR TITLE
community[patch]: Typo fixed in Upstash Ratelimit Callback.

### DIFF
--- a/docs/core_docs/docs/integrations/callbacks/upstash_ratelimit_callback.mdx
+++ b/docs/core_docs/docs/integrations/callbacks/upstash_ratelimit_callback.mdx
@@ -57,7 +57,7 @@ const ratelimit = new Ratelimit({
     token: UPSTASH_REDIS_REST_TOKEN,
   }),
   // 10 requests per window, where window size is 60 seconds:
-  limiter: Ratelimit.fixedWindow(1, "60 s"),
+  limiter: Ratelimit.fixedWindow(10, "60 s"),
 });
 
 // create handler


### PR DESCRIPTION
In the Upstash Ratelimit Callback, `limiter` should be set to `Ratelimit.fixedWindow(10, "60 s")` instead of `Ratelimit.fixedWindow(1, "60 s")`.
 
This is because the comment above it says "10 requests per window, where window size is 60 seconds:". The current docs have it as 1 request every 60 seconds

If you visit the Upstash docs, you see the correct syntax is as follows: 

<img width="792" alt="UpstashDocs" src="https://github.com/user-attachments/assets/f5e195f2-8752-41aa-ae68-559474e52a53">
