### PR TITLE
fix(docs): Cosmos Db Cache sample link

### DIFF
--- a/examples/src/caches/azure_cosmosdb_nosql/azure_cosmosdb_nosql.ts
+++ b/examples/src/caches/azure_cosmosdb_nosql/azure_cosmosdb_nosql.ts
@@ -17,7 +17,7 @@ const config: AzureCosmosDBNoSQLConfig = {
  * Cached output is returned only if the similarity score meets or exceeds this threshold;
  * otherwise, a new result is generated. Default is 0.6, adjustable via the constructor
  * to suit various distance functions and use cases.
- * (see: https://learn.microsoft.com/azure/cosmos-db/nosql/query/vectordistance).
+ * (see: https://aka.ms/CosmosVectorSearch).
  */
 
 const similarityScoreThreshold = 0.5;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

The [Azure Cosmos DB sample for caches](https://github.com/langchain-ai/langchainjs/blob/main/examples/src/caches/azure_cosmosdb_nosql/azure_cosmosdb_nosql.ts) has an incorrect link to the sample. The correct link is: https://aka.ms/CosmosVectorSearch. 

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #7445
