### PR TITLE
fix(ollama): Drop tool_choice from docstrings

### DIFF
--- a/libs/langchain-ollama/src/chat_models.ts
+++ b/libs/langchain-ollama/src/chat_models.ts
@@ -109,7 +109,7 @@ export interface ChatOllamaInput
  * const llmWithTools = llm.bindTools(
  *   [...],
  *   {
- *     tool_choice: "auto",
+ *     stop: ["\n"],
  *   }
  * );
  * ```


### PR DESCRIPTION
[Not yet supported](https://ollama.com/blog/tool-support#:~:text=Tool%20choice%3A%20force%20a%20model%20to%20use%20a%20tool)