### PR TITLE
docs: Fix Firecrawl v0 version in the docs

### DIFF
--- a/docs/core_docs/docs/integrations/document_loaders/web_loaders/firecrawl.ipynb
+++ b/docs/core_docs/docs/integrations/document_loaders/web_loaders/firecrawl.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "## Setup\n",
     "\n",
-    "To access `FireCrawlLoader` document loader you'll need to install the `@langchain/community` integration, and the `@mendable/firecrawl-js` package. Then create a **[FireCrawl](https://firecrawl.dev)** account and get an API key.\n",
+    "To access `FireCrawlLoader` document loader you'll need to install the `@langchain/community` integration, and the `@mendable/firecrawl-js@0.0.36` package. Then create a **[FireCrawl](https://firecrawl.dev)** account and get an API key.\n",
     "\n",
     "### Credentials\n",
     "\n",
@@ -67,7 +67,7 @@
     "<IntegrationInstallTooltip></IntegrationInstallTooltip>\n",
     "\n",
     "<Npm2Yarn>\n",
-    "  @langchain/community @langchain/core @mendable/firecrawl-js\n",
+    "  @langchain/community @langchain/core @mendable/firecrawl-js@0.0.36\n",
     "</Npm2Yarn>\n",
     "\n",
     "```"


### PR DESCRIPTION
Firecrawl integration is currently on v0 - which is supported until version 0.0.36.

@rafaelsideguide is working on a pr for v1 but meanwhile we should fix the docs.