### PR TITLE
feat(community): improve support for Tavily search tool args

### DIFF
--- a/libs/langchain-community/src/tools/tavily_search.ts
+++ b/libs/langchain-community/src/tools/tavily_search.ts
@@ -170,23 +170,23 @@ export class TavilySearchResults extends Tool {
 
   protected kwargs: Record<string, unknown> = {};
 
-  protected includeImages = false;
+  protected includeImages?: boolean;
 
-  protected includeImageDescriptions = false;
+  protected includeImageDescriptions?: boolean;
 
-  protected includeAnswer = false;
+  protected includeAnswer?: boolean;
 
-  protected includeRawContent = false;
+  protected includeRawContent?: boolean;
 
-  protected includeDomains: string[] = [];
+  protected includeDomains?: string[];
 
-  protected excludeDomains: string[] = [];
+  protected excludeDomains?: string[];
 
-  protected searchDepth: "basic" | "deep" = "basic";
+  protected searchDepth?: "basic" | "deep";
 
-  protected topic = "general";
+  protected topic?: string;
 
-  protected days = 3;
+  protected days?: number;
 
   constructor(fields?: TavilySearchAPIRetrieverFields) {
     super(fields);

--- a/libs/langchain-community/src/tools/tavily_search.ts
+++ b/libs/langchain-community/src/tools/tavily_search.ts
@@ -6,9 +6,86 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
  * Options for the TavilySearchResults tool.
  */
 export type TavilySearchAPIRetrieverFields = ToolParams & {
+  /**
+   * The maximum number of search results to return.
+   *
+   * @default 5
+   */
   maxResults?: number;
+
+  /**
+   * Additional keyword arguments to pass to the API.
+   */
   kwargs?: Record<string, unknown>;
+
+  /**
+   * The API key used for authentication with the Tavily Search API.
+   *
+   */
   apiKey?: string;
+
+  /**
+   * Include a list of query-related images in the response.
+   *
+   * @default false
+   */
+  includeImages?: boolean;
+
+  /**
+   * When includeImages is set to True, this option adds descriptive text for each image.
+   *
+   * @default false
+   */
+  includeImageDescriptions?: boolean;
+
+  /**
+   * Include a short answer to the original query.
+   *
+   * @default false
+   */
+  includeAnswer?: boolean;
+
+  /**
+   * Include the cleaned and parsed HTML content of each search result.
+   *
+   * @default false
+   */
+  includeRawContent?: boolean;
+
+  /**
+   * A list of domains to specifically include in the search results.
+   *
+   * @default []
+   */
+  includeDomains?: string[];
+
+  /**
+   * A list of domains to specifically exclude from the search results.
+   *
+   * @default []
+   */
+  excludeDomains?: string[];
+
+  /**
+   * The depth of the search. It can be "basic" or "deep".
+   *
+   * @default "basic"
+   */
+  searchDepth?: "basic" | "deep";
+
+  /**
+   * The category of the search. This will determine which of our agents will be used for the search. Currently, only "general" and "news" are supported. See https://docs.tavily.com/docs/rest-api/api-reference
+   *
+   * @default "general"
+   */
+  topic?: string;
+
+  /**
+   * The number of days back from the current date to include in the search results.
+   *
+   * @default 3
+   */
+  days?: number;
 };
 
 /**
@@ -93,11 +170,41 @@ export class TavilySearchResults extends Tool {
 
   protected kwargs: Record<string, unknown> = {};
 
+  protected includeImages = false;
+
+  protected includeImageDescriptions = false;
+
+  protected includeAnswer = false;
+
+  protected includeRawContent = false;
+
+  protected includeDomains: string[] = [];
+
+  protected excludeDomains: string[] = [];
+
+  protected searchDepth: "basic" | "deep" = "basic";
+
+  protected topic = "general";
+
+  protected days = 3;
+
   constructor(fields?: TavilySearchAPIRetrieverFields) {
     super(fields);
     this.maxResults = fields?.maxResults ?? this.maxResults;
     this.kwargs = fields?.kwargs ?? this.kwargs;
     this.apiKey = fields?.apiKey ?? getEnvironmentVariable("TAVILY_API_KEY");
+    this.includeImages = fields?.includeImages ?? this.includeImages;
+    this.includeImageDescriptions =
+      fields?.includeImageDescriptions ?? this.includeImageDescriptions;
+    this.includeAnswer = fields?.includeAnswer ?? this.includeAnswer;
+    this.includeRawContent =
+      fields?.includeRawContent ?? this.includeRawContent;
+    this.includeDomains = fields?.includeDomains ?? this.includeDomains;
+    this.excludeDomains = fields?.excludeDomains ?? this.excludeDomains;
+    this.searchDepth = fields?.searchDepth ?? this.searchDepth;
+    this.topic = fields?.topic ?? this.topic;
+    this.days = fields?.days ?? this.days;
+
     if (this.apiKey === undefined) {
       throw new Error(
         `No Tavily API key found. Either set an environment variable named "TAVILY_API_KEY" or pass an API key as "apiKey".`
@@ -113,6 +220,15 @@ export class TavilySearchResults extends Tool {
       query: input,
       max_results: this.maxResults,
       api_key: this.apiKey,
+      include_images: this.includeImages,
+      include_image_descriptions: this.includeImageDescriptions,
+      include_answer: this.includeAnswer,
+      include_raw_content: this.includeRawContent,
+      include_domains: this.includeDomains,
+      exclude_domains: this.excludeDomains,
+      search_depth: this.searchDepth,
+      topic: this.topic,
+      days: this.days,
     };
 
     const response = await fetch("https://api.tavily.com/search", {


### PR DESCRIPTION
I needed a property of the API (`includeDomains`) that was not in the `TavilySearchAPIRetrieverFields`, so I decided to update all of the body params from the [Tavily API reference](https://docs.tavily.com/docs/rest-api/api-reference).

Let me know if you have remarks, this is my first contribution 😇 