### PR TITLE
fix: structured output parser

### DIFF
--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -101,9 +101,9 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
    */
   async parse(text: string): Promise<z.infer<T>> {
     try {
-      const jsonRegex = /```(?:json)?\n([\s\S]*?)\n```/;
+      const jsonRegex = /{[\s\S]*}/;
       const match = text.match(jsonRegex);
-      const jsonString = match?.[1]?.trim() ?? text.trim();
+      const jsonString = match ? match[0] : text.trim();
       return await this.schema.parseAsync(JSON.parse(jsonString));
     } catch (e) {
       throw new OutputParserException(

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -101,10 +101,10 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
    */
   async parse(text: string): Promise<z.infer<T>> {
     try {
-      const json = text.includes("```")
-        ? text.trim().split(/```(?:json)?/)[1]
-        : text.trim();
-      return await this.schema.parseAsync(JSON.parse(json));
+      const jsonRegex = /```(?:json)?\n([\s\S]*?)\n```/;
+      const match = text.match(jsonRegex);
+      const jsonString = match?.[1]?.trim() ?? text.trim();
+      return await this.schema.parseAsync(JSON.parse(jsonString));
     } catch (e) {
       throw new OutputParserException(
         `Failed to parse. Text: "${text}". Error: ${e}`,


### PR DESCRIPTION
Fixes #([6734](https://github.com/langchain-ai/langchainjs/issues/6734))

1. Capture JSON object using outer curly brackets.
2. Fix existing integration tests