### PR TITLE
pinecone[patch]: Fix document ID not getting set when returned from PineconeStore

### DIFF
--- a/libs/langchain-pinecone/src/vectorstores.ts
+++ b/libs/langchain-pinecone/src/vectorstores.ts
@@ -450,20 +450,10 @@ export class PineconeStore extends VectorStore {
     k: number,
     filter?: PineconeMetadata
   ): Promise<[Document, number][]> {
-    const results = await this._runPineconeQuery(query, k, filter);
-    const result: [Document, number][] = [];
-
-    if (results.matches) {
-      for (const res of results.matches) {
-        const { [this.textKey]: pageContent, ...metadata } = (res.metadata ??
-          {}) as PineconeMetadata;
-        if (res.score) {
-          result.push([new Document({ metadata, pageContent }), res.score]);
-        }
-      }
-    }
-
-    return result;
+    const { matches = [] } = await this._runPineconeQuery(query, k, filter);
+    const records = this._formatMatches(matches);
+    
+    return records;
   }
 
   /**

--- a/libs/langchain-pinecone/src/vectorstores.ts
+++ b/libs/langchain-pinecone/src/vectorstores.ts
@@ -483,7 +483,7 @@ export class PineconeStore extends VectorStore {
       { includeValues: true }
     );
 
-    const matches = results?.matches ?? [];
+    const { matches = [] } = results;
     const embeddingList = matches.map((match) => match.values);
 
     const mmrIndexes = maximalMarginalRelevance(
@@ -494,17 +494,8 @@ export class PineconeStore extends VectorStore {
     );
 
     const topMmrMatches = mmrIndexes.map((idx) => matches[idx]);
-
-    const finalResult: Document[] = [];
-    for (const res of topMmrMatches) {
-      const { [this.textKey]: pageContent, ...metadata } = (res.metadata ??
-        {}) as PineconeMetadata;
-      if (res.score) {
-        finalResult.push(new Document({ metadata, pageContent }));
-      }
-    }
-
-    return finalResult;
+    const records = this._formatMatches(topMmrMatches);
+    return records.map(([doc, _score]) => doc);
   }
 
   /**

--- a/libs/langchain-pinecone/src/vectorstores.ts
+++ b/libs/langchain-pinecone/src/vectorstores.ts
@@ -407,21 +407,20 @@ export class PineconeStore extends VectorStore {
    * @param matches Matching results from the Pinecone query.
    * @returns An array of arrays, where each inner array contains a document and its score.
    */
-  private _formatMatches(matches: ScoredPineconeRecord<RecordMetadata>[] = []): [Document, number][] {
+  private _formatMatches(
+    matches: ScoredPineconeRecord<RecordMetadata>[] = []
+  ): [Document, number][] {
     const documentsWithScores: [Document, number][] = [];
-    
+
     for (const record of matches) {
       const {
         id,
         score,
-        metadata: {
-          [this.textKey]: pageContent,
-          ...metadata
-        } = {
+        metadata: { [this.textKey]: pageContent, ...metadata } = {
           [this.textKey]: "",
         },
       } = record;
-      
+
       if (score) {
         documentsWithScores.push([
           new Document({
@@ -433,7 +432,7 @@ export class PineconeStore extends VectorStore {
         ]);
       }
     }
-    
+
     return documentsWithScores;
   }
 
@@ -452,7 +451,7 @@ export class PineconeStore extends VectorStore {
   ): Promise<[Document, number][]> {
     const { matches = [] } = await this._runPineconeQuery(query, k, filter);
     const records = this._formatMatches(matches);
-    
+
     return records;
   }
 


### PR DESCRIPTION
When querying for documents using the `PineconeStore` via the various search methods, the documents getting returned from Pinecone currently have their `id` property set to `undefined`.

This is because `id` is omitted when the result is converted to a document prior to being returned, as shown below for each query method respectively:

`similaritySearchVectorWithScore`
https://github.com/langchain-ai/langchainjs/blob/abdcd1fa3b74f066e4a7cbe3688a99f719f8f75b/libs/langchain-pinecone/src/vectorstores.ts#L424-L426

`maxMarginalRelevanceSearch`
https://github.com/langchain-ai/langchainjs/blob/abdcd1fa3b74f066e4a7cbe3688a99f719f8f75b/libs/langchain-pinecone/src/vectorstores.ts#L476-L478

This PR adds a new private method named `_formatMatches` that accepts an array of matches (`ScoredPineconeRecord`) from the `QueryResponse` interface. This method performs the same logic that was duplicated across the query methods, just with some added deconstruction safety rails as well as the addition of the `id` property.

Result from `similaritySearchWithScore` **before** this change (same for `similaritySearchVectorWithScore`):
```
[
  [
    Document {
      pageContent: 'document text',
      metadata: [Object],
      id: undefined
    },
    0.81118
  ]
]
```

Result from `similaritySearchWithScore` **after** this change (same for `similaritySearchVectorWithScore`):
```
[
  [
    Document {
      pageContent: 'document text',
      metadata: [Object],
      id: '91522887-3be3-4937-9ea7-eb235b991a4c'
    },
    0.81118
  ]
]
```

Result from `similaritySearch` **before** this change (same as `maxMarginalRelevanceSearch`):
```
[
  [
    Document {
      pageContent: 'document text',
      metadata: [Object],
      id: undefined
    }
  ]
]
```

Result from `similaritySearch` **after** this change (same as `maxMarginalRelevanceSearch`):
```
[
  [
    Document {
      pageContent: 'document text',
      metadata: [Object],
      id: '91522887-3be3-4937-9ea7-eb235b991a4c'
    }
  ]
]
```