### PR TITLE
Fix PGVectorStore import in install dependencies (npm) example

### DIFF
--- a/docs/core_docs/src/theme/VectorStoreTabs.js
+++ b/docs/core_docs/src/theme/VectorStoreTabs.js
@@ -54,7 +54,7 @@ const ${vectorStoreVarName} = new MongoDBAtlasVectorSearch(embeddings, {
     {
       value: "PGVector",
       label: "PGVector",
-      text: `import PGVectorStore from "@langchain/community/vectorstores/pgvector";
+      text: `import { PGVectorStore } from "@langchain/community/vectorstores/pgvector";
 
 const ${vectorStoreVarName} = await PGVectorStore.initialize(embeddings, {})`,
       dependencies: "@langchain/community",


### PR DESCRIPTION
While following the RAG tutorial for TypeScript, I was getting this error in my code when trying to set up PGVectorStore:

```
Property 'initialize' does not exist on type 'typeof import("/Users/bploetz/workspace/personal/ai-agent/node_modules/@langchain/community/vectorstores/pgvector")'.ts(2339)
```

This is because the import statement shown in the docs is missing the brackets to desctructure PGVectorStore correctly.