### PR TITLE
feat(openai): include raw data in embedQuery method

### DIFF
--- a/libs/langchain-community/src/vectorstores/tests/singlestore.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/singlestore.int.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-process-env */
 /* eslint-disable import/no-extraneous-dependencies */
 import { test, expect } from "@jest/globals";
-import { OpenAIEmbeddings } from "@langchain/openai";
+import { EmbedQueryMethodOptions, EmbedQueryRawResult, OpenAIEmbeddings } from "@langchain/openai";
 import { Document } from "@langchain/core/documents";
 import { SingleStoreVectorStore, SearchStrategy } from "../singlestore.js";
 
@@ -25,7 +25,11 @@ class MockEmbeddings extends OpenAIEmbeddings {
     ];
   }
 
-  async embedQuery(document: string): Promise<number[]> {
+  async embedQuery(document: string, options?: EmbedQueryMethodOptions<false>): Promise<number[]>;
+
+  async embedQuery(document: string, options?: EmbedQueryMethodOptions<true>): Promise<EmbedQueryRawResult>;
+
+  async embedQuery(document: string, _options?: EmbedQueryMethodOptions<boolean>): Promise<number[] | EmbedQueryRawResult> {
     return this.embed(document);
   }
 }

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -51,6 +51,7 @@
     "@langchain/standard-tests": "0.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
+    "@tsconfig/recommended": "^1.0.3",
     "dpdm": "^3.12.0",
     "eslint": "^8.33.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/libs/langchain-openai/src/embeddings.ts
+++ b/libs/langchain-openai/src/embeddings.ts
@@ -6,6 +6,8 @@ import {
   AzureOpenAIInput,
   OpenAICoreRequestOptions,
   LegacyOpenAIInput,
+  EmbedQueryMethodOptions,
+  EmbedQueryRawResult,
 } from "./types.js";
 import { getEndpoint, OpenAIEndpointConfig } from "./utils/azure.js";
 import { wrapOpenAIClientError } from "./utils/openai.js";
@@ -240,9 +242,14 @@ export class OpenAIEmbeddings
    * Method to generate an embedding for a single document. Calls the
    * embeddingWithRetry method with the document as the input.
    * @param text Document to generate an embedding for.
+   * @param options Options to pass to the embedQuery method.
    * @returns Promise that resolves to an embedding for the document.
    */
-  async embedQuery(text: string): Promise<number[]> {
+  async embedQuery(text: string, options?: EmbedQueryMethodOptions<false>): Promise<number[]>;
+
+  async embedQuery(text: string, options?: EmbedQueryMethodOptions<true>): Promise<EmbedQueryRawResult>;
+
+  async embedQuery(text: string, options?: EmbedQueryMethodOptions<boolean>): Promise<number[] | EmbedQueryRawResult> {
     const params: OpenAIClient.EmbeddingCreateParams = {
       model: this.model,
       input: this.stripNewLines ? text.replace(/\n/g, " ") : text,
@@ -250,7 +257,17 @@ export class OpenAIEmbeddings
     if (this.dimensions) {
       params.dimensions = this.dimensions;
     }
-    const { data } = await this.embeddingWithRetry(params);
+
+    const result = await this.embeddingWithRetry(params);
+    const { data } = result;
+
+    if (options?.includeRaw) {
+      return {
+        embedding: data[0].embedding,
+        raw: result,
+      };
+    }
+
     return data[0].embedding;
   }
 

--- a/libs/langchain-openai/src/types.ts
+++ b/libs/langchain-openai/src/types.ts
@@ -254,3 +254,13 @@ export type ChatOpenAIResponseFormat =
   | ResponseFormatText
   | ResponseFormatJSONObject
   | ChatOpenAIResponseFormatJSONSchema;
+
+export type EmbedQueryMethodOptions<IncludeRaw extends boolean = false> = {
+  includeRaw?: IncludeRaw;
+};
+
+export type EmbedQueryRawResult = {
+  embedding: number[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  raw: any;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12515,6 +12515,7 @@ __metadata:
     "@langchain/standard-tests": 0.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
+    "@tsconfig/recommended": ^1.0.3
     dpdm: ^3.12.0
     eslint: ^8.33.0
     eslint-config-airbnb-base: ^15.0.0


### PR DESCRIPTION
I would like to contribute with this small feature because it is a need I have and perhaps others may have as well.

We have the option to obtain the full response data from OpenAI in completion methods such as `withStructuredOutput`, for example, but we don't have it in this embedding generation method. I need to obtain the data on the number of tokens sent without necessarily having another library estimate this data for me.

Here’s an example:

![image](https://github.com/user-attachments/assets/7686437d-9d29-4c55-bff9-d32abb49e8d7)

Additionally, this adjustment will not cause any changes to the existing interface unless we explicitly the `includeRaw` in the options param.