### PR TITLE
docs[patch]: Fix import path in dispatching events doc

### DIFF
--- a/docs/core_docs/docs/how_to/callbacks_custom_events.ipynb
+++ b/docs/core_docs/docs/how_to/callbacks_custom_events.ipynb
@@ -46,7 +46,7 @@
     ":::caution Compatibility\n",
     "Dispatching custom callback events requires `@langchain/core>=0.2.16`. See [this guide](/docs/how_to/installation/#installing-integration-packages) for some considerations to take when upgrading `@langchain/core`.\n",
     "\n",
-    "The default entrypoint below triggers an import and initialization of [`async_hooks`](https://nodejs.org/api/async_hooks.html) to enable automatic `RunnableConfig` passing, which is not supported in all environments. If you see import issues, you must import from `@langchain/callbacks/dispatch/web` and propagate the `RunnableConfig` object manually (see example below).\n",
+    "The default entrypoint below triggers an import and initialization of [`async_hooks`](https://nodejs.org/api/async_hooks.html) to enable automatic `RunnableConfig` passing, which is not supported in all environments. If you see import issues, you must import from `@langchain/core/callbacks/dispatch/web` and propagate the `RunnableConfig` object manually (see example below).\n",
     ":::\n",
     "```"
    ]


### PR DESCRIPTION
`@langchain/callbacks/dispatch/web` -> `@langchain/core/callbacks/dispatch/web`