### PR TITLE
docs: new algolia index

### DIFF
--- a/docs/core_docs/docusaurus.config.js
+++ b/docs/core_docs/docusaurus.config.js
@@ -308,7 +308,7 @@ const config = {
         // this is linked to erick@langchain.dev currently
         apiKey: "180851bbb9ba0ef6be9214849d6efeaf",
 
-        indexName: "js-langchain-0.2",
+        indexName: "js-langchain-latest",
 
         contextualSearch: false,
       },


### PR DESCRIPTION
wait to merge until 0.3 sites are hosted at js.langchain.com/docs, and algolia crawler for js-langchain-latest has been run.