### PR TITLE
feat(google-genai): Add support for fileUri in media type in Google GenAI

### DIFF
--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -86,7 +86,7 @@ function messageContentMedia(content: MessageContentComplex): Part {
       fileData: {
         mimeType: content.mimeType,
         fileUri: content.fileUri,
-        },
+      },
     };
   }
 

--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -81,6 +81,14 @@ function messageContentMedia(content: MessageContentComplex): Part {
       },
     };
   }
+  if ("mimeType" in content && "fileUri" in content) {
+    return {
+      fileData: {
+        mimeType: content.mimeType,
+        fileUri: content.fileUri,
+        },
+    };
+  }
 
   throw new Error("Invalid media content");
 }


### PR DESCRIPTION
Adds support for fileUri type which accepts Google AI Filemanager URIs.

This allows uploading large files and passing the uri as per the Gemini documentation without having to send inline data.
