### PR TITLE
feat(anthropic): langchain-anthropic support custom create anthropic client

### DIFF
--- a/docs/core_docs/docs/integrations/chat/anthropic.ipynb
+++ b/docs/core_docs/docs/integrations/chat/anthropic.ipynb
@@ -933,6 +933,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f8dece4e",
+   "metadata": {},
+   "source": [
+    "## Custom clients\n",
+    "\n",
+    "Anthropic models [may be hosted on cloud services such as Google Vertex](https://docs.anthropic.com/en/api/claude-on-vertex-ai) that rely on a different underlying client with the same interface as the primary Anthropic client. You can access these services by providing a `createClient` method that returns an initialized instance of an Anthropic client. Here's an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00ec6d41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { AnthropicVertex } from \"@anthropic-ai/vertex-sdk\";\n",
+    "\n",
+    "const customClient = new AnthropicVertex();\n",
+    "\n",
+    "const modelWithCustomClient = new ChatAnthropic({\n",
+    "  modelName: \"claude-3-sonnet-20240229\",\n",
+    "  maxRetries: 0,\n",
+    "  createClient: () => customClient,\n",
+    "});\n",
+    "\n",
+    "await modelWithCustomClient.invoke([{ role: \"user\", content: \"Hello!\" }]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3a5bb5ca-c3ae-4a58-be67-2cd18574b9a3",
    "metadata": {},
    "source": [

--- a/docs/core_docs/package.json
+++ b/docs/core_docs/package.json
@@ -30,6 +30,7 @@
     "validate": "yarn notebook_validate"
   },
   "dependencies": {
+    "@anthropic-ai/vertex-sdk": "^0.4.1",
     "@docusaurus/core": "2.4.3",
     "@docusaurus/preset-classic": "2.4.3",
     "@docusaurus/remark-plugin-npm2yarn": "2.4.3",

--- a/libs/langchain-anthropic/package.json
+++ b/libs/langchain-anthropic/package.json
@@ -42,6 +42,7 @@
     "zod-to-json-schema": "^3.22.4"
   },
   "devDependencies": {
+    "@anthropic-ai/vertex-sdk": "^0.4.1",
     "@jest/globals": "^29.5.0",
     "@langchain/scripts": ">=0.1.0 <0.2.0",
     "@langchain/standard-tests": "0.0.0",

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -146,7 +146,7 @@ export interface AnthropicInput {
    */
   streamUsage?: boolean;
 
-  createClient?: (options: ClientOptions) => Anthropic
+  createClient?: (options: ClientOptions) => Anthropic;
 }
 
 /**
@@ -649,7 +649,9 @@ export class ChatAnthropicMessages<
     this.streaming = fields?.streaming ?? false;
     this.streamUsage = fields?.streamUsage ?? this.streamUsage;
 
-    this.createClient = fields?.createClient ?? ((options: ClientOptions) => new Anthropic(options));
+    this.createClient =
+      fields?.createClient ??
+      ((options: ClientOptions) => new Anthropic(options));
   }
 
   getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -146,7 +146,13 @@ export interface AnthropicInput {
    */
   streamUsage?: boolean;
 
-  createClient?: (options: ClientOptions) => Anthropic;
+  /**
+   * Optional method that returns an initialized underlying Anthropic client.
+   * Useful for accessing Anthropic models hosted on other cloud services
+   * such as Google Vertex.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createClient?: (options: ClientOptions) => any;
 }
 
 /**
@@ -613,6 +619,11 @@ export class ChatAnthropicMessages<
 
   streamUsage = true;
 
+  /**
+   * Optional method that returns an initialized underlying Anthropic client.
+   * Useful for accessing Anthropic models hosted on other cloud services
+   * such as Google Vertex.
+   */
   createClient: (options: ClientOptions) => Anthropic;
 
   constructor(fields?: AnthropicInput & BaseChatModelParams) {

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -606,10 +606,10 @@ export class ChatAnthropicMessages<
   clientOptions: ClientOptions;
 
   // Used for non-streaming requests
-  protected batchClient!: Anthropic;
+  protected batchClient: Anthropic;
 
   // Used for streaming requests
-  protected streamingClient!: Anthropic;
+  protected streamingClient: Anthropic;
 
   streamUsage = true;
 

--- a/libs/langchain-anthropic/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-anthropic/src/tests/chat_models.int.test.ts
@@ -17,6 +17,7 @@ import {
 import { CallbackManager } from "@langchain/core/callbacks/manager";
 import { concat } from "@langchain/core/utils/stream";
 import { ChatAnthropic } from "../chat_models.js";
+import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 
 test("Test ChatAnthropic", async () => {
   const chat = new ChatAnthropic({
@@ -734,4 +735,17 @@ test.skip("tool caching", async () => {
   expect(res2.response_metadata.usage.cache_read_input_tokens).toBeGreaterThan(
     0
   );
+});
+
+test.skip("Test ChatAnthropic with custom client", async () => {
+  const client = new AnthropicVertex();
+  const chat = new ChatAnthropic({
+    modelName: "claude-3-sonnet-20240229",
+    maxRetries: 0,
+    createClient: () => client,
+  });
+  const message = new HumanMessage("Hello!");
+  const res = await chat.invoke([message]);
+  // console.log({ res });
+  expect(res.response_metadata.usage).toBeDefined();
 });

--- a/libs/langchain-anthropic/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-anthropic/src/tests/chat_models.int.test.ts
@@ -16,8 +16,8 @@ import {
 } from "@langchain/core/prompts";
 import { CallbackManager } from "@langchain/core/callbacks/manager";
 import { concat } from "@langchain/core/utils/stream";
-import { ChatAnthropic } from "../chat_models.js";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
+import { ChatAnthropic } from "../chat_models.js";
 
 test("Test ChatAnthropic", async () => {
   const chat = new ChatAnthropic({

--- a/yarn.lock
+++ b/yarn.lock
@@ -23288,6 +23288,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "core_docs@workspace:docs/core_docs"
   dependencies:
+    "@anthropic-ai/vertex-sdk": ^0.4.1
     "@babel/eslint-parser": ^7.18.2
     "@docusaurus/core": 2.4.3
     "@docusaurus/preset-classic": 2.4.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anthropic-ai/sdk@npm:>=0.14 <1":
+  version: 0.27.0
+  resolution: "@anthropic-ai/sdk@npm:0.27.0"
+  dependencies:
+    "@types/node": ^18.11.18
+    "@types/node-fetch": ^2.6.4
+    abort-controller: ^3.0.0
+    agentkeepalive: ^4.2.1
+    form-data-encoder: 1.7.2
+    formdata-node: ^4.3.2
+    node-fetch: ^2.6.7
+  checksum: 5cb980769a38a660fa607d9985f4cdae7aabc49053b94fe892f6c3b30f2714c32c6e86c6cf94c8bce9ceea6eed2cd5bac2e1d9d58c9aad0da43681f0a060263d
+  languageName: node
+  linkType: hard
+
 "@anthropic-ai/sdk@npm:^0.25.2":
   version: 0.25.2
   resolution: "@anthropic-ai/sdk@npm:0.25.2"
@@ -223,6 +238,16 @@ __metadata:
     formdata-node: ^4.3.2
     node-fetch: ^2.6.7
   checksum: b38f6a43f6f678e49f1b53226cc55654c23cf0fd1902cf3fcf98c0ae78f4c229518964f4cb31bc39da41925c806e7f4cc7ec14c511d387f07db3136b111bc744
+  languageName: node
+  linkType: hard
+
+"@anthropic-ai/vertex-sdk@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@anthropic-ai/vertex-sdk@npm:0.4.1"
+  dependencies:
+    "@anthropic-ai/sdk": ">=0.14 <1"
+    google-auth-library: ^9.4.2
+  checksum: 3983c6f1b0e0aa2ce6896a0269177d1374343ba86169a30ad6cc0d9beef40ddcf410159baaa3f0942afbf62930951d067a870aa5c5e0624fe2c47981dc8d8c55
   languageName: node
   linkType: hard
 
@@ -10852,6 +10877,7 @@ __metadata:
   resolution: "@langchain/anthropic@workspace:libs/langchain-anthropic"
   dependencies:
     "@anthropic-ai/sdk": ^0.25.2
+    "@anthropic-ai/vertex-sdk": ^0.4.1
     "@jest/globals": ^29.5.0
     "@langchain/core": ">=0.2.21 <0.3.0"
     "@langchain/scripts": ">=0.1.0 <0.2.0"
@@ -28559,6 +28585,20 @@ __metadata:
     gtoken: ^7.0.0
     jws: ^4.0.0
   checksum: 238ef40fbaf1d3be06c6e1aa5af2cecd9dc9483395aa7f74c3addc68a36b8b510a71731f1f5532a9db59d6a04d893d06f4d3fc6515cb269bf93c068d792f4cfa
+  languageName: node
+  linkType: hard
+
+"google-auth-library@npm:^9.4.2":
+  version: 9.14.0
+  resolution: "google-auth-library@npm:9.14.0"
+  dependencies:
+    base64-js: ^1.3.0
+    ecdsa-sig-formatter: ^1.0.11
+    gaxios: ^6.1.1
+    gcp-metadata: ^6.1.0
+    gtoken: ^7.0.0
+    jws: ^4.0.0
+  checksum: ff2a66e84726b3a25711a64583d86cf9e0c0df857d538ce8127822d220e81e1e7d0defcedecb2be7fc407c104bb7d5ca26a4f201bde871c8d09ef72cc83603f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Support for custom Anthropic clients using @langchain/anthropic, which will allow the use of @anthropic-ai/vertex-sdk and @anthropic-ai/bedrock-sdk, and also support custom Anthropic, such as supporting a modified version of the edge runtime.

```ts
import { expect, it } from 'vitest'
import { authenticate } from '../authenticate'
import { ChatAnthropic } from '@langchain/anthropic'
import { AnthropicVertex } from '@anthropic-ai/vertex-sdk'
import { GoogleAuth } from 'google-auth-library'
import { AnthropicVertexWeb } from '../AnthropicVertex'

it('Call Anthropic Vertex on nodejs', async () => {
  const client = new AnthropicVertex({
    region: import.meta.env.VITE_VERTEX_ANTROPIC_REGION,
    projectId: import.meta.env.VITE_VERTEX_ANTROPIC_PROJECTID,
    googleAuth: new GoogleAuth({
      credentials: {
        client_email: import.meta.env
          .VITE_VERTEX_ANTROPIC_GOOGLE_SA_CLIENT_EMAIL!,
        private_key: import.meta.env
          .VITE_VERTEX_ANTROPIC_GOOGLE_SA_PRIVATE_KEY!,
      },
      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
    }),
  })
  const chat = new ChatAnthropic({
    apiKey: 'test',
    model: import.meta.env.VITE_VERTEX_ANTROPIC_MODEL,
    createClient: (() => client) as any,
  })
  const response = await chat.invoke([['human', 'Hello!']])
  console.log(response)
  expect(response).not.undefined
})
it('Call Anthropic Vertex on edge runtime', async () => {
  const token = await authenticate({
    clientEmail: import.meta.env.VITE_VERTEX_ANTROPIC_GOOGLE_SA_CLIENT_EMAIL!,
    privateKey: import.meta.env.VITE_VERTEX_ANTROPIC_GOOGLE_SA_PRIVATE_KEY!,
  })
  const client = new AnthropicVertexWeb({
    region: import.meta.env.VITE_VERTEX_ANTROPIC_REGION,
    projectId: import.meta.env.VITE_VERTEX_ANTROPIC_PROJECTID,
    accessToken: token.access_token,
  })
  const chat = new ChatAnthropic({
    apiKey: 'test',
    model: import.meta.env.VITE_VERTEX_ANTROPIC_MODEL,
    createClient: (() => client) as any,
  })
  const response = await chat.invoke([['human', 'Hello!']])
  console.log(response)
  expect(response).not.undefined
}, 10_000)
```

<!-- Remove if not applicable -->

Fixes https://github.com/langchain-ai/langchainjs/issues/5196
