### PR TITLE
docs[patch]: Fix broken link

### DIFF
--- a/docs/core_docs/docs/how_to/index.mdx
+++ b/docs/core_docs/docs/how_to/index.mdx
@@ -9,7 +9,7 @@ Here you'll find answers to “How do I….?” types of questions.
 These guides are _goal-oriented_ and _concrete_; they're meant to help you complete a specific task.
 For conceptual explanations see [Conceptual Guides](/docs/concepts/).
 For end-to-end walkthroughs see [Tutorials](/docs/tutorials).
-For comprehensive descriptions of every class and function see [API Reference](https://v2.v02.api.js.langchain.com/).
+For comprehensive descriptions of every class and function see [API Reference](https://api.js.langchain.com/).
 
 ## Installation
 


### PR DESCRIPTION
@bracesproul let's try not to prefix API ref links