### PR TITLE
Convert anthropic token reporting to expected langchain format for tracing

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -512,8 +512,17 @@ export class ChatAnthropicMessages<
       additionalKwargs
     );
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { role: _role, type: _type, ...rest } = additionalKwargs;
-    return { generations, llmOutput: rest };
+    const { role: _role, type: _type, usage, ...rest } = additionalKwargs;
+    return {
+      generations,
+      llmOutput: {
+        ...rest,
+        tokenUsage: {
+          promptTokens: usage?.input_tokens,
+          completionTokens: usage?.output_tokens,
+        },
+      },
+    };
   }
 
   /** @ignore */


### PR DESCRIPTION
Previously, llmoutput takes the Anthropic response but it is not utilized by the tracing to provide token metrics due to inconsistency with various API responses. This PR aligns llmoutput to be consistent with other providers for langchain parsability in its Tracer and callbacks. 

Happy to do this a different way if there is a more preferred approach. (e.g custom response parser for compatibility to an internal api?)