### PR TITLE
docs: updates text-to-html example

### DIFF
--- a/examples/src/document_transformers/html_to_text.ts
+++ b/examples/src/document_transformers/html_to_text.ts
@@ -1,8 +1,8 @@
-import { CheerioWebBaseLoader } from "@langchain/community/document_loaders/web/cheerio";
+import { HTMLWebBaseLoader } from "@langchain/community/document_loaders/web/html";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 import { HtmlToTextTransformer } from "@langchain/community/document_transformers/html_to_text";
 
-const loader = new CheerioWebBaseLoader(
+const loader = new HTMLWebBaseLoader(
   "https://news.ycombinator.com/item?id=34817881"
 );
 


### PR DESCRIPTION
The `text-to-html` transformer example was using the `CheerioWebBaseLoader` to fetch HTML, but the `CheerioWebBaseLoader` already strips HTML using Cheerio's `.text()` function. So the `html-to-text` transformer wasn't really doing anything.

This commit updates the example to use the `HTMLWebBaseLoader` instead, to give the `html-to-text` transformer something to do in its own example.
