### PR TITLE
fix(groq): Fix Max Retries for Groq

### DIFF
--- a/libs/langchain-groq/src/chat_models.ts
+++ b/libs/langchain-groq/src/chat_models.ts
@@ -691,6 +691,7 @@ export class ChatGroq extends BaseChatModel<
     this.client = new Groq({
       apiKey,
       dangerouslyAllowBrowser: true,
+      maxRetries: 0,
     });
     this.apiKey = apiKey;
     this.temperature = fields?.temperature ?? this.temperature;


### PR DESCRIPTION
The `maxRetries` field is not respected with the Groq integration. This PR fixes this issue.

By default, the Groq SDK automatically retries any request twice.   
So with a default of 6 max retries, this results in 6 * 3 = 18 retries before the request is passed on to a fallback provider or failing.