### PR TITLE
fix(core): Narrow chat model return type

### DIFF
--- a/langchain-core/src/language_models/chat_models.ts
+++ b/langchain-core/src/language_models/chat_models.ts
@@ -141,7 +141,7 @@ export type BindToolsInput =
 export abstract class BaseChatModel<
   CallOptions extends BaseChatModelCallOptions = BaseChatModelCallOptions,
   // TODO: Fix the parameter order on the next minor version.
-  OutputMessageType extends BaseMessageChunk = BaseMessageChunk
+  OutputMessageType extends BaseMessageChunk = AIMessageChunk
 > extends BaseLanguageModel<OutputMessageType, CallOptions> {
   // Backwards compatibility since fields have been moved to RunnableConfig
   declare ParsedCallOptions: Omit<


### PR DESCRIPTION
Long overdue, remove the need for various casts

Still allows optionality for models to return broader types in the future

CC @dqbd @hinthornw @bracesproul 