### PR TITLE
OpenFGA/OktaFGA retriever to authorize user/document access when doing RAG

### DIFF
--- a/libs/langchain-community/src/retrievers/fga.ts
+++ b/libs/langchain-community/src/retrievers/fga.ts
@@ -1,0 +1,57 @@
+import { BaseRetriever, type BaseRetrieverInput } from "@langchain/core/retrievers";
+import type { CallbackManagerForRetrieverRun } from "@langchain/core/callbacks/manager";
+import { Document, DocumentInterface } from "@langchain/core/documents";
+import { OpenFgaClient, ClientCheckRequest } from "@openfga/sdk";
+
+type FGARetrieverArgs = {
+    user: string;
+    retriever: BaseRetriever;
+    fgaClient: OpenFgaClient;
+    fields?: BaseRetrieverInput;
+    checkFromDocument: (user: string, doc: DocumentInterface<Record<string, any>>, query: string) => ClientCheckRequest;
+}
+
+export class FGARetriever extends BaseRetriever {
+    static lc_name() {
+        return "FGARetriever";
+    }
+
+    lc_namespace = ["langchain", "retrievers", "fga"];
+    private retriever: BaseRetriever;
+    private checkFromDocument: (user: string, doc: DocumentInterface<Record<string, any>>, query: string) => ClientCheckRequest;
+    private user: string;
+    private fgaClient: OpenFgaClient;
+
+    constructor({ user, retriever, fgaClient, fields, checkFromDocument }: FGARetrieverArgs) {
+        super(fields);
+        this.user = user;
+        this.fgaClient = fgaClient;
+        this.retriever = retriever;
+        this.checkFromDocument = checkFromDocument;
+    }
+
+    private async accessByDocument(checks: ClientCheckRequest[]): Promise<Map<string, boolean>> {
+        const results = await this.fgaClient.batchCheck(checks);
+        return results.responses.reduce((c: Map<string, boolean>, v) => {
+            c.set(v._request.object, v.allowed || false);
+            return c;
+        }, new Map<string, boolean>());
+    }
+
+    async _getRelevantDocuments(
+      query: string,
+      runManager?: CallbackManagerForRetrieverRun
+    ): Promise<Document[]> {
+        const documents = await this.retriever._getRelevantDocuments(query, runManager);
+        const out = documents.reduce((out, doc) => { 
+            const check = this.checkFromDocument(this.user, doc, query);
+            out.checks.push(check);
+            out.documentToObject.set(doc, check.object);
+            return out;
+        }, { checks: [] as ClientCheckRequest[], documentToObject: new Map<DocumentInterface<Record<string, any>>, string>() });
+        const { checks, documentToObject } = out;
+        const resultsByObject = await this.accessByDocument(checks);
+
+        return documents.filter((d, _) => resultsByObject.get(documentToObject.get(d) || '') === true);
+    }
+  }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
       "eslint --cache --fix"
     ],
     "*.md": "prettier --config .prettierrc --write"
+  },
+  "dependencies": {
+    "@openfga/sdk": "^0.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13551,6 +13551,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openfga/sdk@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@openfga/sdk@npm:0.6.2"
+  dependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/semantic-conventions": ^1.25.0
+    axios: ^1.6.8
+    tiny-async-pool: ^2.1.0
+  checksum: 6b75080d450b0be659f334dc8e5fd82551a1794fb87b24eb68dc6791c1c14cc4dfb238d55d858a20d2fa2d58c9301980bde1b16bc738cafcc1d4f40ab3f5d5e5
+  languageName: node
+  linkType: hard
+
 "@opensearch-project/opensearch@npm:^2.2.0":
   version: 2.2.0
   resolution: "@opensearch-project/opensearch@npm:2.2.0"
@@ -13568,6 +13580,20 @@ __metadata:
   version: 1.4.1
   resolution: "@opentelemetry/api@npm:1.4.1"
   checksum: e783c40d1a518abf9c4c5d65223237c1392cd9a6c53ac6e2c3ef0c05ff7266e3dfc4fd9874316dae0dcb7a97950878deb513bcbadfaad653d48f0215f2a0911b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@opentelemetry/api@npm:1.9.0"
+  checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.25.0":
+  version: 1.25.1
+  resolution: "@opentelemetry/semantic-conventions@npm:1.25.1"
+  checksum: fea418a4b09c55121c6da11c49dd2105116533838c484aead17e8acf8029dad711e145849812f9c61f9e48fad8e2b6cf103d2c18847ca993032ce9b27c2f863d
   languageName: node
   linkType: hard
 
@@ -32327,6 +32353,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "langchainjs@workspace:."
   dependencies:
+    "@openfga/sdk": ^0.6.2
     "@tsconfig/recommended": ^1.0.2
     "@types/jest": ^29.5.3
     "@types/semver": ^7
@@ -40438,6 +40465,13 @@ __metadata:
     es5-ext: ^0.10.64
     next-tick: ^1.1.0
   checksum: 7d37f90bdcee900aa4ba13e983905e2d16538bb13d38315f1ea3670656d91e7898f018909caedc8ebe964974ddeb3eedb5ffdc21f2329e34e6bcc353d0ee2903
+  languageName: node
+  linkType: hard
+
+"tiny-async-pool@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-async-pool@npm:2.1.0"
+  checksum: 8891326f30e587590f94c5e1f8cab59c9aa305e442fc5b9f7ea997f8611d805a797aae2ea93cd00b42b494ef749353df38b4555e2a769d6fff31a3db7add7208
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Opening this PR to start a discussion on best way to implement this.

First some context: [OpenFGA](https://openfga.dev/)/[Okta FGA](https://fga.dev/) are systems to simplify authorization at scale. When implementing RAG, it is possible that not all users have access to all documents (chunks) to be retrieved. Systems like FGA (there are others beyond the ones I linked to), can help solve this problem.

![fgarag.png](https://cdn.auth0.com/website/labs/ai/fgarag.png)

The `FGARetriever` implementation aims to maintain the same interface for developers doing RAG with Langchain today, but adding support for authorization. This first implementation is a basic one that can be improved over time as use of it increases.

**Usage**
Assuming tuples are already in FGA, the retrieval logic would look like this:
```typescript
import { MemoryVectorStore } from "langchain/vectorstores/memory";
import { Document } from "@langchain/core/documents";
import { OpenAIEmbeddings } from "@langchain/openai";
import { FGARetriever } from "./fgaRetriever";
import dotenv from "dotenv"; 
import { CredentialsMethod, OpenFgaClient } from "@openfga/sdk";

dotenv.config();

const embeddings = new OpenAIEmbeddings();

const docs = [
  new Document({
        metadata: {id: 'mem1'},
        pageContent: 'Document related to Auth0 1',
  }),
  new Document({
    metadata: {id: 'mem2'},
    pageContent: 'Document related to Auth0 2',
  }),
  new Document({
    metadata: {id: 'mem3'},
    pageContent: 'Document related to Auth0 3',
  }),
  new Document({
    metadata: {id: 'mem4'},
    pageContent: 'Document related to Auth0 4',
  }),
];

const fgaClient = new OpenFgaClient({
    apiUrl: process.env.FGA_API_URL,
    storeId: process.env.FGA_STORE_ID,
    authorizationModelId: process.env.FGA_MODEL_ID,
    credentials: {
        method: CredentialsMethod.ClientCredentials,
        config: {
          apiTokenIssuer: process.env.FGA_API_TOKEN_ISSUER || '',
          apiAudience: process.env.FGA_API_AUDIENCE  || '',
          clientId: process.env.FGA_CLIENT_ID  || '',
          clientSecret: process.env.FGA_CLIENT_SECRET  || '',
        },
    }
  });

MemoryVectorStore.fromDocuments(
  docs,
  embeddings
).then(vs => {
    const retriever = new FGARetriever({
        fgaClient, 
        user: 'jane', 
        retriever: vs.asRetriever(), 
        checkFromDocument: (user, doc) => ({
            user: `user:${user}`,
            relation: 'can_read',
            object: `doc:${doc.metadata.id}`,
        })
    });
    
    retriever.invoke('Auth0').then((docs) => console.log(docs));
});
```

**To discuss**
As the example above shows, to make `FGARetriever` filter results based on a specific user, an instance of `FGARetriever` needs to be created per user. This is obvious from the resulting API, but can be confusing to developers.

This can be addressed by adding a `context` object to both `invoke` and `_getRelevantDocuments` in `BaseRetriever`. So instead of
```typescript
_getRelevantDocuments(_query: string, _callbacks?: CallbackManagerForRetrieverRun): Promise<DocumentInterface<Metadata>[]>;
invoke(input: string, options?: RunnableConfig): Promise<DocumentInterface<Metadata>[]>;
```

it'd define:
```typescript
_getRelevantDocuments(_query: string, _context Map<string, any>, _callbacks?: CallbackManagerForRetrieverRun): Promise<DocumentInterface<Metadata>[]>;
invoke(input: string, context Map<string, any>, options?: RunnableConfig): Promise<DocumentInterface<Metadata>[]>;
```

I am not a Langchain expert, so I am open to other suggestions/alternatives. If the above makes sense I could send a PR to support that API first and then update the `FGARetriever` implementation based on it.

**Questions**
- Where should I put usage examples, in which folder? I found them in different places.
- Seems tests are skipped for other retrievers. Why is that? I'd like to add working tests but will adhere to project practices.

Thanks,
Yenkel