### PR TITLE
docs[patch]: Fix ChatModelTabs openai model typo

### DIFF
--- a/docs/core_docs/docs/tutorials/llm_chain.ipynb
+++ b/docs/core_docs/docs/tutorials/llm_chain.ipynb
@@ -76,7 +76,7 @@
     "```{=mdx}\n",
     "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
     "\n",
-    "<ChatModelTabs openaiParams={`model: \"gpt-4\"`} />\n",
+    "<ChatModelTabs openaiParams={`{ model: \"gpt-4\" }`} />\n",
     "```"
    ]
   },


### PR DESCRIPTION
Just fix a typo of document

![image](https://github.com/user-attachments/assets/2e373683-bd7c-4894-ae38-35416fe7457f)
