### PR TITLE
mistralai[patch]: Translate tool call ids to mistral compat format

### DIFF
--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -66,6 +66,7 @@ import {
 } from "@langchain/core/runnables";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { ToolCallChunk } from "@langchain/core/messages/tool";
+import { _convertToolCallIdToMistralCompatible } from "./utils.js";
 
 interface TokenUsage {
   completionTokens?: number;
@@ -208,7 +209,7 @@ function convertMessagesToMistralMessages(
     const toolCalls: Omit<OpenAIToolCall, "index">[] =
       message.additional_kwargs.tool_calls;
     return toolCalls?.map((toolCall) => ({
-      id: toolCall.id,
+      id: _convertToolCallIdToMistralCompatible(toolCall.id),
       type: "function",
       function: toolCall.function,
     }));

--- a/libs/langchain-mistralai/src/chat_models.ts
+++ b/libs/langchain-mistralai/src/chat_models.ts
@@ -601,7 +601,6 @@ export class ChatMistralAI<
     const tokenUsage: TokenUsage = {};
     const params = this.invocationParams(options);
     const mistralMessages = convertMessagesToMistralMessages(messages);
-    console.dir(mistralMessages, { depth: null });
     const input = {
       ...params,
       messages: mistralMessages,

--- a/libs/langchain-mistralai/src/tests/chat_models.standard.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.standard.test.ts
@@ -24,7 +24,7 @@ class ChatMistralAIStandardUnitTests extends ChatModelUnitTests<
 
   expectedLsParams(): Partial<LangSmithParams> {
     console.warn(
-      "Overriding testStandardParams. ChatCloudflareWorkersAI does not support stop sequences."
+      "Overriding testStandardParams. ChatMistralAI does not support stop sequences."
     );
     return {
       ls_provider: "string",

--- a/libs/langchain-mistralai/src/tests/chat_models.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.test.ts
@@ -1,17 +1,22 @@
-import { _isValidMistralToolCallId, _convertToolCallIdToMistralCompatible } from '../utils.js';
+import {
+  _isValidMistralToolCallId,
+  _convertToolCallIdToMistralCompatible,
+} from "../utils.js";
 
-describe('Mistral Tool Call ID Conversion', () => {
-  test('valid and invalid Mistral tool call IDs', () => {
+describe("Mistral Tool Call ID Conversion", () => {
+  test("valid and invalid Mistral tool call IDs", () => {
     expect(_isValidMistralToolCallId("ssAbar4Dr")).toBe(true);
     expect(_isValidMistralToolCallId("abc123")).toBe(false);
-    expect(_isValidMistralToolCallId("call_JIIjI55tTipFFzpcP8re3BpM")).toBe(false);
+    expect(_isValidMistralToolCallId("call_JIIjI55tTipFFzpcP8re3BpM")).toBe(
+      false
+    );
   });
 
-  test('tool call ID conversion', () => {
+  test("tool call ID conversion", () => {
     const resultMap: Record<string, string> = {
-      "ssAbar4Dr": "ssAbar4Dr",
-      "abc123": "0001yoN1K",
-      "call_JIIjI55tTipFFzpcP8re3BpM": "0001sqrj5",
+      ssAbar4Dr: "ssAbar4Dr",
+      abc123: "0001yoN1K",
+      call_JIIjI55tTipFFzpcP8re3BpM: "0001sqrj5",
     };
 
     for (const [inputId, expectedOutput] of Object.entries(resultMap)) {

--- a/libs/langchain-mistralai/src/tests/chat_models.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.test.ts
@@ -1,0 +1,23 @@
+import { _isValidMistralToolCallId, _convertToolCallIdToMistralCompatible } from '../utils.js';
+
+describe('Mistral Tool Call ID Conversion', () => {
+  test('valid and invalid Mistral tool call IDs', () => {
+    expect(_isValidMistralToolCallId("ssAbar4Dr")).toBe(true);
+    expect(_isValidMistralToolCallId("abc123")).toBe(false);
+    expect(_isValidMistralToolCallId("call_JIIjI55tTipFFzpcP8re3BpM")).toBe(false);
+  });
+
+  test('tool call ID conversion', () => {
+    const resultMap: Record<string, string> = {
+      "ssAbar4Dr": "ssAbar4Dr",
+      "abc123": "0001yoN1K",
+      "call_JIIjI55tTipFFzpcP8re3BpM": "0001sqrj5",
+    };
+
+    for (const [inputId, expectedOutput] of Object.entries(resultMap)) {
+      const convertedId = _convertToolCallIdToMistralCompatible(inputId);
+      expect(convertedId).toBe(expectedOutput);
+      expect(_isValidMistralToolCallId(convertedId)).toBe(true);
+    }
+  });
+});

--- a/libs/langchain-mistralai/src/tests/chat_models.test.ts
+++ b/libs/langchain-mistralai/src/tests/chat_models.test.ts
@@ -17,6 +17,7 @@ describe("Mistral Tool Call ID Conversion", () => {
       ssAbar4Dr: "ssAbar4Dr",
       abc123: "0001yoN1K",
       call_JIIjI55tTipFFzpcP8re3BpM: "0001sqrj5",
+      12345: "00003akVR",
     };
 
     for (const [inputId, expectedOutput] of Object.entries(resultMap)) {

--- a/libs/langchain-mistralai/src/utils.ts
+++ b/libs/langchain-mistralai/src/utils.ts
@@ -1,26 +1,27 @@
 // Mistral enforces a specific pattern for tool call IDs
-const TOOL_CALL_ID_PATTERN = new RegExp("^[a-zA-Z0-9]{9}$");
+const TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9]{9}$/;
 
 export function _isValidMistralToolCallId(toolCallId: string): boolean {
   return TOOL_CALL_ID_PATTERN.test(toolCallId);
 }
 
 function _base62Encode(num: number): string {
+  let numCopy = num;
   const base62 =
     "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  if (num === 0) return base62[0];
+  if (numCopy === 0) return base62[0];
   const arr: string[] = [];
   const base = base62.length;
-  while (num) {
-    arr.push(base62[num % base]);
-    num = Math.floor(num / base);
+  while (numCopy) {
+    arr.push(base62[numCopy % base]);
+    numCopy = Math.floor(numCopy / base);
   }
   return arr.reverse().join("");
 }
 
 function _simpleHash(str: string): number {
   let hash = 0;
-  for (let i = 0; i < str.length; i++) {
+  for (let i = 0; i < str.length; i += 1) {
     const char = str.charCodeAt(i);
     hash = (hash << 5) - hash + char;
     hash &= hash; // Convert to 32-bit integer

--- a/libs/langchain-mistralai/src/utils.ts
+++ b/libs/langchain-mistralai/src/utils.ts
@@ -1,0 +1,42 @@
+// Mistral enforces a specific pattern for tool call IDs
+const TOOL_CALL_ID_PATTERN = new RegExp("^[a-zA-Z0-9]{9}$");
+
+export function _isValidMistralToolCallId(toolCallId: string): boolean {
+  return TOOL_CALL_ID_PATTERN.test(toolCallId);
+}
+
+function _base62Encode(num: number): string {
+  const base62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  if (num === 0) return base62[0];
+  const arr: string[] = [];
+  const base = base62.length;
+  while (num) {
+    arr.push(base62[num % base]);
+    num = Math.floor(num / base);
+  }
+  return arr.reverse().join('');
+}
+
+function _simpleHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash);
+}
+
+export function _convertToolCallIdToMistralCompatible(toolCallId: string): string {
+  if (_isValidMistralToolCallId(toolCallId)) {
+    return toolCallId;
+  } else {
+    const hash = _simpleHash(toolCallId);
+    const base62Str = _base62Encode(hash);
+    if (base62Str.length >= 9) {
+      return base62Str.slice(0, 9);
+    } else {
+      return base62Str.padStart(9, '0');
+    }
+  }
+}

--- a/libs/langchain-mistralai/src/utils.ts
+++ b/libs/langchain-mistralai/src/utils.ts
@@ -6,7 +6,8 @@ export function _isValidMistralToolCallId(toolCallId: string): boolean {
 }
 
 function _base62Encode(num: number): string {
-  const base62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const base62 =
+    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   if (num === 0) return base62[0];
   const arr: string[] = [];
   const base = base62.length;
@@ -14,20 +15,22 @@ function _base62Encode(num: number): string {
     arr.push(base62[num % base]);
     num = Math.floor(num / base);
   }
-  return arr.reverse().join('');
+  return arr.reverse().join("");
 }
 
 function _simpleHash(str: string): number {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32-bit integer
+    hash = (hash << 5) - hash + char;
+    hash &= hash; // Convert to 32-bit integer
   }
   return Math.abs(hash);
 }
 
-export function _convertToolCallIdToMistralCompatible(toolCallId: string): string {
+export function _convertToolCallIdToMistralCompatible(
+  toolCallId: string
+): string {
   if (_isValidMistralToolCallId(toolCallId)) {
     return toolCallId;
   } else {
@@ -36,7 +39,7 @@ export function _convertToolCallIdToMistralCompatible(toolCallId: string): strin
     if (base62Str.length >= 9) {
       return base62Str.slice(0, 9);
     } else {
-      return base62Str.padStart(9, '0');
+      return base62Str.padStart(9, "0");
     }
   }
 }


### PR DESCRIPTION
Port of https://github.com/langchain-ai/langchain/pull/24668

I couldn't use the built in `crypto` module because it is not avail in all js environments, so instead I implemented my own method.