### PR TITLE
core[patch]: Remove signal event listener when completed

### DIFF
--- a/langchain-core/src/utils/signal.ts
+++ b/langchain-core/src/utils/signal.ts
@@ -5,6 +5,7 @@ export async function raceWithSignal<T>(
   if (signal === undefined) {
     return promise;
   }
+  let listener: () => void;
   return Promise.race([
     promise.catch<T>((err) => {
       if (!signal?.aborted) {
@@ -14,13 +15,14 @@ export async function raceWithSignal<T>(
       }
     }),
     new Promise<never>((_, reject) => {
-      signal.addEventListener("abort", () => {
+      listener = () => {
         reject(new Error("Aborted"));
-      });
+      };
+      signal.addEventListener("abort", listener);
       // Must be here inside the promise to avoid a race condition
       if (signal.aborted) {
         reject(new Error("Aborted"));
       }
     }),
-  ]);
+  ]).finally(() => signal.removeEventListener("abort", listener));
 }


### PR DESCRIPTION
Partially fixes #6461, though if more than 10 runnables in a chain run in parallel this warning will likely resurface.

CC @nfcampos 