### PR TITLE
feat(core): Adds support for context variables

### DIFF
--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -30,6 +30,10 @@ chat_history.cjs
 chat_history.js
 chat_history.d.ts
 chat_history.d.cts
+context.cjs
+context.js
+context.d.ts
+context.d.cts
 documents.cjs
 documents.js
 documents.d.ts

--- a/langchain-core/langchain.config.js
+++ b/langchain-core/langchain.config.js
@@ -20,6 +20,7 @@ export const config = {
     "callbacks/manager": "callbacks/manager",
     "callbacks/promises": "callbacks/promises",
     chat_history: "chat_history",
+    context: "context",
     documents: "documents/index",
     "document_loaders/base": "document_loaders/base",
     "document_loaders/langsmith": "document_loaders/langsmith",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -37,7 +37,7 @@
     "camelcase": "6",
     "decamelize": "1.2.0",
     "js-tiktoken": "^1.0.12",
-    "langsmith": "^0.1.64",
+    "langsmith": "^0.1.65",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",
     "p-retry": "4",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -37,7 +37,7 @@
     "camelcase": "6",
     "decamelize": "1.2.0",
     "js-tiktoken": "^1.0.12",
-    "langsmith": "^0.1.56",
+    "langsmith": "^0.1.64",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",
     "p-retry": "4",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -160,6 +160,15 @@
       "import": "./chat_history.js",
       "require": "./chat_history.cjs"
     },
+    "./context": {
+      "types": {
+        "import": "./context.d.ts",
+        "require": "./context.d.cts",
+        "default": "./context.d.ts"
+      },
+      "import": "./context.js",
+      "require": "./context.cjs"
+    },
     "./documents": {
       "types": {
         "import": "./documents.d.ts",
@@ -646,6 +655,10 @@
     "chat_history.js",
     "chat_history.d.ts",
     "chat_history.d.cts",
+    "context.cjs",
+    "context.js",
+    "context.d.ts",
+    "context.d.cts",
     "documents.cjs",
     "documents.js",
     "documents.d.ts",

--- a/langchain-core/src/callbacks/dispatch/index.ts
+++ b/langchain-core/src/callbacks/dispatch/index.ts
@@ -1,10 +1,12 @@
+/* __LC_ALLOW_ENTRYPOINT_SIDE_EFFECTS__ */
+
 import { AsyncLocalStorage } from "node:async_hooks";
 import { dispatchCustomEvent as dispatchCustomEventWeb } from "./web.js";
 import { type RunnableConfig, ensureConfig } from "../../runnables/config.js";
 import { AsyncLocalStorageProviderSingleton } from "../../singletons/index.js";
 
-/* #__PURE__ */ AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
-  /* #__PURE__ */ new AsyncLocalStorage()
+AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+  new AsyncLocalStorage()
 );
 
 /**

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -1,0 +1,34 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  _CONTEXT_VARIABLES_KEY,
+  AsyncLocalStorageProviderSingleton,
+} from "./singletons/index.js";
+
+AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+  new AsyncLocalStorage()
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setContextVariable(name: PropertyKey, value: any) {
+  const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
+  if (runTree === undefined) {
+    throw new Error(
+      [
+        "This function can only be called from within an existing run (e.g.,",
+        "inside a tool, RunnableLambda, or LangGraph.js node).",
+      ].join("")
+    );
+  }
+  const contextVars = { ...runTree[_CONTEXT_VARIABLES_KEY] };
+  contextVars[name] = value;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (AsyncLocalStorageProviderSingleton.getInstance() as any).enterWith({
+    ...runTree,
+    [_CONTEXT_VARIABLES_KEY]: contextVars,
+  });
+}
+
+export function getContextVariable(name: string) {
+  const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
+  return runTree?.[_CONTEXT_VARIABLES_KEY]?.[name];
+}

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -20,6 +20,12 @@ AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
  *
  * @example
  * ```ts
+ * import { RunnableLambda } from "@langchain/core/runnables";
+ * import {
+ *   getContextVariable,
+ *   setContextVariable
+ * } from "@langchain/core/context";
+ *
  * const nested = RunnableLambda.from(() => {
  *   // "bar" because it was set by a parent
  *   console.log(getContextVariable("foo"));
@@ -76,6 +82,12 @@ export function setContextVariable(name: PropertyKey, value: any) {
  *
  * @example
  * ```ts
+ * import { RunnableLambda } from "@langchain/core/runnables";
+ * import {
+ *   getContextVariable,
+ *   setContextVariable
+ * } from "@langchain/core/context";
+ *
  * const nested = RunnableLambda.from(() => {
  *   // "bar" because it was set by a parent
  *   console.log(getContextVariable("foo"));

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -8,18 +8,54 @@ AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
   new AsyncLocalStorage()
 );
 
+/**
+ * Set a context variable. Context variables are scoped to any
+ * child runnables called by the current runnable, or globally if set outside
+ * of any runnable.
+ *
+ * @remarks
+ * This function is only supported in environments that support AsyncLocalStorage,
+ * including Node.js, Deno, and Cloudflare Workers.
+ *
+ * @example
+ * ```ts
+ * const nested = RunnableLambda.from(() => {
+ *   // "bar" because it was set by a parent
+ *   console.log(getContextVariable("foo"));
+ *
+ *   // Override to "baz", but only for child runnables
+ *   setContextVariable("foo", "baz");
+ *
+ *   // Now "baz", but only for child runnables
+ *   return getContextVariable("foo");
+ * });
+ *
+ * const runnable = RunnableLambda.from(async () => {
+ *   // Set a context variable named "foo"
+ *   setContextVariable("foo", "bar");
+ *
+ *   const res = await nested.invoke({});
+ *
+ *   // Still "bar" since child changes do not affect parents
+ *   console.log(getContextVariable("foo"));
+ *
+ *   return res;
+ * });
+ *
+ * // undefined, because context variable has not been set yet
+ * console.log(getContextVariable("foo"));
+ *
+ * // Final return value is "baz"
+ * const result = await runnable.invoke({});
+ * ```
+ *
+ * @param name The name of the context variable.
+ * @param value The value to set.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function setContextVariable(name: PropertyKey, value: any) {
   const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
-  if (runTree === undefined) {
-    throw new Error(
-      [
-        "This function can only be called from within an existing run (e.g.,",
-        "inside a tool, RunnableLambda, or LangGraph.js node).",
-      ].join("")
-    );
-  }
-  const contextVars = { ...runTree[_CONTEXT_VARIABLES_KEY] };
+  const contextVars = { ...runTree?.[_CONTEXT_VARIABLES_KEY] };
   contextVars[name] = value;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (AsyncLocalStorageProviderSingleton.getInstance() as any).enterWith({
@@ -28,7 +64,50 @@ export function setContextVariable(name: PropertyKey, value: any) {
   });
 }
 
-export function getContextVariable(name: string) {
+/**
+ * Get the value of a previously set context variable. Context variables
+ * are scoped to any child runnables called by the current runnable,
+ * or globally if set outside of any runnable.
+ *
+ * @remarks
+ * This function is only supported in environments that support AsyncLocalStorage,
+ * including Node.js, Deno, and Cloudflare Workers.
+ *
+ * @example
+ * ```ts
+ * const nested = RunnableLambda.from(() => {
+ *   // "bar" because it was set by a parent
+ *   console.log(getContextVariable("foo"));
+ *
+ *   // Override to "baz", but only for child runnables
+ *   setContextVariable("foo", "baz");
+ *
+ *   // Now "baz", but only for child runnables
+ *   return getContextVariable("foo");
+ * });
+ *
+ * const runnable = RunnableLambda.from(async () => {
+ *   // Set a context variable named "foo"
+ *   setContextVariable("foo", "bar");
+ *
+ *   const res = await nested.invoke({});
+ *
+ *   // Still "bar" since child changes do not affect parents
+ *   console.log(getContextVariable("foo"));
+ *
+ *   return res;
+ * });
+ *
+ * // undefined, because context variable has not been set yet
+ * console.log(getContextVariable("foo"));
+ *
+ * // Final return value is "baz"
+ * const result = await runnable.invoke({});
+ * ```
+ *
+ * @param name The name of the context variable.
+ */
+export function getContextVariable(name: PropertyKey) {
   const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
   return runTree?.[_CONTEXT_VARIABLES_KEY]?.[name];
 }

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -1,3 +1,4 @@
+/* __LC_ALLOW_ENTRYPOINT_SIDE_EFFECTS__ */
 import { AsyncLocalStorage } from "node:async_hooks";
 import {
   _CONTEXT_VARIABLES_KEY,

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -1,11 +1,11 @@
 /* __LC_ALLOW_ENTRYPOINT_SIDE_EFFECTS__ */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { RunTree } from "langsmith";
+import { isRunTree } from "langsmith/run_trees";
 import {
   _CONTEXT_VARIABLES_KEY,
   AsyncLocalStorageProviderSingleton,
 } from "./singletons/index.js";
-import { RunTree } from "langsmith";
-import { isRunTree } from "langsmith/run_trees";
 
 AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
   new AsyncLocalStorage()

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -60,7 +60,7 @@ AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
  * @param value The value to set.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setContextVariable(name: PropertyKey, value: any) {
+export function setContextVariable(name: PropertyKey, value: any): void {
   const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
   const contextVars = { ...runTree?.[_CONTEXT_VARIABLES_KEY] };
   contextVars[name] = value;
@@ -120,7 +120,8 @@ export function setContextVariable(name: PropertyKey, value: any) {
  *
  * @param name The name of the context variable.
  */
-export function getContextVariable(name: PropertyKey) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getContextVariable(name: PropertyKey): any {
   const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
   return runTree?.[_CONTEXT_VARIABLES_KEY]?.[name];
 }

--- a/langchain-core/src/context.ts
+++ b/langchain-core/src/context.ts
@@ -68,7 +68,7 @@ export function setContextVariable(name: PropertyKey, value: any): void {
   contextVars[name] = value;
   let newValue = {};
   if (isRunTree(runTree)) {
-    newValue = new RunTree({ ...runTree, __shallowClone: true });
+    newValue = new RunTree(runTree);
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (newValue as any)[_CONTEXT_VARIABLES_KEY] = contextVars;

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -24,6 +24,8 @@ const mockAsyncLocalStorage = new MockAsyncLocalStorage();
 const TRACING_ALS_KEY = Symbol.for("ls:tracing_async_local_storage");
 const LC_CHILD_KEY = Symbol.for("lc:child_config");
 
+export const _CONTEXT_VARIABLES_KEY = Symbol.for("lc:context_variables");
+
 class AsyncLocalStorageProvider {
   getInstance(): AsyncLocalStorageInterface {
     return (globalThis as any)[TRACING_ALS_KEY] ?? mockAsyncLocalStorage;
@@ -50,6 +52,7 @@ class AsyncLocalStorageProvider {
       config?.metadata
     );
     const storage = this.getInstance();
+    const previousValue = storage.getStore();
     const parentRunId = callbackManager?.getParentRunId();
 
     const langChainTracer = callbackManager?.handlers?.find(
@@ -68,6 +71,14 @@ class AsyncLocalStorageProvider {
 
     if (runTree) {
       runTree.extra = { ...runTree.extra, [LC_CHILD_KEY]: config };
+    }
+
+    if (
+      previousValue !== undefined &&
+      previousValue[_CONTEXT_VARIABLES_KEY] !== undefined
+    ) {
+      (runTree as any)[_CONTEXT_VARIABLES_KEY] =
+        previousValue[_CONTEXT_VARIABLES_KEY];
     }
 
     return storage.run(runTree, callback);

--- a/langchain-core/src/singletons/index.ts
+++ b/langchain-core/src/singletons/index.ts
@@ -7,6 +7,8 @@ export interface AsyncLocalStorageInterface {
   getStore: () => any | undefined;
 
   run: <T>(store: any, callback: () => T) => T;
+
+  enterWith: (store: any) => void;
 }
 
 export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
@@ -16,6 +18,10 @@ export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
 
   run<T>(_store: any, callback: () => T): T {
     return callback();
+  }
+
+  enterWith(_store: any) {
+    return undefined;
   }
 }
 

--- a/langchain-core/src/tests/context.test.ts
+++ b/langchain-core/src/tests/context.test.ts
@@ -1,0 +1,20 @@
+import { RunnableLambda } from "../runnables/base.js";
+import { getContextVariable, setContextVariable } from "../context.js";
+
+test("RunnableLambda that returns a runnable should invoke the runnable", async () => {
+  const nested = RunnableLambda.from(() => {
+    expect(getContextVariable("foo")).toEqual("bar");
+    setContextVariable("foo", "baz");
+    return getContextVariable("foo");
+  });
+  const runnable = RunnableLambda.from(async () => {
+    setContextVariable("foo", "bar");
+    expect(getContextVariable("foo")).toEqual("bar");
+    const res = await nested.invoke({});
+    expect(getContextVariable("foo")).toEqual("bar");
+    return res;
+  });
+  expect(getContextVariable("foo")).toEqual(undefined);
+  const result = await runnable.invoke({});
+  expect(result).toEqual("baz");
+});

--- a/langchain-core/src/tests/context.test.ts
+++ b/langchain-core/src/tests/context.test.ts
@@ -4,17 +4,22 @@ import { getContextVariable, setContextVariable } from "../context.js";
 test("RunnableLambda that returns a runnable should invoke the runnable", async () => {
   const nested = RunnableLambda.from(() => {
     expect(getContextVariable("foo")).toEqual("bar");
+    expect(getContextVariable("toplevel")).toEqual(9);
     setContextVariable("foo", "baz");
     return getContextVariable("foo");
   });
   const runnable = RunnableLambda.from(async () => {
     setContextVariable("foo", "bar");
     expect(getContextVariable("foo")).toEqual("bar");
+    expect(getContextVariable("toplevel")).toEqual(9);
     const res = await nested.invoke({});
     expect(getContextVariable("foo")).toEqual("bar");
     return res;
   });
   expect(getContextVariable("foo")).toEqual(undefined);
+  setContextVariable("toplevel", 9);
+  expect(getContextVariable("toplevel")).toEqual(9);
   const result = await runnable.invoke({});
+  expect(getContextVariable("toplevel")).toEqual(9);
   expect(result).toEqual("baz");
 });

--- a/langchain-core/src/tests/context.test.ts
+++ b/langchain-core/src/tests/context.test.ts
@@ -1,3 +1,4 @@
+import { test, expect } from "@jest/globals";
 import { RunnableLambda } from "../runnables/base.js";
 import { getContextVariable, setContextVariable } from "../context.js";
 

--- a/langchain-core/src/tests/context.test.ts
+++ b/langchain-core/src/tests/context.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@jest/globals";
 import { RunnableLambda } from "../runnables/base.js";
 import { getContextVariable, setContextVariable } from "../context.js";
 
-test("RunnableLambda that returns a runnable should invoke the runnable", async () => {
+test("Getting and setting context variables within nested runnables", async () => {
   const nested = RunnableLambda.from(() => {
     expect(getContextVariable("foo")).toEqual("bar");
     expect(getContextVariable("toplevel")).toEqual(9);

--- a/langchain-core/src/tracers/tests/langsmith_interop.test.ts
+++ b/langchain-core/src/tracers/tests/langsmith_interop.test.ts
@@ -179,6 +179,155 @@ test.each(["true", "false"])(
 );
 
 test.each(["true", "false"])(
+  "traceables nested within runnables with a context var set and with background callbacks %s",
+  async (value) => {
+    const { setContextVariable, getContextVariable } = await import(
+      "../../context.js"
+    );
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = value;
+
+    setContextVariable("foo", "bar");
+    const aiGreet = traceable(
+      async (msg: BaseMessage, name = "world") => {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(getContextVariable("foo")).toEqual("baz");
+        return msg.content + name;
+      },
+      { name: "aiGreet", tracingEnabled: true }
+    );
+
+    const root = RunnableLambda.from(async (messages: BaseMessage[]) => {
+      const lastMsg = messages.at(-1) as HumanMessage;
+      expect(getContextVariable("foo")).toEqual("bar");
+      setContextVariable("foo", "baz");
+      const greetOne = await aiGreet(lastMsg, "David");
+
+      return [greetOne];
+    });
+
+    await root.invoke([new HumanMessage({ content: "Hello!" })]);
+
+    const relevantCalls = fetchMock.mock.calls.filter((call: any) => {
+      return call[0].startsWith("https://api.smith.langchain.com/runs");
+    });
+
+    expect(relevantCalls.length).toEqual(4);
+    const firstCallParams = JSON.parse((relevantCalls[0][1] as any).body);
+    const secondCallParams = JSON.parse((relevantCalls[1][1] as any).body);
+    const thirdCallParams = JSON.parse((relevantCalls[2][1] as any).body);
+    const fourthCallParams = JSON.parse((relevantCalls[3][1] as any).body);
+    expect(firstCallParams).toMatchObject({
+      id: firstCallParams.id,
+      name: "RunnableLambda",
+      start_time: expect.any(Number),
+      serialized: {
+        lc: 1,
+        type: "not_implemented",
+        id: ["langchain_core", "runnables", "RunnableLambda"],
+      },
+      events: [{ name: "start", time: expect.any(String) }],
+      inputs: {
+        input: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+        ],
+      },
+      execution_order: 1,
+      child_execution_order: 1,
+      run_type: "chain",
+      extra: expect.any(Object),
+      tags: [],
+      trace_id: firstCallParams.id,
+      dotted_order: expect.any(String),
+    });
+    expect(secondCallParams).toMatchObject({
+      id: expect.any(String),
+      name: "aiGreet",
+      start_time: expect.any(Number),
+      run_type: "chain",
+      extra: expect.any(Object),
+      serialized: {},
+      inputs: {
+        args: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+          "David",
+        ],
+      },
+      child_runs: [],
+      parent_run_id: firstCallParams.id,
+      trace_id: firstCallParams.id,
+      dotted_order: expect.stringContaining(`${firstCallParams.dotted_order}.`),
+      tags: [],
+    });
+    expect(thirdCallParams).toMatchObject({
+      end_time: expect.any(Number),
+      inputs: {
+        args: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+          "David",
+        ],
+      },
+      outputs: { outputs: "Hello!David" },
+      parent_run_id: firstCallParams.id,
+      extra: expect.any(Object),
+      dotted_order: secondCallParams.dotted_order,
+      trace_id: firstCallParams.id,
+      tags: [],
+    });
+    expect(fourthCallParams).toMatchObject({
+      end_time: expect.any(Number),
+      outputs: { output: ["Hello!David"] },
+      events: [
+        { name: "start", time: expect.any(String) },
+        { name: "end", time: expect.any(String) },
+      ],
+      inputs: {
+        input: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+        ],
+      },
+      trace_id: firstCallParams.id,
+      dotted_order: firstCallParams.dotted_order,
+    });
+  }
+);
+
+test.each(["true", "false"])(
   "streaming traceables nested within runnables with background callbacks %s",
   async (value) => {
     process.env.LANGCHAIN_CALLBACKS_BACKGROUND = value;
@@ -330,6 +479,153 @@ test.each(["true", "false"])(
     const aiGreet = traceable(
       async (msg: BaseMessage, name = "world") => {
         const contents = await nested.invoke([msg]);
+        return contents[0] + name;
+      },
+      { name: "aiGreet", tracingEnabled: true }
+    );
+
+    await aiGreet(new HumanMessage({ content: "Hello!" }), "mitochondria");
+
+    const relevantCalls = fetchMock.mock.calls.filter((call: any) => {
+      return call[0].startsWith("https://api.smith.langchain.com/runs");
+    });
+
+    expect(relevantCalls.length).toEqual(4);
+    const firstCallParams = JSON.parse((relevantCalls[0][1] as any).body);
+    const secondCallParams = JSON.parse((relevantCalls[1][1] as any).body);
+    const thirdCallParams = JSON.parse((relevantCalls[2][1] as any).body);
+    const fourthCallParams = JSON.parse((relevantCalls[3][1] as any).body);
+    expect(firstCallParams).toMatchObject({
+      id: firstCallParams.id,
+      name: "aiGreet",
+      start_time: expect.any(Number),
+      run_type: "chain",
+      extra: expect.any(Object),
+      serialized: {},
+      inputs: {
+        args: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+          "mitochondria",
+        ],
+      },
+      child_runs: [],
+      trace_id: firstCallParams.id,
+      dotted_order: firstCallParams.dotted_order,
+      tags: [],
+    });
+    expect(secondCallParams).toMatchObject({
+      id: secondCallParams.id,
+      name: "RunnableLambda",
+      parent_run_id: firstCallParams.id,
+      start_time: expect.any(Number),
+      serialized: {
+        lc: 1,
+        type: "not_implemented",
+        id: ["langchain_core", "runnables", "RunnableLambda"],
+      },
+      events: [{ name: "start", time: expect.any(String) }],
+      inputs: {
+        input: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+        ],
+      },
+      execution_order: 2,
+      child_execution_order: 2,
+      run_type: "chain",
+      extra: expect.any(Object),
+      tags: [],
+      trace_id: firstCallParams.id,
+      dotted_order: expect.stringContaining(`${firstCallParams.dotted_order}.`),
+    });
+    expect(thirdCallParams).toMatchObject({
+      end_time: expect.any(Number),
+      outputs: { output: ["Hello!"] },
+      events: [
+        { name: "start", time: expect.any(String) },
+        { name: "end", time: expect.any(String) },
+      ],
+      inputs: {
+        input: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+        ],
+      },
+      trace_id: firstCallParams.id,
+      dotted_order: expect.stringContaining(`${firstCallParams.dotted_order}.`),
+      parent_run_id: firstCallParams.id,
+    });
+    expect(fourthCallParams).toMatchObject({
+      end_time: expect.any(Number),
+      inputs: {
+        args: [
+          {
+            lc: 1,
+            type: "constructor",
+            id: ["langchain_core", "messages", "HumanMessage"],
+            kwargs: {
+              content: "Hello!",
+              additional_kwargs: {},
+              response_metadata: {},
+            },
+          },
+          "mitochondria",
+        ],
+      },
+      outputs: { outputs: "Hello!mitochondria" },
+      extra: expect.any(Object),
+      dotted_order: firstCallParams.dotted_order,
+      trace_id: firstCallParams.id,
+      tags: [],
+    });
+  }
+);
+
+test.each(["true", "false"])(
+  "runnables nested within traceables and a context var set with background callbacks %s",
+  async (value) => {
+    const { setContextVariable, getContextVariable } = await import(
+      "../../context.js"
+    );
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = value;
+    setContextVariable("foo", "bar");
+
+    const nested = RunnableLambda.from(async (messages: BaseMessage[]) => {
+      const lastMsg = messages.at(-1) as HumanMessage;
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(getContextVariable("foo")).toEqual("bar");
+      return [lastMsg.content];
+    });
+
+    const aiGreet = traceable(
+      async (msg: BaseMessage, name = "world") => {
+        const contents = await nested.invoke([msg]);
+        expect(getContextVariable("foo")).toEqual("bar");
         return contents[0] + name;
       },
       { name: "aiGreet", tracingEnabled: true }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12000,7 +12000,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.12
-    langsmith: ^0.1.56
+    langsmith: ^0.1.64
     ml-matrix: ^6.10.4
     mustache: ^4.2.0
     p-queue: ^6.6.2
@@ -32819,6 +32819,25 @@ __metadata:
     openai:
       optional: true
   checksum: 61db6dc3016e35d14d25e78a8ecebcc6356f2efc00310f5582dce9d28a88377525425622d1b98f053e73c0b3233d44c5a2f9d5654ca72ee2e61163edd5be2d28
+  languageName: node
+  linkType: hard
+
+"langsmith@npm:^0.1.64":
+  version: 0.1.64
+  resolution: "langsmith@npm:0.1.64"
+  dependencies:
+    "@types/uuid": ^10.0.0
+    commander: ^10.0.1
+    p-queue: ^6.6.2
+    p-retry: 4
+    semver: ^7.6.3
+    uuid: ^10.0.0
+  peerDependencies:
+    openai: "*"
+  peerDependenciesMeta:
+    openai:
+      optional: true
+  checksum: 91b2dd6f029617944ba5b9dc9b9b6e9678ca3c2b7ea03e9bff5413c29153d57140867647f3ede5f84db1299d9c6db9deb92c433bbb9f6b6bf198baa007292ada
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12000,7 +12000,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.12
-    langsmith: ^0.1.64
+    langsmith: ^0.1.65
     ml-matrix: ^6.10.4
     mustache: ^4.2.0
     p-queue: ^6.6.2
@@ -32822,9 +32822,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"langsmith@npm:^0.1.64":
-  version: 0.1.64
-  resolution: "langsmith@npm:0.1.64"
+"langsmith@npm:^0.1.65":
+  version: 0.1.65
+  resolution: "langsmith@npm:0.1.65"
   dependencies:
     "@types/uuid": ^10.0.0
     commander: ^10.0.1
@@ -32837,7 +32837,7 @@ __metadata:
   peerDependenciesMeta:
     openai:
       optional: true
-  checksum: 91b2dd6f029617944ba5b9dc9b9b6e9678ca3c2b7ea03e9bff5413c29153d57140867647f3ede5f84db1299d9c6db9deb92c433bbb9f6b6bf198baa007292ada
+  checksum: ca44f26733fbb20675b84f2586b90622b8cf1aedc82123f5574af04e88ba29348e28b2b63f410479aeb7e5c174d2fef13b4bd9eb68581d93a104950b1fafa40f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Modifies the `RunTree` object to maintain backwards compatibility with older LangSmith instances