### PR TITLE
ollama[patch]: Include raw messages from API response in response_metadata

### DIFF
--- a/libs/langchain-ollama/src/chat_models.ts
+++ b/libs/langchain-ollama/src/chat_models.ts
@@ -467,7 +467,10 @@ export class ChatOllama
       yield new ChatGenerationChunk({
         text: responseMessage.content,
         message: convertOllamaMessagesToLangChain(responseMessage, {
-          responseMetadata: rest,
+          responseMetadata: {
+            ...rest,
+            message: responseMessage,
+          },
           usageMetadata,
         }),
       });


### PR DESCRIPTION
This will allow users to access the raw messages & tool calls via the `response_metadata` field