### PR TITLE
fix(google-genai): Update multimodal model check to include gemini-2 support

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -580,7 +580,7 @@ export class ChatGoogleGenerativeAI
   private client: GenerativeModel;
 
   get _isMultimodalModel() {
-    return this.model.includes("vision") || this.model.startsWith("gemini-1.5");
+    return this.model.includes("vision") || this.model.startsWith("gemini-1.5") || this.model.startsWith("gemini-2");
   }
 
   constructor(fields?: GoogleGenerativeAIChatInput) {

--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -580,7 +580,11 @@ export class ChatGoogleGenerativeAI
   private client: GenerativeModel;
 
   get _isMultimodalModel() {
-    return this.model.includes("vision") || this.model.startsWith("gemini-1.5") || this.model.startsWith("gemini-2");
+    return (
+      this.model.includes("vision") ||
+      this.model.startsWith("gemini-1.5") ||
+      this.model.startsWith("gemini-2")
+    );
   }
 
   constructor(fields?: GoogleGenerativeAIChatInput) {


### PR DESCRIPTION
This PR extends multimodal support to include the Gemini 2 family of models by updating the `_isMultimodalModel` check. 

Fixes # (issue)
- https://github.com/langchain-ai/langchainjs/issues/7355