### PR TITLE
fix(google-vertexai): fix bug when not using logprobs

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -195,7 +195,7 @@ export abstract class ChatGoogleBase<AuthOptions>
 
   stopSequences: string[] = [];
 
-  logprobs: boolean = false;
+  logprobs: boolean;
 
   topLogprobs: number = 0;
 

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -1320,7 +1320,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(result).toBeDefined();
     const data = record?.opts?.data;
     expect(data).toBeDefined();
-    expect(data.generationConfig.responseLogprobs).toEqual(false);
+    expect(data.generationConfig.responseLogprobs).not.toBeDefined();
     expect(data.generationConfig.logprobs).not.toBeDefined();
   });
 

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -1251,7 +1251,80 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(record.opts.data.tools[0]).toHaveProperty("googleSearch");
   });
 
-  test("7. logprobs", async () => {
+  test("7. logprobs request true", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-7-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-flash-002",
+      logprobs: true,
+      topLogprobs: 5,
+    });
+    const result = await model.invoke(
+      "What are some names for a company that makes fancy socks?"
+    );
+    expect(result).toBeDefined();
+    const data = record?.opts?.data;
+    expect(data).toBeDefined();
+    expect(data.generationConfig.responseLogprobs).toEqual(true);
+    expect(data.generationConfig.logprobs).toEqual(5);
+  });
+
+  test("7. logprobs request false", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-7-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-flash-002",
+      logprobs: false,
+      topLogprobs: 5,
+    });
+    const result = await model.invoke(
+      "What are some names for a company that makes fancy socks?"
+    );
+    expect(result).toBeDefined();
+    const data = record?.opts?.data;
+    expect(data).toBeDefined();
+    expect(data.generationConfig.responseLogprobs).toEqual(false);
+    expect(data.generationConfig.logprobs).not.toBeDefined();
+  });
+
+  test("7. logprobs request not defined", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-7-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-1.5-flash-002",
+    });
+    const result = await model.invoke(
+      "What are some names for a company that makes fancy socks?"
+    );
+    expect(result).toBeDefined();
+    const data = record?.opts?.data;
+    expect(data).toBeDefined();
+    expect(data.generationConfig.responseLogprobs).toEqual(false);
+    expect(data.generationConfig.logprobs).not.toBeDefined();
+  });
+
+  test("7. logprobs response", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
     const authOptions: MockClientAuthInfo = {

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1092,10 +1092,12 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     };
 
     // Add the logprobs if explicitly set
-    console.log('parameters.logprobs', parameters.logprobs);
     if (typeof parameters.logprobs !== "undefined") {
       ret.responseLogprobs = parameters.logprobs;
-      if (parameters.logprobs && typeof parameters.topLogprobs !== "undefined") {
+      if (
+        parameters.logprobs &&
+        typeof parameters.topLogprobs !== "undefined"
+      ) {
         ret.logprobs = parameters.topLogprobs;
       }
     }

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1080,7 +1080,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   function formatGenerationConfig(
     parameters: GoogleAIModelRequestParams
   ): GeminiGenerationConfig {
-    return {
+    const ret: GeminiGenerationConfig = {
       temperature: parameters.temperature,
       topK: parameters.topK,
       topP: parameters.topP,
@@ -1089,9 +1089,18 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       maxOutputTokens: parameters.maxOutputTokens,
       stopSequences: parameters.stopSequences,
       responseMimeType: parameters.responseMimeType,
-      responseLogprobs: parameters.logprobs,
-      logprobs: parameters.topLogprobs,
     };
+
+    // Add the logprobs if explicitly set
+    console.log('parameters.logprobs', parameters.logprobs);
+    if (typeof parameters.logprobs !== "undefined") {
+      ret.responseLogprobs = parameters.logprobs;
+      if (parameters.logprobs && typeof parameters.topLogprobs !== "undefined") {
+        ret.logprobs = parameters.topLogprobs;
+      }
+    }
+
+    return ret;
   }
 
   function formatSafetySettings(


### PR DESCRIPTION
Fixes #7509 

This only explicitly uses `logprobs` and `topLogprobs` if `logprobs` is explicitly set. `topLogprobs` is only set if logprobs is explicitly true.