### PR TITLE
fix(BedrockChat): Update handleLLMNewToken to include chunk metadata

### DIFF
--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -918,7 +918,14 @@ export class BedrockChat
               yield chunk;
             }
             // eslint-disable-next-line no-void
-            void runManager?.handleLLMNewToken(chunk.text);
+            void runManager?.handleLLMNewToken(
+              chunk.text,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              { chunk }
+            );
           } else {
             const text = BedrockLLMInputOutputAdapter.prepareOutput(
               provider,


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

When using langgraph workflow's `streamEvents`, I expect to see `tool_calls` in the `data.chunk` payload of event `on_chat_model_stream`. This works as with ChatOpenAI, however, BedrockChat doesn't expose the actual chunk.

```ts
const output = langgraphWorkflow.streamEvents(...);

for await (const event of output) {
  if (event.event === "on_chat_model_stream") {
    // This currently works with ChatOpenAI, but BedrockChat gives undefined
    console.log(event.data.chunk.tool_calls);
  }
}
```

After tracing the call stack, I learned that the issue stems from the `handleLLMNewToken` call and this is not in parity with ChatOpenAI's impl:

https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-openai/src/chat_models.ts#L1464-L1471