### PR TITLE
fix(docs): usage web-streams-polyfill

### DIFF
--- a/docs/core_docs/docs/how_to/installation.mdx
+++ b/docs/core_docs/docs/how_to/installation.mdx
@@ -270,13 +270,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill@3
+npm i web-streams-polyfill@4
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill";
+import "web-streams-polyfill/polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/docs/core_docs/docs/how_to/installation.mdx
+++ b/docs/core_docs/docs/how_to/installation.mdx
@@ -270,13 +270,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill
+npm i web-streams-polyfill@3
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill/es6";
+import "web-streams-polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -68,7 +68,7 @@
     "rimraf": "^5.0.1",
     "ts-jest": "^29.1.0",
     "typescript": "~5.1.6",
-    "web-streams-polyfill": "^3.3.3"
+    "web-streams-polyfill": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/langchain-core/src/utils/tests/polyfill_stream.test.ts
+++ b/langchain-core/src/utils/tests/polyfill_stream.test.ts
@@ -1,4 +1,4 @@
-import "web-streams-polyfill";
+import "web-streams-polyfill/polyfill";
 import { test, expect } from "@jest/globals";
 import { FakeStreamingLLM } from "../testing/index.js";
 import { StringOutputParser } from "../../output_parsers/string.js";

--- a/libs/langchain-scripts/src/tests/__mdx__/modules/index.mdx
+++ b/libs/langchain-scripts/src/tests/__mdx__/modules/index.mdx
@@ -224,13 +224,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill
+npm i web-streams-polyfill@3
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill/es6";
+import "web-streams-polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/libs/langchain-scripts/src/tests/__mdx__/modules/index.mdx
+++ b/libs/langchain-scripts/src/tests/__mdx__/modules/index.mdx
@@ -224,13 +224,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill@3
+npm i web-streams-polyfill@4
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill";
+import "web-streams-polyfill/polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/libs/langchain-scripts/src/tests/__mdx__/modules/two.mdx
+++ b/libs/langchain-scripts/src/tests/__mdx__/modules/two.mdx
@@ -223,13 +223,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill
+npm i web-streams-polyfill@3
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill/es6";
+import "web-streams-polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/libs/langchain-scripts/src/tests/__mdx__/modules/two.mdx
+++ b/libs/langchain-scripts/src/tests/__mdx__/modules/two.mdx
@@ -223,13 +223,13 @@ You will have to make `fetch` available globally, either:
 You'll also need to [polyfill `ReadableStream`](https://www.npmjs.com/package/web-streams-polyfill) by installing:
 
 ```bash npm2yarn
-npm i web-streams-polyfill@3
+npm i web-streams-polyfill@4
 ```
 
 And then adding it to the global namespace in your main entrypoint:
 
 ```typescript
-import "web-streams-polyfill";
+import "web-streams-polyfill/polyfill";
 ```
 
 Additionally you'll have to polyfill `structuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).

--- a/yarn.lock
+++ b/yarn.lock
@@ -12011,7 +12011,7 @@ __metadata:
     ts-jest: ^29.1.0
     typescript: ~5.1.6
     uuid: ^10.0.0
-    web-streams-polyfill: ^3.3.3
+    web-streams-polyfill: ^4.0.0
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.3
   languageName: unknown
@@ -42866,13 +42866,6 @@ __metadata:
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
-  languageName: node
-  linkType: hard
-
-"web-streams-polyfill@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "web-streams-polyfill@npm:3.3.3"
-  checksum: 21ab5ea08a730a2ef8023736afe16713b4f2023ec1c7085c16c8e293ee17ed085dff63a0ad8722da30c99c4ccbd4ccd1b2e79c861829f7ef2963d7de7004c2cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
it is useless when `import "web-streams-polyfill/es6"` ，When `web-streams-polyfill` is at version 3, 

it should be referenced like in the file `langchain-core\src\utils\tests\polyfill_stream.test.ts`. That is, import "web-streams-polyfill".

![usage_polyfill](https://github.com/user-attachments/assets/76ca8ee5-18ef-465f-99e3-09e747501cfb)
