### PR TITLE
feat(core): Add a way to manually specify serializable fields

### DIFF
--- a/langchain-core/src/callbacks/base.ts
+++ b/langchain-core/src/callbacks/base.ts
@@ -328,6 +328,10 @@ export abstract class BaseCallbackHandler
     return undefined;
   }
 
+  get lc_serializable_keys(): string[] | undefined {
+    return undefined;
+  }
+
   /**
    * The name of the serializable. Override to provide an alias or
    * to preserve the serialized module name in minified environments.

--- a/langchain-core/src/load/serializable.ts
+++ b/langchain-core/src/load/serializable.ts
@@ -140,8 +140,24 @@ export abstract class Serializable implements SerializableInterface {
     return undefined;
   }
 
+  /**
+   * A manual list of keys that should be serialized.
+   * If not overridden, all fields passed into the constructor will be serialized.
+   */
+  get lc_serialized_keys(): string[] | undefined {
+    return undefined;
+  }
+
   constructor(kwargs?: SerializedFields, ..._args: never[]) {
-    this.lc_kwargs = kwargs || {};
+    if (this.lc_serialized_keys !== undefined) {
+      this.lc_kwargs = Object.fromEntries(
+        Object.entries(kwargs || {}).filter(([key]) =>
+          this.lc_serialized_keys?.includes(key)
+        )
+      );
+    } else {
+      this.lc_kwargs = kwargs ?? {};
+    }
   }
 
   toJSON(): Serialized {

--- a/langchain-core/src/load/serializable.ts
+++ b/langchain-core/src/load/serializable.ts
@@ -144,15 +144,15 @@ export abstract class Serializable implements SerializableInterface {
    * A manual list of keys that should be serialized.
    * If not overridden, all fields passed into the constructor will be serialized.
    */
-  get lc_serialized_keys(): string[] | undefined {
+  get lc_serializable_keys(): string[] | undefined {
     return undefined;
   }
 
   constructor(kwargs?: SerializedFields, ..._args: never[]) {
-    if (this.lc_serialized_keys !== undefined) {
+    if (this.lc_serializable_keys !== undefined) {
       this.lc_kwargs = Object.fromEntries(
         Object.entries(kwargs || {}).filter(([key]) =>
-          this.lc_serialized_keys?.includes(key)
+          this.lc_serializable_keys?.includes(key)
         )
       );
     } else {


### PR DESCRIPTION
Plan will be to publish a new version of core, and publish new releases of integration packages. Then keep a running list of keys that we can serialize for each classes where important

@baskaryan @madams0013 @dqbd 