### PR TITLE
fix(core, langchain): Update langsmith dep to rc

### DIFF
--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -37,7 +37,7 @@
     "camelcase": "6",
     "decamelize": "1.2.0",
     "js-tiktoken": "^1.0.12",
-    "langsmith": "^0.1.43",
+    "langsmith": "^0.1.56-rc.1",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",
     "p-retry": "4",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -524,7 +524,7 @@
     "js-tiktoken": "^1.0.12",
     "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",
-    "langsmith": "~0.1.40",
+    "langsmith": "^0.1.56-rc.1",
     "openapi-types": "^12.1.3",
     "p-retry": "4",
     "uuid": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11997,7 +11997,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.12
-    langsmith: ^0.1.43
+    langsmith: ^0.1.56-rc.1
     ml-matrix: ^6.10.4
     mustache: ^4.2.0
     p-queue: ^6.6.2
@@ -19476,6 +19476,13 @@ __metadata:
   version: 2.0.8
   resolution: "@types/unist@npm:2.0.8"
   checksum: f4852d10a6752dc70df363917ef74453e5d2fd42824c0f6d09d19d530618e1402193977b1207366af4415aaec81d4e262c64d00345402020c4ca179216e553c7
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@types/uuid@npm:10.0.0"
+  checksum: e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
   languageName: node
   linkType: hard
 
@@ -32595,7 +32602,7 @@ __metadata:
     js-tiktoken: ^1.0.12
     js-yaml: ^4.1.0
     jsonpointer: ^5.0.1
-    langsmith: ~0.1.40
+    langsmith: ^0.1.56-rc.1
     openai: ^4.41.1
     openapi-types: ^12.1.3
     p-retry: 4
@@ -32702,6 +32709,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"langsmith@npm:^0.1.56-rc.1":
+  version: 0.1.56-rc.1
+  resolution: "langsmith@npm:0.1.56-rc.1"
+  dependencies:
+    "@types/uuid": ^10.0.0
+    commander: ^10.0.1
+    p-queue: ^6.6.2
+    p-retry: 4
+    semver: ^7.6.3
+    uuid: ^10.0.0
+  peerDependencies:
+    openai: "*"
+  peerDependenciesMeta:
+    openai:
+      optional: true
+  checksum: 6d144958641bc7bca97b1fd0031fe9214d0e524e758d4a2efb0f34254de218bcfd4354ac71bed7b7d96893063f90a9db7103a6c921448519b1ab7a2200a1506f
+  languageName: node
+  linkType: hard
+
 "langsmith@npm:~0.1.30":
   version: 0.1.39
   resolution: "langsmith@npm:0.1.39"
@@ -32723,31 +32749,6 @@ __metadata:
     openai:
       optional: true
   checksum: df21332662ec3a2d2d5cf915acede52b96aedf2a286259435d683f230af5926500b129cab1f0275450e0d3de6d9d8476e410ac46f5e994beb43f2e2df8a1965f
-  languageName: node
-  linkType: hard
-
-"langsmith@npm:~0.1.40":
-  version: 0.1.40
-  resolution: "langsmith@npm:0.1.40"
-  dependencies:
-    "@types/uuid": ^9.0.1
-    commander: ^10.0.1
-    p-queue: ^6.6.2
-    p-retry: 4
-    semver: ^7.6.3
-    uuid: ^9.0.0
-  peerDependencies:
-    "@langchain/core": "*"
-    langchain: "*"
-    openai: "*"
-  peerDependenciesMeta:
-    "@langchain/core":
-      optional: true
-    langchain:
-      optional: true
-    openai:
-      optional: true
-  checksum: 8c5bcf5137e93a9a17203fbe21d6a61f45c98fccafc2040d56e9cc15a4ee432456d986adf0e590d8c436b72d18143053ce6e65f021115f1596dd4519ec2805d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves the circular peer dep issue that is now seen when running `npm install`

Fixes #6792
Fixes #6789