### PR TITLE
ollama[patch]: fix @langchain/core dependency version constraint

### DIFF
--- a/libs/langchain-ollama/package.json
+++ b/libs/langchain-ollama/package.json
@@ -35,7 +35,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/core": ">0.2.17 <0.3.0",
+    "@langchain/core": ">=0.2.17 <0.3.0",
     "ollama": "^0.5.6",
     "uuid": "^10.0.0"
   },


### PR DESCRIPTION
The dependency to @langchain/core was set to be greater than 0.2.17 while the current version is equal to 0.2.17. 
This PR Relaxes the dependency to greater than or equal 0.2.17

Fixes #6159 
