### PR TITLE
Fix top-level dependency install for node 22+

### DIFF
--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -133,7 +133,7 @@
     "@zilliz/milvus2-sdk-node": ">=2.3.5",
     "apify-client": "^2.7.1",
     "assemblyai": "^4.6.0",
-    "better-sqlite3": ">=9.4.0 <12.0.0",
+    "better-sqlite3": "9.5.0",
     "cassandra-driver": "^4.7.2",
     "cborg": "^4.1.1",
     "cheerio": "^1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "typedoc-plugin-markdown@next": "patch:typedoc-plugin-markdown@npm%3A4.0.0-next.6#./.yarn/patches/typedoc-plugin-markdown-npm-4.0.0-next.6-96b4b47746.patch",
     "voy-search@0.6.2": "patch:voy-search@npm%3A0.6.2#./.yarn/patches/voy-search-npm-0.6.2-d4aca30a0e.patch",
     "@langchain/core": "workspace:*",
-    "better-sqlite3": "9.4.0",
     "protobufjs": "^7.2.5",
     "zod": "3.23.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21427,14 +21427,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:9.4.0":
-  version: 9.4.0
-  resolution: "better-sqlite3@npm:9.4.0"
+"better-sqlite3@npm:>=9.4.0 <12.0.0":
+  version: 11.2.1
+  resolution: "better-sqlite3@npm:11.2.1"
   dependencies:
     bindings: ^1.5.0
     node-gyp: latest
     prebuild-install: ^7.1.1
-  checksum: a1a470fae20dfba82d6e74ae90b35ea8996c60922e95574162732d6e076e84c0c90fc4ff77ab8c27554671899eb15f284e2c8de5e4ee406aa9f7eb170eca5bee
+  checksum: 22259c298e76d4bc2bd993dfc9392bb80ecef948f48342804a7bd38a43ff7693089a9ea0ac0c14ebc195453aa94fce588755f6eea234d7550383b9f6ac7150a9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11235,7 +11235,7 @@ __metadata:
     "@zilliz/milvus2-sdk-node": ">=2.3.5"
     apify-client: ^2.7.1
     assemblyai: ^4.6.0
-    better-sqlite3: ">=9.4.0 <12.0.0"
+    better-sqlite3: 9.5.0
     binary-extensions: ^2.2.0
     cassandra-driver: ^4.7.2
     cborg: ^4.1.1
@@ -21427,14 +21427,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:>=9.4.0 <12.0.0":
-  version: 11.2.1
-  resolution: "better-sqlite3@npm:11.2.1"
+"better-sqlite3@npm:9.5.0":
+  version: 9.5.0
+  resolution: "better-sqlite3@npm:9.5.0"
   dependencies:
     bindings: ^1.5.0
     node-gyp: latest
     prebuild-install: ^7.1.1
-  checksum: 22259c298e76d4bc2bd993dfc9392bb80ecef948f48342804a7bd38a43ff7693089a9ea0ac0c14ebc195453aa94fce588755f6eea234d7550383b9f6ac7150a9
+  checksum: cfa56519755d6dd29ef8361c872c6f29392fcfcc44a435099eb61729aae23c4f18057972592a0b9ff0fcedc98e43db4ee7a1a2de21ab2868f8dcec4f8272ad9d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Prior to this change, running `yarn` in the top-level directory of the repo failed on node >= v22. After this change, it succeeds.

This was cased by the version of the `better-sqlite3` package being pinned to 9.4.0 in the top-level `package.json`. This change was introduced by @jacoblee93 in [#5694](https://github.com/langchain-ai/langchainjs/pull/5694/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R64). It's not clear from that PR why he added the package to the top-level `package.json` (I can't find anything that references it in the top-level), or why he pinned it to that specific version. Perhaps he could chime in here.

Edit: I updated this change to remove the range definition from the top-level `resolutions` object, as my initial change would've had the same effect, but with the caveat that it'd need to be maintained in step with the version of `better-sqlite3` defined in the community package.

~~Rather than removing it, my change aligns the version range with one in the @langchain/community package (listed [here as a devDependency](https://github.com/langchain-ai/langchainjs/blob/5d63f397c02f232d2a3729ed34461e209cfb0350/libs/langchain-community/package.json#L136) and [here as an optional peerDependency](https://github.com/langchain-ai/langchainjs/blob/5d63f397c02f232d2a3729ed34461e209cfb0350/libs/langchain-community/package.json#L276)), which is the only other package in the repo that depends on `better-sqlite3`.~~