### PR TITLE
[HOLD]fix: Update doc urls to not include version

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -21,7 +21,7 @@ body:
         Relevant links to check before opening a question to see if your question has already been answered, fixed or
         if there's another way to solve your problem:
         
-        [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
+        [LangChain.js documentation with the integrated search](https://js.langchain.com/docs/introduction),
         [API Reference](https://api.js.langchain.com/),
         [GitHub search](https://github.com/langchain-ai/langchainjs),
         [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -22,7 +22,7 @@ body:
         if there's another way to solve your problem:
         
         [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
-        [API Reference](https://v02.api.js.langchain.com/),
+        [API Reference](https://api.js.langchain.com/),
         [GitHub search](https://github.com/langchain-ai/langchainjs),
         [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),
         [LangChain.js Github Issues](https://github.com/langchain-ai/langchainjs/issues?q=is%3Aissue),

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,7 @@ body:
         if there's another way to solve your problem:
         
         [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
-        [API Reference](https://v02.api.js.langchain.com/),
+        [API Reference](https://api.js.langchain.com/),
         [GitHub search](https://github.com/langchain-ai/langchainjs),
         [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),
         [LangChain.js Github Issues](https://github.com/langchain-ai/langchainjs/issues?q=is%3Aissue),

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,7 +15,7 @@ body:
         Relevant links to check before filing a bug report to see if your issue has already been reported, fixed or
         if there's another way to solve your problem:
         
-        [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
+        [LangChain.js documentation with the integrated search](https://js.langchain.com/docs/introduction),
         [API Reference](https://api.js.langchain.com/),
         [GitHub search](https://github.com/langchain-ai/langchainjs),
         [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -21,7 +21,7 @@ body:
       place to ask your question:
       
       [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
-      [API Reference](https://v02.api.js.langchain.com/),
+      [API Reference](https://api.js.langchain.com/),
       [GitHub search](https://github.com/langchain-ai/langchainjs),
       [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),
       [LangChain.js Github Issues](https://github.com/langchain-ai/langchainjs/issues?q=is%3Aissue),

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -20,7 +20,7 @@ body:
       If you're in the wrong place, here are some helpful links to find a better
       place to ask your question:
       
-      [LangChain.js documentation with the integrated search](https://js.langchain.com/v0.2/docs/introduction),
+      [LangChain.js documentation with the integrated search](https://js.langchain.com/docs/introduction),
       [API Reference](https://api.js.langchain.com/),
       [GitHub search](https://github.com/langchain-ai/langchainjs),
       [LangChain.js Github Discussions](https://github.com/langchain-ai/langchainjs/discussions),

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Agents allow an LLM autonomy over how a task is accomplished. Agents make decisi
 
 Please see [here](https://js.langchain.com) for full documentation, which includes:
 
-- [Getting started](https://js.langchain.com/v0.2/docs/introduction): installation, setting up the environment, simple examples
+- [Getting started](https://js.langchain.com/docs/introduction): installation, setting up the environment, simple examples
 - Overview of the [interfaces](https://js.langchain.com/v0.2/docs/how_to/lcel_cheatsheet/), [modules](https://js.langchain.com/v0.2/docs/concepts) and [integrations](https://js.langchain.com/v0.2/docs/integrations/platforms/)
 - [Tutorial](https://js.langchain.com/v0.2/docs/tutorials/) walkthroughs
 - [Reference](https://api.js.langchain.com): full API docs

--- a/docs/core_docs/docs/contributing/documentation/style_guide.mdx
+++ b/docs/core_docs/docs/contributing/documentation/style_guide.mdx
@@ -22,7 +22,7 @@ Under this framework, all documentation falls under one of four categories:
   - The clearest examples of this are our [Use case](/docs/how_to/#use-cases) pages.
 - **Reference**: Technical descriptions of the machinery and how to operate it.
   - Our [Runnable](/docs/how_to/#langchain-expression-language-lcel) pages is an example of this.
-  - The [API reference pages](https://v02.api.js.langchain.com/) are another.
+  - The [API reference pages](https://api.js.langchain.com/) are another.
 - **Explanation**: Explanations that clarify and illuminate a particular topic.
 
 Each category serves a distinct purpose and requires a specific approach to writing and structuring the content.

--- a/docs/core_docs/docs/introduction.mdx
+++ b/docs/core_docs/docs/introduction.mdx
@@ -58,7 +58,7 @@ Explore the full list of LangChain tutorials [here](/docs/tutorials), and check 
 ## [How-To Guides](/docs/how_to/)
 
 [Here](/docs/how_to/) you'll find short answers to “How do I….?” types of questions.
-These how-to guides don't cover topics in depth - you'll find that material in the [Tutorials](/docs/tutorials) and the [API Reference](https://v02.api.js.langchain.com).
+These how-to guides don't cover topics in depth - you'll find that material in the [Tutorials](/docs/tutorials) and the [API Reference](https://api.js.langchain.com/).
 However, these guides will help you quickly accomplish common tasks.
 
 Check out [LangGraph-specific how-tos here](https://langchain-ai.github.io/langgraphjs/how-tos/).

--- a/examples/src/document_loaders/example_data/notion.md
+++ b/examples/src/document_loaders/example_data/notion.md
@@ -32,7 +32,7 @@ The [LangChainHub](https://github.com/hwchase17/langchain-hub) is a central plac
 
 ## 📖 Documentation
 
-For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/v0.2/docs/introduction).
+For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/docs/introduction).
 
 ## 💁 Contributing
 

--- a/langchain/README.md
+++ b/langchain/README.md
@@ -88,7 +88,7 @@ Agents allow an LLM autonomy over how a task is accomplished. Agents make decisi
 
 Please see [here](https://js.langchain.com) for full documentation, which includes:
 
-- [Getting started](https://js.langchain.com/v0.2/docs/introduction): installation, setting up the environment, simple examples
+- [Getting started](https://js.langchain.com/docs/introduction): installation, setting up the environment, simple examples
 - Overview of the [interfaces](https://js.langchain.com/v0.2/docs/how_to/lcel_cheatsheet/), [modules](https://js.langchain.com/v0.2/docs/concepts) and [integrations](https://js.langchain.com/v0.2/docs/integrations/platforms/)
 - [Tutorial](https://js.langchain.com/v0.2/docs/tutorials/) walkthroughs
 - [Reference](https://api.js.langchain.com): full API docs

--- a/langchain/src/document_loaders/tests/example_data/notion/notion.md
+++ b/langchain/src/document_loaders/tests/example_data/notion/notion.md
@@ -32,7 +32,7 @@ The [LangChainHub](https://github.com/hwchase17/langchain-hub) is a central plac
 
 ## 📖 Documentation
 
-For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/v0.2/docs/introduction).
+For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/docs/introduction).
 
 ## 💁 Contributing
 

--- a/libs/langchain-community/src/document_loaders/tests/example_data/notion/notion.md
+++ b/libs/langchain-community/src/document_loaders/tests/example_data/notion/notion.md
@@ -32,7 +32,7 @@ The [LangChainHub](https://github.com/hwchase17/langchain-hub) is a central plac
 
 ## 📖 Documentation
 
-For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/v0.2/docs/introduction).
+For full documentation of prompts, chains, agents and more, please see [here](https://js.langchain.com/docs/introduction).
 
 ## 💁 Contributing
 


### PR DESCRIPTION
do not merge until issue with `/docs/introduction` redirecting to `/v0.1/docs/introduction` is fixed