### PR TITLE
feat(aws): Added AWS Bedrock Document and Image Support

### DIFF
--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -144,11 +144,14 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
               return {
                 text: block.text,
               };
-            } else if (block.type === 'document' && block.document !== undefined) {
+            } else if (
+              block.type === "document" &&
+              block.document !== undefined
+            ) {
               return {
                 document: block.document,
               };
-            } else if (block.type === 'image' && block.image !== undefined) {
+            } else if (block.type === "image" && block.image !== undefined) {
               return {
                 image: block.image,
               };

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -144,6 +144,14 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
               return {
                 text: block.text,
               };
+            } else if (block.type === 'document' && block.document !== undefined) {
+              return {
+                document: block.document,
+              };
+            } else if (block.type === 'image' && block.image !== undefined) {
+              return {
+                image: block.image,
+              };
             } else {
               throw new Error(`Unsupported content block type: ${block.type}`);
             }


### PR DESCRIPTION
Currently, Amazon Bedrock supports text, images and documents in their [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-examples.html). 

It appears that the [langchain-aws](https://github.com/langchain-ai/langchain-aws) (the python version), has added support for both of these message content types:
- Link to the [Issue](https://github.com/langchain-ai/langchain-aws/issues/132)
- Link to the [Pull Request](https://github.com/langchain-ai/langchain-aws/pull/143)

This change adds support for both `type === 'document'` and  `type === 'image'` per the Converse API examples.

Fixes #6955 
