### PR TITLE
Pass input value to `handleChainStart` in `_transformStreamWithConfig`

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -521,7 +521,7 @@ export abstract class Runnable<
         async () =>
           callbackManager_?.handleChainStart(
             this.toJSON(),
-            { input: "" },
+            finalInput,
             config.runId,
             config.runType,
             undefined,


### PR DESCRIPTION
This pull request makes a small change to the `Runnable` class in the `langchain-core` package. The change passes `finalInput` instead of `{ input: "" }` to the `handleChainStart` method. This allows the actual input value to be logged with tools like Langfuse.