### PR TITLE
fix(google-common): Search grounding formatting

### DIFF
--- a/libs/langchain-google-common/src/output_parsers.ts
+++ b/libs/langchain-google-common/src/output_parsers.ts
@@ -144,7 +144,7 @@ export abstract class BaseGoogleSearchOutputParser extends BaseLLMOutputParser<s
    * @param grounding
    */
   protected searchSuggestion(grounding: GroundingInfo): string {
-    return grounding.metadata.searchEntryPoint?.renderedContent ?? "";
+    return grounding?.metadata?.searchEntryPoint?.renderedContent ?? "";
   }
 
   protected annotateText(text: string, grounding: GroundingInfo): string {
@@ -198,7 +198,7 @@ export class SimpleGoogleSearchOutputParser extends BaseGoogleSearchOutputParser
 
   protected textSuffix(_text: string, grounding: GroundingInfo): string {
     let ret = "\n";
-    const chunks: GeminiGroundingChunk[] = grounding.metadata.groundingChunks;
+    const chunks: GeminiGroundingChunk[] = grounding?.metadata?.groundingChunks ??[];
     chunks.forEach((chunk, index) => {
       ret = `${ret}${this.chunkToString(chunk, index)}\n`;
     });

--- a/libs/langchain-google-common/src/output_parsers.ts
+++ b/libs/langchain-google-common/src/output_parsers.ts
@@ -23,9 +23,9 @@ export abstract class BaseGoogleSearchOutputParser extends BaseLLMOutputParser<s
   ): GroundingInfo | undefined {
     if ("message" in generation) {
       const responseMetadata = generation?.message?.response_metadata;
-      const metadata = responseMetadata.groundingMetadata;
+      const metadata = responseMetadata?.groundingMetadata;
       const supports =
-        responseMetadata.groundingSupport ?? metadata.groundingSupports ?? [];
+        responseMetadata?.groundingSupport ?? metadata?.groundingSupports ?? [];
       if (metadata) {
         return {
           metadata,

--- a/libs/langchain-google-common/src/output_parsers.ts
+++ b/libs/langchain-google-common/src/output_parsers.ts
@@ -198,7 +198,8 @@ export class SimpleGoogleSearchOutputParser extends BaseGoogleSearchOutputParser
 
   protected textSuffix(_text: string, grounding: GroundingInfo): string {
     let ret = "\n";
-    const chunks: GeminiGroundingChunk[] = grounding?.metadata?.groundingChunks ??[];
+    const chunks: GeminiGroundingChunk[] =
+      grounding?.metadata?.groundingChunks ?? [];
     chunks.forEach((chunk, index) => {
       ret = `${ret}${this.chunkToString(chunk, index)}\n`;
     });

--- a/libs/langchain-google-common/src/tests/output_parsers.test.ts
+++ b/libs/langchain-google-common/src/tests/output_parsers.test.ts
@@ -232,5 +232,5 @@ describe("GoogleSearchOutputParsers", () => {
     const chain = model.pipe(parser);
     const result = await chain.invoke("Flip a coin.");
     expect(result).toEqual("T");
-  })
+  });
 });

--- a/libs/langchain-google-common/src/tests/output_parsers.test.ts
+++ b/libs/langchain-google-common/src/tests/output_parsers.test.ts
@@ -214,4 +214,23 @@ describe("GoogleSearchOutputParsers", () => {
 
     expect(result).toEqual(expectation);
   });
+
+  test("non-grounded", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-pro-002",
+    });
+    const parser = new SimpleGoogleSearchOutputParser();
+    const chain = model.pipe(parser);
+    const result = await chain.invoke("Flip a coin.");
+    expect(result).toEqual("T");
+  })
 });


### PR DESCRIPTION
Problem: 
If using a subclass of `BaseGoogleSearchOutputParser` where the input doesn't have grounding info, it attempts to dereference undefined.

Solution:
Return the input text, unchanged, if there is no grounding info to annotate.

Fix and tests for same.