### PR TITLE
google-common[patch]: Merge adjacent function results in google common

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -117,8 +117,15 @@ class ChatConnection<AuthOptions> extends AbstractGoogleLLMConnection<
         }
 
         // Combine adjacent function messages
-        if (cur[0]?.role === "function" && acc.length > 0 && acc[acc.length - 1].role === "function") {
-          acc[acc.length - 1].parts = [...acc[acc.length - 1].parts, ...cur[0].parts];
+        if (
+          cur[0]?.role === "function" &&
+          acc.length > 0 &&
+          acc[acc.length - 1].role === "function"
+        ) {
+          acc[acc.length - 1].parts = [
+            ...acc[acc.length - 1].parts,
+            ...cur[0].parts,
+          ];
         } else {
           acc.push(...cur);
         }

--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -111,11 +111,20 @@ class ChatConnection<AuthOptions> extends AbstractGoogleLLMConnection<
         baseMessageToContent(msg, input[i - 1], this.useSystemInstruction)
       )
       .reduce((acc, cur) => {
-        // Filter out the system content, since those don't belong
-        // in the actual content.
-        const hasNoSystem = cur.every((content) => content.role !== "system");
-        return hasNoSystem ? [...acc, ...cur] : acc;
-      }, []);
+        // Filter out the system content
+        if (cur.every((content) => content.role === "system")) {
+          return acc;
+        }
+
+        // Combine adjacent function messages
+        if (cur[0]?.role === "function" && acc.length > 0 && acc[acc.length - 1].role === "function") {
+          acc[acc.length - 1].parts = [...acc[acc.length - 1].parts, ...cur[0].parts];
+        } else {
+          acc.push(...cur);
+        }
+
+        return acc;
+      }, [] as GeminiContent[]);
   }
 
   formatSystemInstruction(


### PR DESCRIPTION
This allows for Google VertexAI to properly handle message histories where two or more tool results are passed back at once.

I am still unable to make Google VertexAI actually call two functions at once.