### PR TITLE
feat(community): Add boolean metadata type support in Supabase structured query translator

### DIFF
--- a/libs/langchain-community/src/structured_query/supabase.ts
+++ b/libs/langchain-community/src/structured_query/supabase.ts
@@ -12,6 +12,7 @@ import {
   Operator,
   Operators,
   StructuredQuery,
+  isBoolean,
 } from "@langchain/core/structured_query";
 import type {
   SupabaseFilterRPCCall,
@@ -134,6 +135,8 @@ export class SupabaseTranslator<
       column = `metadata->${attr}${includeType ? "::int" : ""}`;
     } else if (isFloat(value)) {
       column = `metadata->${attr}${includeType ? "::float" : ""}`;
+    } else if (isBoolean(value)) {
+      column = `metadata->${attr}${includeType ? "::boolean" : ""}`;
     } else {
       throw new Error("Data type not supported");
     }


### PR DESCRIPTION
This pull request introduces support for boolean filters in the Supabase structured query translator and adds corresponding tests to ensure the functionality works as expected.
Support for boolean filters:

* [`libs/langchain-community/src/structured_query/supabase.ts`](diffhunk://#diff-05e57f6dabe3863de15ad33a8a91cdcbe597aee7a4b36292baa0aef8ba119c40R15): Added `isBoolean` to the import statements and updated the `SupabaseTranslator` class to handle boolean values in the `metadata` attribute. [[1]](diffhunk://#diff-05e57f6dabe3863de15ad33a8a91cdcbe597aee7a4b36292baa0aef8ba119c40R15) [[2]](diffhunk://#diff-05e57f6dabe3863de15ad33a8a91cdcbe597aee7a4b36292baa0aef8ba119c40R138-R139)

Testing for boolean filters:

* [`libs/langchain-community/src/structured_query/tests/supabase_self_query.int.test.ts`](diffhunk://#diff-e871e6b2973dc33997d0791133482773648f72888df997528fa8707c51882226R605-R706): Added a new test case to verify the functionality of boolean filters in the Supabase structured query translator.