### PR TITLE
fix(openai): Check `configuration.apiKey` in `ChatOpenAI` constructor

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -956,6 +956,7 @@ export class ChatOpenAI<
     this.openAIApiKey =
       fields?.apiKey ??
       fields?.openAIApiKey ??
+      fields?.configuration?.apiKey ??
       getEnvironmentVariable("OPENAI_API_KEY");
     this.apiKey = this.openAIApiKey;
 


### PR DESCRIPTION
OpenAI SDK's `ClientOptions` includes `apiKey`. It looks like `@langchain/openai`'s `ChatOpenAI` constructor does not honor that field. 

![image](https://github.com/user-attachments/assets/4ed97afb-fe15-4752-aaa8-56c5445465ff)

Referenced in the docs [here](https://v02.api.js.langchain.com/interfaces/_langchain_openai.ClientOptions.html).