### PR TITLE
feat(community): ElasticVectorSearch: add a not_exists filter 

### DIFF
--- a/libs/langchain-community/src/vectorstores/elasticsearch.ts
+++ b/libs/langchain-community/src/vectorstores/elasticsearch.ts
@@ -342,6 +342,12 @@ export class ElasticVectorSearch extends VectorStore {
             field: metadataField,
           },
         });
+      } else if (condition.operator === "not_exists") {
+        must_not.push({
+          exists: {
+            field: metadataField,
+          },
+        });
       } else if (condition.operator === "exclude") {
         const toExclude = { [metadataField]: condition.value };
         must_not.push({

--- a/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/elasticsearch.int.test.ts
@@ -101,8 +101,8 @@ describe("ElasticVectorSearch", () => {
       { pageContent: "responsible", metadata: { a: createdAt } },
       { pageContent: "friendly", metadata: { a: createdAt } },
       { pageContent: "confident", metadata: { a: createdAt } },
-      { pageContent: "generous", metadata: { a: createdAt } },
-      { pageContent: "compassionate", metadata: { a: createdAt } },
+      { pageContent: "generous", metadata: { a: null } },
+      { pageContent: "compassionate", metadata: {} },
     ]);
     const results = await store.similaritySearch("*", 11);
     expect(results).toHaveLength(11);
@@ -113,7 +113,7 @@ describe("ElasticVectorSearch", () => {
         operator: "exclude",
       },
     ]);
-    expect(results2).toHaveLength(1);
+    expect(results2).toHaveLength(3);
     const results3 = await store.similaritySearch("*", 11, [
       {
         field: "a",
@@ -121,7 +121,14 @@ describe("ElasticVectorSearch", () => {
         operator: "exclude",
       },
     ]);
-    expect(results3).toHaveLength(1);
+    expect(results3).toHaveLength(3);
+    const results4 = await store.similaritySearch("*", 11, [
+      {
+        field: "a",
+        operator: "not_exists",
+      },
+    ]);
+    expect(results4).toHaveLength(2);
   });
 
   test.skip("ElasticVectorSearch integration with text splitting metadata", async () => {


### PR DESCRIPTION
We have recently implemented a new functionality in our application where the customer is able to archive items.
As we want to exclude archived items by default from our vectorstore search we need a filter to add a statement to the must_not  filtering being a must_not exists and then we pass ```{ field: 'archivedAt', operator: 'not_exists' }``` .
If we then want to include archived items later one, we can just not pass this filter.

I think by adding this custom check, we add a lot of flexibility to the similarity search as well.