### PR TITLE
fix(core): Make sure to return a callback manager if configure hooks

### DIFF
--- a/langchain-core/src/callbacks/manager.ts
+++ b/langchain-core/src/callbacks/manager.ts
@@ -1,31 +1,31 @@
 import { v4 as uuidv4 } from "uuid";
 import { AgentAction, AgentFinish } from "../agents.js";
-import type { ChainValues } from "../utils/types/index.js";
-import { LLMResult } from "../outputs.js";
-import {
-  BaseCallbackHandler,
-  CallbackHandlerMethods,
-  HandleLLMNewTokenCallbackFields,
-  isBaseCallbackHandler,
-  NewTokenIndices,
-} from "./base.js";
-import { ConsoleCallbackHandler } from "../tracers/console.js";
+import type { DocumentInterface } from "../documents/document.js";
+import { Serialized } from "../load/serializable.js";
 import { type BaseMessage } from "../messages/base.js";
 import { getBufferString } from "../messages/utils.js";
-import { getEnvironmentVariable } from "../utils/env.js";
+import { LLMResult } from "../outputs.js";
+import {
+  _getConfigureHooks,
+  getContextVariable,
+} from "../singletons/async_local_storage/context.js";
+import { isBaseTracer } from "../tracers/base.js";
+import { ConsoleCallbackHandler } from "../tracers/console.js";
 import {
   LangChainTracer,
   LangChainTracerFields,
 } from "../tracers/tracer_langchain.js";
-import { consumeCallback } from "./promises.js";
-import { Serialized } from "../load/serializable.js";
-import type { DocumentInterface } from "../documents/document.js";
 import { isTracingEnabled } from "../utils/callbacks.js";
-import { isBaseTracer } from "../tracers/base.js";
+import { getEnvironmentVariable } from "../utils/env.js";
+import type { ChainValues } from "../utils/types/index.js";
 import {
-  getContextVariable,
-  _getConfigureHooks,
-} from "../singletons/async_local_storage/context.js";
+  BaseCallbackHandler,
+  CallbackHandlerMethods,
+  HandleLLMNewTokenCallbackFields,
+  NewTokenIndices,
+  isBaseCallbackHandler,
+} from "./base.js";
+import { consumeCallback } from "./promises.js";
 
 type BaseCallbackManagerMethods = {
   [K in keyof CallbackHandlerMethods]?: (
@@ -1276,8 +1276,12 @@ export class CallbackManager
         handler = new (handlerClass as any)({});
       }
       if (handler !== undefined) {
-        if (!callbackManager?.handlers.some((h) => h.name === handler!.name)) {
-          callbackManager?.addHandler(handler, inheritable);
+        if (!callbackManager) {
+          callbackManager = new CallbackManager();
+        }
+
+        if (!callbackManager.handlers.some((h) => h.name === handler!.name)) {
+          callbackManager.addHandler(handler, inheritable);
         }
       }
     }

--- a/langchain-core/src/callbacks/manager.ts
+++ b/langchain-core/src/callbacks/manager.ts
@@ -1,31 +1,31 @@
 import { v4 as uuidv4 } from "uuid";
 import { AgentAction, AgentFinish } from "../agents.js";
-import type { DocumentInterface } from "../documents/document.js";
-import { Serialized } from "../load/serializable.js";
-import { type BaseMessage } from "../messages/base.js";
-import { getBufferString } from "../messages/utils.js";
-import { LLMResult } from "../outputs.js";
-import {
-  _getConfigureHooks,
-  getContextVariable,
-} from "../singletons/async_local_storage/context.js";
-import { isBaseTracer } from "../tracers/base.js";
-import { ConsoleCallbackHandler } from "../tracers/console.js";
-import {
-  LangChainTracer,
-  LangChainTracerFields,
-} from "../tracers/tracer_langchain.js";
-import { isTracingEnabled } from "../utils/callbacks.js";
-import { getEnvironmentVariable } from "../utils/env.js";
 import type { ChainValues } from "../utils/types/index.js";
+import { LLMResult } from "../outputs.js";
 import {
   BaseCallbackHandler,
   CallbackHandlerMethods,
   HandleLLMNewTokenCallbackFields,
-  NewTokenIndices,
   isBaseCallbackHandler,
+  NewTokenIndices,
 } from "./base.js";
+import { ConsoleCallbackHandler } from "../tracers/console.js";
+import { type BaseMessage } from "../messages/base.js";
+import { getBufferString } from "../messages/utils.js";
+import { getEnvironmentVariable } from "../utils/env.js";
+import {
+  LangChainTracer,
+  LangChainTracerFields,
+} from "../tracers/tracer_langchain.js";
 import { consumeCallback } from "./promises.js";
+import { Serialized } from "../load/serializable.js";
+import type { DocumentInterface } from "../documents/document.js";
+import { isTracingEnabled } from "../utils/callbacks.js";
+import { isBaseTracer } from "../tracers/base.js";
+import {
+  getContextVariable,
+  _getConfigureHooks,
+} from "../singletons/async_local_storage/context.js";
 
 type BaseCallbackManagerMethods = {
   [K in keyof CallbackHandlerMethods]?: (

--- a/langchain-core/src/callbacks/manager.ts
+++ b/langchain-core/src/callbacks/manager.ts
@@ -1245,18 +1245,6 @@ export class CallbackManager
         }
       }
     }
-    if (inheritableTags || localTags) {
-      if (callbackManager) {
-        callbackManager.addTags(inheritableTags ?? []);
-        callbackManager.addTags(localTags ?? [], false);
-      }
-    }
-    if (inheritableMetadata || localMetadata) {
-      if (callbackManager) {
-        callbackManager.addMetadata(inheritableMetadata ?? {});
-        callbackManager.addMetadata(localMetadata ?? {}, false);
-      }
-    }
 
     for (const {
       contextVar,
@@ -1283,6 +1271,19 @@ export class CallbackManager
         if (!callbackManager.handlers.some((h) => h.name === handler!.name)) {
           callbackManager.addHandler(handler, inheritable);
         }
+      }
+    }
+
+    if (inheritableTags || localTags) {
+      if (callbackManager) {
+        callbackManager.addTags(inheritableTags ?? []);
+        callbackManager.addTags(localTags ?? [], false);
+      }
+    }
+    if (inheritableMetadata || localMetadata) {
+      if (callbackManager) {
+        callbackManager.addMetadata(inheritableMetadata ?? {});
+        callbackManager.addMetadata(localMetadata ?? {}, false);
       }
     }
 

--- a/langchain-core/src/callbacks/tests/manager.test.ts
+++ b/langchain-core/src/callbacks/tests/manager.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-process-env */
-import { expect, test, beforeAll, afterEach } from "@jest/globals";
+import { afterEach, beforeAll, expect, test } from "@jest/globals";
 
-import { setContextVariable, registerConfigureHook } from "../../context.js";
+import { registerConfigureHook, setContextVariable } from "../../context.js";
 import { BaseCallbackHandler } from "../base.js";
 import { CallbackManager } from "../manager.js";
 
@@ -24,6 +24,20 @@ afterEach(() => {
 test("configure with empty array", async () => {
   const manager = CallbackManager.configure([]);
   expect(manager?.handlers.length).toBe(0);
+});
+
+test("configure with no arguments", async () => {
+  const manager = CallbackManager.configure();
+  expect(manager).toBe(undefined);
+});
+
+test("configure with no arguments but with handler", async () => {
+  setContextVariable("my_test_handler", handlerInstance);
+  registerConfigureHook({
+    contextVar: "my_test_handler",
+  });
+  const manager = CallbackManager.configure();
+  expect(manager?.handlers[0]).toBe(handlerInstance);
 });
 
 test("configure with one handler", async () => {


### PR DESCRIPTION
Set a campaign manager, if we know there are callback managers we'd like to use

This preserves existing behavior except for when library creators want handlers registered with the `registerConfigureHook` function. In that case, we want to make sure we return a callback manager.

Twitter: @ibolmo