### PR TITLE
Implement support for concatSupported = false for OpenAI models

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -1989,7 +1989,7 @@ export class RunnableSequence<
       otherOptions?.runName
     );
     const steps = [this.first, ...this.middle, this.last];
-    let concatSupported = true;
+    let concatSupported = options?.concatSupported ?? true;
     let finalOutput;
     async function* inputGenerator() {
       yield input;
@@ -2029,6 +2029,8 @@ export class RunnableSequence<
               concatSupported = false;
             }
           }
+        } else {
+          finalOutput = chunk;
         }
       }
     } catch (e) {

--- a/langchain-core/src/runnables/types.ts
+++ b/langchain-core/src/runnables/types.ts
@@ -107,4 +107,9 @@ export interface RunnableConfig<
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   signal?: AbortSignal;
+
+  /**
+   * Whether to concatenate the stream of outputs into a single output or not.
+   */
+  concatSupported?: boolean;
 }


### PR DESCRIPTION
When streaming structured output with the ChatOpenAI model the event on_chain_end is incorrect. All of the variables within data.output are a concatenation of all the intermediary streamed output messages instead of just the final result.

This happens since when combining the streamed chunks in RunnableSequence._streamIterator() we check if concatenation is supported by checking concatSupported, but this variable is hardcoded to true and the false branch of the if statement is not implemented so for every model it assumes that concatenation is supported which is not the case for the ChatOpenAI model.

To solve this issue we have implemented the false branch which takes the last streamed chunk as the final output, instead of concatenating them all together to support models which don’t support concatenation.

Fixes #7114
