### PR TITLE
anthropic[patch]: ensure content exists when parsing tool tokens

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -602,7 +602,7 @@ function extractToken(chunk: AIMessageChunk): string | undefined {
     return chunk.content;
   } else if (
     Array.isArray(chunk.content) &&
-    chunk.content.length === 1 &&
+    chunk.content.length >= 1 &&
     "input" in chunk.content[0]
   ) {
     return typeof chunk.content[0].input === "string"

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -600,7 +600,11 @@ function extractToolCallChunk(
 function extractToken(chunk: AIMessageChunk): string | undefined {
   if (typeof chunk.content === "string") {
     return chunk.content;
-  } else if (Array.isArray(chunk.content) && "input" in chunk.content[0]) {
+  } else if (
+    Array.isArray(chunk.content) &&
+    chunk.content.length === 1 &&
+    "input" in chunk.content[0]
+  ) {
     return typeof chunk.content[0].input === "string"
       ? chunk.content[0].input
       : JSON.stringify(chunk.content[0].input);


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchainjs/issues/6045

When anthropic extracts tokens during tool use, it's throwing an error on the `message_start` event, as it results in a chunk with an empty content array, but the current token parsing assumes that a single content item always exists. This PR fixes the issue.

```
{
  type: 'message_start',
  message: {
    id: 'msg123',
    type: 'message',
    role: 'assistant',
    model: 'claude-3-5-sonnet-20240620',
    content: [],
    stop_reason: null,
    stop_sequence: null,
    usage: { input_tokens: 1486, output_tokens: 12 }
  }
}
```

The current error thrown:

```
error: TypeError: Cannot use 'in' operator to search for 'input' in undefined
        at extractToken
```