### PR TITLE
weaviate[minor]: Add Document className as metadata

### DIFF
--- a/libs/langchain-weaviate/src/vectorstores.ts
+++ b/libs/langchain-weaviate/src/vectorstores.ts
@@ -322,7 +322,7 @@ export class WeaviateStore extends VectorStore {
             pageContent: text,
             metadata: {
               ...rest,
-              collectionName: this.indexName
+              collectionName: this.indexName,
             },
             id: _additional.id,
           }),

--- a/libs/langchain-weaviate/src/vectorstores.ts
+++ b/libs/langchain-weaviate/src/vectorstores.ts
@@ -322,7 +322,7 @@ export class WeaviateStore extends VectorStore {
             pageContent: text,
             metadata: {
               ...rest,
-              className: this.indexName
+              collectionName: this.indexName
             },
             id: _additional.id,
           }),

--- a/libs/langchain-weaviate/src/vectorstores.ts
+++ b/libs/langchain-weaviate/src/vectorstores.ts
@@ -320,7 +320,10 @@ export class WeaviateStore extends VectorStore {
         documents.push([
           new Document({
             pageContent: text,
-            metadata: rest,
+            metadata: {
+              ...rest,
+              className: this.indexName
+            },
             id: _additional.id,
           }),
           _additional.distance,


### PR DESCRIPTION
### Description

- Added `className` as part of Document metadata.

### Why

- If we have multiple weaviate classes and use wrapper retrievers like `EnsembleRetriever`, we don't know where the docs are coming from. 
