### PR TITLE
fix: fix mapStoredMessageToChatMessage to check on generic role when creating ChatMessage

### DIFF
--- a/langchain-core/src/messages/tests/message_utils.test.ts
+++ b/langchain-core/src/messages/tests/message_utils.test.ts
@@ -5,10 +5,15 @@ import {
   trimMessages,
 } from "../transformers.js";
 import { AIMessage } from "../ai.js";
+import { ChatMessage } from "../chat.js";
 import { HumanMessage } from "../human.js";
 import { SystemMessage } from "../system.js";
 import { BaseMessage } from "../base.js";
-import { getBufferString } from "../utils.js";
+import {
+  getBufferString,
+  mapChatMessagesToStoredMessages,
+  mapStoredMessagesToChatMessages,
+} from "../utils.js";
 
 describe("filterMessage", () => {
   const getMessages = () => [
@@ -498,4 +503,20 @@ test("getBufferString can handle complex messages", () => {
       2
     )}`
   );
+});
+
+describe("chat message conversions", () => {
+  it("can convert a chat message to a stored message and back", () => {
+    const originalMessages = [
+      new ChatMessage("I'm a generic message!", "human"),
+      new HumanMessage("I'm a human message!"),
+    ];
+
+    const storedMessages = mapChatMessagesToStoredMessages(originalMessages);
+
+    const convertedBackMessages =
+      mapStoredMessagesToChatMessages(storedMessages);
+
+    expect(convertedBackMessages).toEqual(originalMessages);
+  });
 });

--- a/langchain-core/src/messages/utils.ts
+++ b/langchain-core/src/messages/utils.ts
@@ -141,7 +141,7 @@ export function mapStoredMessageToChatMessage(message: StoredMessage) {
       return new ToolMessage(
         storedMessage.data as ToolMessageFieldsWithToolCallId
       );
-    case "chat": {
+    case "generic": {
       if (storedMessage.data.role === undefined) {
         throw new Error("Role must be defined for chat messages");
       }

--- a/langchain-core/src/runnables/remote.ts
+++ b/langchain-core/src/runnables/remote.ts
@@ -70,7 +70,7 @@ function revive(obj: any): any {
           content: obj.content,
         });
       }
-      if (obj.type === "ChatMessage" || obj.type === "chat") {
+      if (obj.type === "ChatMessage" || obj.type === "generic") {
         return new ChatMessage({
           content: obj.content,
           role: obj.role,


### PR DESCRIPTION
- Fixes mapStoredMessageToChatMessage to check on generic role when creating ChatMessage
- Added test to ensure that when an instance of ChatMessage is converted to StoredMessage, it can be converted back.
