### PR TITLE
ci[minor]: Start building on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Check linting
         run: yarn run lint
 
-  test-exports:
-    uses:
-      ./.github/workflows/test-exports.yml
-    secrets: inherit
+  # test-exports:
+  #   uses:
+  #     ./.github/workflows/test-exports.yml
+  #   secrets: inherit
 
   build-core:
     name: Build @langchain/core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,24 @@ jobs:
       - name: Check linting
         run: yarn run lint
 
-  # test-exports:
-  #   uses:
-  #     ./.github/workflows/test-exports.yml
-  #   secrets: inherit
+  test-exports:
+    uses:
+      ./.github/workflows/test-exports.yml
+    secrets: inherit
 
-  build-core:
-    name: Build @langchain/core
-    runs-on: windows-latest
+  platform-compatibility:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
-      - name: Check linting
+        run: yarn install --immutable
+      - name: Build `@langchain/core`
         run: yarn build --filter=@langchain/core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,18 @@ jobs:
     uses:
       ./.github/workflows/test-exports.yml
     secrets: inherit
+
+  build-core:
+    name: Build @langchain/core
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable --mode=skip-build
+      - name: Check linting
+        run: yarn build --filter=@langchain/core

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -93,19 +93,41 @@ jobs:
       - name: Test `@langchain/community` with latest deps
         run: docker compose -f dependency_range_tests/docker-compose.yml run community-latest-deps
 
+  # community-lowest-deps:
+  #   runs-on: ubuntu-latest
+  #   needs: get-changed-files
+  #   if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Use Node.js ${{ env.NODE_VERSION }}
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #         cache: "yarn"
+  #     - name: Install dependencies
+  #       run: yarn install --immutable
+  #     - name: Build `@langchain/standard-tests`
+  #       run: yarn build --filter=@langchain/standard-tests
+  #     - name: Test `@langchain/community` with lowest deps
+  #       run: docker compose -f dependency_range_tests/docker-compose.yml run community-lowest-deps
+
   community-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
     if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ env.NODE_VERSION }}
+      - name: Use Node.js 20 for installation
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: '20'
           cache: "yarn"
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Switch to Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Build `@langchain/standard-tests`
         run: yarn build --filter=@langchain/standard-tests
       - name: Test `@langchain/community` with lowest deps

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -93,41 +93,19 @@ jobs:
       - name: Test `@langchain/community` with latest deps
         run: docker compose -f dependency_range_tests/docker-compose.yml run community-latest-deps
 
-  # community-lowest-deps:
-  #   runs-on: ubuntu-latest
-  #   needs: get-changed-files
-  #   if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Use Node.js ${{ env.NODE_VERSION }}
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #         cache: "yarn"
-  #     - name: Install dependencies
-  #       run: yarn install --immutable
-  #     - name: Build `@langchain/standard-tests`
-  #       run: yarn build --filter=@langchain/standard-tests
-  #     - name: Test `@langchain/community` with lowest deps
-  #       run: docker compose -f dependency_range_tests/docker-compose.yml run community-lowest-deps
-
   community-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
     if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20 for installation
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-          cache: "yarn"
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Switch to Node.js ${{ env.NODE_VERSION }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Build `@langchain/standard-tests`
         run: yarn build --filter=@langchain/standard-tests
       - name: Test `@langchain/community` with lowest deps

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -274,3 +274,22 @@ jobs:
         run: yarn build --filter=@langchain/standard-tests
       - name: Test `@langchain/cohere` with lowest deps
         run: docker compose -f dependency_range_tests/docker-compose.yml run cohere-lowest-deps
+
+  # platform-compatibility:
+  #   runs-on: ${{ matrix.os }}
+  #   needs: get-changed-files
+  #   if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/')
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Use Node.js ${{ env.NODE_VERSION }}
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ env.NODE_VERSION }}
+  #         cache: "yarn"
+  #     - name: Install dependencies
+  #       run: yarn install --immutable
+  #     - name: Build `@langchain/core`
+  #       run: yarn build --filter=@langchain/core

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -274,22 +274,3 @@ jobs:
         run: yarn build --filter=@langchain/standard-tests
       - name: Test `@langchain/cohere` with lowest deps
         run: docker compose -f dependency_range_tests/docker-compose.yml run cohere-lowest-deps
-
-  # platform-compatibility:
-  #   runs-on: ${{ matrix.os }}
-  #   needs: get-changed-files
-  #   if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/')
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Use Node.js ${{ env.NODE_VERSION }}
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ env.NODE_VERSION }}
-  #         cache: "yarn"
-  #     - name: Install dependencies
-  #       run: yarn install --immutable
-  #     - name: Build `@langchain/core`
-  #       run: yarn build --filter=@langchain/core

--- a/examples/package.json
+++ b/examples/package.json
@@ -57,7 +57,7 @@
     "@langchain/pinecone": "workspace:*",
     "@langchain/qdrant": "workspace:*",
     "@langchain/redis": "workspace:*",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/textsplitters": "workspace:*",
     "@langchain/weaviate": "workspace:*",
     "@langchain/yandex": "workspace:*",

--- a/examples/package.json
+++ b/examples/package.json
@@ -57,7 +57,7 @@
     "@langchain/pinecone": "workspace:*",
     "@langchain/qdrant": "workspace:*",
     "@langchain/redis": "workspace:*",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/textsplitters": "workspace:*",
     "@langchain/weaviate": "workspace:*",
     "@langchain/yandex": "workspace:*",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/langchain-core/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/core",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "clean": "rm -rf .turbo dist/",
     "build:deps": "yarn turbo build",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rimraf dist/tests dist/**/tests",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@types/mustache": "^4",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@types/mustache": "^4",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -610,7 +610,7 @@
     "@gomomento/sdk-core": "^1.51.1",
     "@jest/globals": "^29.5.0",
     "@langchain/cohere": "^0.0.8",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@mendable/firecrawl-js": "^0.0.13",
     "@notionhq/client": "^2.2.10",
     "@pinecone-database/pinecone": "^1.1.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -610,7 +610,7 @@
     "@gomomento/sdk-core": "^1.51.1",
     "@jest/globals": "^29.5.0",
     "@langchain/cohere": "^0.0.8",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@mendable/firecrawl-js": "^0.0.13",
     "@notionhq/client": "^2.2.10",
     "@pinecone-database/pinecone": "^1.1.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -570,7 +570,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/langchain/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=langchain",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking --gen-maps",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking --gen-maps",
     "build:deps": "yarn run turbo:command build --filter=@langchain/openai --filter=@langchain/textsplitters --filter=@langchain/cohere --concurrency=1",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rimraf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rimraf dist-cjs",

--- a/libs/create-langchain-integration/template/package.json
+++ b/libs/create-langchain-integration/template/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-INTEGRATION_NAME/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/INTEGRATION_NAME",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/create-langchain-integration/template/package.json
+++ b/libs/create-langchain-integration/template/package.json
@@ -45,7 +45,7 @@
     "@jest/globals": "^29.5.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@tsconfig/recommended": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/libs/create-langchain-integration/template/package.json
+++ b/libs/create-langchain-integration/template/package.json
@@ -45,7 +45,7 @@
     "@jest/globals": "^29.5.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@tsconfig/recommended": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/libs/langchain-anthropic/package.json
+++ b/libs/langchain-anthropic/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/community": "workspace:*",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-anthropic/package.json
+++ b/libs/langchain-anthropic/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-anthropic/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/anthropic",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking --gen-maps",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking --gen-maps",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-anthropic/package.json
+++ b/libs/langchain-anthropic/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/community": "workspace:*",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-aws/package.json
+++ b/libs/langchain-aws/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@aws-sdk/types": "^3.598.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@smithy/types": "^3.2.0",
     "@swc/core": "^1.3.90",

--- a/libs/langchain-aws/package.json
+++ b/libs/langchain-aws/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-aws/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/aws",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-aws/package.json
+++ b/libs/langchain-aws/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@aws-sdk/types": "^3.598.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@smithy/types": "^3.2.0",
     "@swc/core": "^1.3.90",

--- a/libs/langchain-azure-dynamic-sessions/package.json
+++ b/libs/langchain-azure-dynamic-sessions/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-azure-dynamic-sessions/package.json
+++ b/libs/langchain-azure-dynamic-sessions/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-azure-openai/package.json
+++ b/libs/langchain-azure-openai/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@azure/identity": "^4.0.1",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-azure-openai/package.json
+++ b/libs/langchain-azure-openai/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/azure-openai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-azure-openai/package.json
+++ b/libs/langchain-azure-openai/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@azure/identity": "^4.0.1",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-baidu-qianfan/package.json
+++ b/libs/langchain-baidu-qianfan/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-baidu-qianfan/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/baidu-qianfan",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-baidu-qianfan/package.json
+++ b/libs/langchain-baidu-qianfan/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "~0.1.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-baidu-qianfan/package.json
+++ b/libs/langchain-baidu-qianfan/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "~0.1.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-cloudflare/package.json
+++ b/libs/langchain-cloudflare/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-cloudflare/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/cloudflare",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-cloudflare/package.json
+++ b/libs/langchain-cloudflare/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-cloudflare/package.json
+++ b/libs/langchain-cloudflare/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-cohere/package.json
+++ b/libs/langchain-cohere/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-cohere/package.json
+++ b/libs/langchain-cohere/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-cohere/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/cohere",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-cohere/package.json
+++ b/libs/langchain-cohere/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -79,7 +79,7 @@
     "@huggingface/inference": "^2.6.4",
     "@jest/globals": "^29.5.0",
     "@langchain/langgraph": "<0.1.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@layerup/layerup-security": "^1.5.12",
     "@mendable/firecrawl-js": "^0.0.13",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -79,7 +79,7 @@
     "@huggingface/inference": "^2.6.4",
     "@jest/globals": "^29.5.0",
     "@langchain/langgraph": "<0.1.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@layerup/layerup-security": "^1.5.12",
     "@mendable/firecrawl-js": "^0.0.13",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-community/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/community",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking --gen-maps",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking --gen-maps",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-exa/package.json
+++ b/libs/langchain-exa/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-exa/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/exa",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/core",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-exa/package.json
+++ b/libs/langchain-exa/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-exa/package.json
+++ b/libs/langchain-exa/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-common/package.json
+++ b/libs/langchain-google-common/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-common/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-common",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/core",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-google-common/package.json
+++ b/libs/langchain-google-common/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-common/package.json
+++ b/libs/langchain-google-common/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-gauth/package.json
+++ b/libs/langchain-google-gauth/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-gauth/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-gauth",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-google-gauth/package.json
+++ b/libs/langchain-google-gauth/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-gauth/package.json
+++ b/libs/langchain-google-gauth/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-genai/package.json
+++ b/libs/langchain-google-genai/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-google-genai/package.json
+++ b/libs/langchain-google-genai/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-google-genai/package.json
+++ b/libs/langchain-google-genai/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-genai/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-genai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-google-vertexai-web/package.json
+++ b/libs/langchain-google-vertexai-web/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-vertexai-web/package.json
+++ b/libs/langchain-google-vertexai-web/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-vertexai-web/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-vertexai-web",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/google-gauth",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-google-vertexai-web/package.json
+++ b/libs/langchain-google-vertexai-web/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-vertexai/package.json
+++ b/libs/langchain-google-vertexai/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/google-common": "latest",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-google-vertexai/package.json
+++ b/libs/langchain-google-vertexai/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-vertexai/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-vertexai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/google-gauth",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-google-vertexai/package.json
+++ b/libs/langchain-google-vertexai/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/google-common": "latest",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-google-webauth/package.json
+++ b/libs/langchain-google-webauth/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-webauth/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/google-webauth",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/google-common",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-google-webauth/package.json
+++ b/libs/langchain-google-webauth/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-google-webauth/package.json
+++ b/libs/langchain-google-webauth/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-groq/package.json
+++ b/libs/langchain-groq/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-groq/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/groq",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-groq/package.json
+++ b/libs/langchain-groq/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-groq/package.json
+++ b/libs/langchain-groq/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-mistralai/package.json
+++ b/libs/langchain-mistralai/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-mistralai/package.json
+++ b/libs/langchain-mistralai/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mistralai/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/mistralai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-mistralai/package.json
+++ b/libs/langchain-mistralai/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-mixedbread-ai/package.json
+++ b/libs/langchain-mixedbread-ai/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-mixedbread-ai/package.json
+++ b/libs/langchain-mixedbread-ai/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-mixedbread-ai/package.json
+++ b/libs/langchain-mixedbread-ai/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mixedbread-ai/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/mixedbread-ai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mongodb/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/mongodb",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/openai",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:*",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:*",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-nomic/package.json
+++ b/libs/langchain-nomic/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-nomic/package.json
+++ b/libs/langchain-nomic/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-nomic/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/nomic",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/core",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-nomic/package.json
+++ b/libs/langchain-nomic/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-ollama/package.json
+++ b/libs/langchain-ollama/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-ollama/package.json
+++ b/libs/langchain-ollama/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-ollama/package.json
+++ b/libs/langchain-ollama/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-ollama/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/ollama",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@azure/identity": "^4.2.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@azure/identity": "^4.2.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-openai/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/openai",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-pinecone/package.json
+++ b/libs/langchain-pinecone/package.json
@@ -48,7 +48,7 @@
     "@faker-js/faker": "^8.3.1",
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:*",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-pinecone/package.json
+++ b/libs/langchain-pinecone/package.json
@@ -48,7 +48,7 @@
     "@faker-js/faker": "^8.3.1",
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:*",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-pinecone/package.json
+++ b/libs/langchain-pinecone/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-pinecone/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/pinecone",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-qdrant/package.json
+++ b/libs/langchain-qdrant/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-qdrant",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/qdrant",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-qdrant/package.json
+++ b/libs/langchain-qdrant/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-qdrant/package.json
+++ b/libs/langchain-qdrant/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-redis/package.json
+++ b/libs/langchain-redis/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-redis/package.json
+++ b/libs/langchain-redis/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.0",
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-redis/package.json
+++ b/libs/langchain-redis/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-redis/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/redis",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-scripts/bin/build_v2.js
+++ b/libs/langchain-scripts/bin/build_v2.js
@@ -1,1 +1,1 @@
-import "../dist_build/build_v2.js";
+import "../dist/build_v2.js";

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -19,7 +19,8 @@
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/scripts",
-    "build:internal": "rm -rf ./build_new && tsc --project ./tsconfig.build.json && yarn build:generated",
+    "build:internal": "tsc --project ./tsconfig.build.json && yarn move:artifacts && yarn build:generated",
+    "move:artifacts": "mkdir -p ./dist && mv ./dist_build/* ./dist/",
     "build:generated": "node bin/build_v2.js --create-entrypoints --pre --tree-shaking",
     "build:turbo": "yarn turbo:command build --filter=@langchain/scripts",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/scripts",
-  "version": "0.0.18",
+  "version": "0.0.19-rc.0",
   "description": "Shared scripts for LangChain.js",
   "type": "module",
   "engines": {

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -43,7 +43,7 @@
     "axios": "^1.6.7",
     "commander": "^11.1.0",
     "glob": "^10.3.10",
-    "rimraf": "^5.0.1",
+    "rimraf": "^6.0.1",
     "rollup": "^4.5.2",
     "ts-morph": "^21.0.1",
     "typescript": "^5.4.5"

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -43,7 +43,7 @@
     "axios": "^1.6.7",
     "commander": "^11.1.0",
     "glob": "^10.3.10",
-    "rimraf": "^6.0.1",
+    "rimraf": "^5.0.1",
     "rollup": "^4.5.2",
     "ts-morph": "^21.0.1",
     "typescript": "^5.4.5"

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-scripts/",
   "bin": {
     "lc-build": "bin/build.js",
-    "lc-build:v2": "bin/build_v2.js"
+    "lc_build_v2": "bin/build_v2.js"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/scripts",

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/scripts",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Shared scripts for LangChain.js",
   "type": "module",
   "engines": {

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/scripts",
-  "version": "0.0.19-rc.0",
+  "version": "0.0.19",
   "description": "Shared scripts for LangChain.js",
   "type": "module",
   "engines": {

--- a/libs/langchain-scripts/package.json
+++ b/libs/langchain-scripts/package.json
@@ -38,6 +38,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
+    "@rollup/wasm-node": "^4.19.0",
     "axios": "^1.6.7",
     "commander": "^11.1.0",
     "glob": "^10.3.10",

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -634,10 +634,11 @@ export async function buildWithTSup() {
   //     "/langchain.config.js"
   //   );
   // }
-  console.log("------process.cwd()------", process.cwd())
-  const lcPath = path.join(process.cwd(), "langchain.config.js");
+  console.log("------process.cwd()------", process.cwd());
+  console.log("------path.resolve()------", path.resolve());
   
-  const { config }: { config: LangChainConfig } = await import(lcPath);
+  // @ts-ignore - dynamic import
+  const { config }: { config: LangChainConfig } = await import("langchain.config.js");
 
   // Clean & generate build files
   if (pre && shouldGenMaps) {

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -28,30 +28,34 @@ async function asyncSpawn(command: string, args: string[]) {
 }
 
 const deleteFolderRecursive = async function (inputPath: string) {
+  // Verify the path exists
   if (
     await fs.promises
       .access(inputPath)
       .then(() => true)
       .catch(() => false)
   ) {
-    const files = await fs.promises.readdir(inputPath);
-    for await (const file of files) {
-      const curPath = path.join(inputPath, file);
-      if ((await fs.promises.lstat(curPath)).isDirectory()) {
-        // recurse
-        await deleteFolderRecursive(curPath);
-      } else {
-        // delete file
-        await fs.promises.unlink(curPath);
+    const pathStat = await fs.promises.lstat(inputPath);
+    // If it's a file, delete it and return
+    if (pathStat.isFile()) {
+      await fs.promises.unlink(inputPath);
+    } else if (pathStat.isDirectory()) {
+      // List contents of directory
+      const directoryContents = await fs.promises.readdir(inputPath);
+      if (directoryContents.length) {
+        for await (const item of directoryContents) {
+          const itemStat = await fs.promises.lstat(path.join(inputPath, item));
+          if (itemStat.isFile()) {
+            // Delete file
+            await fs.promises.unlink(path.join(inputPath, item));
+          } else if (itemStat.isDirectory()) {
+            await deleteFolderRecursive(path.join(inputPath, item));
+          }
+        }
+      } else if (directoryContents.length === 0) {
+        // If the directory is empty, delete it
+        await fs.promises.rmdir(inputPath);
       }
-    }
-
-    // Verify again that the directory is empty
-    const filesAfter = await fs.promises.readdir(inputPath);
-    if (filesAfter.length === 0) {
-      await fs.promises.rmdir(inputPath);
-    } else {
-      throw new Error(`Failed to delete ${inputPath} because dir is not empty`);
     }
   }
 };

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -628,7 +628,10 @@ export async function buildWithTSup() {
     if (!config) {
       console.log("----- trying to load via new URL() -----")
       // Required for cross-platform compatibility.
-      const importPath = new URL('langchain.config.js', import.meta.url).pathname;
+      let importPath = new URL('langchain.config.js', import.meta.url).pathname;
+      if (importPath.endsWith("/dist/langchain.config.js")) {
+        importPath = importPath.replace("/dist/langchain.config.js", "/langchain.config.js");
+      }
       const configFile = await import(importPath);
       config = configFile.config;
     } else {

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -670,9 +670,12 @@ export async function buildWithTSup() {
       rimraf(".turbo", {
         retryDelay: 1000,
         maxRetries: 5,
-      }).catch((e) => {
+      }).catch(async (e) => {
         console.error("Error removing .turbo (pre && !shouldGenMaps)");
-        throw e;
+        console.log("Trying move remove");
+        await fs.promises.rm(".turbo", { recursive: true });
+        console.log("SUCCESSFULLY DELETED WIF RM!!!")
+        // throw e;
       }),
       cleanGeneratedFiles(config),
     ]);

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -7,6 +7,7 @@ import { Command } from "commander";
 import { rollup } from "@rollup/wasm-node";
 import path from "node:path";
 import { ExportsMapValue, ImportData, LangChainConfig } from "./types.js";
+import { fileURLToPath } from 'url';
 
 async function asyncSpawn(command: string, args: string[]) {
   return new Promise<void>((resolve, reject) => {
@@ -613,7 +614,9 @@ export async function buildWithTSup() {
     pre,
   } = processOptions();
 
-  const importPath = `${process.cwd()}/langchain.config.js`;
+  // const importPath = `${process.cwd()}/langchain.config.js`;
+  // const { config }: { config: LangChainConfig } = await import(importPath);
+  const importPath = fileURLToPath(new URL('langchain.config.js', `file://${process.cwd()}/`));
   const { config }: { config: LangChainConfig } = await import(importPath);
 
   // Clean & generate build files

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -35,7 +35,7 @@ const deleteFolderRecursive = async function (inputPath: string) {
       .catch(() => false)
   ) {
     const files = await fs.promises.readdir(inputPath);
-    for (const file of files) {
+    for await (const file of files) {
       const curPath = path.join(inputPath, file);
       if ((await fs.promises.lstat(curPath)).isDirectory()) {
         // recurse
@@ -45,7 +45,14 @@ const deleteFolderRecursive = async function (inputPath: string) {
         await fs.promises.unlink(curPath);
       }
     }
-    await fs.promises.rmdir(inputPath);
+
+    // Verify again that the directory is empty
+    const filesAfter = await fs.promises.readdir(inputPath);
+    if (filesAfter.length === 0) {
+      await fs.promises.rmdir(inputPath);
+    } else {
+      throw new Error(`Failed to delete ${inputPath} because dir is not empty`);
+    }
   }
 };
 

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -670,7 +670,7 @@ export async function buildWithTSup() {
       rimraf(".turbo", {
         retryDelay: 1000,
         maxRetries: 5,
-      }).catch(async (e) => {
+      }).catch(async () => {
         console.error("Error removing .turbo (pre && !shouldGenMaps)");
         console.log("Trying move remove");
         await fs.promises.rm(".turbo", { recursive: true });

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -27,15 +27,15 @@ async function asyncSpawn(command: string, args: string[]) {
   });
 }
 
-async function rmRf(dir: string) {
-  // Check if the directory exists
-  const exists = fs.existsSync(dir);
-  if (!exists) {
-    return;
-  }
-  // Remove the directory
-  await fs.promises.rm(dir, { recursive: true });
-}
+// async function rmRf(dir: string) {
+//   // Check if the directory exists
+//   const exists = fs.existsSync(dir);
+//   if (!exists) {
+//     return;
+//   }
+//   // Remove the directory
+//   await fs.promises.rm(dir, { recursive: true });
+// }
 
 const NEWLINE = `
 `;
@@ -627,14 +627,17 @@ export async function buildWithTSup() {
   } = processOptions();
 
   // Required for cross-platform compatibility.
-  let importPath = new URL("langchain.config.js", import.meta.url).pathname;
-  if (importPath.endsWith("/dist/langchain.config.js")) {
-    importPath = importPath.replace(
-      "/dist/langchain.config.js",
-      "/langchain.config.js"
-    );
-  }
-  const { config }: { config: LangChainConfig } = await import(importPath);
+  // let importPath = new URL("langchain.config.js", import.meta.url).pathname;
+  // if (importPath.endsWith("/dist/langchain.config.js")) {
+  //   importPath = importPath.replace(
+  //     "/dist/langchain.config.js",
+  //     "/langchain.config.js"
+  //   );
+  // }
+  console.log("------process.cwd()------", process.cwd())
+  const lcPath = path.join(process.cwd(), "langchain.config.js");
+  
+  const { config }: { config: LangChainConfig } = await import(lcPath);
 
   // Clean & generate build files
   if (pre && shouldGenMaps) {

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -626,20 +626,11 @@ export async function buildWithTSup() {
     pre,
   } = processOptions();
 
-  // Required for cross-platform compatibility.
-  // let importPath = new URL("langchain.config.js", import.meta.url).pathname;
-  // if (importPath.endsWith("/dist/langchain.config.js")) {
-  //   importPath = importPath.replace(
-  //     "/dist/langchain.config.js",
-  //     "/langchain.config.js"
-  //   );
-  // }
-  console.log("------process.cwd()------", process.cwd());
-  console.log(
-    "------path.resolve()------",
-    path.resolve("langchain.config.js")
-  );
-  const langchainConfigPath = path.resolve("langchain.config.js");
+  let langchainConfigPath = path.resolve("langchain.config.js");
+  if (process.platform === "win32") {
+    // windows, must resolve path with file://
+    langchainConfigPath = `file:///${langchainConfigPath}`;
+  }
 
   const { config }: { config: LangChainConfig } = await import(
     langchainConfigPath

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -16,6 +16,7 @@ async function asyncSpawn(command: string, args: string[]) {
         ...process.env,
         NODE_OPTIONS: "--max-old-space-size=4096",
       },
+      shell: true,
     });
     child.on("close", (code) => {
       if (code !== 0) {
@@ -26,6 +27,44 @@ async function asyncSpawn(command: string, args: string[]) {
     });
   });
 }
+
+// function findNodeModulesBin() {
+//   const isWindows = process.platform === "win32";
+//   const nodeModulesBinPath = isWindows ? "node_modules\\.bin\\" : "node_modules/.bin/";
+//   // check if the path exists
+//   if (fs.existsSync(nodeModulesBinPath)) {
+//     return nodeModulesBinPath;
+//   } else {
+//     // navigate up the directory tree
+
+//   }
+//   return isWindows ? "node_modules\\.bin\\" : "node_modules/.bin/";
+
+// }
+
+// async function asyncSpawn(command: string, args: string[]) {
+//   return new Promise<void>((resolve, reject) => {
+//     const isWindows = process.platform === "win32";
+//     const cmd = isWindows ? path.join("node_modules", ".bin", `${command}.cmd`) : command;
+
+//     const child = spawn(cmd, args, {
+//       stdio: "inherit",
+//       shell: isWindows,
+//       env: {
+//         ...process.env,
+//         NODE_OPTIONS: "--max-old-space-size=4096",
+//       },
+//     });
+
+//     child.on("close", (code) => {
+//       if (code !== 0) {
+//         reject(new Error(`Command failed: ${command} ${args.join(" ")}`));
+//         return;
+//       }
+//       resolve();
+//     });
+//   });
+// }
 
 const deleteFolderRecursive = async function (inputPath: string) {
   // Verify the path exists

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -639,11 +639,17 @@ export async function buildWithTSup() {
   // Clean & generate build files
   if (pre && shouldGenMaps) {
     await Promise.all([
-      rimraf("dist").catch((e) => {
+      rimraf("dist", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing dist (pre && shouldGenMaps)");
         throw e;
       }),
-      rimraf(".turbo").catch((e) => {
+      rimraf(".turbo", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing .turbo (pre && shouldGenMaps)");
         throw e;
       }),
@@ -654,11 +660,17 @@ export async function buildWithTSup() {
     ]);
   } else if (pre && !shouldGenMaps) {
     await Promise.all([
-      rimraf("dist").catch((e) => {
+      rimraf("dist", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing dist (pre && !shouldGenMaps)");
         throw e;
       }),
-      rimraf(".turbo").catch((e) => {
+      rimraf(".turbo", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing .turbo (pre && !shouldGenMaps)");
         throw e;
       }),
@@ -679,15 +691,24 @@ export async function buildWithTSup() {
     // move CJS to dist
     await Promise.all([
       updatePackageJson(config),
-      rimraf("dist-cjs").catch((e) => {
+      rimraf("dist-cjs", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing dist-cjs");
         throw e;
       }),
-      rimraf("dist/tests").catch((e) => {
+      rimraf("dist/tests", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing dist/tests");
         throw e;
       }),
-      rimraf("dist/**/tests").catch((e) => {
+      rimraf("dist/**/tests", {
+        retryDelay: 1000,
+        maxRetries: 5,
+      }).catch((e) => {
         console.error("Error removing dist/**/tests");
         throw e;
       }),

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -722,11 +722,9 @@ export async function buildWithTSup() {
         console.error("Error removing dist/tests");
         throw e;
       }),
-      // deleteFolderRecursive("dist/**/tests").catch((e) => {
-      //   console.error("Error removing dist/**/tests");
-      //   throw e;
-      // }),
       (async () => {
+        // Required for cross-platform compatibility.
+        // Windows does not manage globs the same as Max/Linux when deleting directories.
         const testFolders = await glob("dist/**/tests");
         await Promise.all(
           testFolders.map((folder) => deleteFolderRecursive(folder))

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -645,6 +645,8 @@ export async function buildWithTSup() {
 
   if (!config) {
     throw new Error("No config found");
+  } else {
+    console.log("--------- CONFIG SUCCESSFULLY LOADED ---------")
   }
   
 

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -3,7 +3,8 @@ import ts from "typescript";
 import fs from "node:fs";
 import { rimraf } from "rimraf";
 import { Command } from "commander";
-import { rollup } from "rollup";
+// import { rollup } from "rollup";
+import { rollup } from "@rollup/wasm-node";
 import path from "node:path";
 import { ExportsMapValue, ImportData, LangChainConfig } from "./types.js";
 

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -4,8 +4,8 @@ import fs from "node:fs";
 import { Command } from "commander";
 import { rollup } from "@rollup/wasm-node";
 import path from "node:path";
-import { ExportsMapValue, ImportData, LangChainConfig } from "./types.js";
 import { rimraf } from "rimraf";
+import { ExportsMapValue, ImportData, LangChainConfig } from "./types.js";
 
 async function asyncSpawn(command: string, args: string[]) {
   return new Promise<void>((resolve, reject) => {
@@ -635,10 +635,15 @@ export async function buildWithTSup() {
   //   );
   // }
   console.log("------process.cwd()------", process.cwd());
-  console.log("------path.resolve()------", path.resolve());
-  
-  // @ts-ignore - dynamic import
-  const { config }: { config: LangChainConfig } = await import("langchain.config.js");
+  console.log(
+    "------path.resolve()------",
+    path.resolve("langchain.config.js")
+  );
+  const langchainConfigPath = path.resolve("langchain.config.js");
+
+  const { config }: { config: LangChainConfig } = await import(
+    langchainConfigPath
+  );
 
   // Clean & generate build files
   if (pre && shouldGenMaps) {

--- a/libs/langchain-scripts/src/build_v2.ts
+++ b/libs/langchain-scripts/src/build_v2.ts
@@ -667,16 +667,20 @@ export async function buildWithTSup() {
         console.error("Error removing dist (pre && !shouldGenMaps)");
         throw e;
       }),
-      rimraf(".turbo", {
-        retryDelay: 1000,
-        maxRetries: 5,
-      }).catch(async () => {
-        console.error("Error removing .turbo (pre && !shouldGenMaps)");
-        console.log("Trying move remove");
-        await fs.promises.rm(".turbo", { recursive: true });
-        console.log("SUCCESSFULLY DELETED WIF RM!!!")
-        // throw e;
+      fs.promises.rm(".turbo", { recursive: true, force: true }).catch((e) => {
+        console.error("Error deleting with fs.promises.rm");
+        throw e;
       }),
+      // rimraf(".turbo", {
+      //   retryDelay: 1000,
+      //   maxRetries: 5,
+      // }).catch(async () => {
+      //   console.error("Error removing .turbo (pre && !shouldGenMaps)");
+      //   console.log("Trying move remove");
+      //   await fs.promises.rm(".turbo", { recursive: true });
+      //   console.log("SUCCESSFULLY DELETED WIF RM!!!")
+      //   // throw e;
+      // }),
       cleanGeneratedFiles(config),
     ]);
   }

--- a/libs/langchain-standard-tests/package.json
+++ b/libs/langchain-standard-tests/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-standard-tests/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/standard-tests",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-textsplitters/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/textsplitters",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-weaviate/package.json
+++ b/libs/langchain-weaviate/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-weaviate/package.json
+++ b/libs/langchain-weaviate/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@langchain/openai": "workspace:^",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-weaviate/package.json
+++ b/libs/langchain-weaviate/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-weaviate/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/weaviate",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:deps": "yarn run turbo:command build --filter=@langchain/core",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",

--- a/libs/langchain-yandex/package.json
+++ b/libs/langchain-yandex/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.14",
+    "@langchain/scripts": "~0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/langchain-yandex/package.json
+++ b/libs/langchain-yandex/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-yandex/",
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/yandex",
-    "build:internal": "yarn lc-build:v2 --create-entrypoints --pre --tree-shaking",
+    "build:internal": "yarn lc_build_v2 --create-entrypoints --pre --tree-shaking",
     "build:esm": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist/ && rm -rf dist/tests dist/**/tests",
     "build:cjs": "NODE_OPTIONS=--max-old-space-size=4096 tsc --outDir dist-cjs/ -p tsconfig.cjs.json && yarn move-cjs-to-dist && rm -rf dist-cjs",
     "build:watch": "yarn create-entrypoints && tsc --outDir dist/ --watch",

--- a/libs/langchain-yandex/package.json
+++ b/libs/langchain-yandex/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
-    "@langchain/scripts": "~0.0.19",
+    "@langchain/scripts": "~0.0.20",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11687,6 +11687,7 @@ __metadata:
   resolution: "@langchain/scripts@workspace:libs/langchain-scripts"
   dependencies:
     "@jest/globals": ^29.5.0
+    "@rollup/wasm-node": ^4.19.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -13181,6 +13182,21 @@ __metadata:
   version: 4.8.0
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.8.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/wasm-node@npm:^4.19.0":
+  version: 4.19.0
+  resolution: "@rollup/wasm-node@npm:4.19.0"
+  dependencies:
+    "@types/estree": 1.0.5
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: c84a1e35296b95a80d9b587d8632ddb518083213548caf1292a782794a7439921d224deaa99a7f14cede99ce15a60d03ab6c7b2e4f41c5746002c521dbcba555
   languageName: node
   linkType: hard
 
@@ -16976,6 +16992,13 @@ __metadata:
   version: 1.0.2
   resolution: "@types/estree@npm:1.0.2"
   checksum: aeedb1b2fe20cbe06f44b99b562bf9703e360bfcdf5bb3d61d248182ee1dd63500f2474e12f098ffe1f5ac3202b43b3e18ec99902d9328d5374f5512fa077e45
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@types/estree@npm:1.0.5"
+  checksum: dd8b5bed28e6213b7acd0fb665a84e693554d850b0df423ac8076cc3ad5823a6bc26b0251d080bdc545af83179ede51dd3f6fa78cad2c46ed1f29624ddf3e41a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11682,25 +11682,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@langchain/scripts@npm:~0.0, @langchain/scripts@npm:~0.0.14":
-  version: 0.0.18
-  resolution: "@langchain/scripts@npm:0.0.18"
-  dependencies:
-    axios: ^1.6.7
-    commander: ^11.1.0
-    glob: ^10.3.10
-    rimraf: ^5.0.1
-    rollup: ^4.5.2
-    ts-morph: ^21.0.1
-    typescript: ^5.4.5
-  bin:
-    lc-build: bin/build.js
-    v2: bin/build_v2.js
-  checksum: 97d5de819093c951a6af564b917a79f6a13dc6bf21e8a05ab92e14ca0283580257d8db16e353b5b25412231abcd15a797c6f5f8a939b29152f916c115d894143
-  languageName: node
-  linkType: hard
-
-"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts":
+"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0, @langchain/scripts@~0.0.14":
   version: 0.0.0-use.local
   resolution: "@langchain/scripts@workspace:libs/langchain-scripts"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11708,7 +11708,7 @@ __metadata:
     jest-environment-node: ^29.6.4
     prettier: ^2.8.3
     release-it: ^15.10.1
-    rimraf: ^5.0.1
+    rimraf: ^6.0.1
     rollup: ^4.5.2
     ts-jest: ^29.1.0
     ts-morph: ^21.0.1
@@ -26572,6 +26572,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^4.0.1
+    minimatch: ^10.0.0
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.0.0, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -28833,6 +28849,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jackspeak@npm:4.0.1"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+    "@pkgjs/parseargs": ^0.11.0
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 7989d19eddeff0631ef653df413e26290db77dc3791438bd12b56bed1c0b24d5d535fdfec13cf35775cd5b47f8ee57d36fd0bceaf2df672b1f523533fd4184cc
+  languageName: node
+  linkType: hard
+
 "javascript-stringify@npm:^2.0.1":
   version: 2.1.0
   resolution: "javascript-stringify@npm:2.1.0"
@@ -31042,6 +31071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "lru-cache@npm:11.0.0"
+  checksum: c29385f9369b1a566e1db9eda9a4b12f6507de906e5720ca12844dd775b7139c42b8e5837e7d5162bcc292ce4d3eecfa74ec2856c6afcc0caa2e3c9ea3a17f27
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -31635,6 +31671,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^5.0.1":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
@@ -31787,6 +31832,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
   languageName: node
   linkType: hard
 
@@ -33387,6 +33439,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
 "package-json@npm:^6.3.0":
   version: 6.5.0
   resolution: "package-json@npm:6.5.0"
@@ -33663,6 +33722,16 @@ __metadata:
     lru-cache: ^9.1.1
     minipass: ^5.0.0 || ^6.0.2
   checksum: 92888dfb68e285043c6d3291c8e971d5d2bc2f5082f4d7b5392896f34be47024c9d0a8b688dd7ae6d125acc424699195474927cb4f00049a9b1ec7c4256fa8e0
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 
@@ -36282,6 +36351,18 @@ __metadata:
   bin:
     rimraf: dist/cjs/src/bin.js
   checksum: bafce85391349a2d960847980bf9b5caa2a8887f481af630f1ea27e08288217293cec72d75e9a2ba35495c212789f66a7f3d23366ba6197026ab71c535126857
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: ^11.0.0
+    package-json-from-dist: ^1.0.0
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 8ba5b84131c1344e9417cb7e8c05d8368bb73cbe5dd4c1d5eb49fc0b558209781658d18c450460e30607d0b7865bb067482839a2f343b186b07ae87715837e66
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11682,7 +11682,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0, @langchain/scripts@~0.0.14":
+"@langchain/scripts@npm:~0.0, @langchain/scripts@npm:~0.0.14":
+  version: 0.0.18
+  resolution: "@langchain/scripts@npm:0.0.18"
+  dependencies:
+    axios: ^1.6.7
+    commander: ^11.1.0
+    glob: ^10.3.10
+    rimraf: ^5.0.1
+    rollup: ^4.5.2
+    ts-morph: ^21.0.1
+    typescript: ^5.4.5
+  bin:
+    lc-build: bin/build.js
+    v2: bin/build_v2.js
+  checksum: 97d5de819093c951a6af564b917a79f6a13dc6bf21e8a05ab92e14ca0283580257d8db16e353b5b25412231abcd15a797c6f5f8a939b29152f916c115d894143
+  languageName: node
+  linkType: hard
+
+"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts":
   version: 0.0.0-use.local
   resolution: "@langchain/scripts@workspace:libs/langchain-scripts"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10215,7 +10215,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/community": "workspace:*"
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10251,7 +10251,7 @@ __metadata:
     "@aws-sdk/types": ^3.598.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@smithy/types": ^3.2.0
     "@swc/core": ^1.3.90
@@ -10287,7 +10287,7 @@ __metadata:
     "@azure/identity": ^4.2.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ~0.2
-    "@langchain/scripts": ~0.0
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -10322,7 +10322,7 @@ __metadata:
     "@azure/openai": 1.0.0-beta.11
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10354,7 +10354,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/openai": ~0.1.0
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -10390,7 +10390,7 @@ __metadata:
     "@cloudflare/workers-types": ^4.20231218.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10433,7 +10433,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10500,7 +10500,7 @@ __metadata:
     "@langchain/core": ">=0.2.16 <0.3.0"
     "@langchain/langgraph": <0.1.0
     "@langchain/openai": ">=0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@layerup/layerup-security": ^1.5.12
     "@mendable/firecrawl-js": ^0.0.13
@@ -11015,7 +11015,7 @@ __metadata:
   resolution: "@langchain/core@workspace:langchain-core"
   dependencies:
     "@jest/globals": ^29.5.0
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@types/mustache": ^4
@@ -11057,7 +11057,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11100,7 +11100,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11134,7 +11134,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": ~0.0.21
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11167,7 +11167,7 @@ __metadata:
     "@google/generative-ai": ^0.7.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11202,7 +11202,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-webauth": ~0.0.20
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11235,7 +11235,7 @@ __metadata:
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": latest
     "@langchain/google-gauth": ~0.0.20
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11267,7 +11267,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": ~0.0.21
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11299,7 +11299,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11367,7 +11367,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@mistralai/mistralai": ^0.4.0
     "@swc/core": ^1.3.90
@@ -11403,7 +11403,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.5 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@mixedbread-ai/sdk": ^2.2.3
     "@swc/core": ^1.3.90
@@ -11437,7 +11437,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
     "@langchain/openai": "workspace:*"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11471,7 +11471,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@nomic-ai/atlas": ^0.8.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11503,7 +11503,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.17 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11539,7 +11539,7 @@ __metadata:
     "@azure/identity": ^4.2.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11586,7 +11586,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
     "@langchain/openai": "workspace:*"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@pinecone-database/pinecone": ^3.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11621,7 +11621,7 @@ __metadata:
     "@faker-js/faker": ^8.4.1
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@qdrant/js-client-rest": ^1.9.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11655,7 +11655,7 @@ __metadata:
     "@faker-js/faker": ^8.4.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11682,7 +11682,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0, @langchain/scripts@~0.0.14":
+"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0.19":
   version: 0.0.0-use.local
   resolution: "@langchain/scripts@workspace:libs/langchain-scripts"
   dependencies:
@@ -11708,7 +11708,7 @@ __metadata:
     jest-environment-node: ^29.6.4
     prettier: ^2.8.3
     release-it: ^15.10.1
-    rimraf: ^6.0.1
+    rimraf: ^5.0.1
     rollup: ^4.5.2
     ts-jest: ^29.1.0
     ts-morph: ^21.0.1
@@ -11757,7 +11757,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11789,7 +11789,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11823,7 +11823,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0  <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -25003,7 +25003,7 @@ __metadata:
     "@langchain/pinecone": "workspace:*"
     "@langchain/qdrant": "workspace:*"
     "@langchain/redis": "workspace:*"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/textsplitters": "workspace:*"
     "@langchain/weaviate": "workspace:*"
     "@langchain/yandex": "workspace:*"
@@ -26569,22 +26569,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 4f2fe2511e157b5a3f525a54092169a5f92405f24d2aed3142f4411df328baca13059f4182f1db1bf933e2c69c0bd89e57ae87edd8950cba8c7ccbe84f721cf3
-  languageName: node
-  linkType: hard
-
-"glob@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "glob@npm:11.0.0"
-  dependencies:
-    foreground-child: ^3.1.0
-    jackspeak: ^4.0.1
-    minimatch: ^10.0.0
-    minipass: ^7.1.2
-    package-json-from-dist: ^1.0.0
-    path-scurry: ^2.0.0
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
   languageName: node
   linkType: hard
 
@@ -28849,19 +28833,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "jackspeak@npm:4.0.1"
-  dependencies:
-    "@isaacs/cliui": ^8.0.2
-    "@pkgjs/parseargs": ^0.11.0
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 7989d19eddeff0631ef653df413e26290db77dc3791438bd12b56bed1c0b24d5d535fdfec13cf35775cd5b47f8ee57d36fd0bceaf2df672b1f523533fd4184cc
-  languageName: node
-  linkType: hard
-
 "javascript-stringify@npm:^2.0.1":
   version: 2.1.0
   resolution: "javascript-stringify@npm:2.1.0"
@@ -30184,7 +30155,7 @@ __metadata:
     "@langchain/cohere": ^0.0.8
     "@langchain/core": ">=0.2.11 <0.3.0"
     "@langchain/openai": ">=0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.14
+    "@langchain/scripts": ~0.0.19
     "@langchain/textsplitters": ~0.0.0
     "@mendable/firecrawl-js": ^0.0.13
     "@notionhq/client": ^2.2.10
@@ -31071,13 +31042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "lru-cache@npm:11.0.0"
-  checksum: c29385f9369b1a566e1db9eda9a4b12f6507de906e5720ca12844dd775b7139c42b8e5837e7d5162bcc292ce4d3eecfa74ec2856c6afcc0caa2e3c9ea3a17f27
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -31671,15 +31635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^5.0.1":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
@@ -31832,13 +31787,6 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
   languageName: node
   linkType: hard
 
@@ -33439,13 +33387,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-json-from-dist@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "package-json-from-dist@npm:1.0.0"
-  checksum: ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
-  languageName: node
-  linkType: hard
-
 "package-json@npm:^6.3.0":
   version: 6.5.0
   resolution: "package-json@npm:6.5.0"
@@ -33722,16 +33663,6 @@ __metadata:
     lru-cache: ^9.1.1
     minipass: ^5.0.0 || ^6.0.2
   checksum: 92888dfb68e285043c6d3291c8e971d5d2bc2f5082f4d7b5392896f34be47024c9d0a8b688dd7ae6d125acc424699195474927cb4f00049a9b1ec7c4256fa8e0
-  languageName: node
-  linkType: hard
-
-"path-scurry@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "path-scurry@npm:2.0.0"
-  dependencies:
-    lru-cache: ^11.0.0
-    minipass: ^7.1.2
-  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 
@@ -36351,18 +36282,6 @@ __metadata:
   bin:
     rimraf: dist/cjs/src/bin.js
   checksum: bafce85391349a2d960847980bf9b5caa2a8887f481af630f1ea27e08288217293cec72d75e9a2ba35495c212789f66a7f3d23366ba6197026ab71c535126857
-  languageName: node
-  linkType: hard
-
-"rimraf@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "rimraf@npm:6.0.1"
-  dependencies:
-    glob: ^11.0.0
-    package-json-from-dist: ^1.0.0
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: 8ba5b84131c1344e9417cb7e8c05d8368bb73cbe5dd4c1d5eb49fc0b558209781658d18c450460e30607d0b7865bb067482839a2f343b186b07ae87715837e66
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11715,7 +11715,7 @@ __metadata:
     typescript: ^5.4.5
   bin:
     lc-build: bin/build.js
-    "lc-build:v2": bin/build_v2.js
+    lc_build_v2: bin/build_v2.js
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10215,7 +10215,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/community": "workspace:*"
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10251,7 +10251,7 @@ __metadata:
     "@aws-sdk/types": ^3.598.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@smithy/types": ^3.2.0
     "@swc/core": ^1.3.90
@@ -10287,7 +10287,7 @@ __metadata:
     "@azure/identity": ^4.2.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ~0.2
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -10322,7 +10322,7 @@ __metadata:
     "@azure/openai": 1.0.0-beta.11
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10354,7 +10354,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/openai": ~0.1.0
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -10390,7 +10390,7 @@ __metadata:
     "@cloudflare/workers-types": ^4.20231218.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10433,7 +10433,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -10500,7 +10500,7 @@ __metadata:
     "@langchain/core": ">=0.2.16 <0.3.0"
     "@langchain/langgraph": <0.1.0
     "@langchain/openai": ">=0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@layerup/layerup-security": ^1.5.12
     "@mendable/firecrawl-js": ^0.0.13
@@ -11015,7 +11015,7 @@ __metadata:
   resolution: "@langchain/core@workspace:langchain-core"
   dependencies:
     "@jest/globals": ^29.5.0
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@types/mustache": ^4
@@ -11057,7 +11057,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11100,7 +11100,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11134,7 +11134,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": ~0.0.21
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11167,7 +11167,7 @@ __metadata:
     "@google/generative-ai": ^0.7.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11202,7 +11202,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-webauth": ~0.0.20
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11235,7 +11235,7 @@ __metadata:
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": latest
     "@langchain/google-gauth": ~0.0.20
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11267,7 +11267,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.56 <0.3.0"
     "@langchain/google-common": ~0.0.21
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11299,7 +11299,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11367,7 +11367,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@mistralai/mistralai": ^0.4.0
     "@swc/core": ^1.3.90
@@ -11403,7 +11403,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.5 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@mixedbread-ai/sdk": ^2.2.3
     "@swc/core": ^1.3.90
@@ -11437,7 +11437,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
     "@langchain/openai": "workspace:*"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11471,7 +11471,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@nomic-ai/atlas": ^0.8.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11503,7 +11503,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.17 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11539,7 +11539,7 @@ __metadata:
     "@azure/identity": ^4.2.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.16 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11586,7 +11586,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
     "@langchain/openai": "workspace:*"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@pinecone-database/pinecone": ^3.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11621,7 +11621,7 @@ __metadata:
     "@faker-js/faker": ^8.4.1
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@qdrant/js-client-rest": ^1.9.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
@@ -11655,7 +11655,7 @@ __metadata:
     "@faker-js/faker": ^8.4.0
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11682,7 +11682,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0.19":
+"@langchain/scripts@workspace:*, @langchain/scripts@workspace:libs/langchain-scripts, @langchain/scripts@~0.0.20":
   version: 0.0.0-use.local
   resolution: "@langchain/scripts@workspace:libs/langchain-scripts"
   dependencies:
@@ -11757,7 +11757,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11789,7 +11789,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.2.0 <0.3.0"
     "@langchain/openai": "workspace:^"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -11823,7 +11823,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/core": ">0.1.0  <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -25003,7 +25003,7 @@ __metadata:
     "@langchain/pinecone": "workspace:*"
     "@langchain/qdrant": "workspace:*"
     "@langchain/redis": "workspace:*"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/textsplitters": "workspace:*"
     "@langchain/weaviate": "workspace:*"
     "@langchain/yandex": "workspace:*"
@@ -30155,7 +30155,7 @@ __metadata:
     "@langchain/cohere": ^0.0.8
     "@langchain/core": ">=0.2.11 <0.3.0"
     "@langchain/openai": ">=0.1.0 <0.3.0"
-    "@langchain/scripts": ~0.0.19
+    "@langchain/scripts": ~0.0.20
     "@langchain/textsplitters": ~0.0.0
     "@mendable/firecrawl-js": ^0.0.13
     "@notionhq/client": ^2.2.10


### PR DESCRIPTION
Fixes build when running on windows
Renames build script (npm deals with `:` in a funny way for scripts)
Added CI test for building `@langchain/core` in macos, windows and ubuntu