### PR TITLE
feat(community): Provide fallback relationshipType in case it is not present in graph_transformer

### DIFF
--- a/libs/langchain-community/src/experimental/graph_transformers/llm.ts
+++ b/libs/langchain-community/src/experimental/graph_transformers/llm.ts
@@ -201,7 +201,11 @@ function mapToBaseNode(node: any): Node {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mapToBaseRelationship({ fallbackRelationshipType }: { fallbackRelationshipType: string | null }) {
+function mapToBaseRelationship({
+  fallbackRelationshipType,
+}: {
+  fallbackRelationshipType: string | null;
+}) {
   return function (relationship: any): Relationship {
     return new Relationship({
       source: new Node({
@@ -216,12 +220,14 @@ function mapToBaseRelationship({ fallbackRelationshipType }: { fallbackRelations
           ? toTitleCase(relationship.targetNodeType)
           : "",
       }),
-      type: (relationship.relationshipType || fallbackRelationshipType).replace(" ", "_").toUpperCase(),
+      type: (relationship.relationshipType || fallbackRelationshipType)
+        .replace(" ", "_")
+        .toUpperCase(),
       properties: relationship.properties
         ? convertPropertiesToRecord(relationship.properties)
         : {},
     });
-  }
+  };
 }
 
 export interface LLMGraphTransformerProps {
@@ -238,7 +244,7 @@ export interface LLMGraphTransformerProps {
    * The LLM may rarely create relationships without a type, causing extraction to fail.
    * Use this to provide a fallback relationship type in such case.
    */
-  fallbackRelationshipType?: string | null
+  fallbackRelationshipType?: string | null;
 }
 
 export class LLMGraphTransformer {
@@ -278,7 +284,7 @@ export class LLMGraphTransformer {
     this.strictMode = strictMode;
     this.nodeProperties = nodeProperties;
     this.relationshipProperties = relationshipProperties;
-    this.fallbackRelationshipType = fallbackRelationshipType
+    this.fallbackRelationshipType = fallbackRelationshipType;
 
     // Define chain
     const schema = createSchema(
@@ -310,7 +316,9 @@ export class LLMGraphTransformer {
     let relationships: Relationship[] = [];
     if (rawSchema?.relationships) {
       relationships = rawSchema.relationships.map(
-        mapToBaseRelationship({ fallbackRelationshipType: this.fallbackRelationshipType })
+        mapToBaseRelationship({
+          fallbackRelationshipType: this.fallbackRelationshipType,
+        })
       );
     }
 

--- a/libs/langchain-community/src/experimental/graph_transformers/llm.ts
+++ b/libs/langchain-community/src/experimental/graph_transformers/llm.ts
@@ -216,7 +216,7 @@ function mapToBaseRelationship({ fallbackRelationshipType = "unknown" }: { fallb
           ? toTitleCase(relationship.targetNodeType)
           : "",
       }),
-      type: (relationship.relationshipType || "unknown").replace(" ", "_").toUpperCase(),
+      type: (relationship.relationshipType || fallbackRelationshipType).replace(" ", "_").toUpperCase(),
       properties: relationship.properties
         ? convertPropertiesToRecord(relationship.properties)
         : {},

--- a/libs/langchain-community/src/experimental/graph_transformers/llm.ts
+++ b/libs/langchain-community/src/experimental/graph_transformers/llm.ts
@@ -232,6 +232,12 @@ export interface LLMGraphTransformerProps {
   strictMode?: boolean;
   nodeProperties?: string[];
   relationshipProperties?: string[];
+
+  /**
+   * @description
+   * The LLM may rarely create relationships without a type, causing extraction to fail.
+   * Use this to provide a fallback relationship type in such case.
+   */
   fallbackRelationshipType?: string | null
 }
 

--- a/libs/langchain-community/src/experimental/graph_transformers/llm.ts
+++ b/libs/langchain-community/src/experimental/graph_transformers/llm.ts
@@ -201,7 +201,7 @@ function mapToBaseNode(node: any): Node {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mapToBaseRelationship({ fallbackRelationshipType = "unknown" }: { fallbackRelationshipType: string }) {
+function mapToBaseRelationship({ fallbackRelationshipType }: { fallbackRelationshipType: string | null }) {
   return function (relationship: any): Relationship {
     return new Relationship({
       source: new Node({
@@ -232,6 +232,7 @@ export interface LLMGraphTransformerProps {
   strictMode?: boolean;
   nodeProperties?: string[];
   relationshipProperties?: string[];
+  fallbackRelationshipType?: string | null
 }
 
 export class LLMGraphTransformer {
@@ -248,7 +249,7 @@ export class LLMGraphTransformer {
 
   relationshipProperties: string[];
 
-  fallbackRelationshipType: string = "unknown";
+  fallbackRelationshipType: string | null = null;
 
   constructor({
     llm,
@@ -258,7 +259,7 @@ export class LLMGraphTransformer {
     strictMode = true,
     nodeProperties = [],
     relationshipProperties = [],
-    fallbackRelationshipType = "unknown,
+    fallbackRelationshipType = null,
   }: LLMGraphTransformerProps) {
     if (typeof llm.withStructuredOutput !== "function") {
       throw new Error(


### PR DESCRIPTION
Although difficult to reproduce, I've ran into a few times when `relationshipType` was undefined and so the extraction fails. 

In these cases I'd still like to have the relationship being captured in my knowledge graph, so it seems appropriate to provide the transformer with a fallback value it can use, in this case defaulted to `"unknown"`. This also allows for the value to be overridden with something else in cases where `"unknown"` already means something in an existing context.

I'm happy to contribute to anything that may need to be updated to reflect this info, like documentations, just need a pointer :)