### PR TITLE
mongodb[patch]: Fix bug in mongodb storage.ts

### DIFF
--- a/libs/langchain-mongodb/src/storage.ts
+++ b/libs/langchain-mongodb/src/storage.ts
@@ -103,12 +103,10 @@ export class MongoDBStore extends BaseStore<string, Uint8Array> {
       }
       if (value === undefined || value === null) {
         return undefined;
-      } 
-      else if (typeof value.value === "object") {
+      } else if (typeof value.value === "object") {
         return encoder.encode(JSON.stringify(value.value));
-      }
-      else if (typeof value.value === "string") {
-        return encoder.encode(value.value);    
+      } else if (typeof value.value === "string") {
+        return encoder.encode(value.value);
       } else {
         throw new Error("Unexpected value type");
       }

--- a/libs/langchain-mongodb/src/storage.ts
+++ b/libs/langchain-mongodb/src/storage.ts
@@ -103,8 +103,12 @@ export class MongoDBStore extends BaseStore<string, Uint8Array> {
       }
       if (value === undefined || value === null) {
         return undefined;
-      } else if (typeof value === "object") {
+      } 
+      else if (typeof value.value === "object") {
         return encoder.encode(JSON.stringify(value.value));
+      }
+      else if (typeof value.value === "string") {
+        return encoder.encode(value.value);    
       } else {
         throw new Error("Unexpected value type");
       }


### PR DESCRIPTION
When retrieving records from MongoDBStore the value was always JSON.stringified even if the value was already in JSON.  As a result, MongoDBStore does not work with standard retrievers like the ParentRetriever as it would always return documents with undefined for pageContent.  This corrects that behavior by look at the value and only JSON.stringify if it is an Object.  If it is a string then it just returns the value as is.