### PR TITLE
feat(openai): baseUrl for DallEAPIWrapper

### DIFF
--- a/libs/langchain-openai/src/tools/dalle.ts
+++ b/libs/langchain-openai/src/tools/dalle.ts
@@ -80,6 +80,10 @@ export interface DallEAPIWrapperParams extends ToolParams {
    * The organization to use
    */
   organization?: string;
+  /**
+   * The base URL of the OpenAI API.
+   */
+  baseUrl?: string;
 }
 
 /**
@@ -141,6 +145,7 @@ export class DallEAPIWrapper extends Tool {
       apiKey: openAIApiKey,
       organization,
       dangerouslyAllowBrowser: true,
+      baseUrl: fields?.baseUrl,
     };
     this.client = new OpenAIClient(clientConfig);
     this.model = fields?.model ?? fields?.modelName ?? this.model;


### PR DESCRIPTION
This simple pull request adds the `baseUrl` to DallEAPIWrapper. It can be used for Cloudflare AI Gateway or other use cases.