### PR TITLE
feat(core): add sync versions of load

### DIFF
--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -74,6 +74,10 @@ load/serializable.cjs
 load/serializable.js
 load/serializable.d.ts
 load/serializable.d.cts
+load/sync.cjs
+load/sync.js
+load/sync.d.ts
+load/sync.d.cts
 memory.cjs
 memory.js
 memory.d.ts

--- a/langchain-core/langchain.config.js
+++ b/langchain-core/langchain.config.js
@@ -31,6 +31,7 @@ export const config = {
     "language_models/llms": "language_models/llms",
     load: "load/index",
     "load/serializable": "load/serializable",
+    "load/sync": "load/sync",
     memory: "memory",
     messages: "messages/index",
     "messages/tool": "messages/tool",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -259,6 +259,15 @@
       "import": "./load/serializable.js",
       "require": "./load/serializable.cjs"
     },
+    "./load/sync": {
+      "types": {
+        "import": "./load/sync.d.ts",
+        "require": "./load/sync.d.cts",
+        "default": "./load/sync.d.ts"
+      },
+      "import": "./load/sync.js",
+      "require": "./load/sync.cjs"
+    },
     "./memory": {
       "types": {
         "import": "./memory.d.ts",
@@ -690,6 +699,10 @@
     "load/serializable.js",
     "load/serializable.d.ts",
     "load/serializable.d.cts",
+    "load/sync.cjs",
+    "load/sync.js",
+    "load/sync.d.ts",
+    "load/sync.d.cts",
     "memory.cjs",
     "memory.js",
     "memory.d.ts",

--- a/langchain-core/src/load/utils.ts
+++ b/langchain-core/src/load/utils.ts
@@ -1,0 +1,17 @@
+import { Serializable } from "./serializable.js";
+
+export function combineAliasesAndInvert(constructor: typeof Serializable) {
+  const aliases: { [key: string]: string } = {};
+  for (
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let current = constructor;
+    current && current.prototype;
+    current = Object.getPrototypeOf(current)
+  ) {
+    Object.assign(aliases, Reflect.get(current.prototype, "lc_aliases"));
+  }
+  return Object.entries(aliases).reduce((acc, [key, value]) => {
+    acc[value] = key;
+    return acc;
+  }, {} as Record<string, string>);
+}

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -10,6 +10,7 @@ import {
   SystemMessage,
 } from "../index.js";
 import { load } from "../../load/index.js";
+import { syncLoad } from "../../load/sync.js";
 
 test("Test ChatPromptTemplate can format OpenAI content image messages", async () => {
   const message = new HumanMessage({
@@ -95,7 +96,10 @@ test("Deserialisation and serialisation of additional_kwargs and tool_call_id", 
     },
   });
 
-  const deserialized: AIMessage = await load(JSON.stringify(message), config);
+  let deserialized: AIMessage = await load(JSON.stringify(message), config);
+  expect(deserialized).toEqual(message);
+
+  deserialized = syncLoad(JSON.stringify(message), config);
   expect(deserialized).toEqual(message);
 });
 
@@ -112,7 +116,10 @@ test("Deserialisation and serialisation of tool_call_id", async () => {
     tool_call_id: "call_tXJNP1S6LHT5tLfaNHCbYCtH",
   });
 
-  const deserialized: ToolMessage = await load(JSON.stringify(message), config);
+  let deserialized: ToolMessage = await load(JSON.stringify(message), config);
+  expect(deserialized).toEqual(message);
+
+  deserialized = syncLoad(JSON.stringify(message), config);
   expect(deserialized).toEqual(message);
 });
 
@@ -131,7 +138,11 @@ test("Deserialisation and serialisation of messages with ID", async () => {
     id: messageId,
   });
 
-  const deserialized: AIMessage = await load(JSON.stringify(message), config);
+  let deserialized: AIMessage = await load(JSON.stringify(message), config);
+  expect(deserialized).toEqual(message);
+  expect(deserialized.id).toBe(messageId);
+
+  deserialized = syncLoad(JSON.stringify(message), config);
   expect(deserialized).toEqual(message);
   expect(deserialized.id).toBe(messageId);
 });


### PR DESCRIPTION
This would allow us to deserialise within `syncLoad` a single task, which is especially useful if we would use `syncLoad` to deserialise messages and message chunks.

