### PR TITLE
community[patch]: avoid shouldIgnore on folders for GithubRepoLoader

### DIFF
--- a/libs/langchain-community/src/document_loaders/web/github.ts
+++ b/libs/langchain-community/src/document_loaders/web/github.ts
@@ -510,7 +510,7 @@ export class GithubRepoLoader
     >[] = [];
 
     for (const file of files) {
-      if (this.shouldIgnore(file.path, file.type)) {
+      if (file.type !== "dir" && this.shouldIgnore(file.path, file.type)) {
         continue;
       }
       if (file.type === "file" && file.size === 0) {
@@ -566,7 +566,7 @@ export class GithubRepoLoader
   ): AsyncGenerator<Document, void, undefined> {
     const files = await this.fetchRepoFiles(path);
     for (const file of files) {
-      if (this.shouldIgnore(file.path, file.type)) {
+      if (file.type !== "dir" && this.shouldIgnore(file.path, file.type)) {
         continue;
       }
 
@@ -619,7 +619,7 @@ export class GithubRepoLoader
     const files = await this.fetchRepoFiles(path);
 
     for (const file of files) {
-      if (this.shouldIgnore(file.path, file.type)) {
+      if (file.type !== "dir" && this.shouldIgnore(file.path, file.type)) {
         continue;
       }
 


### PR DESCRIPTION
This PR avoids the `shouldIgnore` check on directories when looping over files in a github repo that is loaded using the `GithubRepoLoader`. 

The issue with checking `shouldIgnore` on a directory is that a directory path might match an ignore pattern while its content does not. For instance, `ignorePaths: ["*", "!*/", "!**/*.txt"]` results in `ignore.ignores("subfolder") == true` but `ignore.ignores("subfolder/file.txt") == false`. Before this fix, the `GithubRepoLoader` will miss `subfolder/file.txt` and any other files in subfolders that should be included. My solution here is to avoid the `shouldIgnore` test on directories and only check `shouldIgnore` on files. This means all directories will be traversed in a recursive load but only the correct files will be loaded. 

I was unsure how to add a test case for this as an accessToken is required to do recursive collection of github repos.


<!-- Remove if not applicable -->

Fixes https://github.com/langchain-ai/langchainjs/issues/6214
