### PR TITLE
fix(experimental): openai assistant attachments

### DIFF
--- a/langchain/src/experimental/openai_assistant/index.ts
+++ b/langchain/src/experimental/openai_assistant/index.ts
@@ -115,7 +115,7 @@ export class OpenAIAssistantRunnable<
           {
             role: "user",
             content: input.content,
-            file_ids: input.fileIds,
+            attachments: input.attachments,
             metadata: input.messagesMetadata,
           },
         ],
@@ -129,7 +129,7 @@ export class OpenAIAssistantRunnable<
       await this.client.beta.threads.messages.create(input.threadId, {
         content: input.content,
         role: "user",
-        file_ids: input.file_ids,
+        attachments: input.attachments,
         metadata: input.messagesMetadata,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);


### PR DESCRIPTION
Fixing openai assistants thread run. Parameters to create and run a thread do not match the latest from openai. 
This results in a unknown parameter error when trying to provide a file.

See docs:
https://platform.openai.com/docs/api-reference/runs/createThreadAndRun#runs-createthreadandrun-thread

Langchain Docs:
https://js.langchain.com/v0.1/docs/modules/agents/agent_types/openai_assistant/#use-file-in-ai-assistant


Fixes [# (issue)](https://github.com/langchain-ai/langchainjs/issues/7665)
