### PR TITLE
API Reference: Examples for Runnables

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -1181,6 +1181,40 @@ export type RunnableBindingArgs<
 
 /**
  * A runnable that delegates calls to another runnable with a set of kwargs.
+ * @example
+ * ```typescript
+ * import { type RunnableConfig, RunnableLambda } from "@langchain/core/runnables";
+ *
+ * const enhanceProfile = (
+ *   profile: Record<string, any>,
+ *   config?: RunnableConfig
+ * ) => {
+ *   if (config?.configurable?.role) {
+ *     return { ...profile, role: config.configurable.role };
+ *   }
+ *   return profile;
+ * };
+ *
+ * const runnable = RunnableLambda.from(enhanceProfile);
+ *
+ * // Bind configuration to the runnable to set the user's role dynamically
+ * const adminRunnable = runnable.bind({ configurable: { role: "Admin" } });
+ * const userRunnable = runnable.bind({ configurable: { role: "User" } });
+ *
+ * adminRunnable
+ *   .invoke({ name: "Alice", email: "alice@example.com" })
+ *   .then((result) => {
+ *     console.log(result);
+ *     // Output: { name: "Alice", email: "alice@example.com", role: "Admin" }
+ *   });
+ *
+ * userRunnable
+ *   .invoke({ name: "Bob", email: "bob@example.com" })
+ *   .then((result) => {
+ *     console.log(result);
+ *     // Output: { name: "Bob", email: "bob@example.com", role: "User" }
+ *   });
+ * ```
  */
 export class RunnableBinding<
   RunInput,
@@ -1432,6 +1466,25 @@ export class RunnableBinding<
 /**
  * A runnable that delegates calls to another runnable
  * with each element of the input sequence.
+ * @example
+ * ```typescript
+ * import { RunnableEach, RunnableLambda } from "@langchain/core/runnables";
+ *
+ * const toUpperCase = (input: string): string => input.toUpperCase();
+ * const addGreeting = (input: string): string => `Hello, ${input}!`;
+ *
+ * const upperCaseLambda = RunnableLambda.from(toUpperCase);
+ * const greetingLambda = RunnableLambda.from(addGreeting);
+ *
+ * const chain = new RunnableEach({
+ *   bound: upperCaseLambda.pipe(greetingLambda),
+ * });
+ *
+ * chain.invoke(["alice", "bob", "carol"]).then((result) => {
+ *   console.log(result);
+ *   // Output: ["Hello, ALICE!", "Hello, BOB!", "Hello, CAROL!"]
+ * });
+ * ```
  */
 export class RunnableEach<
   RunInputItem,
@@ -1526,6 +1579,48 @@ export class RunnableEach<
 /**
  * Base class for runnables that can be retried a
  * specified number of times.
+ * @example
+ * ```typescript
+ * import { RunnableLambda, RunnableRetry } from "@langchain/core/runnables";
+ *
+ * // Simulate an API call that fails randomly
+ * const simulateApiCall = (input: string): string => {
+ *   console.log(`Attempting API call with input: ${input}`);
+ *   throw new Error("API call failed due to network issue");
+ * };
+ *
+ * const apiCallLambda = RunnableLambda.from(simulateApiCall);
+ *
+ * // Apply retry logic using the .withRetry() method
+ * const apiCallWithRetry = apiCallLambda.withRetry({ stopAfterAttempt: 3 });
+ *
+ * // Alternatively, create a RunnableRetry instance manually
+ * const manualRetry = new RunnableRetry({
+ *   bound: apiCallLambda,
+ *   maxAttemptNumber: 3,
+ *   config: {},
+ * });
+ *
+ * // Example invocation using the .withRetry() method
+ * apiCallWithRetry
+ *   .invoke("Request 1")
+ *   .then((result) => {
+ *     console.log(result);
+ *   })
+ *   .catch((error) => {
+ *     console.error("Failed after multiple retries:", error.message);
+ *   });
+ *
+ * // Example invocation using the manual retry instance
+ * manualRetry
+ *   .invoke("Request 2")
+ *   .then((result) => {
+ *     console.log(result);
+ *   })
+ *   .catch((error) => {
+ *     console.error("Failed after multiple retries:", error.message);
+ *   });
+ * ```
  */
 export class RunnableRetry<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2303,6 +2398,28 @@ function assertNonTraceableFunction<
 
 /**
  * A runnable that runs a callable.
+ * @example
+ * ```typescript
+ * import { RunnableLambda } from "@langchain/core/runnables";
+ *
+ * const add = (input: { x: number; y: number }) => input.x + input.y;
+ * const multiply = (input: { value: number; multiplier: number }) =>
+ *   input.value * input.multiplier;
+ *
+ * // Create runnables for the functions
+ * const addLambda = RunnableLambda.from(add);
+ * const multiplyLambda = RunnableLambda.from(multiply);
+ *
+ * // Chain the lambdas for a mathematical operation
+ * const chainedLambda = addLambda.pipe((result) =>
+ *   multiplyLambda.invoke({ value: result, multiplier: 2 })
+ * );
+ *
+ * // Example invocation of the chainedLambda
+ * chainedLambda.invoke({ x: 2, y: 3 }).then((result) => {
+ *   console.log(result); // Output: 10 (since (2 + 3) * 2 = 10)
+ * });
+ * ```
  */
 export class RunnableLambda<
   RunInput,
@@ -2579,6 +2696,43 @@ export class RunnableLambda<
   }
 }
 
+/**
+ * @example
+ * ```typescript
+ * import { RunnableLambda, RunnableParallel } from "@langchain/core/runnables";
+ *
+ * const addYears = (age: number): number => age + 5;
+ * const yearsToFifty = (age: number): number => 50 - age;
+ * const yearsToHundred = (age: number): number => 100 - age;
+ *
+ * const addYearsLambda = RunnableLambda.from(addYears);
+ * const milestoneFiftyLambda = RunnableLambda.from(yearsToFifty);
+ * const milestoneHundredLambda = RunnableLambda.from(yearsToHundred);
+ *
+ * const sequence = addYearsLambda.pipe(
+ *   RunnableParallel.from({
+ *     years_to_fifty: milestoneFiftyLambda,
+ *     years_to_hundred: milestoneHundredLambda,
+ *   })
+ * );
+ *
+ * // Invoke the sequence with a single age input
+ * sequence.invoke(25).then((result) => {
+ *   console.log(result);
+ *   // Output: { years_to_fifty: 20, years_to_hundred: 70 }
+ * });
+ *
+ * // Batch processing with multiple age inputs
+ * sequence.batch([25, 35, 45]).then((results) => {
+ *   console.log(results);
+ *   // Output: [
+ *   //   { years_to_fifty: 20, years_to_hundred: 70 },
+ *   //   { years_to_fifty: 10, years_to_hundred: 60 },
+ *   //   { years_to_fifty: 0, years_to_hundred: 50 }
+ *   // ]
+ * });
+ * ```
+ */
 export class RunnableParallel<RunInput> extends RunnableMap<RunInput> {}
 
 /**
@@ -2599,6 +2753,59 @@ export class RunnableParallel<RunInput> extends RunnableMap<RunInput> {}
  * When streaming, fallbacks will only be called on failures during the initial
  * stream creation. Errors that occur after a stream starts will not fallback
  * to the next Runnable.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   RunnableLambda,
+ *   RunnableWithFallbacks,
+ * } from "@langchain/core/runnables";
+ *
+ * const primaryOperation = (input: string): string => {
+ *   if (input !== "safe") {
+ *     throw new Error("Primary operation failed due to unsafe input");
+ *   }
+ *   return `Processed: ${input}`;
+ * };
+ *
+ * // Define a fallback operation that processes the input differently
+ * const fallbackOperation = (input: string): string =>
+ *   `Fallback processed: ${input}`;
+ *
+ * const primaryRunnable = RunnableLambda.from(primaryOperation);
+ * const fallbackRunnable = RunnableLambda.from(fallbackOperation);
+ *
+ * // Apply the fallback logic using the .withFallbacks() method
+ * const runnableWithFallback = primaryRunnable.withFallbacks([fallbackRunnable]);
+ *
+ * // Alternatively, create a RunnableWithFallbacks instance manually
+ * const manualFallbackChain = new RunnableWithFallbacks({
+ *   runnable: primaryRunnable,
+ *   fallbacks: [fallbackRunnable],
+ * });
+ *
+ * // Example invocation using .withFallbacks()
+ * runnableWithFallback
+ *   .invoke("unsafe input")
+ *   .then((result) => {
+ *     console.log(result);
+ *     // Output: "Fallback processed: unsafe input"
+ *   })
+ *   .catch((error) => {
+ *     console.error("Failed after all attempts:", error.message);
+ *   });
+ *
+ * // Example invocation using manual instantiation
+ * manualFallbackChain
+ *   .invoke("safe")
+ *   .then((result) => {
+ *     console.log(result);
+ *     // Output: "Processed: safe"
+ *   })
+ *   .catch((error) => {
+ *     console.error("Failed after all attempts:", error.message);
+ *   });
+ * ```
  */
 export class RunnableWithFallbacks<RunInput, RunOutput> extends Runnable<
   RunInput,
@@ -2849,6 +3056,35 @@ export interface RunnableAssignFields<RunInput> {
 
 /**
  * A runnable that assigns key-value pairs to inputs of type `Record<string, unknown>`.
+ * @example
+ * ```typescript
+ * import {
+ *   RunnableAssign,
+ *   RunnableLambda,
+ *   RunnableParallel,
+ * } from "@langchain/core/runnables";
+ *
+ * const calculateAge = (x: { birthYear: number }): { age: number } => {
+ *   const currentYear = new Date().getFullYear();
+ *   return { age: currentYear - x.birthYear };
+ * };
+ *
+ * const createGreeting = (x: { name: string }): { greeting: string } => {
+ *   return { greeting: `Hello, ${x.name}!` };
+ * };
+ *
+ * const mapper = RunnableParallel.from({
+ *   age_step: RunnableLambda.from(calculateAge),
+ *   greeting_step: RunnableLambda.from(createGreeting),
+ * });
+ *
+ * const runnableAssign = new RunnableAssign({ mapper });
+ *
+ * runnableAssign.invoke({ name: "Alice", birthYear: 1990 }).then((result) => {
+ *   console.log(result);
+ *   // Output: { name: "Alice", birthYear: 1990, age_step: { age: 34 }, greeting_step: { greeting: "Hello, Alice!" } }
+ * });
+ * ```
  */
 export class RunnableAssign<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2963,6 +3199,27 @@ export interface RunnablePickFields {
 
 /**
  * A runnable that assigns key-value pairs to inputs of type `Record<string, unknown>`.
+ * @example
+ * ```typescript
+ * import { RunnablePick } from "@langchain/core/runnables";
+ *
+ * const inputData = {
+ *   name: "John",
+ *   age: 30,
+ *   city: "New York",
+ *   country: "USA",
+ *   email: "john.doe@example.com",
+ *   phone: "+1234567890",
+ * };
+ *
+ * const basicInfoRunnable = new RunnablePick(["name", "city"]);
+ *
+ * // Example invocation
+ * basicInfoRunnable.invoke(inputData).then((outputData) => {
+ *   console.log(outputData);
+ *   // Output: { name: 'John', city: 'New York' }
+ * });
+ * ```
  */
 export class RunnablePick<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/langchain-core/src/runnables/router.ts
+++ b/langchain-core/src/runnables/router.ts
@@ -11,6 +11,25 @@ export type RouterInput = {
 /**
  * A runnable that routes to a set of runnables based on Input['key'].
  * Returns the output of the selected runnable.
+ * @example
+ * ```typescript
+ * import { RouterRunnable, RunnableLambda } from "@langchain/core/runnables";
+ *
+ * const router = new RouterRunnable({
+ *   runnables: {
+ *     toUpperCase: RunnableLambda.from((text: string) => text.toUpperCase()),
+ *     reverseText: RunnableLambda.from((text: string) =>
+ *       text.split("").reverse().join("")
+ *     ),
+ *   },
+ * });
+ *
+ * // Invoke the 'reverseText' runnable
+ * const result1 = router.invoke({ key: "reverseText", input: "Hello World" }); // Output: "dlroW olleH"
+ *
+ * // Invoke the 'toUpperCase' runnable
+ * const result2 = router.invoke({ key: "toUpperCase", input: "Hello World" }); // Output: "HELLO WORLD"
+ * ```
  */
 export class RouterRunnable<
   RunInput extends RouterInput,


### PR DESCRIPTION
This pull request introduces updates to the API reference examples for a set of Runnable interfaces.
The API Reference page is missing examples for the following Runnables:

- RouterRunnable
- RunnableAssign
- RunnableBinding
- RunnableEach
- RunnableLambda
- RunnableParallel
- RunnablePick
- RunnableRetry
- RunnableWithFallbacks

All examples were tested and are working.
I've created a separate repo to illustrate it: [SkSirius/langchain-js-examples](https://github.com/SkSirius/langchain-js-examples)
