### PR TITLE
fix(community): Set awaitHandlers to true in upstash ratelimit

### DIFF
--- a/libs/langchain-community/src/callbacks/handlers/upstash_ratelimit.ts
+++ b/libs/langchain-community/src/callbacks/handlers/upstash_ratelimit.ts
@@ -101,7 +101,7 @@ class UpstashRatelimitHandler extends BaseCallbackHandler {
     this.llmOutputPromptTokenField =
       options.llmOutputPromptTokenField ?? "promptTokens";
 
-    this.awaitHandlers = true
+    this.awaitHandlers = true;
   }
 
   /**

--- a/libs/langchain-community/src/callbacks/handlers/upstash_ratelimit.ts
+++ b/libs/langchain-community/src/callbacks/handlers/upstash_ratelimit.ts
@@ -100,6 +100,8 @@ class UpstashRatelimitHandler extends BaseCallbackHandler {
       options.llmOutputTotalTokenField ?? "totalTokens";
     this.llmOutputPromptTokenField =
       options.llmOutputPromptTokenField ?? "promptTokens";
+
+    this.awaitHandlers = true
   }
 
   /**


### PR DESCRIPTION
Fixes #7279

When I tried initializing `UpstashRatelimitHandler` directly using the source code, `awaitHandlers` and `raiseError` were set to true. But when I installed the package, `awaitHandlers` was false.

Then I checked the build, and I noticed that `raiseError` is set after `super()`:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/cd292375-97a9-4729-a16e-4b3909c7da80" />

Since `raiseError` is set after `super()`, `awaitHandlers` stays false ([because in this line `raiseError` is still false](https://github.com/langchain-ai/langchainjs/blob/5bdbb755bdbb05c3f2bca30c8bd3c64b8295b02a/langchain-core/src/callbacks/base.ts#L381)).

With this PR, we set the `awaitHandlers` directly in the `UpstashRatelimitHandler` constructor.

I believe this was working correctly before and somehow broke. Wanted to share in case there are similar problems in other integrations.