### PR TITLE
feat(community): Add Origin/langchain to Apify's client's user-agent to attribute API activity to langchainhs

### DIFF
--- a/docs/core_docs/docs/integrations/document_loaders/web_loaders/apify_dataset.mdx
+++ b/docs/core_docs/docs/integrations/document_loaders/web_loaders/apify_dataset.mdx
@@ -10,7 +10,7 @@ This guide shows how to use [Apify](https://apify.com) with LangChain to load do
 ## Overview
 
 [Apify](https://apify.com) is a cloud platform for web scraping and data extraction,
-which provides an [ecosystem](https://apify.com/store) of more than a thousand
+which provides an [ecosystem](https://apify.com/store) of more than two thousand
 ready-made apps called _Actors_ for various web scraping, crawling, and data extraction use cases.
 
 This guide shows how to load documents
@@ -19,11 +19,14 @@ storage built for storing structured web scraping results,
 such as a list of products or Google SERPs, and then export them to various
 formats like JSON, CSV, or Excel.
 
-Datasets are typically used to save results of Actors.
+Datasets are typically used to save results of different Actors.
 For example, [Website Content Crawler](https://apify.com/apify/website-content-crawler) Actor
 deeply crawls websites such as documentation, knowledge bases, help centers, or blogs,
 and then stores the text content of webpages into a dataset,
-from which you can feed the documents into a vector index and answer questions from it.
+from which you can feed the documents into a vector database and use it for information retrieval.
+Another example is the [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor,
+which queries Google Search, scrapes the top N pages from the results, and returns the cleaned
+content in Markdown format for further processing by a large language model.
 
 ## Setup
 
@@ -38,18 +41,21 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 <IntegrationInstallTooltip></IntegrationInstallTooltip>
 
 ```bash npm2yarn
-npm install @langchain/openai @langchain/community @langchain/core
+npm install hnswlib-node @langchain/openai @langchain/community @langchain/core
 ```
 
-You'll also need to sign up and retrieve your [Apify API token](https://console.apify.com/account/integrations).
+You'll also need to sign up and retrieve your [Apify API token](https://console.apify.com/settings/integrations).
 
 ## Usage
 
-### From a New Dataset
+### From a New Dataset (Crawl a Website and Store the data in Apify Dataset)
 
 If you don't already have an existing dataset on the Apify platform, you'll need to initialize the document loader by calling an Actor and waiting for the results.
+In the example below, we use the [Website Content Crawler](https://apify.com/apify/website-content-crawler) Actor to crawl
+LangChain documentation, store the results in Apify Dataset, and then load the dataset using the `ApifyDatasetLoader`.
+For this demonstration, we'll use a fast Cheerio crawler type and limit the number of crawled pages to 10.
 
-**Note:** Calling an Actor can take a significant amount of time, on the order of hours, or even days for large sites!
+**Note:** Running the Website Content Crawler may take some time, depending on the size of the website. For large sites, it can take several hours or even days!
 
 Here's an example:
 
@@ -60,7 +66,7 @@ import NewExample from "@examples/document_loaders/apify_dataset_new.ts";
 
 ## From an Existing Dataset
 
-If you already have an existing dataset on the Apify platform, you can initialize the document loader with the constructor directly:
+If you've already run an Actor and have an existing dataset on the Apify platform, you can initialize the document loader directly using the constructor
 
 import ExistingExample from "@examples/document_loaders/apify_dataset_existing.ts";
 

--- a/examples/src/document_loaders/apify_dataset_existing.ts
+++ b/examples/src/document_loaders/apify_dataset_existing.ts
@@ -1,3 +1,4 @@
+import { ApifyDatasetLoader } from "@langchain/community/document_loaders/web/apify_dataset";
 import { HNSWLib } from "@langchain/community/vectorstores/hnswlib";
 import { OpenAIEmbeddings, ChatOpenAI } from "@langchain/openai";
 import { Document } from "@langchain/core/documents";

--- a/examples/src/document_loaders/apify_dataset_existing.ts
+++ b/examples/src/document_loaders/apify_dataset_existing.ts
@@ -1,10 +1,12 @@
-import { ApifyDatasetLoader } from "@langchain/community/document_loaders/web/apify_dataset";
 import { HNSWLib } from "@langchain/community/vectorstores/hnswlib";
 import { OpenAIEmbeddings, ChatOpenAI } from "@langchain/openai";
 import { Document } from "@langchain/core/documents";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { createRetrievalChain } from "langchain/chains/retrieval";
 import { createStuffDocumentsChain } from "langchain/chains/combine_documents";
+
+const APIFY_API_TOKEN = "YOUR-APIFY-API-TOKEN"; // or set as process.env.APIFY_API_TOKEN
+const OPENAI_API_KEY = "YOUR-OPENAI-API-KEY"; // or set as process.env.OPENAI_API_KEY
 
 /*
  * datasetMappingFunction is a function that maps your Apify dataset format to LangChain documents.
@@ -21,16 +23,20 @@ const loader = new ApifyDatasetLoader("your-dataset-id", {
       metadata: { source: item.url },
     }),
   clientOptions: {
-    token: "your-apify-token", // Or set as process.env.APIFY_API_TOKEN
+    token: APIFY_API_TOKEN,
   },
 });
 
 const docs = await loader.load();
 
-const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
+const vectorStore = await HNSWLib.fromDocuments(
+  docs,
+  new OpenAIEmbeddings({ apiKey: OPENAI_API_KEY })
+);
 
 const model = new ChatOpenAI({
   temperature: 0,
+  apiKey: OPENAI_API_KEY,
 });
 
 const questionAnsweringPrompt = ChatPromptTemplate.fromMessages([

--- a/examples/src/document_loaders/apify_dataset_new.ts
+++ b/examples/src/document_loaders/apify_dataset_new.ts
@@ -6,6 +6,9 @@ import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { createStuffDocumentsChain } from "langchain/chains/combine_documents";
 import { createRetrievalChain } from "langchain/chains/retrieval";
 
+const APIFY_API_TOKEN = "YOUR-APIFY-API-TOKEN"; // or set as process.env.APIFY_API_TOKEN
+const OPENAI_API_KEY = "YOUR-OPENAI-API-KEY"; // or set as process.env.OPENAI_API_KEY
+
 /*
  * datasetMappingFunction is a function that maps your Apify dataset format to LangChain documents.
  * In the below example, the Apify dataset format looks like this:
@@ -17,6 +20,8 @@ import { createRetrievalChain } from "langchain/chains/retrieval";
 const loader = await ApifyDatasetLoader.fromActorCall(
   "apify/website-content-crawler",
   {
+    maxCrawlPages: 10,
+    crawlerType: "cheerio",
     startUrls: [{ url: "https://js.langchain.com/docs/" }],
   },
   {
@@ -26,17 +31,21 @@ const loader = await ApifyDatasetLoader.fromActorCall(
         metadata: { source: item.url },
       }),
     clientOptions: {
-      token: "your-apify-token", // Or set as process.env.APIFY_API_TOKEN
+      token: APIFY_API_TOKEN,
     },
   }
 );
 
 const docs = await loader.load();
 
-const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
+const vectorStore = await HNSWLib.fromDocuments(
+  docs,
+  new OpenAIEmbeddings({ apiKey: OPENAI_API_KEY })
+);
 
 const model = new ChatOpenAI({
   temperature: 0,
+  apiKey: OPENAI_API_KEY,
 });
 
 const questionAnsweringPrompt = ChatPromptTemplate.fromMessages([


### PR DESCRIPTION
- Add Origin/langchain to Apify's client's user-agent to attribute API activity to LangChain (at Apify, we aim to monitor our integrations to evaluate whether we should invest more in the LangChainjs integration regarding functionality and content).
- Fix issues in documentation (and improve content)
