### PR TITLE
fix(community): togetherai response different format handling

### DIFF
--- a/libs/langchain-community/src/llms/togetherai.ts
+++ b/libs/langchain-community/src/llms/togetherai.ts
@@ -27,7 +27,7 @@ interface TogetherAIInferenceResult {
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   subjobs: Array<any>;
-  output: {
+  output?: {
     choices: Array<{
       finish_reason: string;
       index: number;
@@ -36,6 +36,11 @@ interface TogetherAIInferenceResult {
     raw_compute_time: number;
     result_type: string;
   };
+  choices?: Array<{
+    finish_reason: string;
+    index: number;
+    text: string;
+  }>;
 }
 
 /**
@@ -110,19 +115,19 @@ export interface TogetherAIInputs extends BaseLLMParams {
 
 export interface TogetherAICallOptions
   extends BaseLLMCallOptions,
-    Pick<
-      TogetherAIInputs,
-      | "modelName"
-      | "model"
-      | "temperature"
-      | "topP"
-      | "topK"
-      | "repetitionPenalty"
-      | "logprobs"
-      | "safetyModel"
-      | "maxTokens"
-      | "stop"
-    > {}
+  Pick<
+    TogetherAIInputs,
+    | "modelName"
+    | "model"
+    | "temperature"
+    | "topP"
+    | "topK"
+    | "repetitionPenalty"
+    | "logprobs"
+    | "safetyModel"
+    | "maxTokens"
+    | "stop"
+  > { }
 
 export class TogetherAI extends LLM<TogetherAICallOptions> {
   lc_serializable = true;
@@ -247,8 +252,11 @@ export class TogetherAI extends LLM<TogetherAICallOptions> {
       prompt,
       options
     );
-    const outputText = response.output.choices[0].text;
-    return outputText ?? "";
+    if (response.output) {
+      return response.output.choices[0]?.text ?? "";
+    } else {
+      return response.choices?.[0]?.text ?? "";
+    }
   }
 
   async *_streamResponseChunks(

--- a/libs/langchain-community/src/llms/togetherai.ts
+++ b/libs/langchain-community/src/llms/togetherai.ts
@@ -115,19 +115,19 @@ export interface TogetherAIInputs extends BaseLLMParams {
 
 export interface TogetherAICallOptions
   extends BaseLLMCallOptions,
-  Pick<
-    TogetherAIInputs,
-    | "modelName"
-    | "model"
-    | "temperature"
-    | "topP"
-    | "topK"
-    | "repetitionPenalty"
-    | "logprobs"
-    | "safetyModel"
-    | "maxTokens"
-    | "stop"
-  > { }
+    Pick<
+      TogetherAIInputs,
+      | "modelName"
+      | "model"
+      | "temperature"
+      | "topP"
+      | "topK"
+      | "repetitionPenalty"
+      | "logprobs"
+      | "safetyModel"
+      | "maxTokens"
+      | "stop"
+    > {}
 
 export class TogetherAI extends LLM<TogetherAICallOptions> {
   lc_serializable = true;


### PR DESCRIPTION
Apparently togetherAI now have more than one response format, other than the old one it also have a format like this:

```json
{
    "id": "8fef9f62bf2dbef4-YYC",
    "object": "text.completion",
    "created": 1736375327,
    "model": "deepseek-ai/DeepSeek-V3",
    "choices": [
        {
            "index": 0,
            "text": " Paris",
            "logprobs": null,
            "finish_reason": "length",
            "matched_stop": null
        }
    ],
    "usage": {
        "prompt_tokens": 11,
        "total_tokens": 12,
        "completion_tokens": 1,
        "prompt_tokens_details": null
    },
    "prompt": []
}
```

This PR will update the code to handle format like that. Thanks for your time to review this!

Fixes # (issue) #6993 
https://github.com/langchain-ai/langchainjs/issues/6993