### PR TITLE
fix(community): Column VEC_VECTOR has the wrong length

### DIFF
--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -269,8 +269,14 @@ export class HanaDB extends VectorStore {
         throw new Error(`Column ${columnName} has the wrong type: ${dataType}`);
       }
 
+      // For the vector column, we have defined a default value of -1
+      // which refers to dynamic length
+      // However, Length can either be -1 (QRC01+02-24) or 0 (QRC03-24 onwards)
+      // i.e. HANA db can return 0 (length) even when we set the default value
+      // Hence, ignoring this check for now only in case of default value
+
       // Check length, if parameter was provided
-      if (columnLength !== undefined && length !== columnLength) {
+      if (columnLength !== undefined && length !== columnLength && length > 0) {
         throw new Error(`Column ${columnName} has the wrong length: ${length}`);
       }
     }

--- a/libs/langchain-community/src/vectorstores/hanavector.ts
+++ b/libs/langchain-community/src/vectorstores/hanavector.ts
@@ -269,11 +269,8 @@ export class HanaDB extends VectorStore {
         throw new Error(`Column ${columnName} has the wrong type: ${dataType}`);
       }
 
-      // For the vector column, we have defined a default value of -1
-      // which refers to dynamic length
-      // However, Length can either be -1 (QRC01+02-24) or 0 (QRC03-24 onwards)
-      // i.e. HANA db can return 0 (length) even when we set the default value
-      // Hence, ignoring this check for now only in case of default value
+      // Length can either be -1 (QRC01+02-24) or 0 (QRC03-24 onwards)
+      // to indicate no length constraint being present.
 
       // Check length, if parameter was provided
       if (columnLength !== undefined && length !== columnLength && length > 0) {


### PR DESCRIPTION
* Description: This PR fixes an issue with SAP HANA Cloud QRC03 version. In that version the number to indicate no length being set for a vector column changed from -1 to 0. The change in this PR support both behaviours (old/new).
* Dependencies: No dependencies have been introduced.

The same issue has been fixed in the python library as well:
https://github.com/langchain-ai/langchain/pull/23516

Fixes # (issue)
https://github.com/langchain-ai/langchainjs/issues/6913
