### PR TITLE
fix(core): Handle empty model output in memory

### DIFF
--- a/langchain-core/src/memory.ts
+++ b/langchain-core/src/memory.ts
@@ -90,7 +90,7 @@ export const getOutputValue = (
   outputKey?: string
 ) => {
   const value = getValue(outputValues, outputKey);
-  if (!value) {
+  if (!value && value !== "") {
     const keys = Object.keys(outputValues);
     throw new Error(
       `output values have ${keys.length} keys, you must specify an output key or pass only 1 key as output`

--- a/langchain/src/memory/tests/buffer_window_memory.test.ts
+++ b/langchain/src/memory/tests/buffer_window_memory.test.ts
@@ -47,10 +47,3 @@ test("Test buffer window memory with pre-loaded history", async () => {
   const result = await memory.loadMemoryVariables({});
   expect(result).toStrictEqual({ history: pastMessages });
 });
-
-test("Test buffer window memory with empty output", async () => {
-  const memory = new BufferWindowMemory({ k: 1 });
-  await memory.saveContext({ input: "foo" }, { output: "" });
-  const result = await memory.loadMemoryVariables({});
-  expect(result).toStrictEqual({ history: "Human: foo\nAI: " });
-});

--- a/langchain/src/memory/tests/buffer_window_memory.test.ts
+++ b/langchain/src/memory/tests/buffer_window_memory.test.ts
@@ -47,3 +47,10 @@ test("Test buffer window memory with pre-loaded history", async () => {
   const result = await memory.loadMemoryVariables({});
   expect(result).toStrictEqual({ history: pastMessages });
 });
+
+test("Test buffer window memory with empty output", async () => {
+  const memory = new BufferWindowMemory({ k: 1 });
+  await memory.saveContext({ input: "foo" }, { output: "" });
+  const result = await memory.loadMemoryVariables({});
+  expect(result).toStrictEqual({ history: "Human: foo\nAI: " });
+});


### PR DESCRIPTION
## Summary

This PR addresses the issue that happens when a model is used together with a memory, and LLM produces an empty output (empty string).

Because of the coercion to boolean, saving the history to memory fails when the output is an empty string:
https://github.com/langchain-ai/langchainjs/blob/391bc4645036fd0c2c41b5ed35236919732edf2a/langchain-core/src/memory.ts#L93C1-L98C4

Here is the minimal reproducible example:
```js
const { ChatOpenAI } = require("@langchain/openai");
const { initializeAgentExecutorWithOptions } = require("langchain/agents");
const { SerpAPI } = require("langchain/tools");
const { Calculator } = require("@langchain/community/tools/calculator");
const { BufferMemory } = require("langchain/memory");

// Initialize the language model
const model = new ChatOpenAI({ temperature: 0, model: 'gpt-4o-mini' });

// Define tools
const tools = [
  new Calculator(),
];

// Initialize memory
const memory = new BufferMemory({
  memoryKey: "chat_history",
  returnMessages: true,
});

async function main() {
  // Initialize the agent
  const executor = await initializeAgentExecutorWithOptions(tools, model, {
    agentType: "chat-conversational-react-description",
    verbose: true,
    memory: memory,
  });

  // Run the agent
  const result1 = await executor.call({
    input: "Answer with an empty string without any explanations and without any additional characters",
  });
  console.log(result1.output);
}

main().catch(console.error);
```

It throws an exception: `Error: output values have 1 keys, you must specify an output key or pass only 1 key as output`

## Related issues
- https://github.com/langchain-ai/langchainjs/issues/5128
