### PR TITLE
core[patch]: Allow dynamic tools to be initialized with JSON schema

### DIFF
--- a/langchain-core/src/tools/index.ts
+++ b/langchain-core/src/tools/index.ts
@@ -386,6 +386,9 @@ export class DynamicTool extends Tool {
  * description, designed to work with structured data. It extends the
  * StructuredTool class and overrides the _call method to execute the
  * provided function when the tool is called.
+ *
+ * Schema can be passed as Zod or JSON schema. The tool will not validate
+ * input if JSON schema is passed.
  */
 export class DynamicStructuredTool<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -455,6 +458,8 @@ export abstract class BaseToolkit {
 
 /**
  * Parameters for the tool function.
+ * Schema can be provided as Zod or JSON schema.
+ * If you pass JSON schema, tool inputs will not be validated.
  * @template {ZodObjectAny | z.ZodString | Record<string, any> = ZodObjectAny} RunInput The input schema for the tool. Either any Zod object, a Zod string, or JSON schema.
  */
 interface ToolWrapperParams<
@@ -495,8 +500,11 @@ interface ToolWrapperParams<
 /**
  * Creates a new StructuredTool instance with the provided function, name, description, and schema.
  *
+ * Schema can be provided as Zod or JSON schema.
+ * If you pass JSON schema, tool inputs will not be validated.
+ *
  * @function
- * @template {ZodObjectAny | z.ZodString = ZodObjectAny} T The input schema for the tool. Either any Zod object, or a Zod string.
+ * @template {ZodObjectAny | z.ZodString | Record<string, any> = ZodObjectAny} T The input schema for the tool. Either any Zod object, a Zod string, or JSON schema instance.
  *
  * @param {RunnableFunc<z.output<T>, ToolReturnType>} func - The function to invoke when the tool is called.
  * @param {ToolWrapperParams<T>} fields - An object containing the following properties:
@@ -539,6 +547,7 @@ export function tool<
         fields.description ??
         fields.schema?.description ??
         `${fields.name} tool`,
+      // TS doesn't restrict the type here based on the guard above
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       func: func as any,
     });
@@ -562,6 +571,7 @@ export function tool<
           childConfig,
           async () => {
             try {
+              // TS doesn't restrict the type here based on the guard above
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve(func(input as any, childConfig));
             } catch (e) {

--- a/langchain-core/src/tools/index.ts
+++ b/langchain-core/src/tools/index.ts
@@ -320,6 +320,7 @@ export interface DynamicToolInput extends BaseDynamicToolInput {
  * Interface for the input parameters of the DynamicStructuredTool class.
  */
 export interface DynamicStructuredToolInput<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends ZodObjectAny | Record<string, any> = ZodObjectAny
 > extends BaseDynamicToolInput {
   func: (
@@ -387,6 +388,7 @@ export class DynamicTool extends Tool {
  * provided function when the tool is called.
  */
 export class DynamicStructuredTool<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends ZodObjectAny | Record<string, any> = ZodObjectAny
 > extends StructuredTool<T extends ZodObjectAny ? T : ZodObjectAny> {
   static lc_name() {
@@ -433,6 +435,7 @@ export class DynamicStructuredTool<
     runManager?: CallbackManagerForToolRun,
     parentConfig?: RunnableConfig
   ): Promise<ToolReturnType> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.func(arg as any, runManager, parentConfig);
   }
 }
@@ -458,6 +461,7 @@ interface ToolWrapperParams<
   RunInput extends
     | ZodObjectAny
     | z.ZodString
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     | Record<string, any> = ZodObjectAny
 > extends ToolParams {
   /**
@@ -512,12 +516,14 @@ export function tool<T extends ZodObjectAny>(
   fields: ToolWrapperParams<T>
 ): DynamicStructuredTool<T>;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function tool<T extends Record<string, any>>(
   func: RunnableFunc<T, ToolReturnType>,
   fields: ToolWrapperParams<T>
 ): DynamicStructuredTool<T>;
 
 export function tool<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends ZodObjectAny | z.ZodString | Record<string, any> = ZodObjectAny
 >(
   func: RunnableFunc<T extends ZodObjectAny ? z.output<T> : T, ToolReturnType>,
@@ -533,6 +539,7 @@ export function tool<
         fields.description ??
         fields.schema?.description ??
         `${fields.name} tool`,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       func: func as any,
     });
   }
@@ -543,6 +550,7 @@ export function tool<
   return new DynamicStructuredTool<T extends ZodObjectAny ? T : ZodObjectAny>({
     ...fields,
     description,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     schema: fields.schema as any,
     // TODO: Consider moving into DynamicStructuredTool constructor
     func: async (input, runManager, config) => {
@@ -554,6 +562,7 @@ export function tool<
           childConfig,
           async () => {
             try {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               resolve(func(input as any, childConfig));
             } catch (e) {
               reject(e);

--- a/langchain-core/src/tools/index.ts
+++ b/langchain-core/src/tools/index.ts
@@ -20,6 +20,7 @@ import { ZodObjectAny } from "../types/zod.js";
 import { MessageContent } from "../messages/base.js";
 import { AsyncLocalStorageProviderSingleton } from "../singletons/index.js";
 import { _isToolCall, ToolInputParsingException } from "./utils.js";
+import { isZodSchema } from "../utils/types/is_zod_schema.js";
 
 export { ToolInputParsingException };
 
@@ -319,16 +320,18 @@ export interface DynamicToolInput extends BaseDynamicToolInput {
  * Interface for the input parameters of the DynamicStructuredTool class.
  */
 export interface DynamicStructuredToolInput<
-  T extends ZodObjectAny = ZodObjectAny
+  T extends ZodObjectAny | Record<string, any> = ZodObjectAny
 > extends BaseDynamicToolInput {
   func: (
     input: BaseDynamicToolInput["responseFormat"] extends "content_and_artifact"
       ? ToolCall
-      : z.infer<T>,
+      : T extends ZodObjectAny
+      ? z.infer<T>
+      : T,
     runManager?: CallbackManagerForToolRun,
     config?: RunnableConfig
   ) => Promise<ToolReturnType>;
-  schema: T;
+  schema: T extends ZodObjectAny ? T : T;
 }
 
 /**
@@ -384,8 +387,8 @@ export class DynamicTool extends Tool {
  * provided function when the tool is called.
  */
 export class DynamicStructuredTool<
-  T extends ZodObjectAny = ZodObjectAny
-> extends StructuredTool<T> {
+  T extends ZodObjectAny | Record<string, any> = ZodObjectAny
+> extends StructuredTool<T extends ZodObjectAny ? T : ZodObjectAny> {
   static lc_name() {
     return "DynamicStructuredTool";
   }
@@ -396,7 +399,7 @@ export class DynamicStructuredTool<
 
   func: DynamicStructuredToolInput<T>["func"];
 
-  schema: T;
+  schema: T extends ZodObjectAny ? T : ZodObjectAny;
 
   constructor(fields: DynamicStructuredToolInput<T>) {
     super(fields);
@@ -404,14 +407,16 @@ export class DynamicStructuredTool<
     this.description = fields.description;
     this.func = fields.func;
     this.returnDirect = fields.returnDirect ?? this.returnDirect;
-    this.schema = fields.schema;
+    this.schema = (
+      isZodSchema(fields.schema) ? fields.schema : z.object({})
+    ) as T extends ZodObjectAny ? T : ZodObjectAny;
   }
 
   /**
    * @deprecated Use .invoke() instead. Will be removed in 0.3.0.
    */
   async call(
-    arg: z.output<T> | ToolCall,
+    arg: (T extends ZodObjectAny ? z.output<T> : T) | ToolCall,
     configArg?: RunnableConfig | Callbacks,
     /** @deprecated */
     tags?: string[]
@@ -424,11 +429,11 @@ export class DynamicStructuredTool<
   }
 
   protected _call(
-    arg: z.output<T> | ToolCall,
+    arg: (T extends ZodObjectAny ? z.output<T> : T) | ToolCall,
     runManager?: CallbackManagerForToolRun,
     parentConfig?: RunnableConfig
   ): Promise<ToolReturnType> {
-    return this.func(arg, runManager, parentConfig);
+    return this.func(arg as any, runManager, parentConfig);
   }
 }
 
@@ -447,10 +452,13 @@ export abstract class BaseToolkit {
 
 /**
  * Parameters for the tool function.
- * @template {ZodObjectAny | z.ZodString = ZodObjectAny} RunInput The input schema for the tool. Either any Zod object, or a Zod string.
+ * @template {ZodObjectAny | z.ZodString | Record<string, any> = ZodObjectAny} RunInput The input schema for the tool. Either any Zod object, a Zod string, or JSON schema.
  */
 interface ToolWrapperParams<
-  RunInput extends ZodObjectAny | z.ZodString = ZodObjectAny
+  RunInput extends
+    | ZodObjectAny
+    | z.ZodString
+    | Record<string, any> = ZodObjectAny
 > extends ToolParams {
   /**
    * The name of the tool. If using with an LLM, this
@@ -494,18 +502,25 @@ interface ToolWrapperParams<
  *
  * @returns {DynamicStructuredTool<T>} A new StructuredTool instance.
  */
-export function tool<T extends z.ZodString = z.ZodString>(
+export function tool<T extends z.ZodString>(
   func: RunnableFunc<z.output<T>, ToolReturnType>,
   fields: ToolWrapperParams<T>
 ): DynamicTool;
 
-export function tool<T extends ZodObjectAny = ZodObjectAny>(
+export function tool<T extends ZodObjectAny>(
   func: RunnableFunc<z.output<T>, ToolReturnType>,
   fields: ToolWrapperParams<T>
 ): DynamicStructuredTool<T>;
 
-export function tool<T extends ZodObjectAny | z.ZodString = ZodObjectAny>(
-  func: RunnableFunc<z.output<T>, ToolReturnType>,
+export function tool<T extends Record<string, any>>(
+  func: RunnableFunc<T, ToolReturnType>,
+  fields: ToolWrapperParams<T>
+): DynamicStructuredTool<T>;
+
+export function tool<
+  T extends ZodObjectAny | z.ZodString | Record<string, any> = ZodObjectAny
+>(
+  func: RunnableFunc<T extends ZodObjectAny ? z.output<T> : T, ToolReturnType>,
   fields: ToolWrapperParams<T>
 ):
   | DynamicStructuredTool<T extends ZodObjectAny ? T : ZodObjectAny>
@@ -518,7 +533,7 @@ export function tool<T extends ZodObjectAny | z.ZodString = ZodObjectAny>(
         fields.description ??
         fields.schema?.description ??
         `${fields.name} tool`,
-      func,
+      func: func as any,
     });
   }
 
@@ -528,7 +543,7 @@ export function tool<T extends ZodObjectAny | z.ZodString = ZodObjectAny>(
   return new DynamicStructuredTool<T extends ZodObjectAny ? T : ZodObjectAny>({
     ...fields,
     description,
-    schema: fields.schema as T extends ZodObjectAny ? T : ZodObjectAny,
+    schema: fields.schema as any,
     // TODO: Consider moving into DynamicStructuredTool constructor
     func: async (input, runManager, config) => {
       return new Promise((resolve, reject) => {
@@ -539,7 +554,7 @@ export function tool<T extends ZodObjectAny | z.ZodString = ZodObjectAny>(
           childConfig,
           async () => {
             try {
-              resolve(func(input, childConfig));
+              resolve(func(input as any, childConfig));
             } catch (e) {
               reject(e);
             }


### PR DESCRIPTION
If you init a tool with JSON schema, it will not currently validate/infer any types.

Types are starting to get pretty hairy in general but I've added some tests around them.

CC @bracesproul @nfcampos 