### PR TITLE
pinecone[patch]: Update `@pinecone/pinecone-database` version to resolve type errors

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -65,7 +65,7 @@
     "@langchain/yandex": "workspace:*",
     "@layerup/layerup-security": "^1.5.12",
     "@opensearch-project/opensearch": "^2.2.0",
-    "@pinecone-database/pinecone": "^3.0.0",
+    "@pinecone-database/pinecone": "^4.0.0",
     "@planetscale/database": "^1.8.0",
     "@prisma/client": "^4.11.0",
     "@qdrant/js-client-rest": "^1.9.0",

--- a/libs/langchain-pinecone/package.json
+++ b/libs/langchain-pinecone/package.json
@@ -32,7 +32,7 @@
   "author": "Pinecone, Inc",
   "license": "MIT",
   "dependencies": {
-    "@pinecone-database/pinecone": "^3.0.0",
+    "@pinecone-database/pinecone": "^4.0.0",
     "flat": "^5.0.2",
     "uuid": "^10.0.0"
   },

--- a/libs/langchain-pinecone/package.json
+++ b/libs/langchain-pinecone/package.json
@@ -32,7 +32,7 @@
   "author": "Pinecone, Inc",
   "license": "MIT",
   "dependencies": {
-    "@pinecone-database/pinecone": "^4.0.0",
+    "@pinecone-database/pinecone": "^3.0.0 || ^4.0.0",
     "flat": "^5.0.2",
     "uuid": "^10.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14121,19 +14121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pinecone-database/pinecone@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@pinecone-database/pinecone@npm:3.0.0"
-  dependencies:
-    "@sinclair/typebox": ^0.29.0
-    ajv: ^8.12.0
-    cross-fetch: ^3.1.5
-    encoding: ^0.1.13
-  checksum: 3803c6fead5343e495ccfe177793ed6f58411c2c5efdb1538cdcb0203164ebefb299ed30c8b9c1590d00cafb1dd20e2d06d6b0339159ea237d2939856f377ca9
-  languageName: node
-  linkType: hard
-
-"@pinecone-database/pinecone@npm:^3.0.0 || ^4.0.0":
+"@pinecone-database/pinecone@npm:^3.0.0 || ^4.0.0, @pinecone-database/pinecone@npm:^4.0.0":
   version: 4.0.0
   resolution: "@pinecone-database/pinecone@npm:4.0.0"
   dependencies:
@@ -27354,7 +27342,7 @@ __metadata:
     "@langchain/yandex": "workspace:*"
     "@layerup/layerup-security": ^1.5.12
     "@opensearch-project/opensearch": ^2.2.0
-    "@pinecone-database/pinecone": ^3.0.0
+    "@pinecone-database/pinecone": ^4.0.0
     "@planetscale/database": ^1.8.0
     "@prisma/client": ^4.11.0
     "@qdrant/js-client-rest": ^1.9.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -12574,7 +12574,7 @@ __metadata:
     "@langchain/core": "workspace:*"
     "@langchain/openai": "workspace:*"
     "@langchain/scripts": ">=0.1.0 <0.2.0"
-    "@pinecone-database/pinecone": ^3.0.0
+    "@pinecone-database/pinecone": ^4.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -14129,6 +14129,15 @@ __metadata:
     cross-fetch: ^3.1.5
     encoding: ^0.1.13
   checksum: 3803c6fead5343e495ccfe177793ed6f58411c2c5efdb1538cdcb0203164ebefb299ed30c8b9c1590d00cafb1dd20e2d06d6b0339159ea237d2939856f377ca9
+  languageName: node
+  linkType: hard
+
+"@pinecone-database/pinecone@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@pinecone-database/pinecone@npm:4.0.0"
+  dependencies:
+    encoding: ^0.1.13
+  checksum: 7523d7b8dc6a5d7b5d5cf37c97f6070112473f26d82aec23ca198554634e6bc0883866fcc9a8b2978e287daad8665085cef1d4f16d86a7ba0f8b623d88bdda54
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12574,7 +12574,7 @@ __metadata:
     "@langchain/core": "workspace:*"
     "@langchain/openai": "workspace:*"
     "@langchain/scripts": ">=0.1.0 <0.2.0"
-    "@pinecone-database/pinecone": ^4.0.0
+    "@pinecone-database/pinecone": ^3.0.0 || ^4.0.0
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -14132,7 +14132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pinecone-database/pinecone@npm:^4.0.0":
+"@pinecone-database/pinecone@npm:^3.0.0 || ^4.0.0":
   version: 4.0.0
   resolution: "@pinecone-database/pinecone@npm:4.0.0"
   dependencies:


### PR DESCRIPTION
Due to a recent `@pinecone/pinecone-database` release (`v4.0.0`), there is a type collision between `@langchain/pinecone` and `@pinecone/pinecone-database`, since `@langchain/pinecone` still uses `v3.0.0`.

Here is the issue in the `pinecone-ts-client` repository which mentions this bug: https://github.com/pinecone-io/pinecone-ts-client/issues/309

Updating the `@langchain/pinecone` module to use the `v4.0.0` version of `@pinecone/pinecone-database` fixes the issue.


