### PR TITLE
fix(google-common): add tool_use param when using structured outputs

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -469,6 +469,7 @@ export abstract class ChatGoogleBase<AuthOptions>
     }
     const llm = this.bind({
       tools,
+      tool_choice: functionName,
     });
 
     if (!includeRaw) {

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1047,10 +1047,20 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       return undefined;
     }
 
+    if (["auto", "any", "none"].includes(parameters.tool_choice)) {
+      return {
+        functionCallingConfig: {
+          mode: parameters.tool_choice as "auto" | "any" | "none",
+          allowedFunctionNames: parameters.allowed_function_names,
+        },
+      };
+    }
+
+    // force tool choice to be a single function name in case of structured output
     return {
       functionCallingConfig: {
-        mode: parameters.tool_choice as "auto" | "any" | "none",
-        allowedFunctionNames: parameters.allowed_function_names,
+        mode: "any",
+        allowedFunctionNames: [parameters.tool_choice],
       },
     };
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

When using `.withStructuredOutput` we need to force tool use. If not, the model tends produce an empty response and the chain eventually returns `undefined`.
1. Modified tool_use param in gemini utils to handle structured output
2. withStructuredOutput will now bind tool_use parameter
3. anthropic utils already handles the tool use param by setting the tool use object to the function name if provided
