### PR TITLE
fix(community): ElasticVectorSearch: exclude metadata filters not working due changing to term instead of terms

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -343,10 +343,9 @@ export class ElasticVectorSearch extends VectorStore {
           },
         });
       } else if (condition.operator === "exclude") {
+        const toExclude = { [metadataField]: condition.value }
         must_not.push({
-          term: {
-            [metadataField]: condition.value,
-          },
+          ...(Array.isArray(condition.value) ? { terms: toExclude } : { term: toExclude })
         });
       } else if (condition.operator === "or") {
         should.push({


### PR DESCRIPTION
The fix merged in #6536 broke our code due to the following error:

`parsing_exception: [term] query does not support array of values`

As we also need to allow an array, I made some changes to allow both term and terms.