### PR TITLE
docs[patch]: Fix ChatModelTabs openaiParams typo

### DIFF
--- a/docs/core_docs/docs/how_to/agent_executor.ipynb
+++ b/docs/core_docs/docs/how_to/agent_executor.ipynb
@@ -232,7 +232,7 @@
     "```{=mdx}\n",
     "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
     "\n",
-    "<ChatModelTabs openaiParams={`model: \"gpt-4\"`} />\n",
+    "<ChatModelTabs openaiParams={`{ model: \"gpt-4\" }`} />\n",
     "```"
    ]
   },

--- a/docs/core_docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/core_docs/docs/tutorials/pdf_qa.ipynb
@@ -134,7 +134,7 @@
     "```{=mdx}\n",
     "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
     "\n",
-    "<ChatModelTabs openaiParams={`model: \"gpt-4o\"`} />\n",
+    "<ChatModelTabs openaiParams={`{ model: \"gpt-4o\" }`} />\n",
     "```"
    ]
   },


### PR DESCRIPTION
https://js.langchain.com/v0.2/docs/how_to/agent_executor/#using-language-models
https://js.langchain.com/v0.2/docs/tutorials/pdf_qa/#question-answering-with-rag

This PR fixes the same type of typo as in #6191.
