### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/core_docs/docs/introduction.mdx
+++ b/docs/core_docs/docs/introduction.mdx
@@ -71,7 +71,7 @@ For a deeper dive into LangGraph concepts, check out [this page](https://langcha
 
 ## [API reference](https://api.js.langchain.com)
 
-Head to the reference section for full documentation of all classes and methods in the LangChain Python packages.
+Head to the reference section for full documentation of all classes and methods in the LangChain JavaScript packages.
 
 ## Ecosystem
 


### PR DESCRIPTION
Noticed a place in the docs where it references "Python" instead of "JavaScript", thought I'd submit a quick PR to fix it.

Thanks!