### PR TITLE
fix(google-common,google-*) Gemini 2.0 support

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -98,7 +98,10 @@ export class ChatConnection<AuthOptions> extends AbstractGoogleLLMConnection<
     return true;
   }
 
-  computeGoogleSearchToolAdjustmentFromModel(): Exclude<GoogleSearchToolSetting, boolean> {
+  computeGoogleSearchToolAdjustmentFromModel(): Exclude<
+    GoogleSearchToolSetting,
+    boolean
+  > {
     if (this.modelName.startsWith("gemini-1.0")) {
       return "googleSearchRetrieval";
     } else if (this.modelName.startsWith("gemini-1.5")) {
@@ -108,7 +111,9 @@ export class ChatConnection<AuthOptions> extends AbstractGoogleLLMConnection<
     }
   }
 
-  computeGoogleSearchToolAdjustment(apiConfig: GeminiAPIConfig): Exclude<GoogleSearchToolSetting, true> {
+  computeGoogleSearchToolAdjustment(
+    apiConfig: GeminiAPIConfig
+  ): Exclude<GoogleSearchToolSetting, true> {
     const adj = apiConfig.googleSearchToolAdjustment;
     if (adj === undefined || adj === true) {
       return this.computeGoogleSearchToolAdjustmentFromModel();
@@ -118,8 +123,10 @@ export class ChatConnection<AuthOptions> extends AbstractGoogleLLMConnection<
   }
 
   buildGeminiAPI(): GoogleAIAPI {
-    const apiConfig: GeminiAPIConfig = this.apiConfig as GeminiAPIConfig ?? {};
-    const googleSearchToolAdjustment = this.computeGoogleSearchToolAdjustment(apiConfig);
+    const apiConfig: GeminiAPIConfig =
+      (this.apiConfig as GeminiAPIConfig) ?? {};
+    const googleSearchToolAdjustment =
+      this.computeGoogleSearchToolAdjustment(apiConfig);
     const geminiConfig: GeminiAPIConfig = {
       useSystemInstruction: this.useSystemInstruction,
       googleSearchToolAdjustment,

--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -231,7 +231,12 @@ export abstract class ChatGoogleBase<AuthOptions>
   }
 
   buildApiKey(fields?: GoogleAIBaseLLMInput<AuthOptions>): string | undefined {
-    return fields?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
+    if (fields?.platformType !== "gcp") {
+      return fields?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
+    } else {
+      // GCP doesn't support API Keys
+      return undefined;
+    }
   }
 
   buildClient(

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -1105,6 +1105,150 @@ describe("Mock ChatGoogle - Gemini", () => {
 
     // console.log(JSON.stringify(record?.opts?.data, null, 1));
   });
+
+  test("6. GoogleSearchRetrievalTool result", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const searchRetrievalTool = {
+      googleSearchRetrieval: {
+        dynamicRetrievalConfig: {
+          mode: "MODE_DYNAMIC",
+          dynamicThreshold: 0.7, // default is 0.7
+        },
+      },
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-pro-002",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchRetrievalTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+    expect(result).toHaveProperty("response_metadata");
+    expect(result.response_metadata).toHaveProperty("groundingMetadata");
+    expect(result.response_metadata).toHaveProperty("groundingSupport");
+    expect(Array.isArray(result.response_metadata.groundingSupport)).toEqual(true);
+    expect(result.response_metadata.groundingSupport).toHaveLength(4);
+  });
+
+  test("6. GoogleSearchRetrievalTool request 1.5 ", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const searchRetrievalTool = {
+      googleSearchRetrieval: {
+        dynamicRetrievalConfig: {
+          mode: "MODE_DYNAMIC",
+          dynamicThreshold: 0.7, // default is 0.7
+        },
+      },
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-pro-002",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchRetrievalTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+
+    expect(record.opts.data.tools[0]).toHaveProperty("googleSearchRetrieval");
+  });
+
+  test("6. GoogleSearchRetrievalTool request 2.0 ", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const searchRetrievalTool = {
+      googleSearchRetrieval: {
+        dynamicRetrievalConfig: {
+          mode: "MODE_DYNAMIC",
+          dynamicThreshold: 0.7, // default is 0.7
+        },
+      },
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchRetrievalTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+
+    expect(record.opts.data.tools[0]).toHaveProperty("googleSearch");
+  });
+
+  test("6. GoogleSearchTool request 1.5 ", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const searchTool = {
+      googleSearch: {},
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-pro-002",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+
+    expect(record.opts.data.tools[0]).toHaveProperty("googleSearchRetrieval");
+  });
+
+  test("6. GoogleSearchTool request 2.0 ", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const searchTool = {
+      googleSearch: {},
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+
+    expect(record.opts.data.tools[0]).toHaveProperty("googleSearch");
+  });
+
 });
 
 describe("Mock ChatGoogle - Anthropic", () => {

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -1135,7 +1135,9 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(result).toHaveProperty("response_metadata");
     expect(result.response_metadata).toHaveProperty("groundingMetadata");
     expect(result.response_metadata).toHaveProperty("groundingSupport");
-    expect(Array.isArray(result.response_metadata.groundingSupport)).toEqual(true);
+    expect(Array.isArray(result.response_metadata.groundingSupport)).toEqual(
+      true
+    );
     expect(result.response_metadata.groundingSupport).toHaveLength(4);
   });
 
@@ -1248,7 +1250,6 @@ describe("Mock ChatGoogle - Gemini", () => {
 
     expect(record.opts.data.tools[0]).toHaveProperty("googleSearch");
   });
-
 });
 
 describe("Mock ChatGoogle - Anthropic", () => {

--- a/libs/langchain-google-common/src/tests/data/chat-6-mock.json
+++ b/libs/langchain-google-common/src/tests/data/chat-6-mock.json
@@ -40,12 +40,8 @@
               "endIndex": 100,
               "text": "The Los Angeles Dodgers won the 2024 World Series, defeating the New York Yankees 4-1 in the series."
             },
-            "groundingChunkIndices": [
-              0
-            ],
-            "confidenceScores": [
-              0.95898277
-            ]
+            "groundingChunkIndices": [0],
+            "confidenceScores": [0.95898277]
           },
           {
             "segment": {
@@ -53,12 +49,8 @@
               "endIndex": 377,
               "text": "It was also their first World Series win in a full season since 1988."
             },
-            "groundingChunkIndices": [
-              1
-            ],
-            "confidenceScores": [
-              0.96841997
-            ]
+            "groundingChunkIndices": [1],
+            "confidenceScores": [0.96841997]
           },
           {
             "segment": {
@@ -66,12 +58,8 @@
               "endIndex": 508,
               "text": "Mookie Betts earned his third World Series ring (2018, 2020, and 2024), becoming the only active player with three championships."
             },
-            "groundingChunkIndices": [
-              2
-            ],
-            "confidenceScores": [
-              0.99043523
-            ]
+            "groundingChunkIndices": [2],
+            "confidenceScores": [0.99043523]
           },
           {
             "segment": {
@@ -79,17 +67,11 @@
               "endIndex": 611,
               "text": "Shohei Ohtani, in his first year with the Dodgers, also experienced his first post-season appearance."
             },
-            "groundingChunkIndices": [
-              0
-            ],
-            "confidenceScores": [
-              0.95767003
-            ]
+            "groundingChunkIndices": [0],
+            "confidenceScores": [0.95767003]
           }
         ],
-        "webSearchQueries": [
-          "2024 MLB World Series winner"
-        ]
+        "webSearchQueries": ["2024 MLB World Series winner"]
       },
       "avgLogprobs": -0.040494912748883484
     }

--- a/libs/langchain-google-common/src/tests/data/chat-6-mock.json
+++ b/libs/langchain-google-common/src/tests/data/chat-6-mock.json
@@ -1,0 +1,103 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The Los Angeles Dodgers won the 2024 World Series, defeating the New York Yankees 4-1 in the series.  The Dodgers clinched the title with a 7-6 comeback victory in Game 5 at Yankee Stadium on Wednesday, October 30th. This was their eighth World Series title overall and their second in the past five years.  It was also their first World Series win in a full season since 1988.  Mookie Betts earned his third World Series ring (2018, 2020, and 2024), becoming the only active player with three championships.  Shohei Ohtani, in his first year with the Dodgers, also experienced his first post-season appearance.\n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "searchEntryPoint": {
+          "renderedContent": "<style>\n.container {\n  align-items: center;\n  border-radius: 8px;\n  display: flex;\n  font-family: Google Sans, Roboto, sans-serif;\n  font-size: 14px;\n  line-height: 20px;\n  padding: 8px 12px;\n}\n.chip {\n  display: inline-block;\n  border: solid 1px;\n  border-radius: 16px;\n  min-width: 14px;\n  padding: 5px 16px;\n  text-align: center;\n  user-select: none;\n  margin: 0 8px;\n  -webkit-tap-highlight-color: transparent;\n}\n.carousel {\n  overflow: auto;\n  scrollbar-width: none;\n  white-space: nowrap;\n  margin-right: -12px;\n}\n.headline {\n  display: flex;\n  margin-right: 4px;\n}\n.gradient-container {\n  position: relative;\n}\n.gradient {\n  position: absolute;\n  transform: translate(3px, -9px);\n  height: 36px;\n  width: 9px;\n}\n@media (prefers-color-scheme: light) {\n  .container {\n    background-color: #fafafa;\n    box-shadow: 0 0 0 1px #0000000f;\n  }\n  .headline-label {\n    color: #1f1f1f;\n  }\n  .chip {\n    background-color: #ffffff;\n    border-color: #d2d2d2;\n    color: #5e5e5e;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #f2f2f2;\n  }\n  .chip:focus {\n    background-color: #f2f2f2;\n  }\n  .chip:active {\n    background-color: #d8d8d8;\n    border-color: #b6b6b6;\n  }\n  .logo-dark {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #fafafa 15%, #fafafa00 100%);\n  }\n}\n@media (prefers-color-scheme: dark) {\n  .container {\n    background-color: #1f1f1f;\n    box-shadow: 0 0 0 1px #ffffff26;\n  }\n  .headline-label {\n    color: #fff;\n  }\n  .chip {\n    background-color: #2c2c2c;\n    border-color: #3c4043;\n    color: #fff;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #353536;\n  }\n  .chip:focus {\n    background-color: #353536;\n  }\n  .chip:active {\n    background-color: #464849;\n    border-color: #53575b;\n  }\n  .logo-light {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #1f1f1f 15%, #1f1f1f00 100%);\n  }\n}\n</style>\n<div class=\"container\">\n  <div class=\"headline\">\n    <svg class=\"logo-light\" width=\"18\" height=\"18\" viewBox=\"9 9 35 35\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n      <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M42.8622 27.0064C42.8622 25.7839 42.7525 24.6084 42.5487 23.4799H26.3109V30.1568H35.5897C35.1821 32.3041 33.9596 34.1222 32.1258 35.3448V39.6864H37.7213C40.9814 36.677 42.8622 32.2571 42.8622 27.0064V27.0064Z\" fill=\"#4285F4\"/>\n      <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 43.8555C30.9659 43.8555 34.8687 42.3195 37.7213 39.6863L32.1258 35.3447C30.5898 36.3792 28.6306 37.0061 26.3109 37.0061C21.8282 37.0061 18.0195 33.9811 16.6559 29.906H10.9194V34.3573C13.7563 39.9841 19.5712 43.8555 26.3109 43.8555V43.8555Z\" fill=\"#34A853\"/>\n      <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M16.6559 29.8904C16.3111 28.8559 16.1074 27.7588 16.1074 26.6146C16.1074 25.4704 16.3111 24.3733 16.6559 23.3388V18.8875H10.9194C9.74388 21.2072 9.06992 23.8247 9.06992 26.6146C9.06992 29.4045 9.74388 32.022 10.9194 34.3417L15.3864 30.8621L16.6559 29.8904V29.8904Z\" fill=\"#FBBC05\"/>\n      <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M26.3109 16.2386C28.85 16.2386 31.107 17.1164 32.9095 18.8091L37.8466 13.8719C34.853 11.082 30.9659 9.3736 26.3109 9.3736C19.5712 9.3736 13.7563 13.245 10.9194 18.8875L16.6559 23.3388C18.0195 19.2636 21.8282 16.2386 26.3109 16.2386V16.2386Z\" fill=\"#EA4335\"/>\n    </svg>\n    <svg class=\"logo-dark\" width=\"18\" height=\"18\" viewBox=\"0 0 48 48\" xmlns=\"http://www.w3.org/2000/svg\">\n      <circle cx=\"24\" cy=\"23\" fill=\"#FFF\" r=\"22\"/>\n      <path d=\"M33.76 34.26c2.75-2.56 4.49-6.37 4.49-11.26 0-.89-.08-1.84-.29-3H24.01v5.99h8.03c-.4 2.02-1.5 3.56-3.07 4.56v.75l3.91 2.97h.88z\" fill=\"#4285F4\"/>\n      <path d=\"M15.58 25.77A8.845 8.845 0 0 0 24 31.86c1.92 0 3.62-.46 4.97-1.31l4.79 3.71C31.14 36.7 27.65 38 24 38c-5.93 0-11.01-3.4-13.45-8.36l.17-1.01 4.06-2.85h.8z\" fill=\"#34A853\"/>\n      <path d=\"M15.59 20.21a8.864 8.864 0 0 0 0 5.58l-5.03 3.86c-.98-2-1.53-4.25-1.53-6.64 0-2.39.55-4.64 1.53-6.64l1-.22 3.81 2.98.22 1.08z\" fill=\"#FBBC05\"/>\n      <path d=\"M24 14.14c2.11 0 4.02.75 5.52 1.98l4.36-4.36C31.22 9.43 27.81 8 24 8c-5.93 0-11.01 3.4-13.45 8.36l5.03 3.85A8.86 8.86 0 0 1 24 14.14z\" fill=\"#EA4335\"/>\n    </svg>\n    <div class=\"gradient-container\"><div class=\"gradient\"></div></div>\n  </div>\n  <div class=\"carousel\">\n    <a class=\"chip\" href=\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AYygrcQWF3H6dUbqP__cEJvZ4DdyAiuWN7O1T5Phcdnz8OYILqvvoeZQFpbjLuhNzjeACw4mUqBy3-cFo7QRcTK36CY3euMjieT95AOs65bAjMI6AaQ60hSLk8wEz1e_1-LRvQUp3ZZFxB9EjNvroDS9cIqLQxMj-x5CeT3QqohrUam2yVfGEV8P-NWI8F2VQfWDtFRmcvCJTsBiUV136lSXoJ4=\">2024 MLB World Series winner</a>\n  </div>\n</div>\n"
+        },
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AYygrcTYmdnM71OvWYUTG4JggmRj8cIIgA2KtKas5RPj09CiALB4n8hl-SfCD6r8WnimL2psBoYmEN9ng9sENjpeP5VxgLMTlm0zgxhrWFfx3yA6B_n0N9j-BgHLISAUi-_Ql4_Buyw68Svq-3v6BgrXzn9hLOtK",
+              "title": "bbc.com"
+            }
+          },
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AYygrcQRhhvHTdpb8OMOEMVxv9fkevPoMWMnhrpuC7E0E0R94xmFxT9Vv5na1hMrfHGKxVZ9aE3PgCAs5nftC3iAkeD7B6ZTfKGH2Im1CqssMM7zorGx1Ds5_7QPPBDQps_JvpkOuvRluGCVg8KwNaIU-hm3Kg==",
+              "title": "mlb.com"
+            }
+          },
+          {
+            "web": {
+              "uri": "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AYygrcSwvb2t622A2ZpKxqOWKy16L1mEUvmsAJoHjaR7uffKO71SeZkpdRXRsST9HJzJkGSkMF9kOaXGoDtcvUrttqKYOQHvHSUBYO7LWMlU00KyNlSoQzrBsgN4KuJ4O4acnNyNCSVX3-E=",
+              "title": "youtube.com"
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "endIndex": 100,
+              "text": "The Los Angeles Dodgers won the 2024 World Series, defeating the New York Yankees 4-1 in the series."
+            },
+            "groundingChunkIndices": [
+              0
+            ],
+            "confidenceScores": [
+              0.95898277
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 308,
+              "endIndex": 377,
+              "text": "It was also their first World Series win in a full season since 1988."
+            },
+            "groundingChunkIndices": [
+              1
+            ],
+            "confidenceScores": [
+              0.96841997
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 379,
+              "endIndex": 508,
+              "text": "Mookie Betts earned his third World Series ring (2018, 2020, and 2024), becoming the only active player with three championships."
+            },
+            "groundingChunkIndices": [
+              2
+            ],
+            "confidenceScores": [
+              0.99043523
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 510,
+              "endIndex": 611,
+              "text": "Shohei Ohtani, in his first year with the Dodgers, also experienced his first post-season appearance."
+            },
+            "groundingChunkIndices": [
+              0
+            ],
+            "confidenceScores": [
+              0.95767003
+            ]
+          }
+        ],
+        "webSearchQueries": [
+          "2024 MLB World Series winner"
+        ]
+      },
+      "avgLogprobs": -0.040494912748883484
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 13,
+    "candidatesTokenCount": 157,
+    "totalTokenCount": 170
+  },
+  "modelVersion": "gemini-1.5-pro-002"
+}

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -307,11 +307,36 @@ export interface GeminiContent {
   role: GeminiRole; // Vertex AI requires the role
 }
 
+/*
+ * If additional attributes are added here, they should also be
+ * added to the attributes below
+ */
 export interface GeminiTool {
   functionDeclarations?: GeminiFunctionDeclaration[];
-  googleSearchRetrieval?: GoogleSearchRetrieval;
+  googleSearchRetrieval?: GoogleSearchRetrieval;  // Gemini-1.5
+  googleSearch?: GoogleSearch;  // Gemini-2.0
   retrieval?: VertexAIRetrieval;
 }
+
+/*
+ * The known strings in this type should match those in GeminiSearchToolAttribuets
+ */
+export type GoogleSearchToolSetting =
+  | boolean
+  | "googleSearchRetrieval"
+  | "googleSearch"
+  | string;
+
+export const GeminiSearchToolAttributes = [
+  "googleSearchRetrieval",
+  "googleSearch",
+]
+
+export const GeminiToolAttributes = [
+  "functionDeclaration",
+  "retrieval",
+  ...GeminiSearchToolAttributes,
+]
 
 export interface GoogleSearchRetrieval {
   dynamicRetrievalConfig?: {
@@ -319,6 +344,8 @@ export interface GoogleSearchRetrieval {
     dynamicThreshold?: number;
   };
 }
+
+export interface GoogleSearch {}
 
 export interface VertexAIRetrieval {
   vertexAiSearch: {
@@ -467,6 +494,18 @@ export interface GeminiAPIConfig {
   safetyHandler?: GoogleAISafetyHandler;
   mediaManager?: MediaManager;
   useSystemInstruction?: boolean;
+
+  /**
+   * How to handle the Google Search tool, since the name (and format)
+   * of the tool changes between Gemini 1.5 and Gemini 2.0.
+   * true - Change based on the model version. (Default)
+   * false - Do not change the tool name provided
+   * string value - Use this as the attribute name for the search
+   *   tool, adapting any tool attributes if possible.
+   * When the model is created, a "true" or default setting
+   * will be changed to a string based on the model.
+   */
+  googleSearchToolAdjustment?: GoogleSearchToolSetting;
 }
 
 export type GoogleAIAPIConfig = GeminiAPIConfig | AnthropicAPIConfig;

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -299,6 +299,71 @@ export type GeminiSafetyRating = {
   probability: string;
 } & Record<string, unknown>;
 
+export interface GeminiCitationMetadata {
+  citations: GeminiCitation[];
+}
+
+export interface GeminiCitation {
+  startIndex: number;
+  endIndex: number;
+  uri: string;
+  title: string;
+  license: string;
+  publicationDate: GoogleTypeDate;
+}
+
+export interface GoogleTypeDate {
+  year: number;  // 1-9999 or 0 to specify a date without a year
+  month: number; // 1-12 or 0 to specify a year without a month and day
+  day: number;   // Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant
+}
+
+export interface GeminiGroundingMetadata {
+  webSearchQueries?: string[];
+  searchEntryPoint?: GeminiSearchEntryPoint;
+  groundingChunks: GeminiGroundingChunk[];
+  groundingSupports?: GeminiGroundingSupport[];
+  retrievalMetadata?: GeminiRetrievalMetadata;
+}
+
+export interface GeminiSearchEntryPoint {
+  renderedContent?: string;
+  sdkBlob?: string;  // Base64 encoded JSON representing array of tuple.
+}
+
+export interface GeminiGroundingChunk {
+  web: GeminiGroundingChunkWeb;
+  retrievedContext: GeminiGroundingChunkRetrievedContext;
+}
+
+export interface GeminiGroundingChunkWeb {
+  uri: string;
+  title: string;
+}
+
+export interface GeminiGroundingChunkRetrievedContext {
+  uri: string;
+  title: string;
+  text: string;
+}
+
+export interface GeminiGroundingSupport {
+  segment: GeminiSegment;
+  groundingChunkIndices: number[];
+  confidenceScores: number[];
+}
+
+export interface GeminiSegment {
+  partIndex: number;
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+
+export interface GeminiRetrievalMetadata {
+  googleSearchDynamicRetrievalScore: number;
+}
+
 // The "system" content appears to only be valid in the systemInstruction
 export type GeminiRole = "system" | "user" | "model" | "function";
 
@@ -412,6 +477,8 @@ interface GeminiResponseCandidate {
   index: number;
   tokenCount?: number;
   safetyRatings: GeminiSafetyRating[];
+  citationMetadata?: GeminiCitationMetadata;
+  groundingMetadata?: GeminiGroundingMetadata;
 }
 
 interface GeminiResponsePromptFeedback {

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -313,9 +313,9 @@ export interface GeminiCitation {
 }
 
 export interface GoogleTypeDate {
-  year: number;  // 1-9999 or 0 to specify a date without a year
+  year: number; // 1-9999 or 0 to specify a date without a year
   month: number; // 1-12 or 0 to specify a year without a month and day
-  day: number;   // Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant
+  day: number; // Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant
 }
 
 export interface GeminiGroundingMetadata {
@@ -328,7 +328,7 @@ export interface GeminiGroundingMetadata {
 
 export interface GeminiSearchEntryPoint {
   renderedContent?: string;
-  sdkBlob?: string;  // Base64 encoded JSON representing array of tuple.
+  sdkBlob?: string; // Base64 encoded JSON representing array of tuple.
 }
 
 export interface GeminiGroundingChunk {
@@ -378,8 +378,8 @@ export interface GeminiContent {
  */
 export interface GeminiTool {
   functionDeclarations?: GeminiFunctionDeclaration[];
-  googleSearchRetrieval?: GoogleSearchRetrieval;  // Gemini-1.5
-  googleSearch?: GoogleSearch;  // Gemini-2.0
+  googleSearchRetrieval?: GoogleSearchRetrieval; // Gemini-1.5
+  googleSearch?: GoogleSearch; // Gemini-2.0
   retrieval?: VertexAIRetrieval;
 }
 
@@ -395,13 +395,13 @@ export type GoogleSearchToolSetting =
 export const GeminiSearchToolAttributes = [
   "googleSearchRetrieval",
   "googleSearch",
-]
+];
 
 export const GeminiToolAttributes = [
   "functionDeclaration",
   "retrieval",
   ...GeminiSearchToolAttributes,
-]
+];
 
 export interface GoogleSearchRetrieval {
   dynamicRetrievalConfig?: {

--- a/libs/langchain-google-common/src/utils/common.ts
+++ b/libs/langchain-google-common/src/utils/common.ts
@@ -62,7 +62,7 @@ function processToolChoice(
   throw new Error("Object inputs for tool_choice not supported.");
 }
 
-function isGeminiTool(tool: GoogleAIToolType): boolean {
+function isGeminiTool(tool: GoogleAIToolType): tool is GeminiTool {
   for (const toolAttribute of GeminiToolAttributes) {
     if (toolAttribute in tool) {
       return true;
@@ -71,7 +71,7 @@ function isGeminiTool(tool: GoogleAIToolType): boolean {
   return false;
 }
 
-function isGeminiNonFunctionTool(tool: GoogleAIToolType): boolean {
+function isGeminiNonFunctionTool(tool: GoogleAIToolType): tool is GeminiTool {
   return isGeminiTool(tool) && !("functionDeclaration" in tool);
 }
 
@@ -80,7 +80,7 @@ export function convertToGeminiTools(tools: GoogleAIToolType[]): GeminiTool[] {
   let functionDeclarationsIndex = -1;
   tools.forEach((tool) => {
     if (isGeminiNonFunctionTool(tool)) {
-      geminiTools.push(tool as GeminiTool);
+      geminiTools.push(tool);
     } else {
       if (functionDeclarationsIndex === -1) {
         geminiTools.push({

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -36,7 +36,8 @@ import type {
   GoogleAISafetyHandler,
   GeminiPartFunctionCall,
   GoogleAIAPI,
-  GeminiAPIConfig, GeminiGroundingSupport,
+  GeminiAPIConfig,
+  GeminiGroundingSupport,
 } from "../types.js";
 import { GoogleAISafetyError } from "./safety.js";
 import { MediaBlob } from "../experimental/utils/media_core.js";
@@ -757,7 +758,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   ): GeminiGroundingSupport[][] {
     const ret: GeminiGroundingSupport[][] = [];
 
-    if (!groundingSupports || groundingSupports.length === 0){
+    if (!groundingSupports || groundingSupports.length === 0) {
       return [];
     }
 
@@ -769,7 +770,6 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       } else {
         ret[partIndex] = [groundingSupport];
       }
-
     });
 
     return ret;
@@ -786,10 +786,13 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
 
     // Citation and grounding information connected to each part / ChatGeneration
     // to make sure they are available in downstream filters.
-    const candidate = (response?.data as GenerateContentResponseData)?.candidates?.[0];
+    const candidate = (response?.data as GenerateContentResponseData)
+      ?.candidates?.[0];
     const groundingMetadata = candidate?.groundingMetadata;
     const citationMetadata = candidate?.citationMetadata;
-    const groundingParts = groundingSupportByPart(groundingMetadata?.groundingSupports);
+    const groundingParts = groundingSupportByPart(
+      groundingMetadata?.groundingSupports
+    );
 
     const ret = parts.map((part, index) => {
       const gen = partToChatGeneration(part);
@@ -1080,7 +1083,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   function searchToolName(tool: GeminiTool): string | undefined {
     for (const name of GeminiSearchToolAttributes) {
       if (name in tool) {
-        return name
+        return name;
       }
     }
     return undefined;
@@ -1092,7 +1095,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     if (orig && adj && adj !== orig) {
       return {
         [adj as string]: {},
-      }
+      };
     } else {
       return tool;
     }
@@ -1108,13 +1111,13 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     // Gemini Tools may be normalized to different tool names
     const langChainTools: StructuredToolParams[] = [];
     const otherTools: GeminiTool[] = [];
-    tools.forEach(tool => {
+    tools.forEach((tool) => {
       if (isLangChainTool(tool)) {
         langChainTools.push(tool);
       } else {
         otherTools.push(cleanGeminiTool(tool as GeminiTool));
       }
-    })
+    });
 
     const result: GeminiTool[] = [...otherTools];
 

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -67,7 +67,7 @@ const testGeminiModelNames = [
   ["gemini-1.5-flash-002"],
   ["gemini-2.0-flash-exp"],
   // ["gemini-2.0-flash-thinking-exp-1219"],
-]
+];
 
 /*
  * Some models may have usage quotas still.
@@ -76,7 +76,7 @@ const testGeminiModelNames = [
 const testGeminiModelDelay: Record<string, number> = {
   "gemini-2.0-flash-exp": 5000,
   "gemini-2.0-flash-thinking-exp-1219": 5000,
-}
+};
 
 describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   let recorder: GoogleRequestRecorder;
@@ -88,9 +88,9 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
 
     const delay = testGeminiModelDelay[modelName] ?? 0;
     if (delay) {
-      console.log(`Delaying for ${delay}ms`)
+      console.log(`Delaying for ${delay}ms`);
       // eslint-disable-next-line no-promise-executor-return
-      await new Promise(resolve => setTimeout(resolve,delay));
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   });
 
@@ -573,8 +573,7 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
 
   test("Supports GoogleSearchTool", async () => {
     const searchTool: GeminiTool = {
-      googleSearch: {
-      },
+      googleSearch: {},
     };
     const model = new ChatVertexAI({
       modelName,
@@ -611,7 +610,6 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
     }
     expect(finalMsg.content as string).toContain("Dodgers");
   });
-
 });
 
 describe("GAuth Anthropic Chat", () => {

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -59,18 +59,43 @@ const calculatorTool = tool((_) => "no-op", {
   }),
 });
 
-describe("GAuth Gemini Chat", () => {
+/*
+ * Which models do we want to run the test suite against?
+ */
+const testGeminiModelNames = [
+  ["gemini-1.5-pro-002"],
+  ["gemini-1.5-flash-002"],
+  ["gemini-2.0-flash-exp"],
+]
+
+/*
+ * Some models may have usage quotas still.
+ * For those models, set how long (in millis) to wait in between each test.
+ */
+const testGeminiModelDelay: Record<string, number> = {
+  "gemini-2.0-flash-exp": 5000,
+}
+
+describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   let recorder: GoogleRequestRecorder;
   let callbacks: BaseCallbackHandler[];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     recorder = new GoogleRequestRecorder();
     callbacks = [recorder, new GoogleRequestLogger()];
+
+    const delay = testGeminiModelDelay[modelName] ?? 0;
+    if (delay) {
+      console.log(`Delaying for ${delay}ms`)
+      // eslint-disable-next-line no-promise-executor-return
+      await new Promise(resolve => setTimeout(resolve,delay));
+    }
   });
 
   test("invoke", async () => {
     const model = new ChatVertexAI({
       callbacks,
+      modelName,
     });
     const res = await model.invoke("What is 1 + 1?");
     expect(res).toBeDefined();
@@ -84,8 +109,10 @@ describe("GAuth Gemini Chat", () => {
     expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
   });
 
-  test("generate", async () => {
-    const model = new ChatVertexAI();
+  test(`generate`, async () => {
+    const model = new ChatVertexAI({
+      modelName,
+    });
     const messages: BaseMessage[] = [
       new SystemMessage(
         "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
@@ -103,12 +130,13 @@ describe("GAuth Gemini Chat", () => {
 
     expect(typeof aiMessage.content).toBe("string");
     const text = aiMessage.content as string;
-    expect(["H", "T"]).toContainEqual(text);
+    expect(["H", "T"]).toContainEqual(text.trim());
   });
 
   test("stream", async () => {
     const model = new ChatVertexAI({
       callbacks,
+      modelName,
     });
     const input: BaseLanguageModelInput = new ChatPromptValue([
       new SystemMessage(
@@ -153,7 +181,11 @@ describe("GAuth Gemini Chat", () => {
         ],
       },
     ];
-    const model = new ChatVertexAI().bind({ tools });
+    const model = new ChatVertexAI({
+      modelName,
+    }).bind({
+      tools,
+    });
     const result = await model.invoke("Run a test on the cobalt project");
     expect(result).toHaveProperty("content");
     expect(result.content).toBe("");
@@ -197,7 +229,11 @@ describe("GAuth Gemini Chat", () => {
         ],
       },
     ];
-    const model = new ChatVertexAI().bind({ tools });
+    const model = new ChatVertexAI({
+      modelName,
+    }).bind({
+      tools,
+    });
     const toolResult = {
       testPassed: true,
     };
@@ -241,7 +277,9 @@ describe("GAuth Gemini Chat", () => {
         required: ["location"],
       },
     };
-    const model = new ChatVertexAI().withStructuredOutput(tool);
+    const model = new ChatVertexAI({
+      modelName,
+    }).withStructuredOutput(tool);
     const result = await model.invoke("What is the weather in Paris?");
     expect(result).toHaveProperty("location");
   });
@@ -275,7 +313,7 @@ describe("GAuth Gemini Chat", () => {
       resolvers: [resolver],
     });
     const model = new ChatGoogle({
-      modelName: "gemini-1.5-flash",
+      modelName,
       apiConfig: {
         mediaManager,
       },
@@ -320,6 +358,7 @@ describe("GAuth Gemini Chat", () => {
     const model = new ChatVertexAI({
       temperature: 0,
       maxOutputTokens: 10,
+      modelName,
     });
     let res: AIMessageChunk | null = null;
     for await (const chunk of await model.stream(
@@ -347,6 +386,7 @@ describe("GAuth Gemini Chat", () => {
     const model = new ChatVertexAI({
       temperature: 0,
       streamUsage: false,
+      modelName,
     });
     let res: AIMessageChunk | null = null;
     for await (const chunk of await model.stream(
@@ -366,6 +406,7 @@ describe("GAuth Gemini Chat", () => {
     const model = new ChatVertexAI({
       temperature: 0,
       maxOutputTokens: 10,
+      modelName,
     });
     const res = await model.invoke("Why is the sky blue? Be concise.");
     // console.log(res);
@@ -384,6 +425,7 @@ describe("GAuth Gemini Chat", () => {
     const modelWithStreaming = new ChatVertexAI({
       maxOutputTokens: 50,
       streaming: true,
+      modelName,
     });
 
     let totalTokenCount = 0;
@@ -407,7 +449,7 @@ describe("GAuth Gemini Chat", () => {
 
   test("Can force a model to invoke a tool", async () => {
     const model = new ChatVertexAI({
-      model: "gemini-1.5-pro",
+      modelName,
     });
     const modelWithTools = model.bind({
       tools: [calculatorTool, weatherTool],
@@ -425,8 +467,10 @@ describe("GAuth Gemini Chat", () => {
     expect(result.tool_calls?.[0].args).toHaveProperty("expression");
   });
 
-  test("ChatGoogleGenerativeAI can stream tools", async () => {
-    const model = new ChatVertexAI({});
+  test(`stream tools`, async () => {
+    const model = new ChatVertexAI({
+      modelName,
+    });
 
     const weatherTool = tool(
       (_) => "The weather in San Francisco today is 18 degrees and sunny.",
@@ -474,7 +518,7 @@ describe("GAuth Gemini Chat", () => {
     const audioMimeType = "audio/wav";
 
     const model = new ChatVertexAI({
-      model: "gemini-1.5-flash",
+      model: modelName,
       temperature: 0,
       maxRetries: 0,
     });

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { StructuredTool } from "@langchain/core/tools";
+import { StructuredTool, tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import {
   AIMessage,
   AIMessageChunk,
   BaseMessage,
-  BaseMessageChunk,
+  BaseMessageChunk, BaseMessageLike,
   HumanMessage,
   HumanMessageChunk,
   MessageContentComplex,
@@ -16,10 +16,21 @@ import {
 import { BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import { ChatPromptValue } from "@langchain/core/prompt_values";
 import {
+  BackedBlobStore,
+  MediaBlob,
   MediaManager,
+  ReadThroughBlobStore,
   SimpleWebBlobStore,
 } from "@langchain/google-common/experimental/utils/media_core";
-import { ChatGoogle } from "../chat_models.js";
+import {GeminiTool, GooglePlatformType, GoogleRequestLogger, GoogleRequestRecorder} from "@langchain/google-common";
+import {BaseCallbackHandler} from "@langchain/core/callbacks/base";
+import {InMemoryStore} from "@langchain/core/stores";
+import {BlobStoreGoogleCloudStorage} from "@langchain/google-gauth";
+import {GoogleCloudStorageUri} from "@langchain/google-common/experimental/media";
+import {concat} from "@langchain/core/utils/stream";
+import fs from "fs/promises";
+import {ChatPromptTemplate, MessagesPlaceholder} from "@langchain/core/prompts";
+import {ChatGoogle, ChatGoogleInput} from "../chat_models.js";
 import { BlobStoreAIStudioFile } from "../media.js";
 
 class WeatherTool extends StructuredTool {
@@ -246,4 +257,567 @@ describe("Google APIKey Chat", () => {
       throw e;
     }
   });
+});
+
+const weatherTool = tool((_) => "no-op", {
+  name: "get_weather",
+  description:
+    "Get the weather of a specific location and return the temperature in Celsius.",
+  schema: z.object({
+    location: z.string().describe("The name of city to get the weather for."),
+  }),
+});
+
+const calculatorTool = tool((_) => "no-op", {
+  name: "calculator",
+  description: "Calculate the result of a math expression.",
+  schema: z.object({
+    expression: z.string().describe("The math expression to calculate."),
+  }),
+});
+
+/*
+ * Which models do we want to run the test suite against
+ * and on which platforms?
+ */
+const testGeminiModelNames = [
+  {modelName: "gemini-1.5-pro-002", platformType: "gai", apiVersion: "v1beta"},
+  {modelName: "gemini-1.5-pro-002", platformType: "gcp", apiVersion: "v1"},
+  {modelName: "gemini-1.5-flash-002", platformType: "gai", apiVersion: "v1beta"},
+  {modelName: "gemini-1.5-flash-002", platformType: "gcp", apiVersion: "v1"},
+  {modelName: "gemini-2.0-flash-exp", platformType: "gai", apiVersion: "v1beta"},
+  {modelName: "gemini-2.0-flash-exp", platformType: "gcp", apiVersion: "v1"},
+  // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},
+  // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gcp"},
+]
+
+/*
+ * Some models may have usage quotas still.
+ * For those models, set how long (in millis) to wait in between each test.
+ */
+const testGeminiModelDelay: Record<string, number> = {
+  "gemini-2.0-flash-exp": 10000,
+  "gemini-2.0-flash-thinking-exp-1219": 10000,
+}
+
+describe.each(testGeminiModelNames)("Webauth ($platformType) Gemini Chat ($modelName)", ({modelName, platformType, apiVersion}) => {
+  let recorder: GoogleRequestRecorder;
+  let callbacks: BaseCallbackHandler[];
+
+  function newChatGoogle(fields?: ChatGoogleInput): ChatGoogle {
+    return new ChatGoogle({
+      modelName,
+      platformType: platformType as GooglePlatformType,
+      apiVersion,
+      ...fields ?? {},
+    })
+  }
+
+  beforeEach(async () => {
+    recorder = new GoogleRequestRecorder();
+    callbacks = [recorder, new GoogleRequestLogger()];
+
+    const delay = testGeminiModelDelay[modelName] ?? 0;
+    if (delay) {
+      console.log(`Delaying for ${delay}ms`)
+      // eslint-disable-next-line no-promise-executor-return
+      await new Promise(resolve => setTimeout(resolve,delay));
+    }
+  });
+
+  test("invoke", async () => {
+    const model = newChatGoogle({
+      callbacks,
+    });
+    const res = await model.invoke("What is 1 + 1?");
+    expect(res).toBeDefined();
+    expect(res._getType()).toEqual("ai");
+
+    const aiMessage = res as AIMessageChunk;
+    expect(aiMessage.content).toBeDefined();
+
+    expect(typeof aiMessage.content).toBe("string");
+    const text = aiMessage.content as string;
+    expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
+  });
+
+  test(`generate`, async () => {
+    const model = newChatGoogle();
+    const messages: BaseMessage[] = [
+      new SystemMessage(
+        "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
+      ),
+      new HumanMessage("Flip it"),
+      new AIMessage("T"),
+      new HumanMessage("Flip the coin again"),
+    ];
+    const res = await model.predictMessages(messages);
+    expect(res).toBeDefined();
+    expect(res._getType()).toEqual("ai");
+
+    const aiMessage = res as AIMessageChunk;
+    expect(aiMessage.content).toBeDefined();
+
+    expect(typeof aiMessage.content).toBe("string");
+    const text = aiMessage.content as string;
+    expect(["H", "T"]).toContainEqual(text.trim());
+  });
+
+  test("stream", async () => {
+    const model = newChatGoogle({
+      callbacks,
+    });
+    const input: BaseLanguageModelInput = new ChatPromptValue([
+      new SystemMessage(
+        "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
+      ),
+      new HumanMessage("Flip it"),
+      new AIMessage("T"),
+      new HumanMessage("Flip the coin again"),
+    ]);
+    const res = await model.stream(input);
+    const resArray: BaseMessageChunk[] = [];
+    for await (const chunk of res) {
+      resArray.push(chunk);
+    }
+    expect(resArray).toBeDefined();
+    expect(resArray.length).toBeGreaterThanOrEqual(1);
+
+    const lastChunk = resArray[resArray.length - 1];
+    expect(lastChunk).toBeDefined();
+    expect(lastChunk._getType()).toEqual("ai");
+  });
+
+  test("function", async () => {
+    const tools: GeminiTool[] = [
+      {
+        functionDeclarations: [
+          {
+            name: "test",
+            description:
+              "Run a test with a specific name and get if it passed or failed",
+            parameters: {
+              type: "object",
+              properties: {
+                testName: {
+                  type: "string",
+                  description: "The name of the test that should be run.",
+                },
+              },
+              required: ["testName"],
+            },
+          },
+        ],
+      },
+    ];
+    const model = newChatGoogle().bind({
+      tools,
+    });
+    const result = await model.invoke("Run a test on the cobalt project");
+    expect(result).toHaveProperty("content");
+    expect(result.content).toBe("");
+    const args = result?.lc_kwargs?.additional_kwargs;
+    expect(args).toBeDefined();
+    expect(args).toHaveProperty("tool_calls");
+    expect(Array.isArray(args.tool_calls)).toBeTruthy();
+    expect(args.tool_calls).toHaveLength(1);
+    const call = args.tool_calls[0];
+    expect(call).toHaveProperty("type");
+    expect(call.type).toBe("function");
+    expect(call).toHaveProperty("function");
+    const func = call.function;
+    expect(func).toBeDefined();
+    expect(func).toHaveProperty("name");
+    expect(func.name).toBe("test");
+    expect(func).toHaveProperty("arguments");
+    expect(typeof func.arguments).toBe("string");
+    expect(func.arguments.replaceAll("\n", "")).toBe('{"testName":"cobalt"}');
+  });
+
+  test("function reply", async () => {
+    const tools: GeminiTool[] = [
+      {
+        functionDeclarations: [
+          {
+            name: "test",
+            description:
+              "Run a test with a specific name and get if it passed or failed",
+            parameters: {
+              type: "object",
+              properties: {
+                testName: {
+                  type: "string",
+                  description: "The name of the test that should be run.",
+                },
+              },
+              required: ["testName"],
+            },
+          },
+        ],
+      },
+    ];
+    const model = newChatGoogle().bind({
+      tools,
+    });
+    const toolResult = {
+      testPassed: true,
+    };
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Run a test on the cobalt project."),
+      new AIMessage("", {
+        tool_calls: [
+          {
+            id: "test",
+            type: "function",
+            function: {
+              name: "test",
+              arguments: '{"testName":"cobalt"}',
+            },
+          },
+        ],
+      }),
+      new ToolMessage(JSON.stringify(toolResult), "test"),
+    ];
+    const res = await model.stream(messages);
+    const resArray: BaseMessageChunk[] = [];
+    for await (const chunk of res) {
+      resArray.push(chunk);
+    }
+    // console.log(JSON.stringify(resArray, null, 2));
+  });
+
+  test("withStructuredOutput", async () => {
+    const tool = {
+      name: "get_weather",
+      description:
+        "Get the weather of a specific location and return the temperature in Celsius.",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "The name of city to get the weather for.",
+          },
+        },
+        required: ["location"],
+      },
+    };
+    const model = newChatGoogle().withStructuredOutput(tool);
+    const result = await model.invoke("What is the weather in Paris?");
+    expect(result).toHaveProperty("location");
+  });
+
+  test("media - fileData", async () => {
+    class MemStore extends InMemoryStore<MediaBlob> {
+      get length() {
+        return Object.keys(this.store).length;
+      }
+    }
+    const aliasMemory = new MemStore();
+    const aliasStore = new BackedBlobStore({
+      backingStore: aliasMemory,
+      defaultFetchOptions: {
+        actionIfBlobMissing: undefined,
+      },
+    });
+    const backingStore = new BlobStoreGoogleCloudStorage({
+      uriPrefix: new GoogleCloudStorageUri("gs://test-langchainjs/mediatest/"),
+      defaultStoreOptions: {
+        actionIfInvalid: "prefixPath",
+      },
+    });
+    const blobStore = new ReadThroughBlobStore({
+      baseStore: aliasStore,
+      backingStore,
+    });
+    const resolver = new SimpleWebBlobStore();
+    const mediaManager = new MediaManager({
+      store: blobStore,
+      resolvers: [resolver],
+    });
+    const model = newChatGoogle({
+      apiConfig: {
+        mediaManager,
+      },
+    });
+
+    const message: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "What is in this image?",
+      },
+      {
+        type: "media",
+        fileUri: "https://js.langchain.com/v0.2/img/brand/wordmark.png",
+      },
+    ];
+
+    const messages: BaseMessage[] = [
+      new HumanMessageChunk({ content: message }),
+    ];
+
+    try {
+      const res = await model.invoke(messages);
+
+      console.log(res);
+
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      const aiMessage = res as AIMessageChunk;
+      expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/LangChain/);
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  });
+
+  test("Stream token count usage_metadata", async () => {
+    const model = newChatGoogle({
+      temperature: 0,
+      maxOutputTokens: 10,
+    });
+    let res: AIMessageChunk | null = null;
+    for await (const chunk of await model.stream(
+      "Why is the sky blue? Be concise."
+    )) {
+      if (!res) {
+        res = chunk;
+      } else {
+        res = res.concat(chunk);
+      }
+    }
+    // console.log(res);
+    expect(res?.usage_metadata).toBeDefined();
+    if (!res?.usage_metadata) {
+      return;
+    }
+    expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
+    expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
+    expect(res.usage_metadata.total_tokens).toBe(
+      res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
+    );
+  });
+
+  test("streamUsage excludes token usage", async () => {
+    const model = newChatGoogle({
+      temperature: 0,
+      streamUsage: false,
+    });
+    let res: AIMessageChunk | null = null;
+    for await (const chunk of await model.stream(
+      "Why is the sky blue? Be concise."
+    )) {
+      if (!res) {
+        res = chunk;
+      } else {
+        res = res.concat(chunk);
+      }
+    }
+    // console.log(res);
+    expect(res?.usage_metadata).not.toBeDefined();
+  });
+
+  test("Invoke token count usage_metadata", async () => {
+    const model = newChatGoogle({
+      temperature: 0,
+      maxOutputTokens: 10,
+    });
+    const res = await model.invoke("Why is the sky blue? Be concise.");
+    // console.log(res);
+    expect(res?.usage_metadata).toBeDefined();
+    if (!res?.usage_metadata) {
+      return;
+    }
+    expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
+    expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
+    expect(res.usage_metadata.total_tokens).toBe(
+      res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
+    );
+  });
+
+  test("Streaming true constructor param will stream", async () => {
+    const modelWithStreaming = newChatGoogle({
+      maxOutputTokens: 50,
+      streaming: true,
+    });
+
+    let totalTokenCount = 0;
+    let tokensString = "";
+    const result = await modelWithStreaming.invoke("What is 1 + 1?", {
+      callbacks: [
+        {
+          handleLLMNewToken: (tok) => {
+            totalTokenCount += 1;
+            tokensString += tok;
+          },
+        },
+      ],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.content).toBe(tokensString);
+
+    expect(totalTokenCount).toBeGreaterThan(1);
+  });
+
+  test("Can force a model to invoke a tool", async () => {
+    const model = newChatGoogle();
+    const modelWithTools = model.bind({
+      tools: [calculatorTool, weatherTool],
+      tool_choice: "calculator",
+    });
+
+    const result = await modelWithTools.invoke(
+      "Whats the weather like in paris today? What's 1836 plus 7262?"
+    );
+
+    expect(result.tool_calls).toHaveLength(1);
+    expect(result.tool_calls?.[0]).toBeDefined();
+    if (!result.tool_calls?.[0]) return;
+    expect(result.tool_calls?.[0].name).toBe("calculator");
+    expect(result.tool_calls?.[0].args).toHaveProperty("expression");
+  });
+
+  test(`stream tools`, async () => {
+    const model = newChatGoogle();
+
+    const weatherTool = tool(
+      (_) => "The weather in San Francisco today is 18 degrees and sunny.",
+      {
+        name: "current_weather_tool",
+        description: "Get the current weather for a given location.",
+        schema: z.object({
+          location: z.string().describe("The location to get the weather for."),
+        }),
+      }
+    );
+
+    const modelWithTools = model.bindTools([weatherTool]);
+    const stream = await modelWithTools.stream(
+      "Whats the weather like today in San Francisco?"
+    );
+    let finalChunk: AIMessageChunk | undefined;
+    for await (const chunk of stream) {
+      finalChunk = !finalChunk ? chunk : concat(finalChunk, chunk);
+    }
+
+    expect(finalChunk).toBeDefined();
+    if (!finalChunk) return;
+
+    const toolCalls = finalChunk.tool_calls;
+    expect(toolCalls).toBeDefined();
+    if (!toolCalls) {
+      throw new Error("tool_calls not in response");
+    }
+    expect(toolCalls.length).toBe(1);
+    expect(toolCalls[0].name).toBe("current_weather_tool");
+    expect(toolCalls[0].args).toHaveProperty("location");
+  });
+
+  async function fileToBase64(filePath: string): Promise<string> {
+    const fileData = await fs.readFile(filePath);
+    const base64String = Buffer.from(fileData).toString("base64");
+    return base64String;
+  }
+
+  test("Gemini can understand audio", async () => {
+    // Update this with the correct path to an audio file on your machine.
+    const audioPath =
+      "../langchain-google-genai/src/tests/data/gettysburg10.wav";
+    const audioMimeType = "audio/wav";
+
+    const model = newChatGoogle({
+      temperature: 0,
+      maxRetries: 0,
+    });
+
+    const audioBase64 = await fileToBase64(audioPath);
+
+    const prompt = ChatPromptTemplate.fromMessages([
+      new MessagesPlaceholder("audio"),
+    ]);
+
+    const chain = prompt.pipe(model);
+    const response = await chain.invoke({
+      audio: new HumanMessage({
+        content: [
+          {
+            type: "media",
+            mimeType: audioMimeType,
+            data: audioBase64,
+          },
+          {
+            type: "text",
+            text: "Summarize the content in this audio. ALso, what is the speaker's tone?",
+          },
+        ],
+      }),
+    });
+
+    expect(typeof response.content).toBe("string");
+    expect((response.content as string).length).toBeGreaterThan(15);
+  });
+
+  test("Supports GoogleSearchRetrievalTool", async () => {
+    const searchRetrievalTool = {
+      googleSearchRetrieval: {
+        dynamicRetrievalConfig: {
+          mode: "MODE_DYNAMIC",
+          dynamicThreshold: 0.7, // default is 0.7
+        },
+      },
+    };
+    const model = newChatGoogle({
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchRetrievalTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+  });
+
+  test("Supports GoogleSearchTool", async () => {
+    const searchTool: GeminiTool = {
+      googleSearch: {
+      },
+    };
+    const model = newChatGoogle({
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchTool]);
+
+    const result = await model.invoke("Who won the 2024 MLB World Series?");
+    expect(result.content as string).toContain("Dodgers");
+  });
+
+  test("Can stream GoogleSearchRetrievalTool", async () => {
+    const searchRetrievalTool = {
+      googleSearchRetrieval: {
+        dynamicRetrievalConfig: {
+          mode: "MODE_DYNAMIC",
+          dynamicThreshold: 0.7, // default is 0.7
+        },
+      },
+    };
+    const model = newChatGoogle({
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([searchRetrievalTool]);
+
+    const stream = await model.stream("Who won the 2024 MLB World Series?");
+    let finalMsg: AIMessageChunk | undefined;
+    for await (const msg of stream) {
+      finalMsg = finalMsg ? concat(finalMsg, msg) : msg;
+    }
+    if (!finalMsg) {
+      throw new Error("finalMsg is undefined");
+    }
+    expect(finalMsg.content as string).toContain("Dodgers");
+  });
+
 });

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -17,10 +17,7 @@ import {
 import { BaseLanguageModelInput } from "@langchain/core/language_models/base";
 import { ChatPromptValue } from "@langchain/core/prompt_values";
 import {
-  BackedBlobStore,
-  MediaBlob,
   MediaManager,
-  ReadThroughBlobStore,
   SimpleWebBlobStore,
 } from "@langchain/google-common/experimental/utils/media_core";
 import {
@@ -29,9 +26,6 @@ import {
   GoogleRequestRecorder,
 } from "@langchain/google-common";
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
-import { InMemoryStore } from "@langchain/core/stores";
-import { BlobStoreGoogleCloudStorage } from "@langchain/google-gauth";
-import { GoogleCloudStorageUri } from "@langchain/google-common/experimental/media";
 import { concat } from "@langchain/core/utils/stream";
 import fs from "fs/promises";
 import {
@@ -535,76 +529,76 @@ describe.each(testGeminiModelNames)(
       expect(result).toHaveProperty("location");
     });
 
-    test("media - fileData", async () => {
-      class MemStore extends InMemoryStore<MediaBlob> {
-        get length() {
-          return Object.keys(this.store).length;
-        }
-      }
-      const aliasMemory = new MemStore();
-      const aliasStore = new BackedBlobStore({
-        backingStore: aliasMemory,
-        defaultFetchOptions: {
-          actionIfBlobMissing: undefined,
-        },
-      });
-      const backingStore = new BlobStoreGoogleCloudStorage({
-        uriPrefix: new GoogleCloudStorageUri(
-          "gs://test-langchainjs/mediatest/"
-        ),
-        defaultStoreOptions: {
-          actionIfInvalid: "prefixPath",
-        },
-      });
-      const blobStore = new ReadThroughBlobStore({
-        baseStore: aliasStore,
-        backingStore,
-      });
-      const resolver = new SimpleWebBlobStore();
-      const mediaManager = new MediaManager({
-        store: blobStore,
-        resolvers: [resolver],
-      });
-      const model = newChatGoogle({
-        apiConfig: {
-          mediaManager,
-        },
-      });
+    // test("media - fileData", async () => {
+    //   class MemStore extends InMemoryStore<MediaBlob> {
+    //     get length() {
+    //       return Object.keys(this.store).length;
+    //     }
+    //   }
+    //   const aliasMemory = new MemStore();
+    //   const aliasStore = new BackedBlobStore({
+    //     backingStore: aliasMemory,
+    //     defaultFetchOptions: {
+    //       actionIfBlobMissing: undefined,
+    //     },
+    //   });
+    //   const backingStore = new BlobStoreGoogleCloudStorage({
+    //     uriPrefix: new GoogleCloudStorageUri(
+    //       "gs://test-langchainjs/mediatest/"
+    //     ),
+    //     defaultStoreOptions: {
+    //       actionIfInvalid: "prefixPath",
+    //     },
+    //   });
+    //   const blobStore = new ReadThroughBlobStore({
+    //     baseStore: aliasStore,
+    //     backingStore,
+    //   });
+    //   const resolver = new SimpleWebBlobStore();
+    //   const mediaManager = new MediaManager({
+    //     store: blobStore,
+    //     resolvers: [resolver],
+    //   });
+    //   const model = newChatGoogle({
+    //     apiConfig: {
+    //       mediaManager,
+    //     },
+    //   });
 
-      const message: MessageContentComplex[] = [
-        {
-          type: "text",
-          text: "What is in this image?",
-        },
-        {
-          type: "media",
-          fileUri: "https://js.langchain.com/v0.2/img/brand/wordmark.png",
-        },
-      ];
+    //   const message: MessageContentComplex[] = [
+    //     {
+    //       type: "text",
+    //       text: "What is in this image?",
+    //     },
+    //     {
+    //       type: "media",
+    //       fileUri: "https://js.langchain.com/v0.2/img/brand/wordmark.png",
+    //     },
+    //   ];
 
-      const messages: BaseMessage[] = [
-        new HumanMessageChunk({ content: message }),
-      ];
+    //   const messages: BaseMessage[] = [
+    //     new HumanMessageChunk({ content: message }),
+    //   ];
 
-      try {
-        const res = await model.invoke(messages);
+    //   try {
+    //     const res = await model.invoke(messages);
 
-        console.log(res);
+    //     console.log(res);
 
-        expect(res).toBeDefined();
-        expect(res._getType()).toEqual("ai");
+    //     expect(res).toBeDefined();
+    //     expect(res._getType()).toEqual("ai");
 
-        const aiMessage = res as AIMessageChunk;
-        expect(aiMessage.content).toBeDefined();
+    //     const aiMessage = res as AIMessageChunk;
+    //     expect(aiMessage.content).toBeDefined();
 
-        expect(typeof aiMessage.content).toBe("string");
-        const text = aiMessage.content as string;
-        expect(text).toMatch(/LangChain/);
-      } catch (e) {
-        console.error(e);
-        throw e;
-      }
-    });
+    //     expect(typeof aiMessage.content).toBe("string");
+    //     const text = aiMessage.content as string;
+    //     expect(text).toMatch(/LangChain/);
+    //   } catch (e) {
+    //     console.error(e);
+    //     throw e;
+    //   }
+    // });
 
     test("Stream token count usage_metadata", async () => {
       const model = newChatGoogle({

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -6,7 +6,8 @@ import {
   AIMessage,
   AIMessageChunk,
   BaseMessage,
-  BaseMessageChunk, BaseMessageLike,
+  BaseMessageChunk,
+  BaseMessageLike,
   HumanMessage,
   HumanMessageChunk,
   MessageContentComplex,
@@ -22,15 +23,22 @@ import {
   ReadThroughBlobStore,
   SimpleWebBlobStore,
 } from "@langchain/google-common/experimental/utils/media_core";
-import {GeminiTool, GooglePlatformType, GoogleRequestRecorder} from "@langchain/google-common";
-import {BaseCallbackHandler} from "@langchain/core/callbacks/base";
-import {InMemoryStore} from "@langchain/core/stores";
-import {BlobStoreGoogleCloudStorage} from "@langchain/google-gauth";
-import {GoogleCloudStorageUri} from "@langchain/google-common/experimental/media";
-import {concat} from "@langchain/core/utils/stream";
+import {
+  GeminiTool,
+  GooglePlatformType,
+  GoogleRequestRecorder,
+} from "@langchain/google-common";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import { InMemoryStore } from "@langchain/core/stores";
+import { BlobStoreGoogleCloudStorage } from "@langchain/google-gauth";
+import { GoogleCloudStorageUri } from "@langchain/google-common/experimental/media";
+import { concat } from "@langchain/core/utils/stream";
 import fs from "fs/promises";
-import {ChatPromptTemplate, MessagesPlaceholder} from "@langchain/core/prompts";
-import {ChatGoogle, ChatGoogleInput} from "../chat_models.js";
+import {
+  ChatPromptTemplate,
+  MessagesPlaceholder,
+} from "@langchain/core/prompts";
+import { ChatGoogle, ChatGoogleInput } from "../chat_models.js";
 import { BlobStoreAIStudioFile } from "../media.js";
 
 class WeatherTool extends StructuredTool {
@@ -281,17 +289,29 @@ const calculatorTool = tool((_) => "no-op", {
  * and on which platforms?
  */
 const testGeminiModelNames = [
-  {modelName: "gemini-1.5-pro-002", platformType: "gai", apiVersion: "v1beta"},
-  {modelName: "gemini-1.5-pro-002", platformType: "gcp", apiVersion: "v1"},
-  {modelName: "gemini-1.5-flash-002", platformType: "gai", apiVersion: "v1beta"},
-  {modelName: "gemini-1.5-flash-002", platformType: "gcp", apiVersion: "v1"},
-  {modelName: "gemini-2.0-flash-exp", platformType: "gai", apiVersion: "v1beta"},
-  {modelName: "gemini-2.0-flash-exp", platformType: "gcp", apiVersion: "v1"},
+  {
+    modelName: "gemini-1.5-pro-002",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  { modelName: "gemini-1.5-pro-002", platformType: "gcp", apiVersion: "v1" },
+  {
+    modelName: "gemini-1.5-flash-002",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  { modelName: "gemini-1.5-flash-002", platformType: "gcp", apiVersion: "v1" },
+  {
+    modelName: "gemini-2.0-flash-exp",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  { modelName: "gemini-2.0-flash-exp", platformType: "gcp", apiVersion: "v1" },
 
   // Flash Thinking doesn't have functions or other features
   // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},
   // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gcp"},
-]
+];
 
 /*
  * Some models may have usage quotas still.
@@ -300,273 +320,40 @@ const testGeminiModelNames = [
 const testGeminiModelDelay: Record<string, number> = {
   "gemini-2.0-flash-exp": 10000,
   "gemini-2.0-flash-thinking-exp-1219": 10000,
-}
+};
 
-describe.each(testGeminiModelNames)("Webauth ($platformType) Gemini Chat ($modelName)", ({modelName, platformType, apiVersion}) => {
-  let recorder: GoogleRequestRecorder;
-  let callbacks: BaseCallbackHandler[];
+describe.each(testGeminiModelNames)(
+  "Webauth ($platformType) Gemini Chat ($modelName)",
+  ({ modelName, platformType, apiVersion }) => {
+    let recorder: GoogleRequestRecorder;
+    let callbacks: BaseCallbackHandler[];
 
-  function newChatGoogle(fields?: ChatGoogleInput): ChatGoogle {
-    // const logger = new GoogleRequestLogger();
-    recorder = new GoogleRequestRecorder();
-    callbacks = [recorder];
+    function newChatGoogle(fields?: ChatGoogleInput): ChatGoogle {
+      // const logger = new GoogleRequestLogger();
+      recorder = new GoogleRequestRecorder();
+      callbacks = [recorder];
 
-    return new ChatGoogle({
-      modelName,
-      platformType: platformType as GooglePlatformType,
-      apiVersion,
-      callbacks,
-      ...fields ?? {},
-    })
-  }
-
-  beforeEach(async () => {
-    const delay = testGeminiModelDelay[modelName] ?? 0;
-    if (delay) {
-      console.log(`Delaying for ${delay}ms`)
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise(resolve => setTimeout(resolve,delay));
+      return new ChatGoogle({
+        modelName,
+        platformType: platformType as GooglePlatformType,
+        apiVersion,
+        callbacks,
+        ...(fields ?? {}),
+      });
     }
-  });
 
-  test("invoke", async () => {
-    const model = newChatGoogle();
-    const res = await model.invoke("What is 1 + 1?");
-    expect(res).toBeDefined();
-    expect(res._getType()).toEqual("ai");
-
-    const aiMessage = res as AIMessageChunk;
-    expect(aiMessage.content).toBeDefined();
-
-    expect(typeof aiMessage.content).toBe("string");
-    const text = aiMessage.content as string;
-    expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
-
-    expect(res).toHaveProperty("response_metadata");
-    expect(res.response_metadata).not.toHaveProperty("groundingMetadata");
-    expect(res.response_metadata).not.toHaveProperty("groundingSupport");
-
-    console.log(recorder);
-  });
-
-  test(`generate`, async () => {
-    const model = newChatGoogle();
-    const messages: BaseMessage[] = [
-      new SystemMessage(
-        "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
-      ),
-      new HumanMessage("Flip it"),
-      new AIMessage("T"),
-      new HumanMessage("Flip the coin again"),
-    ];
-    const res = await model.predictMessages(messages);
-    expect(res).toBeDefined();
-    expect(res._getType()).toEqual("ai");
-
-    const aiMessage = res as AIMessageChunk;
-    expect(aiMessage.content).toBeDefined();
-
-    expect(typeof aiMessage.content).toBe("string");
-    const text = aiMessage.content as string;
-    expect(["H", "T"]).toContainEqual(text.trim());
-  });
-
-  test("stream", async () => {
-    const model = newChatGoogle();
-    const input: BaseLanguageModelInput = new ChatPromptValue([
-      new SystemMessage(
-        "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
-      ),
-      new HumanMessage("Flip it"),
-      new AIMessage("T"),
-      new HumanMessage("Flip the coin again"),
-    ]);
-    const res = await model.stream(input);
-    const resArray: BaseMessageChunk[] = [];
-    for await (const chunk of res) {
-      resArray.push(chunk);
-    }
-    expect(resArray).toBeDefined();
-    expect(resArray.length).toBeGreaterThanOrEqual(1);
-
-    const lastChunk = resArray[resArray.length - 1];
-    expect(lastChunk).toBeDefined();
-    expect(lastChunk._getType()).toEqual("ai");
-  });
-
-  test("function", async () => {
-    const tools: GeminiTool[] = [
-      {
-        functionDeclarations: [
-          {
-            name: "test",
-            description:
-              "Run a test with a specific name and get if it passed or failed",
-            parameters: {
-              type: "object",
-              properties: {
-                testName: {
-                  type: "string",
-                  description: "The name of the test that should be run.",
-                },
-              },
-              required: ["testName"],
-            },
-          },
-        ],
-      },
-    ];
-    const model = newChatGoogle().bind({
-      tools,
-    });
-    const result = await model.invoke("Run a test on the cobalt project");
-    expect(result).toHaveProperty("content");
-    expect(result.content).toBe("");
-    const args = result?.lc_kwargs?.additional_kwargs;
-    expect(args).toBeDefined();
-    expect(args).toHaveProperty("tool_calls");
-    expect(Array.isArray(args.tool_calls)).toBeTruthy();
-    expect(args.tool_calls).toHaveLength(1);
-    const call = args.tool_calls[0];
-    expect(call).toHaveProperty("type");
-    expect(call.type).toBe("function");
-    expect(call).toHaveProperty("function");
-    const func = call.function;
-    expect(func).toBeDefined();
-    expect(func).toHaveProperty("name");
-    expect(func.name).toBe("test");
-    expect(func).toHaveProperty("arguments");
-    expect(typeof func.arguments).toBe("string");
-    expect(func.arguments.replaceAll("\n", "")).toBe('{"testName":"cobalt"}');
-  });
-
-  test("function reply", async () => {
-    const tools: GeminiTool[] = [
-      {
-        functionDeclarations: [
-          {
-            name: "test",
-            description:
-              "Run a test with a specific name and get if it passed or failed",
-            parameters: {
-              type: "object",
-              properties: {
-                testName: {
-                  type: "string",
-                  description: "The name of the test that should be run.",
-                },
-              },
-              required: ["testName"],
-            },
-          },
-        ],
-      },
-    ];
-    const model = newChatGoogle().bind({
-      tools,
-    });
-    const toolResult = {
-      testPassed: true,
-    };
-    const messages: BaseMessageLike[] = [
-      new HumanMessage("Run a test on the cobalt project."),
-      new AIMessage("", {
-        tool_calls: [
-          {
-            id: "test",
-            type: "function",
-            function: {
-              name: "test",
-              arguments: '{"testName":"cobalt"}',
-            },
-          },
-        ],
-      }),
-      new ToolMessage(JSON.stringify(toolResult), "test"),
-    ];
-    const res = await model.stream(messages);
-    const resArray: BaseMessageChunk[] = [];
-    for await (const chunk of res) {
-      resArray.push(chunk);
-    }
-    // console.log(JSON.stringify(resArray, null, 2));
-  });
-
-  test("withStructuredOutput", async () => {
-    const tool = {
-      name: "get_weather",
-      description:
-        "Get the weather of a specific location and return the temperature in Celsius.",
-      parameters: {
-        type: "object",
-        properties: {
-          location: {
-            type: "string",
-            description: "The name of city to get the weather for.",
-          },
-        },
-        required: ["location"],
-      },
-    };
-    const model = newChatGoogle().withStructuredOutput(tool);
-    const result = await model.invoke("What is the weather in Paris?");
-    expect(result).toHaveProperty("location");
-  });
-
-  test("media - fileData", async () => {
-    class MemStore extends InMemoryStore<MediaBlob> {
-      get length() {
-        return Object.keys(this.store).length;
+    beforeEach(async () => {
+      const delay = testGeminiModelDelay[modelName] ?? 0;
+      if (delay) {
+        console.log(`Delaying for ${delay}ms`);
+        // eslint-disable-next-line no-promise-executor-return
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
-    }
-    const aliasMemory = new MemStore();
-    const aliasStore = new BackedBlobStore({
-      backingStore: aliasMemory,
-      defaultFetchOptions: {
-        actionIfBlobMissing: undefined,
-      },
-    });
-    const backingStore = new BlobStoreGoogleCloudStorage({
-      uriPrefix: new GoogleCloudStorageUri("gs://test-langchainjs/mediatest/"),
-      defaultStoreOptions: {
-        actionIfInvalid: "prefixPath",
-      },
-    });
-    const blobStore = new ReadThroughBlobStore({
-      baseStore: aliasStore,
-      backingStore,
-    });
-    const resolver = new SimpleWebBlobStore();
-    const mediaManager = new MediaManager({
-      store: blobStore,
-      resolvers: [resolver],
-    });
-    const model = newChatGoogle({
-      apiConfig: {
-        mediaManager,
-      },
     });
 
-    const message: MessageContentComplex[] = [
-      {
-        type: "text",
-        text: "What is in this image?",
-      },
-      {
-        type: "media",
-        fileUri: "https://js.langchain.com/v0.2/img/brand/wordmark.png",
-      },
-    ];
-
-    const messages: BaseMessage[] = [
-      new HumanMessageChunk({ content: message }),
-    ];
-
-    try {
-      const res = await model.invoke(messages);
-
-      console.log(res);
-
+    test("invoke", async () => {
+      const model = newChatGoogle();
+      const res = await model.invoke("What is 1 + 1?");
       expect(res).toBeDefined();
       expect(res._getType()).toEqual("ai");
 
@@ -575,262 +362,500 @@ describe.each(testGeminiModelNames)("Webauth ($platformType) Gemini Chat ($model
 
       expect(typeof aiMessage.content).toBe("string");
       const text = aiMessage.content as string;
-      expect(text).toMatch(/LangChain/);
-    } catch (e) {
-      console.error(e);
-      throw e;
-    }
-  });
+      expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
 
-  test("Stream token count usage_metadata", async () => {
-    const model = newChatGoogle({
-      temperature: 0,
-      maxOutputTokens: 10,
+      expect(res).toHaveProperty("response_metadata");
+      expect(res.response_metadata).not.toHaveProperty("groundingMetadata");
+      expect(res.response_metadata).not.toHaveProperty("groundingSupport");
+
+      console.log(recorder);
     });
-    let res: AIMessageChunk | null = null;
-    for await (const chunk of await model.stream(
-      "Why is the sky blue? Be concise."
-    )) {
-      if (!res) {
-        res = chunk;
-      } else {
-        res = res.concat(chunk);
+
+    test(`generate`, async () => {
+      const model = newChatGoogle();
+      const messages: BaseMessage[] = [
+        new SystemMessage(
+          "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
+        ),
+        new HumanMessage("Flip it"),
+        new AIMessage("T"),
+        new HumanMessage("Flip the coin again"),
+      ];
+      const res = await model.predictMessages(messages);
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      const aiMessage = res as AIMessageChunk;
+      expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(["H", "T"]).toContainEqual(text.trim());
+    });
+
+    test("stream", async () => {
+      const model = newChatGoogle();
+      const input: BaseLanguageModelInput = new ChatPromptValue([
+        new SystemMessage(
+          "You will reply to all requests to flip a coin with either H, indicating heads, or T, indicating tails."
+        ),
+        new HumanMessage("Flip it"),
+        new AIMessage("T"),
+        new HumanMessage("Flip the coin again"),
+      ]);
+      const res = await model.stream(input);
+      const resArray: BaseMessageChunk[] = [];
+      for await (const chunk of res) {
+        resArray.push(chunk);
       }
-    }
-    // console.log(res);
-    expect(res?.usage_metadata).toBeDefined();
-    if (!res?.usage_metadata) {
-      return;
-    }
-    expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
-    expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
-    expect(res.usage_metadata.total_tokens).toBe(
-      res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
-    );
-  });
+      expect(resArray).toBeDefined();
+      expect(resArray.length).toBeGreaterThanOrEqual(1);
 
-  test("streamUsage excludes token usage", async () => {
-    const model = newChatGoogle({
-      temperature: 0,
-      streamUsage: false,
-    });
-    let res: AIMessageChunk | null = null;
-    for await (const chunk of await model.stream(
-      "Why is the sky blue? Be concise."
-    )) {
-      if (!res) {
-        res = chunk;
-      } else {
-        res = res.concat(chunk);
-      }
-    }
-    // console.log(res);
-    expect(res?.usage_metadata).not.toBeDefined();
-  });
-
-  test("Invoke token count usage_metadata", async () => {
-    const model = newChatGoogle({
-      temperature: 0,
-      maxOutputTokens: 10,
-    });
-    const res = await model.invoke("Why is the sky blue? Be concise.");
-    // console.log(res);
-    expect(res?.usage_metadata).toBeDefined();
-    if (!res?.usage_metadata) {
-      return;
-    }
-    expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
-    expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
-    expect(res.usage_metadata.total_tokens).toBe(
-      res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
-    );
-  });
-
-  test("Streaming true constructor param will stream", async () => {
-    const modelWithStreaming = newChatGoogle({
-      maxOutputTokens: 50,
-      streaming: true,
+      const lastChunk = resArray[resArray.length - 1];
+      expect(lastChunk).toBeDefined();
+      expect(lastChunk._getType()).toEqual("ai");
     });
 
-    let totalTokenCount = 0;
-    let tokensString = "";
-    const result = await modelWithStreaming.invoke("What is 1 + 1?", {
-      callbacks: [
-        ...callbacks,
+    test("function", async () => {
+      const tools: GeminiTool[] = [
         {
-          handleLLMNewToken: (tok) => {
-            totalTokenCount += 1;
-            tokensString += tok;
-          },
+          functionDeclarations: [
+            {
+              name: "test",
+              description:
+                "Run a test with a specific name and get if it passed or failed",
+              parameters: {
+                type: "object",
+                properties: {
+                  testName: {
+                    type: "string",
+                    description: "The name of the test that should be run.",
+                  },
+                },
+                required: ["testName"],
+              },
+            },
+          ],
         },
-      ],
+      ];
+      const model = newChatGoogle().bind({
+        tools,
+      });
+      const result = await model.invoke("Run a test on the cobalt project");
+      expect(result).toHaveProperty("content");
+      expect(result.content).toBe("");
+      const args = result?.lc_kwargs?.additional_kwargs;
+      expect(args).toBeDefined();
+      expect(args).toHaveProperty("tool_calls");
+      expect(Array.isArray(args.tool_calls)).toBeTruthy();
+      expect(args.tool_calls).toHaveLength(1);
+      const call = args.tool_calls[0];
+      expect(call).toHaveProperty("type");
+      expect(call.type).toBe("function");
+      expect(call).toHaveProperty("function");
+      const func = call.function;
+      expect(func).toBeDefined();
+      expect(func).toHaveProperty("name");
+      expect(func.name).toBe("test");
+      expect(func).toHaveProperty("arguments");
+      expect(typeof func.arguments).toBe("string");
+      expect(func.arguments.replaceAll("\n", "")).toBe('{"testName":"cobalt"}');
     });
 
-    expect(result).toBeDefined();
-    expect(result.content).toBe(tokensString);
-
-    expect(totalTokenCount).toBeGreaterThan(1);
-  });
-
-  test("Can force a model to invoke a tool", async () => {
-    const model = newChatGoogle();
-    const modelWithTools = model.bind({
-      tools: [calculatorTool, weatherTool],
-      tool_choice: "calculator",
-    });
-
-    const result = await modelWithTools.invoke(
-      "Whats the weather like in paris today? What's 1836 plus 7262?"
-    );
-
-    expect(result.tool_calls).toHaveLength(1);
-    expect(result.tool_calls?.[0]).toBeDefined();
-    if (!result.tool_calls?.[0]) return;
-    expect(result.tool_calls?.[0].name).toBe("calculator");
-    expect(result.tool_calls?.[0].args).toHaveProperty("expression");
-  });
-
-  test(`stream tools`, async () => {
-    const model = newChatGoogle();
-
-    const weatherTool = tool(
-      (_) => "The weather in San Francisco today is 18 degrees and sunny.",
-      {
-        name: "current_weather_tool",
-        description: "Get the current weather for a given location.",
-        schema: z.object({
-          location: z.string().describe("The location to get the weather for."),
+    test("function reply", async () => {
+      const tools: GeminiTool[] = [
+        {
+          functionDeclarations: [
+            {
+              name: "test",
+              description:
+                "Run a test with a specific name and get if it passed or failed",
+              parameters: {
+                type: "object",
+                properties: {
+                  testName: {
+                    type: "string",
+                    description: "The name of the test that should be run.",
+                  },
+                },
+                required: ["testName"],
+              },
+            },
+          ],
+        },
+      ];
+      const model = newChatGoogle().bind({
+        tools,
+      });
+      const toolResult = {
+        testPassed: true,
+      };
+      const messages: BaseMessageLike[] = [
+        new HumanMessage("Run a test on the cobalt project."),
+        new AIMessage("", {
+          tool_calls: [
+            {
+              id: "test",
+              type: "function",
+              function: {
+                name: "test",
+                arguments: '{"testName":"cobalt"}',
+              },
+            },
+          ],
         }),
+        new ToolMessage(JSON.stringify(toolResult), "test"),
+      ];
+      const res = await model.stream(messages);
+      const resArray: BaseMessageChunk[] = [];
+      for await (const chunk of res) {
+        resArray.push(chunk);
       }
-    );
-
-    const modelWithTools = model.bindTools([weatherTool]);
-    const stream = await modelWithTools.stream(
-      "Whats the weather like today in San Francisco?"
-    );
-    let finalChunk: AIMessageChunk | undefined;
-    for await (const chunk of stream) {
-      finalChunk = !finalChunk ? chunk : concat(finalChunk, chunk);
-    }
-
-    expect(finalChunk).toBeDefined();
-    if (!finalChunk) return;
-
-    const toolCalls = finalChunk.tool_calls;
-    expect(toolCalls).toBeDefined();
-    if (!toolCalls) {
-      throw new Error("tool_calls not in response");
-    }
-    expect(toolCalls.length).toBe(1);
-    expect(toolCalls[0].name).toBe("current_weather_tool");
-    expect(toolCalls[0].args).toHaveProperty("location");
-  });
-
-  async function fileToBase64(filePath: string): Promise<string> {
-    const fileData = await fs.readFile(filePath);
-    const base64String = Buffer.from(fileData).toString("base64");
-    return base64String;
-  }
-
-  test("Gemini can understand audio", async () => {
-    // Update this with the correct path to an audio file on your machine.
-    const audioPath =
-      "../langchain-google-genai/src/tests/data/gettysburg10.wav";
-    const audioMimeType = "audio/wav";
-
-    const model = newChatGoogle({
-      temperature: 0,
-      maxRetries: 0,
+      // console.log(JSON.stringify(resArray, null, 2));
     });
 
-    const audioBase64 = await fileToBase64(audioPath);
-
-    const prompt = ChatPromptTemplate.fromMessages([
-      new MessagesPlaceholder("audio"),
-    ]);
-
-    const chain = prompt.pipe(model);
-    const response = await chain.invoke({
-      audio: new HumanMessage({
-        content: [
-          {
-            type: "media",
-            mimeType: audioMimeType,
-            data: audioBase64,
+    test("withStructuredOutput", async () => {
+      const tool = {
+        name: "get_weather",
+        description:
+          "Get the weather of a specific location and return the temperature in Celsius.",
+        parameters: {
+          type: "object",
+          properties: {
+            location: {
+              type: "string",
+              description: "The name of city to get the weather for.",
+            },
           },
+          required: ["location"],
+        },
+      };
+      const model = newChatGoogle().withStructuredOutput(tool);
+      const result = await model.invoke("What is the weather in Paris?");
+      expect(result).toHaveProperty("location");
+    });
+
+    test("media - fileData", async () => {
+      class MemStore extends InMemoryStore<MediaBlob> {
+        get length() {
+          return Object.keys(this.store).length;
+        }
+      }
+      const aliasMemory = new MemStore();
+      const aliasStore = new BackedBlobStore({
+        backingStore: aliasMemory,
+        defaultFetchOptions: {
+          actionIfBlobMissing: undefined,
+        },
+      });
+      const backingStore = new BlobStoreGoogleCloudStorage({
+        uriPrefix: new GoogleCloudStorageUri(
+          "gs://test-langchainjs/mediatest/"
+        ),
+        defaultStoreOptions: {
+          actionIfInvalid: "prefixPath",
+        },
+      });
+      const blobStore = new ReadThroughBlobStore({
+        baseStore: aliasStore,
+        backingStore,
+      });
+      const resolver = new SimpleWebBlobStore();
+      const mediaManager = new MediaManager({
+        store: blobStore,
+        resolvers: [resolver],
+      });
+      const model = newChatGoogle({
+        apiConfig: {
+          mediaManager,
+        },
+      });
+
+      const message: MessageContentComplex[] = [
+        {
+          type: "text",
+          text: "What is in this image?",
+        },
+        {
+          type: "media",
+          fileUri: "https://js.langchain.com/v0.2/img/brand/wordmark.png",
+        },
+      ];
+
+      const messages: BaseMessage[] = [
+        new HumanMessageChunk({ content: message }),
+      ];
+
+      try {
+        const res = await model.invoke(messages);
+
+        console.log(res);
+
+        expect(res).toBeDefined();
+        expect(res._getType()).toEqual("ai");
+
+        const aiMessage = res as AIMessageChunk;
+        expect(aiMessage.content).toBeDefined();
+
+        expect(typeof aiMessage.content).toBe("string");
+        const text = aiMessage.content as string;
+        expect(text).toMatch(/LangChain/);
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
+    });
+
+    test("Stream token count usage_metadata", async () => {
+      const model = newChatGoogle({
+        temperature: 0,
+        maxOutputTokens: 10,
+      });
+      let res: AIMessageChunk | null = null;
+      for await (const chunk of await model.stream(
+        "Why is the sky blue? Be concise."
+      )) {
+        if (!res) {
+          res = chunk;
+        } else {
+          res = res.concat(chunk);
+        }
+      }
+      // console.log(res);
+      expect(res?.usage_metadata).toBeDefined();
+      if (!res?.usage_metadata) {
+        return;
+      }
+      expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
+      expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
+      expect(res.usage_metadata.total_tokens).toBe(
+        res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
+      );
+    });
+
+    test("streamUsage excludes token usage", async () => {
+      const model = newChatGoogle({
+        temperature: 0,
+        streamUsage: false,
+      });
+      let res: AIMessageChunk | null = null;
+      for await (const chunk of await model.stream(
+        "Why is the sky blue? Be concise."
+      )) {
+        if (!res) {
+          res = chunk;
+        } else {
+          res = res.concat(chunk);
+        }
+      }
+      // console.log(res);
+      expect(res?.usage_metadata).not.toBeDefined();
+    });
+
+    test("Invoke token count usage_metadata", async () => {
+      const model = newChatGoogle({
+        temperature: 0,
+        maxOutputTokens: 10,
+      });
+      const res = await model.invoke("Why is the sky blue? Be concise.");
+      // console.log(res);
+      expect(res?.usage_metadata).toBeDefined();
+      if (!res?.usage_metadata) {
+        return;
+      }
+      expect(res.usage_metadata.input_tokens).toBeGreaterThan(1);
+      expect(res.usage_metadata.output_tokens).toBeGreaterThan(1);
+      expect(res.usage_metadata.total_tokens).toBe(
+        res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
+      );
+    });
+
+    test("Streaming true constructor param will stream", async () => {
+      const modelWithStreaming = newChatGoogle({
+        maxOutputTokens: 50,
+        streaming: true,
+      });
+
+      let totalTokenCount = 0;
+      let tokensString = "";
+      const result = await modelWithStreaming.invoke("What is 1 + 1?", {
+        callbacks: [
+          ...callbacks,
           {
-            type: "text",
-            text: "Summarize the content in this audio. ALso, what is the speaker's tone?",
+            handleLLMNewToken: (tok) => {
+              totalTokenCount += 1;
+              tokensString += tok;
+            },
           },
         ],
-      }),
+      });
+
+      expect(result).toBeDefined();
+      expect(result.content).toBe(tokensString);
+
+      expect(totalTokenCount).toBeGreaterThan(1);
     });
 
-    expect(typeof response.content).toBe("string");
-    expect((response.content as string).length).toBeGreaterThan(15);
-  });
+    test("Can force a model to invoke a tool", async () => {
+      const model = newChatGoogle();
+      const modelWithTools = model.bind({
+        tools: [calculatorTool, weatherTool],
+        tool_choice: "calculator",
+      });
 
-  test("Supports GoogleSearchRetrievalTool", async () => {
-    const searchRetrievalTool = {
-      googleSearchRetrieval: {
-        dynamicRetrievalConfig: {
-          mode: "MODE_DYNAMIC",
-          dynamicThreshold: 0.7, // default is 0.7
-        },
-      },
-    };
-    const model = newChatGoogle({
-      temperature: 0,
-      maxRetries: 0,
-    }).bindTools([searchRetrievalTool]);
+      const result = await modelWithTools.invoke(
+        "Whats the weather like in paris today? What's 1836 plus 7262?"
+      );
 
-    const result = await model.invoke("Who won the 2024 MLB World Series?");
-    expect(result.content as string).toContain("Dodgers");
-    expect(result).toHaveProperty("response_metadata");
-    expect(result.response_metadata).toHaveProperty("groundingMetadata");
-    expect(result.response_metadata).toHaveProperty("groundingSupport");
-  });
+      expect(result.tool_calls).toHaveLength(1);
+      expect(result.tool_calls?.[0]).toBeDefined();
+      if (!result.tool_calls?.[0]) return;
+      expect(result.tool_calls?.[0].name).toBe("calculator");
+      expect(result.tool_calls?.[0].args).toHaveProperty("expression");
+    });
 
-  test("Supports GoogleSearchTool", async () => {
-    const searchTool: GeminiTool = {
-      googleSearch: {
-      },
-    };
-    const model = newChatGoogle({
-      temperature: 0,
-      maxRetries: 0,
-    }).bindTools([searchTool]);
+    test(`stream tools`, async () => {
+      const model = newChatGoogle();
 
-    const result = await model.invoke("Who won the 2024 MLB World Series?");
-    expect(result.content as string).toContain("Dodgers");
-    expect(result).toHaveProperty("response_metadata");
-    expect(result.response_metadata).toHaveProperty("groundingMetadata");
-    expect(result.response_metadata).toHaveProperty("groundingSupport");
-  });
+      const weatherTool = tool(
+        (_) => "The weather in San Francisco today is 18 degrees and sunny.",
+        {
+          name: "current_weather_tool",
+          description: "Get the current weather for a given location.",
+          schema: z.object({
+            location: z
+              .string()
+              .describe("The location to get the weather for."),
+          }),
+        }
+      );
 
-  test("Can stream GoogleSearchRetrievalTool", async () => {
-    const searchRetrievalTool = {
-      googleSearchRetrieval: {
-        dynamicRetrievalConfig: {
-          mode: "MODE_DYNAMIC",
-          dynamicThreshold: 0.7, // default is 0.7
-        },
-      },
-    };
-    const model = newChatGoogle({
-      temperature: 0,
-      maxRetries: 0,
-    }).bindTools([searchRetrievalTool]);
+      const modelWithTools = model.bindTools([weatherTool]);
+      const stream = await modelWithTools.stream(
+        "Whats the weather like today in San Francisco?"
+      );
+      let finalChunk: AIMessageChunk | undefined;
+      for await (const chunk of stream) {
+        finalChunk = !finalChunk ? chunk : concat(finalChunk, chunk);
+      }
 
-    const stream = await model.stream("Who won the 2024 MLB World Series?");
-    let finalMsg: AIMessageChunk | undefined;
-    for await (const msg of stream) {
-      finalMsg = finalMsg ? concat(finalMsg, msg) : msg;
+      expect(finalChunk).toBeDefined();
+      if (!finalChunk) return;
+
+      const toolCalls = finalChunk.tool_calls;
+      expect(toolCalls).toBeDefined();
+      if (!toolCalls) {
+        throw new Error("tool_calls not in response");
+      }
+      expect(toolCalls.length).toBe(1);
+      expect(toolCalls[0].name).toBe("current_weather_tool");
+      expect(toolCalls[0].args).toHaveProperty("location");
+    });
+
+    async function fileToBase64(filePath: string): Promise<string> {
+      const fileData = await fs.readFile(filePath);
+      const base64String = Buffer.from(fileData).toString("base64");
+      return base64String;
     }
-    if (!finalMsg) {
-      throw new Error("finalMsg is undefined");
-    }
-    expect(finalMsg.content as string).toContain("Dodgers");
-  });
 
-});
+    test("Gemini can understand audio", async () => {
+      // Update this with the correct path to an audio file on your machine.
+      const audioPath =
+        "../langchain-google-genai/src/tests/data/gettysburg10.wav";
+      const audioMimeType = "audio/wav";
+
+      const model = newChatGoogle({
+        temperature: 0,
+        maxRetries: 0,
+      });
+
+      const audioBase64 = await fileToBase64(audioPath);
+
+      const prompt = ChatPromptTemplate.fromMessages([
+        new MessagesPlaceholder("audio"),
+      ]);
+
+      const chain = prompt.pipe(model);
+      const response = await chain.invoke({
+        audio: new HumanMessage({
+          content: [
+            {
+              type: "media",
+              mimeType: audioMimeType,
+              data: audioBase64,
+            },
+            {
+              type: "text",
+              text: "Summarize the content in this audio. ALso, what is the speaker's tone?",
+            },
+          ],
+        }),
+      });
+
+      expect(typeof response.content).toBe("string");
+      expect((response.content as string).length).toBeGreaterThan(15);
+    });
+
+    test("Supports GoogleSearchRetrievalTool", async () => {
+      const searchRetrievalTool = {
+        googleSearchRetrieval: {
+          dynamicRetrievalConfig: {
+            mode: "MODE_DYNAMIC",
+            dynamicThreshold: 0.7, // default is 0.7
+          },
+        },
+      };
+      const model = newChatGoogle({
+        temperature: 0,
+        maxRetries: 0,
+      }).bindTools([searchRetrievalTool]);
+
+      const result = await model.invoke("Who won the 2024 MLB World Series?");
+      expect(result.content as string).toContain("Dodgers");
+      expect(result).toHaveProperty("response_metadata");
+      expect(result.response_metadata).toHaveProperty("groundingMetadata");
+      expect(result.response_metadata).toHaveProperty("groundingSupport");
+    });
+
+    test("Supports GoogleSearchTool", async () => {
+      const searchTool: GeminiTool = {
+        googleSearch: {},
+      };
+      const model = newChatGoogle({
+        temperature: 0,
+        maxRetries: 0,
+      }).bindTools([searchTool]);
+
+      const result = await model.invoke("Who won the 2024 MLB World Series?");
+      expect(result.content as string).toContain("Dodgers");
+      expect(result).toHaveProperty("response_metadata");
+      expect(result.response_metadata).toHaveProperty("groundingMetadata");
+      expect(result.response_metadata).toHaveProperty("groundingSupport");
+    });
+
+    test("Can stream GoogleSearchRetrievalTool", async () => {
+      const searchRetrievalTool = {
+        googleSearchRetrieval: {
+          dynamicRetrievalConfig: {
+            mode: "MODE_DYNAMIC",
+            dynamicThreshold: 0.7, // default is 0.7
+          },
+        },
+      };
+      const model = newChatGoogle({
+        temperature: 0,
+        maxRetries: 0,
+      }).bindTools([searchRetrievalTool]);
+
+      const stream = await model.stream("Who won the 2024 MLB World Series?");
+      let finalMsg: AIMessageChunk | undefined;
+      for await (const msg of stream) {
+        finalMsg = finalMsg ? concat(finalMsg, msg) : msg;
+      }
+      if (!finalMsg) {
+        throw new Error("finalMsg is undefined");
+      }
+      expect(finalMsg.content as string).toContain("Dodgers");
+    });
+  }
+);


### PR DESCRIPTION
Assorted updates, primarily to support Gemini 2.0 (fixes #7345)
- Extensive testing across multiple models
- Extensive testing across both the GCP and Google AI Studio platforms
- Backward and (limited) forward compatibility for grounding with Google Search tool (related to stuff found with PR #7280)
- Add grounding detailed results to response (related to #5073 and #7280)
- Do not use API Key for Google Cloud Platform (fixes issues #5000 and #7399)

Some things to note:
- The tests against "gemini-2.0-flash-thinking-exp" have been commented out. While it works for some things, this model doesn't support tools yet, and we need to look at how to handle the reasoning tokens which are provided. (See #7434)
- Functions work with Gemini 2.0, however the prompting for them is more finicky, at least with the configuration used in the testing. (See https://issuetracker.google.com/issues/384752742 where I've opened the issue with Google.) But the functionality itself works.
- This does **not** account for multimodal outputs, which are expected "soon". Can't do anything with that till we get official info on how it will work.