### PR TITLE
feat: runnable generator

### DIFF
--- a/langchain-core/src/runnables/index.ts
+++ b/langchain-core/src/runnables/index.ts
@@ -11,6 +11,7 @@ export {
   RunnableMap,
   RunnableParallel,
   RunnableLambda,
+  RunnableGenerator,
   RunnableWithFallbacks,
   RunnableAssign,
   RunnablePick,


### PR DESCRIPTION
## Add Support for `RunnableGenerator` in LangChain.js  

### Summary  
This PR addresses an issue where **streaming stops working** when using `.withStructuredOutput()` followed by `.pipe()` to transform the output structure in LangChain.js. The stream should continue emitting results as expected, but the current implementation causes it to only return the last chunk.


### Background & Motivation  
#### Issue: [#4936](https://github.com/langchain-ai/langchainjs/issues/4936)  
- When using a LangChain model with `.withStructuredOutput()` and then applying `.pipe()` to transform the output structure, **streaming no longer works**.
- The issue arises because `.pipe()` internally creates a `RunnableLambda`, which buffers all results before invoking the function, preventing the incremental emission of outputs required for streaming.
- Example of broken behavior:  
```typescript
const model = new ChatOpenAI().withStructuredOutput<MyOutputType>();

const mappedChain = model.pipe((output: MyOutputType) => ({
  newField: output.oldField,
}));

for await (const chunk of mappedChain.stream({ input: "Hello" })) {
  console.log(chunk); // Logs only the last chunk
}
```

### Key Changes  
- Implemented `RunnableGenerator` to handle streaming transformations without accumulating input.
```typescript
const model = new ChatOpenAI().withStructuredOutput<MyOutputType>();

const mappedChain = model.pipe(new RunnableGenerator({
  func: (output: MyOutputType) => ({
    newField: output.oldField,
  })
});

for await (const chunk of mappedChain.stream({ input: "Hello" })) {
  console.log(chunk); // Works
}
```

### Expected Impact  
- Streaming will now work when transforming structured outputs using .pipe().
- Simplifies handling streaming transformations, reducing complexity for users.
- Improves real-time processing for cases where output structures need to be modified dynamically.
- LangChain for Python already includes RunnableGenerator, but this feature was missing in LangChain.js.

### Fixes  
Fixes [#4936](https://github.com/langchain-ai/langchainjs/issues/4936)  

## 🚧 Draft: Needs Testing 🚧
This is a draft PR and still needs testing to ensure everything works as expected in all edge cases. Please help by running some tests and sharing feedback!
