### PR TITLE
langchain[patch]: Fixes bug in ReAct agent that prevents parsing error handling

### DIFF
--- a/langchain/src/agents/react/output_parser.ts
+++ b/langchain/src/agents/react/output_parser.ts
@@ -1,6 +1,6 @@
 import { AgentAction, AgentFinish } from "@langchain/core/agents";
 import { renderTemplate } from "@langchain/core/prompts";
-import {OutputParserException} from "@langchain/core/output_parsers";
+import { OutputParserException } from "@langchain/core/output_parsers";
 import { AgentActionOutputParser } from "../types.js";
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 

--- a/langchain/src/agents/react/output_parser.ts
+++ b/langchain/src/agents/react/output_parser.ts
@@ -1,5 +1,6 @@
 import { AgentAction, AgentFinish } from "@langchain/core/agents";
 import { renderTemplate } from "@langchain/core/prompts";
+import {OutputParserException} from "@langchain/core/output_parsers";
 import { AgentActionOutputParser } from "../types.js";
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 
@@ -69,7 +70,7 @@ export class ReActSingleInputOutputParser extends AgentActionOutputParser {
     const actionMatch = text.match(regex);
     if (actionMatch) {
       if (includesAnswer) {
-        throw new Error(
+        throw new OutputParserException(
           `${FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE}: ${text}`
         );
       }
@@ -95,7 +96,7 @@ export class ReActSingleInputOutputParser extends AgentActionOutputParser {
       };
     }
 
-    throw new Error(`Could not parse LLM output: ${text}`);
+    throw new OutputParserException(`Could not parse LLM output: ${text}`);
   }
 
   /**


### PR DESCRIPTION
Fixes #6374 for ReAct agents

`handleParsingErrors` does not work for ReAct agents. This fixes it.