### PR TITLE
fix(community): supabase comparison to string function

### DIFF
--- a/libs/langchain-community/src/structured_query/supabase.ts
+++ b/libs/langchain-community/src/structured_query/supabase.ts
@@ -224,7 +224,7 @@ export class SupabaseTranslator<
       attribute,
       value,
       false
-    )}.${comparator}.${value}}`;
+    )}.${comparator}.${value}`;
   }
 
   /**


### PR DESCRIPTION
# Summary
This PR fixes a minor error in the `SupabaseTranslator` file, specifically in the `visitComparisonAsString()` function that takes in a Comparison object and converts it to a format suitable for RPC.

# Details
- The change fixes an extra `}` that causes the API call to Supabase to return no rows.