### PR TITLE
fix(community): hide console errors on RecursiveUrlLoader

### DIFF
--- a/libs/langchain-community/src/document_loaders/tests/recursive_url.int.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/recursive_url.int.test.ts
@@ -1,10 +1,19 @@
 /* eslint-disable no-process-env */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { test } from "@jest/globals";
+import { test, jest } from "@jest/globals";
 import { compile } from "html-to-text";
 import { RecursiveUrlLoader } from "../web/recursive_url.js";
 
 describe("RecursiveUrlLoader", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+
   test("loading valid url", async () => {
     const url = "https://js.langchain.com/docs/introduction";
 
@@ -83,5 +92,17 @@ describe("RecursiveUrlLoader", () => {
     expect(docs.some((doc) => doc.metadata.source.startsWith(excludeDir))).toBe(
       false
     );
+  });
+
+  test("load docs from langsmith without reporting errors", async () => {
+    const url = "https://docs.smith.langchain.com/";
+    const loader = new RecursiveUrlLoader(url, {
+      maxDepth: 5,
+      timeout: 5000,
+    });
+
+    const docs = await loader.load();
+    expect(docs.length).toBeGreaterThan(1);
+    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/libs/langchain-community/src/document_loaders/tests/recursive_url.int.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/recursive_url.int.test.ts
@@ -13,7 +13,6 @@ describe("RecursiveUrlLoader", () => {
     jest.restoreAllMocks();
   });
 
-
   test("loading valid url", async () => {
     const url = "https://js.langchain.com/docs/introduction";
 

--- a/libs/langchain-community/src/document_loaders/web/recursive_url.ts
+++ b/libs/langchain-community/src/document_loaders/web/recursive_url.ts
@@ -7,7 +7,7 @@ import {
 } from "@langchain/core/document_loaders/base";
 
 const virtualConsole = new VirtualConsole();
-virtualConsole.on("error", () => { });
+virtualConsole.on("error", () => {});
 
 export interface RecursiveUrlLoaderOptions {
   excludeDirs?: string[];

--- a/libs/langchain-community/src/document_loaders/web/recursive_url.ts
+++ b/libs/langchain-community/src/document_loaders/web/recursive_url.ts
@@ -1,10 +1,13 @@
-import { JSDOM } from "jsdom";
+import { JSDOM, VirtualConsole } from "jsdom";
 import { Document } from "@langchain/core/documents";
 import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import {
   BaseDocumentLoader,
   DocumentLoader,
 } from "@langchain/core/document_loaders/base";
+
+const virtualConsole = new VirtualConsole();
+virtualConsole.on("error", () => { });
 
 export interface RecursiveUrlLoaderOptions {
   excludeDirs?: string[];
@@ -62,7 +65,7 @@ export class RecursiveUrlLoader
 
   private getChildLinks(html: string, baseUrl: string): Array<string> {
     const allLinks = Array.from(
-      new JSDOM(html).window.document.querySelectorAll("a")
+      new JSDOM(html, { virtualConsole }).window.document.querySelectorAll("a")
     ).map((a) => a.href);
     const absolutePaths = [];
     // eslint-disable-next-line no-script-url
@@ -117,7 +120,7 @@ export class RecursiveUrlLoader
   private extractMetadata(rawHtml: string, url: string) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const metadata: Record<string, any> = { source: url };
-    const { document } = new JSDOM(rawHtml).window;
+    const { document } = new JSDOM(rawHtml, { virtualConsole }).window;
 
     const title = document.getElementsByTagName("title")[0];
     if (title) {


### PR DESCRIPTION
Hide console errors from JSDOM on RecursiveUrlLoader.