### PR TITLE
community[patch]: support modelName param and update default fireworks model to Llama 3.1 8B

### DIFF
--- a/libs/langchain-community/src/chat_models/fireworks.ts
+++ b/libs/langchain-community/src/chat_models/fireworks.ts
@@ -93,7 +93,10 @@ export class ChatFireworks extends ChatOpenAI<ChatFireworksCallOptions> {
 
     super({
       ...fields,
-      model: fields?.model || "accounts/fireworks/models/llama-v2-13b-chat",
+      model:
+        fields?.model ||
+        fields?.modelName ||
+        "accounts/fireworks/models/llama-v3p1-8b-instruct",
       apiKey: fireworksApiKey,
       configuration: {
         baseURL: "https://api.fireworks.ai/inference/v1",


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->
- ChatFireworks manifest sometimes uses `modelName` to define the model, which incorrectly leads to defaulting to the default model
- Existing default model has been deprecated by Fireworks, causing it to error out. Update default model to llama-3.1-8b