### PR TITLE
fix(google-common, google-vertexai): Invalid URL for embeddings model

### DIFF
--- a/libs/langchain-google-common/src/embeddings.ts
+++ b/libs/langchain-google-common/src/embeddings.ts
@@ -38,6 +38,11 @@ class EmbeddingsConnection<
     return "predict";
   }
 
+  get modelPublisher(): string {
+    // All the embedding models are currently published by "google"
+    return "google";
+  }
+
   async formatData(
     input: GoogleEmbeddingsInstance[],
     parameters: GoogleAIModelRequestParams

--- a/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
@@ -9,9 +9,17 @@ test("Test VertexAIEmbeddings.embedQuery", async () => {
   expect(typeof res[0]).toBe("number");
 });
 
-test("Test VertexAIEmbeddings.embedDocuments", async () => {
+const testModelsLocations = [
+  ["text-embedding-005", "us-central1"],
+  ["text-multilingual-embedding-002", "us-central1"],
+  ["text-embedding-005", "europe-west9"],
+  ["text-multilingual-embedding-002", "europe-west9"],
+]
+
+test.each(testModelsLocations)("VertexAIEmbeddings.embedDocuments %s %s", async (model, location) => {
   const embeddings = new VertexAIEmbeddings({
-    model: "text-embedding-004",
+    model,
+    location,
   });
   const res = await embeddings.embedDocuments([
     "Hello world",

--- a/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
@@ -14,24 +14,27 @@ const testModelsLocations = [
   ["text-multilingual-embedding-002", "us-central1"],
   ["text-embedding-005", "europe-west9"],
   ["text-multilingual-embedding-002", "europe-west9"],
-]
+];
 
-test.each(testModelsLocations)("VertexAIEmbeddings.embedDocuments %s %s", async (model, location) => {
-  const embeddings = new VertexAIEmbeddings({
-    model,
-    location,
-  });
-  const res = await embeddings.embedDocuments([
-    "Hello world",
-    "Bye bye",
-    "we need",
-    "at least",
-    "six documents",
-    "to test pagination",
-  ]);
-  // console.log(res);
-  expect(res).toHaveLength(6);
-  res.forEach((r) => {
-    expect(typeof r[0]).toBe("number");
-  });
-});
+test.each(testModelsLocations)(
+  "VertexAIEmbeddings.embedDocuments %s %s",
+  async (model, location) => {
+    const embeddings = new VertexAIEmbeddings({
+      model,
+      location,
+    });
+    const res = await embeddings.embedDocuments([
+      "Hello world",
+      "Bye bye",
+      "we need",
+      "at least",
+      "six documents",
+      "to test pagination",
+    ]);
+    // console.log(res);
+    expect(res).toHaveLength(6);
+    res.forEach((r) => {
+      expect(typeof r[0]).toBe("number");
+    });
+  }
+);


### PR DESCRIPTION
The URL path for Vertex AI typically includes a publisher name.
For LLMs, this publisher name is determined based on model name.
For embeddings, the publisher name never matched, so was assigned a name of "unknown".

Oddly enough, in some regions and with some embedding models - this was fine. But in other regions, this returned an error.

Fix is to make sure that all embedding models (at least for now) are considered published by Google.

Fixes #7390 
