### PR TITLE
core[minor]: Add status field to tool

### DIFF
--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -141,20 +141,17 @@ export function mergeContent(
 }
 
 /**
- * 'Merge' two statuses. Will return `undefined` if both statuses are passed as `undefined`,
- * 'success' if both statuses are 'success', and 'error' if either status is 'error'.
+ * 'Merge' two statuses. If either value passed is 'error', it will return 'error'. Else
+ * it will return 'success'.
  *
  * @param {"success" | "error" | undefined} left The existing value to 'merge' with the new value.
  * @param {"success" | "error" | undefined} right The new value to 'merge' with the existing value
- * @returns {"success" | "error" | undefined} The 'merged' value, or `undefined` if both values are `undefined`.
+ * @returns {"success" | "error"} The 'merged' value.
  */
 export function _mergeStatus(
   left?: "success" | "error",
   right?: "success" | "error"
 ): "success" | "error" | undefined {
-  if (!left && !right) {
-    return undefined;
-  }
   if (left === "error" || right === "error") {
     return "error";
   }

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -140,10 +140,21 @@ export function mergeContent(
   }
 }
 
+/**
+ * 'Merge' two statuses. Will return `undefined` if both statuses are passed as `undefined`,
+ * 'success' if both statuses are 'success', and 'error' if either status is 'error'.
+ *
+ * @param {"success" | "error" | undefined} left The existing value to 'merge' with the new value.
+ * @param {"success" | "error" | undefined} right The new value to 'merge' with the existing value
+ * @returns {"success" | "error" | undefined} The 'merged' value, or `undefined` if both values are `undefined`.
+ */
 export function _mergeStatus(
   left?: "success" | "error",
   right?: "success" | "error"
-): "success" | "error" {
+): "success" | "error" | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
   if (left === "error" || right === "error") {
     return "error";
   }

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -140,6 +140,16 @@ export function mergeContent(
   }
 }
 
+export function _mergeStatus(
+  left?: "success" | "error",
+  right?: "success" | "error"
+): "success" | "error" {
+  if (left === "error" || right === "error") {
+    return "error";
+  }
+  return "success";
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stringifyWithDepthLimit(obj: any, depthLimit: number): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/langchain-core/src/messages/tool.ts
+++ b/langchain-core/src/messages/tool.ts
@@ -6,6 +6,7 @@ import {
   _mergeDicts,
   type MessageType,
   _mergeObj,
+  _mergeStatus,
 } from "./base.js";
 
 export interface ToolMessageFieldsWithToolCallId extends BaseMessageFields {
@@ -19,6 +20,11 @@ export interface ToolMessageFieldsWithToolCallId extends BaseMessageFields {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   artifact?: any;
   tool_call_id: string;
+  /**
+   * Status of the tool invocation.
+   * @version 0.2.19
+   */
+  status?: "success" | "error";
 }
 
 /**
@@ -33,6 +39,12 @@ export class ToolMessage extends BaseMessage {
     // exclude snake case conversion to pascal case
     return { tool_call_id: "tool_call_id" };
   }
+
+  /**
+   * Status of the tool invocation.
+   * @version 0.2.19
+   */
+  status?: "success" | "error";
 
   tool_call_id: string;
 
@@ -66,6 +78,7 @@ export class ToolMessage extends BaseMessage {
     super(fields);
     this.tool_call_id = fields.tool_call_id;
     this.artifact = fields.artifact;
+    this.status = fields.status;
   }
 
   _getType(): MessageType {
@@ -93,6 +106,12 @@ export class ToolMessageChunk extends BaseMessageChunk {
   tool_call_id: string;
 
   /**
+   * Status of the tool invocation.
+   * @version 0.2.19
+   */
+  status?: "success" | "error";
+
+  /**
    * Artifact of the Tool execution which is not meant to be sent to the model.
    *
    * Should only be specified if it is different from the message content, e.g. if only
@@ -106,6 +125,7 @@ export class ToolMessageChunk extends BaseMessageChunk {
     super(fields);
     this.tool_call_id = fields.tool_call_id;
     this.artifact = fields.artifact;
+    this.status = fields.status;
   }
 
   static lc_name() {
@@ -130,6 +150,7 @@ export class ToolMessageChunk extends BaseMessageChunk {
       artifact: _mergeObj(this.artifact, chunk.artifact),
       tool_call_id: this.tool_call_id,
       id: this.id ?? chunk.id,
+      status: _mergeStatus(this.status, chunk.status),
     });
   }
 

--- a/langchain-core/src/runnables/remote.ts
+++ b/langchain-core/src/runnables/remote.ts
@@ -86,6 +86,7 @@ function revive(obj: any): any {
         return new ToolMessage({
           content: obj.content,
           tool_call_id: obj.tool_call_id,
+          status: obj.status,
         });
       }
       if (obj.type === "AIMessage" || obj.type === "ai") {
@@ -119,6 +120,7 @@ function revive(obj: any): any {
         return new ToolMessageChunk({
           content: obj.content,
           tool_call_id: obj.tool_call_id,
+          status: obj.status,
         });
       }
       if (obj.type === "AIMessageChunk") {

--- a/langchain-core/src/tools/index.ts
+++ b/langchain-core/src/tools/index.ts
@@ -240,7 +240,7 @@ export abstract class StructuredTool<
     let status: "success" | "error" = "success";
     try {
       result = await this._call(parsed, runManager, config);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       await runManager?.handleToolError(e);
       if (!this.continueOnError) {

--- a/langchain-core/src/tools/tests/tools.test.ts
+++ b/langchain-core/src/tools/tests/tools.test.ts
@@ -115,3 +115,28 @@ test("Tool can accept single string input", async () => {
   const result = await stringTool.invoke("b");
   expect(result).toBe("ba");
 });
+
+test("Tool can continue if an error is thrown", async () => {
+  const errorTool = tool((_) => {
+    throw new Error("This tool encountered an error.");
+  }, {
+    name: "error_tool",
+    schema: z.object({
+      input: z.string(),
+    }),
+    continueOnError: true,
+  })
+
+  const result = await errorTool.invoke({
+    id: "testid",
+    args: { input: "test" },
+    name: "error_tool",
+    type: "tool_call",
+  });
+  expect(result).toBeInstanceOf(ToolMessage);
+  expect(result.status).toBe("error");
+  expect(JSON.parse(result.content)).toEqual({
+    code: undefined,
+    message: "This tool encountered an error.",
+  })
+});

--- a/langchain-core/src/tools/tests/tools.test.ts
+++ b/langchain-core/src/tools/tests/tools.test.ts
@@ -115,31 +115,3 @@ test("Tool can accept single string input", async () => {
   const result = await stringTool.invoke("b");
   expect(result).toBe("ba");
 });
-
-test("Tool can continue if an error is thrown", async () => {
-  const errorTool = tool(
-    (_) => {
-      throw new Error("This tool encountered an error.");
-    },
-    {
-      name: "error_tool",
-      schema: z.object({
-        input: z.string(),
-      }),
-      continueOnError: true,
-    }
-  );
-
-  const result = await errorTool.invoke({
-    id: "testid",
-    args: { input: "test" },
-    name: "error_tool",
-    type: "tool_call",
-  });
-  expect(result).toBeInstanceOf(ToolMessage);
-  expect(result.status).toBe("error");
-  expect(JSON.parse(result.content)).toEqual({
-    code: undefined,
-    message: "This tool encountered an error.",
-  });
-});

--- a/langchain-core/src/tools/tests/tools.test.ts
+++ b/langchain-core/src/tools/tests/tools.test.ts
@@ -117,15 +117,18 @@ test("Tool can accept single string input", async () => {
 });
 
 test("Tool can continue if an error is thrown", async () => {
-  const errorTool = tool((_) => {
-    throw new Error("This tool encountered an error.");
-  }, {
-    name: "error_tool",
-    schema: z.object({
-      input: z.string(),
-    }),
-    continueOnError: true,
-  })
+  const errorTool = tool(
+    (_) => {
+      throw new Error("This tool encountered an error.");
+    },
+    {
+      name: "error_tool",
+      schema: z.object({
+        input: z.string(),
+      }),
+      continueOnError: true,
+    }
+  );
 
   const result = await errorTool.invoke({
     id: "testid",
@@ -138,5 +141,5 @@ test("Tool can continue if an error is thrown", async () => {
   expect(JSON.parse(result.content)).toEqual({
     code: undefined,
     message: "This tool encountered an error.",
-  })
+  });
 });


### PR DESCRIPTION
Added new `status` field to tools.

TODO in separate PR:
- [update anthropic to use this field](https://github.com/langchain-ai/langchain/pull/24628/files#diff-e2dea7070f0cc79e3fc72e08f7a809d2ae17ae8924794bd917c72d37dc65cc1c)
- doc section on `status` field.
- update LangGraph `ToolNode` to use `status` field.