### PR TITLE
fix: typo fix in agents doc

### DIFF
--- a/docs/core_docs/docs/concepts.mdx
+++ b/docs/core_docs/docs/concepts.mdx
@@ -657,7 +657,7 @@ const tools = toolkit.getTools()
 
 By themselves, language models can't take actions - they just output text.
 A big use case for LangChain is creating **agents**.
-Agents are systems that use an LLM as a reasoning enginer to determine which actions to take and what the inputs to those actions should be.
+Agents are systems that use an LLM as a reasoning engineer to determine which actions to take and what the inputs to those actions should be.
 The results of those actions can then be fed back into the agent and it determine whether more actions are needed, or whether it is okay to finish.
 
 [LangGraph](https://github.com/langchain-ai/langgraphjs) is an extension of LangChain specifically aimed at creating highly controllable and customizable agents.


### PR DESCRIPTION
### **Pull Request Overview**

This PR addresses a typo in the "Agents" section of the LangChain Conceptual Guide, improving clarity and correctness.

---

### **Typo in Agents section of "Conceptual Guide"**
**Link:** [Agents Section](https://js.langchain.com/docs/concepts/#agents:~:text=Agents%20are%20systems%20that%20use%20an%20LLM%20as%20a%20reasoning%20enginer%20to%20determine%20which%20actions%20to%20take%20and%20what%20the%20inputs%20to%20those%20actions%20should%20be.)

- **Issue:** The word "enginer" is misspelled.
- **Correction:** Changed "enginer" to "engineer" for accuracy.

---
