### PR TITLE
fix(cohere,langchain): handle exceptions in compressDocuments and formatDocuments methods due to empty documents

### DIFF
--- a/langchain/src/chains/combine_documents/base.ts
+++ b/langchain/src/chains/combine_documents/base.ts
@@ -21,6 +21,9 @@ export async function formatDocuments({
   documents: Document[];
   config?: RunnableConfig;
 }) {
+  if (documents == null || documents.length == 0) {
+    return "";
+  }
   const formattedDocs = await Promise.all(
     documents.map((document) =>
       documentPrompt

--- a/langchain/src/chains/combine_documents/base.ts
+++ b/langchain/src/chains/combine_documents/base.ts
@@ -21,7 +21,7 @@ export async function formatDocuments({
   documents: Document[];
   config?: RunnableConfig;
 }) {
-  if (documents == null || documents.length == 0) {
+  if (documents == null || documents.length === 0) {
     return "";
   }
   const formattedDocs = await Promise.all(

--- a/libs/langchain-cohere/src/rerank.ts
+++ b/libs/langchain-cohere/src/rerank.ts
@@ -60,7 +60,7 @@ export class CohereRerank extends BaseDocumentCompressor {
     documents: Array<DocumentInterface>,
     query: string
   ): Promise<Array<DocumentInterface>> {
-    if (documents == null || documents.length == 0) {
+    if (documents == null || documents.length === 0) {
       return [];
     }
     const _docs = documents.map((doc) => doc.pageContent);

--- a/libs/langchain-cohere/src/rerank.ts
+++ b/libs/langchain-cohere/src/rerank.ts
@@ -60,6 +60,9 @@ export class CohereRerank extends BaseDocumentCompressor {
     documents: Array<DocumentInterface>,
     query: string
   ): Promise<Array<DocumentInterface>> {
+    if (documents == null || documents.length == 0) {
+      return [];
+    }
     const _docs = documents.map((doc) => doc.pageContent);
     const { results } = await this.client.rerank({
       model: this.model,


### PR DESCRIPTION


Fixes #7370


1. Prevent the ```invalid request: list of documents must not be empty``` error caused by ```compressDocuments``` method due to ```documents``` being empty. Added a condition to check if ```documents``` is empty. If yes, return an empty array.

2. Prevent exception thrown from ```formattedDocs``` methods when ```documents``` is empty. Added a condition to check if ```documents``` is empty. If yes, return an empty string.
