### PR TITLE
core[patch]: Allow any module to emit a custom event

### DIFF
--- a/langchain-core/src/callbacks/manager.ts
+++ b/langchain-core/src/callbacks/manager.ts
@@ -154,6 +154,42 @@ export class BaseRunManager {
       )
     );
   }
+
+  async handleCustomEvent(
+    eventName: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    _runId?: string,
+    _tags?: string[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _metadata?: Record<string, any>
+  ): Promise<void> {
+    await Promise.all(
+      this.handlers.map((handler) =>
+        consumeCallback(async () => {
+          try {
+            await handler.handleCustomEvent?.(
+              eventName,
+              data,
+              this.runId,
+              this.tags,
+              this.metadata
+            );
+          } catch (err) {
+            const logFunction = handler.raiseError
+              ? console.error
+              : console.warn;
+            logFunction(
+              `Error in handler ${handler.constructor.name}, handleCustomEvent: ${err}`
+            );
+            if (handler.raiseError) {
+              throw err;
+            }
+          }
+        }, handler.awaitHandlers)
+      )
+    );
+  }
 }
 
 /**

--- a/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -249,7 +249,7 @@ test("Test ChatModel can emit a custom event", async () => {
   expect(customEvent).toBeDefined();
 });
 
-test.only("Test ChatModel can stream back a custom event", async () => {
+test("Test ChatModel can stream back a custom event", async () => {
   const model = new FakeListChatModel({
     responses: ["hi"],
     emitCustomEvent: true,


### PR DESCRIPTION
Using:

```ts
await runManager?.handleCustomEvent("some_test_event", {
  someval: true,
});
```

Some concerns about misuse but I think generally useful as an escape hatch.

CC @afirstenberg 