### PR TITLE
Throw with additional tool calls in ChatBedrockConverse `withStructuredOutput`

### DIFF
--- a/libs/langchain-aws/src/chat_models.ts
+++ b/libs/langchain-aws/src/chat_models.ts
@@ -985,6 +985,12 @@ export class ChatBedrockConverse
         if (!input.tool_calls || input.tool_calls.length === 0) {
           throw new Error("No tool calls found in the response.");
         }
+
+        if (toolChoiceObj?.tool_choice === functionName && input.tool_calls?.find((tc) => tc.name !== functionName)) {
+          throw new Error("Unexpected tool calls in response");
+        }
+
+
         const toolCall = input.tool_calls.find(
           (tc) => tc.name === functionName
         );


### PR DESCRIPTION
 This PR adds an error if there are multiple tool calls returned by the model from within `ChatBedrockConverse` `withStructuredOutput` where `supportsToolChoiceValues = ['tool']`.  

My understanding is that additional tool calls in this context would be unexpected. If this is not the case, feel free to close 😊

For context, in our use case we have seen the model calling non-bond tools. Ideally we would have a way to detect / capture this.

## Replication:

When using ChatBedrockConverse with `anthropic.claude-3-5-sonnet` it is possible to provoke the model into calling a tool that isn't _bound_ by providing a schema in the system prompt like so:

> This won't happen on every run but a handful was enough for me to trigger the error log

```
import { ChatBedrockConverse } from "@langchain/aws";
import { HumanMessage, SystemMessage } from "@langchain/core/messages";
import { LLMResult } from "@langchain/core/outputs";
import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
import { z } from "zod";

const modelSchema = z.object({
  done: z
  .boolean()
});

const model = new ChatBedrockConverse({
  model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
  region: "us-west-2",
  callbacks: [
    {
      handleLLMEnd: async (result: LLMResult) => {
        result.generations.forEach((generations) => {
          // eslint-disable-next-line @typescript-eslint/no-explicit-any
          generations.forEach((generation: any) => {
            if (generation?.message?.tool_calls && generation?.message.tool_calls?.length > 1) {
              console.error("Multiple tool calls in structured output", {
                calls: generation
              });
            }
          })
        })
      }
    }
  ],
  streaming: false,
  supportsToolChoiceValues: ['tool'],
})
.withStructuredOutput(modelSchema)

const prompt = ChatPromptTemplate.fromMessages([
  new SystemMessage({
    content: "You are a helpful assistant, whose capabilities are defined by a set of tools."
      // Add a dummy schema in the system prompt, this is not attached.
      + "\n\nAvailable tools:\n\n"
      + `test - a tool for testing schema:{"type":"object","properties":{"testId":{"type":"string"}},"required":["testId"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}`
  }),
  new MessagesPlaceholder("messages"),
]);

prompt.pipe(model).invoke({
  messages: [
    new HumanMessage({
      content: "Call the test tool with ID: abc-123"
    })
  ]
}).then(console.log)
```
