### PR TITLE
chore(ollama): Export `OllamaEmbeddingsParams` interface

### DIFF
--- a/libs/langchain-ollama/src/embeddings.ts
+++ b/libs/langchain-ollama/src/embeddings.ts
@@ -7,7 +7,7 @@ import { OllamaCamelCaseOptions } from "./types.js";
  * Interface for OllamaEmbeddings parameters. Extends EmbeddingsParams and
  * defines additional parameters specific to the OllamaEmbeddings class.
  */
-interface OllamaEmbeddingsParams extends EmbeddingsParams {
+export interface OllamaEmbeddingsParams extends EmbeddingsParams {
   /**
    * The Ollama model to use for embeddings.
    * @default "mxbai-embed-large"


### PR DESCRIPTION
We are already exporting `ChatOllamaInput` in `@langchain/ollama`. It would be great to also export `OllamaEmbeddingsParams` for embeddings instance.