### PR TITLE
community[patch]: fix: ElasticVectorSearch: exclude metadata filters …

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -344,7 +344,7 @@ export class ElasticVectorSearch extends VectorStore {
         });
       } else if (condition.operator === "exclude") {
         must_not.push({
-          terms: {
+          term: {
             [metadataField]: condition.value,
           },
         });

--- a/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
@@ -106,6 +106,14 @@ describe("ElasticVectorSearch", () => {
     ]);
     const results = await store.similaritySearch("*", 11);
     expect(results).toHaveLength(11);
+    const results2 = await store.similaritySearch("*", 11, [
+      {
+        field: "a",
+        value: createdAt,
+        operator: "exclude",
+      },
+    ]);
+    expect(results2).toHaveLength(1);
   });
 
   test.skip("ElasticVectorSearch integration with text splitting metadata", async () => {


### PR DESCRIPTION
…not working due to syntax error in filter creation



Fixes #6535
