### PR TITLE
docs: Update pdf_qa.ipynb

### DIFF
--- a/docs/core_docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/core_docs/docs/tutorials/pdf_qa.ipynb
@@ -287,7 +287,7 @@
         "  [\"human\", \"{input}\"],\n",
         "]);\n",
         "\n",
-        "const questionAnswerChain = await createStuffDocumentsChain({ llm:model, prompt });\n",
+        "const questionAnswerChain = await createStuffDocumentsChain({ llm: model, prompt });\n",
         "const ragChain = await createRetrievalChain({ retriever, combineDocsChain: questionAnswerChain });\n",
         "\n",
         "const results = await ragChain.invoke({\n",

--- a/docs/core_docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/core_docs/docs/tutorials/pdf_qa.ipynb
@@ -287,7 +287,7 @@
         "  [\"human\", \"{input}\"],\n",
         "]);\n",
         "\n",
-        "const questionAnswerChain = await createStuffDocumentsChain({ model, prompt });\n",
+        "const questionAnswerChain = await createStuffDocumentsChain({ llm:model, prompt });\n",
         "const ragChain = await createRetrievalChain({ retriever, combineDocsChain: questionAnswerChain });\n",
         "\n",
         "const results = await ragChain.invoke({\n",

--- a/docs/core_docs/docs/tutorials/pdf_qa.ipynb
+++ b/docs/core_docs/docs/tutorials/pdf_qa.ipynb
@@ -287,7 +287,7 @@
         "  [\"human\", \"{input}\"],\n",
         "]);\n",
         "\n",
-        "const questionAnswerChain = await createStuffDocumentsChain({ llm, prompt });\n",
+        "const questionAnswerChain = await createStuffDocumentsChain({ model, prompt });\n",
         "const ragChain = await createRetrievalChain({ retriever, combineDocsChain: questionAnswerChain });\n",
         "\n",
         "const results = await ragChain.invoke({\n",


### PR DESCRIPTION
Refer the correct variable name

In the tutorial the, llm is instantiated under the variable name **`model`**. But while creating the createStuffDocumentsChain in the following steps, the variable name referred is `llm`.

The issue comes in because the variable llm exists in python documentation and the same is copied here in js documentation
Fixes # (issue)
