### PR TITLE
community[patch]: Support for specifying api url for firecrawl document loader

### DIFF
--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -82,7 +82,7 @@
     "@langchain/scripts": "~0.0.20",
     "@langchain/standard-tests": "0.0.0",
     "@layerup/layerup-security": "^1.5.12",
-    "@mendable/firecrawl-js": "^0.0.13",
+    "@mendable/firecrawl-js": "^0.0.36",
     "@mlc-ai/web-llm": "0.2.46",
     "@mozilla/readability": "^0.4.4",
     "@neondatabase/serverless": "^0.9.1",

--- a/libs/langchain-community/src/document_loaders/web/firecrawl.ts
+++ b/libs/langchain-community/src/document_loaders/web/firecrawl.ts
@@ -19,7 +19,7 @@ interface FirecrawlLoaderParameters {
   apiKey?: string;
 
   /**
-   * API URL for Firecrawl. If not provided, the default value is "https://api.firecrawl.dev".
+   * API URL for Firecrawl.
    */
   apiUrl?: string;
   /**

--- a/libs/langchain-community/src/document_loaders/web/firecrawl.ts
+++ b/libs/langchain-community/src/document_loaders/web/firecrawl.ts
@@ -50,7 +50,7 @@ interface FirecrawlDocument {
 export class FireCrawlLoader extends BaseDocumentLoader {
   private apiKey: string;
 
-  private apiUrl: string;
+  private apiUrl?: string
 
   private url: string;
 
@@ -62,7 +62,7 @@ export class FireCrawlLoader extends BaseDocumentLoader {
     super();
     const {
       apiKey = getEnvironmentVariable("FIRECRAWL_API_KEY"),
-      apiUrl = "https://api.firecrawl.dev",
+      apiUrl,
       url,
       mode = "crawl",
       params,

--- a/libs/langchain-community/src/document_loaders/web/firecrawl.ts
+++ b/libs/langchain-community/src/document_loaders/web/firecrawl.ts
@@ -50,7 +50,7 @@ interface FirecrawlDocument {
 export class FireCrawlLoader extends BaseDocumentLoader {
   private apiKey: string;
 
-  private apiUrl?: string
+  private apiUrl?: string;
 
   private url: string;
 
@@ -81,12 +81,18 @@ export class FireCrawlLoader extends BaseDocumentLoader {
   }
 
   /**
-   * Loads the data from the Firecrawl.
+   * Loads data from Firecrawl.
    * @returns An array of Documents representing the retrieved data.
    * @throws An error if the data could not be loaded.
    */
   public async load(): Promise<DocumentInterface[]> {
-    const app = new FirecrawlApp({ apiKey: this.apiKey, apiUrl: this.apiUrl });
+    const params: ConstructorParameters<typeof FirecrawlApp>[0] = {
+      apiKey: this.apiKey,
+    };
+    if (this.apiUrl !== undefined) {
+      params.apiUrl = this.apiUrl;
+    }
+    const app = new FirecrawlApp(params);
     let firecrawlDocs: FirecrawlDocument[];
 
     if (this.mode === "scrape") {

--- a/libs/langchain-community/src/document_loaders/web/firecrawl.ts
+++ b/libs/langchain-community/src/document_loaders/web/firecrawl.ts
@@ -19,6 +19,10 @@ interface FirecrawlLoaderParameters {
   apiKey?: string;
 
   /**
+   * API URL for Firecrawl. If not provided, the default value is "https://api.firecrawl.dev".
+   */
+  apiUrl?: string;
+  /**
    * Mode of operation. Can be either "crawl" or "scrape". If not provided, the default value is "crawl".
    */
   mode?: "crawl" | "scrape";
@@ -46,6 +50,8 @@ interface FirecrawlDocument {
 export class FireCrawlLoader extends BaseDocumentLoader {
   private apiKey: string;
 
+  private apiUrl: string;
+
   private url: string;
 
   private mode: "crawl" | "scrape";
@@ -56,6 +62,7 @@ export class FireCrawlLoader extends BaseDocumentLoader {
     super();
     const {
       apiKey = getEnvironmentVariable("FIRECRAWL_API_KEY"),
+      apiUrl = "https://api.firecrawl.dev",
       url,
       mode = "crawl",
       params,
@@ -67,6 +74,7 @@ export class FireCrawlLoader extends BaseDocumentLoader {
     }
 
     this.apiKey = apiKey;
+    this.apiUrl = apiUrl;
     this.url = url;
     this.mode = mode;
     this.params = params;
@@ -78,7 +86,7 @@ export class FireCrawlLoader extends BaseDocumentLoader {
    * @throws An error if the data could not be loaded.
    */
   public async load(): Promise<DocumentInterface[]> {
-    const app = new FirecrawlApp({ apiKey: this.apiKey });
+    const app = new FirecrawlApp({ apiKey: this.apiKey, apiUrl: this.apiUrl });
     let firecrawlDocs: FirecrawlDocument[];
 
     if (this.mode === "scrape") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11185,7 +11185,7 @@ __metadata:
     "@langchain/scripts": ~0.0.20
     "@langchain/standard-tests": 0.0.0
     "@layerup/layerup-security": ^1.5.12
-    "@mendable/firecrawl-js": ^0.0.13
+    "@mendable/firecrawl-js": ^0.0.36
     "@mlc-ai/web-llm": 0.2.46
     "@mozilla/readability": ^0.4.4
     "@neondatabase/serverless": ^0.9.1
@@ -12701,6 +12701,19 @@ __metadata:
     axios: ^1.6.8
     dotenv: ^16.4.5
   checksum: 9dbc0b6e5d300bb9ef9f45cebd5c0026ac468863984cdc73a57ed6fdf888eaead5f9e2325c6848d03897c72cab195fffb4ce7d832e39696a11216bc53b417b6d
+  languageName: node
+  linkType: hard
+
+"@mendable/firecrawl-js@npm:^0.0.36":
+  version: 0.0.36
+  resolution: "@mendable/firecrawl-js@npm:0.0.36"
+  dependencies:
+    axios: ^1.6.8
+    dotenv: ^16.4.5
+    uuid: ^9.0.1
+    zod: ^3.23.8
+    zod-to-json-schema: ^3.23.0
+  checksum: 93ac8a7d9d25c04d4f618e282c136af06cf7712ec3402922531094c3cdab0e59d6f484a7f583022032eb58f914a0494193f2fd22986edd0f6712a29545edf95a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->
Fixes #6489 

JS Version of langchain-ai/langchain/pull/24747

This PR would provide support for users to use self-hosted instances of Firecrawl.

The FirecrawlApp class already has support to pass this argument. See https://github.com/mendableai/firecrawl/blob/main/apps/js-sdk/firecrawl/src/index.ts#L9
