### PR TITLE
fix(langchain): Fix ZeroShotAgent createPrompt with correct formatted tool names

### DIFF
--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -128,7 +128,7 @@ export class ZeroShotAgent extends Agent {
       .map((tool) => `${tool.name}: ${tool.description}`)
       .join("\n");
 
-    const toolNames = tools.map((tool) => tool.name);
+    const toolNames = tools.map((tool) => tool.name).join("\n");
 
     const formatInstructions = renderTemplate(FORMAT_INSTRUCTIONS, "f-string", {
       tool_names: toolNames,

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -128,7 +128,7 @@ export class ZeroShotAgent extends Agent {
       .map((tool) => `${tool.name}: ${tool.description}`)
       .join("\n");
 
-    const toolNames = tools.map((tool) => tool.name).join("\n");
+    const toolNames = tools.map((tool) => `"${tool.name}"`).join(", ");
 
     const formatInstructions = renderTemplate(FORMAT_INSTRUCTIONS, "f-string", {
       tool_names: toolNames,


### PR DESCRIPTION
Fix ZeroShotAgent createPrompt with correct formatted tool names
