### PR TITLE
fix: typo in the chatbot tutorial

### DIFF
--- a/docs/core_docs/docs/tutorials/chatbot.ipynb
+++ b/docs/core_docs/docs/tutorials/chatbot.ipynb
@@ -470,7 +470,7 @@
     "]\n",
     "const output = await app.invoke({ messages: input }, config)\n",
     "// The output contains all messages in the state.\n",
-    "// This will long the last message in the conversation.\n",
+    "// This will log the last message in the conversation.\n",
     "console.log(output.messages[output.messages.length - 1]);"
    ]
   },


### PR DESCRIPTION
Fixed a type in the [message persistence section](https://js.langchain.com/docs/tutorials/chatbot#message-persistence)
