### PR TITLE
Update Pinecone indexing example to show use of deletionProtection

### DIFF
--- a/examples/src/indexes/vector_stores/pinecone/index_docs.ts
+++ b/examples/src/indexes/vector_stores/pinecone/index_docs.ts
@@ -11,6 +11,23 @@ import { PineconeStore } from "@langchain/pinecone";
 
 const pinecone = new Pinecone();
 
+// If index already exists:
+// const pineconeIndex = pinecone.Index(process.env.PINECONE_INDEX!);
+
+// If index does not exist, create it:
+await pinecone.createIndex({
+  name: process.env.PINECONE_INDEX!,
+  dimension: 1536,
+  metric: "cosine",
+  spec: {
+    serverless: {
+      cloud: "aws",
+      region: "us-east-1",
+    },
+  },
+  deletionProtection: "disabled", // Note: deletion protection disabled https://docs.pinecone.io/guides/indexes/prevent-index-deletion#disable-deletion-protection
+});
+
 const pineconeIndex = pinecone.Index(process.env.PINECONE_INDEX!);
 
 const docs = [


### PR DESCRIPTION
Now that LangChain uses the newest version of the Pinecone client, let's show users how to use (or not) `deletionProtection` in the examples :) 

More about deletion protection here https://docs.pinecone.io/guides/indexes/prevent-index-deletion#disable-deletion-protection


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208759468706823