### PR TITLE
community[patch]: Add namespace to allow indexing multiple tables within the same schema

### DIFF
--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -712,10 +712,12 @@ export class PGVectorStore extends VectorStore {
         throw new Error(`Unknown distance strategy: ${this.distanceStrategy}`);
     }
 
-    const createIndexQuery = `CREATE INDEX IF NOT EXISTS ${prefix}${this.vectorColumnName
-      }_embedding_hnsw_idx
-        ON ${this.computedTableName} USING hnsw ((${this.vectorColumnName
-      }::vector(${config.dimensions})) ${idxDistanceFunction})
+    const createIndexQuery = `CREATE INDEX IF NOT EXISTS ${prefix}${
+      this.vectorColumnName
+    }_embedding_hnsw_idx
+        ON ${this.computedTableName} USING hnsw ((${
+      this.vectorColumnName
+    }::vector(${config.dimensions})) ${idxDistanceFunction})
         WITH (
             m=${config?.m || 16},
             ef_construction=${config?.efConstruction || 64}

--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -685,6 +685,7 @@ export class PGVectorStore extends VectorStore {
    * @param m - The max number of connections per layer (16 by default). Index build time improves with smaller values, while higher values can speed up search queries.
    * @param efConstruction -  The size of the dynamic candidate list for constructing the graph (64 by default). A higher value can potentially improve the index quality at the cost of index build time.
    * @param distanceFunction -  The distance function name you want to use, is automatically selected based on the distanceStrategy.
+   * @param namespace -  The namespace is used to create the index with a specific name. This is useful when you want to create multiple indexes on the same database schema (within the same schema in PostgreSQL, the index name must be unique across all tables).
    * @returns Promise that resolves with the query response of creating the index.
    */
   async createHnswIndex(config: {
@@ -692,8 +693,10 @@ export class PGVectorStore extends VectorStore {
     m?: number;
     efConstruction?: number;
     distanceFunction?: string;
+    namespace?: string;
   }): Promise<void> {
     let idxDistanceFunction = config?.distanceFunction || "vector_cosine_ops";
+    const prefix = config?.namespace ? `${config.namespace}_` : "";
 
     switch (this.distanceStrategy) {
       case "cosine":
@@ -709,12 +712,10 @@ export class PGVectorStore extends VectorStore {
         throw new Error(`Unknown distance strategy: ${this.distanceStrategy}`);
     }
 
-    const createIndexQuery = `CREATE INDEX IF NOT EXISTS ${
-      this.vectorColumnName
-    }_embedding_hnsw_idx
-        ON ${this.computedTableName} USING hnsw ((${
-      this.vectorColumnName
-    }::vector(${config.dimensions})) ${idxDistanceFunction})
+    const createIndexQuery = `CREATE INDEX IF NOT EXISTS ${prefix}${this.vectorColumnName
+      }_embedding_hnsw_idx
+        ON ${this.computedTableName} USING hnsw ((${this.vectorColumnName
+      }::vector(${config.dimensions})) ${idxDistanceFunction})
         WITH (
             m=${config?.m || 16},
             ef_construction=${config?.efConstruction || 64}


### PR DESCRIPTION
Issue:

We're working on a tenant based SaaS platform where we use separate tables for each tenant (to avoid infinitely growing tables).

The `createHnswIndex` function translates into a query like 

```
CREATE INDEX IF NOT EXISTS vector_embedding_hnsw_idx
        ON tenant_123_index USING hnsw ((vector::vector(1536)) vector_cosine_ops)
        WITH (
            m=16,
            ef_construction=64
        );
```
where the index name is always `vector_embedding_hnsw_idx`.
Within the same schema in PostgreSQL, the index name must be unique across all tables.

This means it’s created for the first tenant, but not for anyone else since then the index with that static name already exists.

This PR allows to pass an optional `namespace` string to `createHnswIndex` which is used a prefixing the index name.