### PR TITLE
aws[patch]: Use abort signal when available with SDK requests

### DIFF
--- a/libs/langchain-aws/src/chat_models.ts
+++ b/libs/langchain-aws/src/chat_models.ts
@@ -817,7 +817,9 @@ export class ChatBedrockConverse
       system: converseSystem,
       ...params,
     });
-    const response = await this.client.send(command);
+    const response = await this.client.send(command, {
+      abortSignal: options.signal,
+    });
     const { output, ...responseMetadata } = response;
     if (!output?.message) {
       throw new Error("No message found in Bedrock response.");
@@ -855,7 +857,9 @@ export class ChatBedrockConverse
       system: converseSystem,
       ...params,
     });
-    const response = await this.client.send(command);
+    const response = await this.client.send(command, {
+      abortSignal: options.signal,
+    });
     if (response.stream) {
       for await (const chunk of response.stream) {
         if (chunk.contentBlockStart) {


### PR DESCRIPTION
When using the Converse APIs in `ChatBedrockConverse` the `AbortSignal` wasn't being passed in. 

This prevented the cancellation from working.
