### PR TITLE
core[patch]: Prevent ConsoleCallbackHandler from throwing TypeError when logging

### DIFF
--- a/langchain-core/src/tracers/console.ts
+++ b/langchain-core/src/tracers/console.ts
@@ -14,6 +14,18 @@ function tryJsonStringify(obj: unknown, fallback: string) {
   }
 }
 
+function formatKVMapItem(value: unknown) {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  
+  if (value === null || value === undefined) {
+    return value;
+  }
+  
+  return tryJsonStringify(value, value.toString());
+}
+
 function elapsed(run: Run): string {
   if (!run.end_time) return "";
   const elapsed = run.end_time - run.start_time;
@@ -210,7 +222,7 @@ export class ConsoleCallbackHandler extends BaseTracer {
       `${wrap(
         color.green,
         "[tool/start]"
-      )} [${crumbs}] Entering Tool run with input: "${run.inputs.input?.trim()}"`
+      )} [${crumbs}] Entering Tool run with input: "${formatKVMapItem(run.inputs.input)}"`
     );
   }
 
@@ -221,10 +233,11 @@ export class ConsoleCallbackHandler extends BaseTracer {
    */
   onToolEnd(run: Run) {
     const crumbs = this.getBreadcrumbs(run);
+
     console.log(
       `${wrap(color.cyan, "[tool/end]")} [${crumbs}] [${elapsed(
         run
-      )}] Exiting Tool run with output: "${run.outputs?.output?.trim()}"`
+      )}] Exiting Tool run with output: "${formatKVMapItem(run.outputs?.output)}"`
     );
   }
 

--- a/langchain-core/src/tracers/console.ts
+++ b/langchain-core/src/tracers/console.ts
@@ -18,11 +18,11 @@ function formatKVMapItem(value: unknown) {
   if (typeof value === "string") {
     return value.trim();
   }
-  
+
   if (value === null || value === undefined) {
     return value;
   }
-  
+
   return tryJsonStringify(value, value.toString());
 }
 
@@ -222,7 +222,9 @@ export class ConsoleCallbackHandler extends BaseTracer {
       `${wrap(
         color.green,
         "[tool/start]"
-      )} [${crumbs}] Entering Tool run with input: "${formatKVMapItem(run.inputs.input)}"`
+      )} [${crumbs}] Entering Tool run with input: "${formatKVMapItem(
+        run.inputs.input
+      )}"`
     );
   }
 
@@ -237,7 +239,9 @@ export class ConsoleCallbackHandler extends BaseTracer {
     console.log(
       `${wrap(color.cyan, "[tool/end]")} [${crumbs}] [${elapsed(
         run
-      )}] Exiting Tool run with output: "${formatKVMapItem(run.outputs?.output)}"`
+      )}] Exiting Tool run with output: "${formatKVMapItem(
+        run.outputs?.output
+      )}"`
     );
   }
 


### PR DESCRIPTION
Prior to this change, when `onToolEnd` is called, it assumed the value of `run.outputs.output` is always of type `string`. In cases when it wasn't a string, this would cause a `TypeError` to be thrown.

Note that it appeared that the same issue could occur in `onToolStart`, so I corrected that case as well.