### PR TITLE
feat: setenv fn used to configure Transformers.js env

### DIFF
--- a/libs/langchain-community/src/embeddings/hf_transformers.ts
+++ b/libs/langchain-community/src/embeddings/hf_transformers.ts
@@ -3,6 +3,7 @@ import type {
   FeatureExtractionPipelineOptions,
   FeatureExtractionPipeline,
 } from "@xenova/transformers";
+import { env } from "@xenova/transformers";
 import { Embeddings, type EmbeddingsParams } from "@langchain/core/embeddings";
 import { chunkArray } from "@langchain/core/utils/chunk_array";
 
@@ -94,6 +95,15 @@ export class HuggingFaceTransformersEmbeddings
       normalize: true,
       ...fields?.pipelineOptions,
     };
+  }
+
+  /**
+   * Transformers env config function
+   */
+  setEnv:((envKey: keyof typeof env, envValue: any) => void) = (
+    envKey,envValue
+  )=>{
+    (env as Record<keyof typeof env, any>)[envKey] = envValue
   }
 
   async embedDocuments(texts: string[]): Promise<number[][]> {


### PR DESCRIPTION
refer:https://huggingface.co/docs/transformers.js/main/en/api/env#env

When I want to set the cache configuration of the transformer, I find that there seems to be a lack of methods to change the configuration of `Transformers.js`

usage
```js
let hgEmbeddings= new HuggingFaceTransformersEmbeddings({ model: "Xenova/all-MiniLM-L6-v2" })
hgEmbeddings.setEnv(KEY,VALUE)
```
