### PR TITLE
fix(docs): Fix broken RAG tutorials link

### DIFF
--- a/docs/core_docs/docs/concepts/rag.mdx
+++ b/docs/core_docs/docs/concepts/rag.mdx
@@ -102,7 +102,7 @@ RAG a deep area with many possible optimization and design choices:
 
 - See [this excellent blog](https://cameronrwolfe.substack.com/p/a-practitioners-guide-to-retrieval?utm_source=profile&utm_medium=reader2) from Cameron Wolfe for a comprehensive overview and history of RAG.
 - See our [RAG how-to guides](/docs/how_to/#qa-with-rag).
-- See our RAG [tutorials](/docs/tutorials/#working-with-external-knowledge).
+- See our RAG [tutorials](/docs/tutorials/rag).
 - See our RAG from Scratch course, with [code](https://github.com/langchain-ai/rag-from-scratch) and [video playlist](https://www.youtube.com/playlist?list=PLfaIDFEXuae2LXbO1_PKyVJiQ23ZztA0x).
 - Also, see our RAG from Scratch course [on Freecodecamp](https://youtu.be/sVcwVQRHIc8?feature=shared).
 


### PR DESCRIPTION
The current RAG tutorials link on the RAG concepts page links to a header that was previously deleted. I've updated the link to the new location.