### PR TITLE
langchain[patch]: Fix: Change sqlite to SQL in query checker prompt

### DIFF
--- a/langchain/src/tools/sql.ts
+++ b/langchain/src/tools/sql.ts
@@ -156,7 +156,7 @@ export class QueryCheckerTool extends Tool {
 
   template = `
     {query}
-Double check the sqlite query above for common mistakes, including:
+Double check the SQL query above for common mistakes, including:
 - Using NOT IN with NULL values
 - Using UNION when UNION ALL should have been used
 - Using BETWEEN for exclusive ranges


### PR DESCRIPTION
In the `sqlAgent`, the `query-checker` step currently references `sqlite` specifically in the prompt, which is incorrect since the `sqlAgent` can interact with multiple types of databases. To make this prompt more accurate and applicable to various SQL databases, I have replaced `sqlite` with `SQL`.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
