### PR TITLE
feat(community): Update Voyage embeddings parameters

### DIFF
--- a/docs/core_docs/docs/integrations/text_embedding/voyageai.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/voyageai.mdx
@@ -8,12 +8,22 @@ The `inputType` parameter allows you to specify the type of input text for bette
 - `document`: Use this for documents or content that you want to be retrievable. Voyage AI will prepend a prompt to optimize the embeddings for document use cases.
 - `None` (default): The input text will be directly encoded without any additional prompt.
 
+Additionally, the class supports new parameters for further customization of the embedding process:
+- **truncation**: Whether to truncate the input texts to the maximum length allowed by the model.
+- **outputDimension**: The desired dimension of the output embeddings.
+- **outputDtype**: The data type of the output embeddings. Can be `"float"` or `"int8"`.
+- **encodingFormat**: The format of the output embeddings. Can be `"float"`, `"base64"`, or `"ubinary"`.
+
 ```typescript
 import { VoyageEmbeddings } from "@langchain/community/embeddings/voyage";
 
 const embeddings = new VoyageEmbeddings({
   apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.VOYAGEAI_API_KEY
-  inputType: "document", // Optional: specify input type as 'query', 'document', or omit for None / Undefined / Null
+  inputType: "document",  // Optional: specify input type as 'query', 'document', or omit for None / Undefined / Null
+  truncation: true,       // Optional: enable truncation of input texts
+  outputDimension: 768,   // Optional: set desired output embedding dimension
+  outputDtype: "float",   // Optional: set output data type ("float" or "int8")
+  encodingFormat: "float" // Optional: set output encoding format ("float", "base64", or "ubinary")
 });
 ```
 

--- a/docs/core_docs/docs/integrations/text_embedding/voyageai.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/voyageai.mdx
@@ -9,6 +9,7 @@ The `inputType` parameter allows you to specify the type of input text for bette
 - `None` (default): The input text will be directly encoded without any additional prompt.
 
 Additionally, the class supports new parameters for further customization of the embedding process:
+
 - **truncation**: Whether to truncate the input texts to the maximum length allowed by the model.
 - **outputDimension**: The desired dimension of the output embeddings.
 - **outputDtype**: The data type of the output embeddings. Can be `"float"` or `"int8"`.
@@ -19,11 +20,11 @@ import { VoyageEmbeddings } from "@langchain/community/embeddings/voyage";
 
 const embeddings = new VoyageEmbeddings({
   apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.VOYAGEAI_API_KEY
-  inputType: "document",  // Optional: specify input type as 'query', 'document', or omit for None / Undefined / Null
-  truncation: true,       // Optional: enable truncation of input texts
-  outputDimension: 768,   // Optional: set desired output embedding dimension
-  outputDtype: "float",   // Optional: set output data type ("float" or "int8")
-  encodingFormat: "float" // Optional: set output encoding format ("float", "base64", or "ubinary")
+  inputType: "document", // Optional: specify input type as 'query', 'document', or omit for None / Undefined / Null
+  truncation: true, // Optional: enable truncation of input texts
+  outputDimension: 768, // Optional: set desired output embedding dimension
+  outputDtype: "float", // Optional: set output data type ("float" or "int8")
+  encodingFormat: "float", // Optional: set output encoding format ("float", "base64", or "ubinary")
 });
 ```
 

--- a/libs/langchain-community/src/embeddings/voyage.ts
+++ b/libs/langchain-community/src/embeddings/voyage.ts
@@ -19,6 +19,26 @@ export interface VoyageEmbeddingsParams extends EmbeddingsParams {
    * Input type for the embeddings request.
    */
   inputType?: string;
+
+  /**
+   * Whether to truncate the input texts to the maximum length allowed by the model.
+   */
+  truncation?: boolean;
+
+  /**
+   * The desired dimension of the output embeddings.
+   */
+  outputDimension?: number;
+
+  /**
+   * The data type of the output embeddings. Can be "float" or "int8".
+   */
+  outputDtype?: string;
+
+  /**
+   * The format of the output embeddings. Can be "float", "base64", or "ubinary".
+   */
+  encodingFormat?: string;
 }
 
 /**
@@ -42,6 +62,26 @@ export interface CreateVoyageEmbeddingRequest {
    * Input type for the embeddings request.
    */
   input_type?: string;
+
+  /**
+   * Whether to truncate the input texts.
+   */
+  truncation?: boolean;
+
+  /**
+   * The desired dimension of the output embeddings.
+   */
+  output_dimension?: number;
+
+  /**
+   * The data type of the output embeddings.
+   */
+  output_dtype?: string;
+
+  /**
+   * The format of the output embeddings.
+   */
+  encoding_format?: string;
 }
 
 /**
@@ -65,6 +105,14 @@ export class VoyageEmbeddings
 
   inputType?: string;
 
+  truncation?: boolean;
+
+  outputDimension?: number;
+
+  outputDtype?: string;
+
+  encodingFormat?: string;
+
   /**
    * Constructor for the VoyageEmbeddings class.
    * @param fields - An optional object with properties to configure the instance.
@@ -73,7 +121,7 @@ export class VoyageEmbeddings
     fields?: Partial<VoyageEmbeddingsParams> & {
       verbose?: boolean;
       apiKey?: string;
-      inputType?: string; // Make inputType optional
+      inputType?: string;
     }
   ) {
     const fieldsWithDefaults = { ...fields };
@@ -92,6 +140,10 @@ export class VoyageEmbeddings
     this.apiKey = apiKey;
     this.apiUrl = `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
+    this.truncation = fieldsWithDefaults?.truncation;
+    this.outputDimension = fieldsWithDefaults?.outputDimension;
+    this.outputDtype = fieldsWithDefaults?.outputDtype;
+    this.encodingFormat = fieldsWithDefaults?.encodingFormat;
   }
 
   /**
@@ -107,6 +159,10 @@ export class VoyageEmbeddings
         model: this.modelName,
         input: batch,
         input_type: this.inputType,
+        truncation: this.truncation,
+        output_dimension: this.outputDimension,
+        output_dtype: this.outputDtype,
+        encoding_format: this.encodingFormat,
       })
     );
 
@@ -135,6 +191,10 @@ export class VoyageEmbeddings
       model: this.modelName,
       input: text,
       input_type: this.inputType,
+      truncation: this.truncation,
+      output_dimension: this.outputDimension,
+      output_dtype: this.outputDtype,
+      encoding_format: this.encodingFormat,
     });
 
     return data[0].embedding;
@@ -145,7 +205,6 @@ export class VoyageEmbeddings
    * @param request - An object with properties to configure the request.
    * @returns A Promise that resolves to the response from the Voyage AI API.
    */
-
   private async embeddingWithRetry(request: CreateVoyageEmbeddingRequest) {
     const makeCompletionRequest = async () => {
       const url = `${this.apiUrl}`;


### PR DESCRIPTION
<!--
Additionally, the class supports new parameters for further customization of the embedding process:
- **truncation**: Whether to truncate the input texts to the maximum length allowed by the model.
- **outputDimension**: The desired dimension of the output embeddings.
- **outputDtype**: The data type of the output embeddings. Can be `"float"` or `"int8"`.
- **encodingFormat**: The format of the output embeddings. Can be `"float"`, `"base64"`, or `"ubinary"`.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
