### PR TITLE
feat(community): Return document ids when querying pgvector store

### DIFF
--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -686,6 +686,7 @@ export class PGVectorStore extends VectorStore {
         const document = new Document({
           pageContent: doc[this.contentColumnName],
           metadata: doc[this.metadataColumnName],
+          id: doc[this.idColumnName],
         });
         results.push([document, doc._distance]);
       }


### PR DESCRIPTION
Currently the ids are not returned when querying a pgvector store. This adds them to the returned document.
