### PR TITLE
community[patch]: bugfix: Unstructured empty text

### DIFF
--- a/libs/langchain-community/src/document_loaders/fs/unstructured.ts
+++ b/libs/langchain-community/src/document_loaders/fs/unstructured.ts
@@ -332,7 +332,7 @@ export class UnstructuredLoader extends BaseDocumentLoader {
     const documents: Document[] = [];
     for (const element of elements) {
       const { metadata, text } = element;
-      if (typeof text === "string") {
+      if (typeof text === "string" && text !== "") {
         documents.push(
           new Document({
             pageContent: text,

--- a/libs/langchain-community/src/document_loaders/fs/unstructured.ts
+++ b/libs/langchain-community/src/document_loaders/fs/unstructured.ts
@@ -114,6 +114,8 @@ export type UnstructuredLoaderOptions = {
   newAfterNChars?: number;
   maxCharacters?: number;
   extractImageBlockTypes?: string[];
+  overlap?: number;
+  overlapAll?: boolean;
 };
 
 export type UnstructuredDirectoryLoaderOptions = UnstructuredLoaderOptions & {
@@ -181,6 +183,10 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
   private extractImageBlockTypes?: string[];
 
+  private overlap?: number;
+
+  private overlapAll?: boolean;
+
   constructor(
     filepathOrBufferOptions: string | UnstructuredMemoryLoaderOptions,
     unstructuredOptions: UnstructuredLoaderOptions | string = {}
@@ -225,6 +231,8 @@ export class UnstructuredLoader extends BaseDocumentLoader {
       this.newAfterNChars = options.newAfterNChars;
       this.maxCharacters = options.maxCharacters;
       this.extractImageBlockTypes = options.extractImageBlockTypes;
+      this.overlap = options.overlap;
+      this.overlapAll = options.overlapAll ?? false;
     }
   }
 
@@ -297,6 +305,14 @@ export class UnstructuredLoader extends BaseDocumentLoader {
         "extract_image_block_types",
         JSON.stringify(this.extractImageBlockTypes)
       );
+    }
+
+    if (this.overlap !== undefined) {
+      formData.append("overlap", String(this.overlap));
+    }
+    
+    if (this.overlapAll === true) {
+      formData.append("overlap_all", "true");
     }
 
     const headers = {

--- a/libs/langchain-community/src/document_loaders/fs/unstructured.ts
+++ b/libs/langchain-community/src/document_loaders/fs/unstructured.ts
@@ -310,7 +310,7 @@ export class UnstructuredLoader extends BaseDocumentLoader {
     if (this.overlap !== undefined) {
       formData.append("overlap", String(this.overlap));
     }
-    
+
     if (this.overlapAll === true) {
       formData.append("overlap_all", "true");
     }


### PR DESCRIPTION
* This issue was raised here https://github.com/langchain-ai/langchainjs/issues/2144
* It was fixed int he old `langchain` module and still is fixed here https://github.com/langchain-ai/langchainjs/blob/main/langchain/src/document_loaders/fs/unstructured.ts#L328
* The community version, however, doesn't have this check. 

This also adds the missing field https://github.com/Unstructured-IO/unstructured-api?tab=readme-ov-file#chunking-elements 