### PR TITLE
fix[community]: Fixed missing tool_choice in call options of chat IBM

### DIFF
--- a/libs/langchain-community/src/chat_models/ibm.ts
+++ b/libs/langchain-community/src/chat_models/ibm.ts
@@ -41,6 +41,7 @@ import {
   TextChatResultChoice,
   TextChatResultMessage,
   TextChatToolCall,
+  TextChatToolChoiceTool,
   TextChatUsage,
 } from "@ibm-cloud/watsonx-ai/dist/watsonx-ai-ml/vml_v1.js";
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
@@ -86,6 +87,7 @@ export interface WatsonxCallOptionsChat
   extends Omit<BaseLanguageModelCallOptions, "stop">,
     WatsonxCallParams {
   promptIndex?: number;
+  tool_choice?: TextChatToolChoiceTool;
 }
 
 type ChatWatsonxToolType = BindToolsInput | TextChatParameterTools;
@@ -470,7 +472,7 @@ export class ChatWatsonx<
       tools: options.tools
         ? _convertToolToWatsonxTool(options.tools)
         : undefined,
-      toolChoice: options.toolChoice,
+      toolChoice: options.tool_choice,
       responseFormat: options.responseFormat,
       toolChoiceOption: options.toolChoiceOption,
     };


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixed missing tool_choice in call options of chat model.
Was not aware of this issue until actually looking into langgraph implementation, maybe there could be an option to avoid such problems in the future?