### PR TITLE
groq[minor]: Fix streaming metadata back to client

### DIFF
--- a/libs/langchain-groq/src/chat_models.ts
+++ b/libs/langchain-groq/src/chat_models.ts
@@ -787,6 +787,7 @@ export class ChatGroq extends BaseChatModel<
       index: number;
       type: "tool_call_chunk";
     }[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let responseMetadata: Record<string, any> | undefined;
     for await (const data of response) {
       responseMetadata = data;

--- a/libs/langchain-groq/src/chat_models.ts
+++ b/libs/langchain-groq/src/chat_models.ts
@@ -228,7 +228,7 @@ function _convertDeltaToMessageChunk(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delta: Record<string, any>,
   index: number,
-  xGroq?: ChatCompletionsAPI.ChatCompletionChunk.XGroq,
+  xGroq?: ChatCompletionsAPI.ChatCompletionChunk.XGroq
 ): {
   message: BaseMessageChunk;
   toolCallData?: {
@@ -260,7 +260,7 @@ function _convertDeltaToMessageChunk(
       input_tokens: xGroq.usage.prompt_tokens,
       output_tokens: xGroq.usage.completion_tokens,
       total_tokens: xGroq.usage.total_tokens,
-    }
+    };
     groqMessageId = xGroq.id;
   }
 
@@ -285,7 +285,7 @@ function _convertDeltaToMessageChunk(
             }))
           : undefined,
         usage_metadata: usageMetadata,
-        id: groqMessageId
+        id: groqMessageId,
       }),
       toolCallData: toolCallChunks
         ? toolCallChunks.map((tc) => ({

--- a/libs/langchain-groq/src/tests/chat_models.standard.int.test.ts
+++ b/libs/langchain-groq/src/tests/chat_models.standard.int.test.ts
@@ -25,22 +25,6 @@ class ChatGroqStandardIntegrationTests extends ChatModelIntegrationTests<
     });
   }
 
-  async testUsageMetadataStreaming() {
-    this.skipTestMessage(
-      "testUsageMetadataStreaming",
-      "ChatGroq",
-      "Streaming tokens is not currently supported."
-    );
-  }
-
-  async testUsageMetadata() {
-    this.skipTestMessage(
-      "testUsageMetadata",
-      "ChatGroq",
-      "Usage metadata tokens is not currently supported."
-    );
-  }
-
   async testToolMessageHistoriesListContent() {
     this.skipTestMessage(
       "testToolMessageHistoriesListContent",


### PR DESCRIPTION
New concatenated `AIMessage` as a result of calling `.stream` looks like this:
```txt
AIMessageChunk {
  "id": "req_01j5pkw120f7wbwsxqs62742nj",
  "content": "The color of the sky can appear different depending on the time of day, weather, and location. On a clear day, the",
  "additional_kwargs": {},
  "response_metadata": {
    "finishReason": "length",
    "id": "chatcmpl-0f82c5dc-5701-4d67-9fe7-a403468466f0",
    "object": "chat.completion.chunk",
    "created": 1724114666,
    "model": "mixtral-8x7b-32768",
    "system_fingerprint": "fp_c5f20b5bb1",
    "x_groq": {
      "id": "req_01j5pkw120f7wbwsxqs62742nj",
      "usage": {
        "queue_time": 0.012457195,
        "prompt_tokens": 14,
        "prompt_time": 0.002072875,
        "completion_tokens": 26,
        "completion_time": 0.04022823,
        "total_tokens": 40,
        "total_time": 0.042301105
      }
    }
  },
  "tool_calls": [],
  "tool_call_chunks": [],
  "invalid_tool_calls": [],
  "usage_metadata": {
    "input_tokens": 14,
    "output_tokens": 26,
    "total_tokens": 40
  }
}
```