### PR TITLE
community[patch]: fix TypeError using the client created with xata init

### DIFF
--- a/libs/langchain-community/src/vectorstores/xata.ts
+++ b/libs/langchain-community/src/vectorstores/xata.ts
@@ -145,7 +145,7 @@ export class XataVectorSearch<
             )
           ),
         }),
-        record.xata.score,
+        record.xata ? record.xata.score : record.xata_score,
       ]) ?? []
     );
   }


### PR DESCRIPTION
* fix: TypeError when using VectorSearchWithScore

The xata client created with the xata init command probably has changed its response, creating a TypeError, as the property xata does not exist in the response created by the client. This stops the code execution, as it is trying to access object.xata.score.
Currently, the expected score is found in the object.xata_score property.

In order to prevent breaking changes, the old way is preserved, but it checks if the property exists first. If it does not exist, it access the "current" property

Fixes #6240
