### PR TITLE
fix(community): ElasticVectorSearch: exclude metadata filters not working due changing to term instead of terms

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -343,9 +343,11 @@ export class ElasticVectorSearch extends VectorStore {
           },
         });
       } else if (condition.operator === "exclude") {
-        const toExclude = { [metadataField]: condition.value }
+        const toExclude = { [metadataField]: condition.value };
         must_not.push({
-          ...(Array.isArray(condition.value) ? { terms: toExclude } : { term: toExclude })
+          ...(Array.isArray(condition.value)
+            ? { terms: toExclude }
+            : { term: toExclude }),
         });
       } else if (condition.operator === "or") {
         should.push({

--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -343,10 +343,9 @@ export class ElasticVectorSearch extends VectorStore {
           },
         });
       } else if (condition.operator === "exclude") {
+        const toExclude = { [metadataField]: condition.value }
         must_not.push({
-          term: {
-            [metadataField]: condition.value,
-          },
+          ...(Array.isArray(condition.value) ? { terms: toExclude } : { term: toExclude })
         });
       } else if (condition.operator === "or") {
         should.push({

--- a/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
@@ -114,6 +114,14 @@ describe("ElasticVectorSearch", () => {
       },
     ]);
     expect(results2).toHaveLength(1);
+    const results3 = await store.similaritySearch("*", 11, [
+      {
+        field: "a",
+        value: [createdAt],
+        operator: "exclude",
+      },
+    ]);
+    expect(results3).toHaveLength(1);
   });
 
   test.skip("ElasticVectorSearch integration with text splitting metadata", async () => {


### PR DESCRIPTION
Extends #6660