### PR TITLE
fix(community): Make postgresConnectionOptions optional in PostgresRecordManager

### DIFF
--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -6,7 +6,7 @@ import {
 } from "./base.js";
 
 export type PostgresRecordManagerOptions = {
-  postgresConnectionOptions: PoolConfig;
+  postgresConnectionOptions?: PoolConfig;
   pool?: Pool;
   tableName?: string;
   schema?: string;
@@ -26,7 +26,10 @@ export class PostgresRecordManager implements RecordManagerInterface {
   constructor(namespace: string, config: PostgresRecordManagerOptions) {
     const { postgresConnectionOptions, tableName, pool } = config;
     this.namespace = namespace;
-    this.pool = pool || new pg.Pool(postgresConnectionOptions);
+    if (!postgresConnectionOptions && !pool) {
+      throw new Error("You must provide either a `postgresConnectionOptions` object or a `pool` instance.");
+    }
+    this.pool = pool ?? new pg.Pool(postgresConnectionOptions);
     this.tableName = tableName || "upsertion_records";
     this.finalTableName = config.schema
       ? `"${config.schema}"."${this.tableName}"`

--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -27,7 +27,9 @@ export class PostgresRecordManager implements RecordManagerInterface {
     const { postgresConnectionOptions, tableName, pool } = config;
     this.namespace = namespace;
     if (!postgresConnectionOptions && !pool) {
-      throw new Error("You must provide either a `postgresConnectionOptions` object or a `pool` instance.");
+      throw new Error(
+        "You must provide either a `postgresConnectionOptions` object or a `pool` instance."
+      );
     }
     this.pool = pool ?? new pg.Pool(postgresConnectionOptions);
     this.tableName = tableName || "upsertion_records";


### PR DESCRIPTION
Make postgresConnectionOptions optional in PostgresRecordManager to be more in line with PGVectorStore



Fixes #7579
