### PR TITLE
Fix anthropic sdk import

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -28,7 +28,7 @@ import { z } from "zod";
 import type {
   MessageCreateParams,
   Tool as AnthropicTool,
-} from "@anthropic-ai/sdk/resources/index.mjs";
+} from "@anthropic-ai/sdk/resources/messages";
 
 import { isLangChainTool } from "@langchain/core/utils/function_calling";
 import { AnthropicToolsOutputParser } from "./output_parsers.js";

--- a/libs/langchain-anthropic/src/types.ts
+++ b/libs/langchain-anthropic/src/types.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/index.mjs";
+import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages";
 import { BindToolsInput } from "@langchain/core/language_models/chat_models";
 
 export type AnthropicToolResponse = {


### PR DESCRIPTION
This PR fixes an error when importing `ChatAnthropic`, due to missing declaration file.

Fixes #7332 
