### PR TITLE
fix(community): PrismaVectorStore handle empty array in filter

### DIFF
--- a/libs/langchain-community/src/vectorstores/prisma.ts
+++ b/libs/langchain-community/src/vectorstores/prisma.ts
@@ -437,6 +437,16 @@ export class PrismaVectorStore<
                   )}`
                 );
               }
+
+              if (value.length === 0) {
+                const isInOperator = OpMap[opNameKey] === OpMap.in;
+
+                // For empty arrays:
+                // - IN () should return FALSE (nothing can be in an empty set)
+                // - NOT IN () should return TRUE (everything is not in an empty set)
+                return this.Prisma.sql`${!isInOperator}`;
+              }
+              
               return this.Prisma.sql`${colRaw} ${opRaw} (${this.Prisma.join(
                 value
               )})`;

--- a/libs/langchain-community/src/vectorstores/prisma.ts
+++ b/libs/langchain-community/src/vectorstores/prisma.ts
@@ -446,7 +446,7 @@ export class PrismaVectorStore<
                 // - NOT IN () should return TRUE (everything is not in an empty set)
                 return this.Prisma.sql`${!isInOperator}`;
               }
-              
+
               return this.Prisma.sql`${colRaw} ${opRaw} (${this.Prisma.join(
                 value
               )})`;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

When an an empty array is passed to IN or NOTIN operator in PrismaVectorStore's filter, it will be directly passed to Prisma.join and cause
 **TypeError: Expected `join([])` to be called with an array of multiple elements, but got an empty array**

This PR adds a separate logic for handling empty arrays in SQL queries:

* [`libs/langchain-community/src/vectorstores/prisma.ts`](diffhunk://#diff-5b221be6896a52539d6efcdf50be7c50df05b6a025c8737730b782b672c90164R440-R449): Added a condition to check if the array is empty and handle `IN` and `NOT IN` operators appropriately. For empty arrays, `IN ()` will return `FALSE` and `NOT IN ()` will return `TRUE`.