### PR TITLE
fix(community): file system chat history

### DIFF
--- a/docs/core_docs/docs/integrations/memory/file.mdx
+++ b/docs/core_docs/docs/integrations/memory/file.mdx
@@ -4,9 +4,9 @@ hide_table_of_contents: true
 
 import CodeBlock from "@theme/CodeBlock";
 
-# File Chat Message History
+# File System Chat Message History
 
-The `FileChatMessageHistory` uses a JSON file to store chat message history. For longer-term persistence across chat sessions, you can swap out the default in-memory `chatHistory` that backs chat memory classes like `BufferMemory`.
+The `FileSystemChatMessageHistory` uses a JSON file to store chat message history. For longer-term persistence across chat sessions, you can swap out the default in-memory `chatHistory` that backs chat memory classes like `BufferMemory`.
 
 ## Setup
 

--- a/examples/src/memory/file.ts
+++ b/examples/src/memory/file.ts
@@ -66,6 +66,6 @@ const sessions = await chatHistory.getAllSessions();
 console.log(sessions);
 /*
  [
-  { sessionId: 'langchain-test-session', context: { title: "Introducing Jim"  } }
+  { id: 'langchain-test-session', context: { title: "Introducing Jim"  } }
  ]
  */

--- a/libs/langchain-community/src/stores/message/file_system.ts
+++ b/libs/langchain-community/src/stores/message/file_system.ts
@@ -189,8 +189,8 @@ export class FileSystemChatMessageHistory extends BaseListChatMessageHistory {
   async getAllSessions(): Promise<FileChatSession[]> {
     await this.init();
     const userSessions = store[this.userId]
-      ? Object.values(store[this.userId]).map((session) => ({
-          id: session.id,
+      ? Object.entries(store[this.userId]).map(([id, session]) => ({
+          id,
           context: session.context,
         }))
       : [];

--- a/libs/langchain-community/src/stores/tests/file_chat_history.int.test.ts
+++ b/libs/langchain-community/src/stores/tests/file_chat_history.int.test.ts
@@ -143,5 +143,7 @@ test("FileSystemChatMessageHistory set context and get all sessions", async () =
 
   expect(sessions.length).toBe(2);
   expect(sessions[0].context).toEqual(context1);
+  expect(sessions[0].id).toBeDefined();
   expect(sessions[1].context).toEqual(context2);
+  expect(sessions[1].id).toBeDefined();
 });


### PR DESCRIPTION
## Changes

- Fixes `getAllSessions()` method not return `id` property
- Fixes doc