### PR TITLE
fix(redis): Add TTL support for redis vector store

### DIFF
--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -62,7 +62,7 @@ export type RedisVectorStoreIndexOptions = Omit<
 /**
  * Interface for the configuration of the RedisVectorStore. It includes
  * the Redis client, index name, index options, key prefix, content key,
- * metadata key, vector key, and filter.
+ * metadata key, vector key, filter and ttl.
  */
 export interface RedisVectorStoreConfig {
   redisClient:
@@ -76,6 +76,7 @@ export interface RedisVectorStoreConfig {
   metadataKey?: string;
   vectorKey?: string;
   filter?: RedisVectorStoreFilterType;
+  ttl?: number; // ttl in second
 }
 
 /**
@@ -123,6 +124,8 @@ export class RedisVectorStore extends VectorStore {
 
   filter?: RedisVectorStoreFilterType;
 
+  ttl?: number;
+
   _vectorstoreType(): string {
     return "redis";
   }
@@ -144,6 +147,7 @@ export class RedisVectorStore extends VectorStore {
     this.metadataKey = _dbConfig.metadataKey ?? "metadata";
     this.vectorKey = _dbConfig.vectorKey ?? "content_vector";
     this.filter = _dbConfig.filter;
+    this.ttl = _dbConfig.ttl;
     this.createIndexOptions = {
       ON: "HASH",
       PREFIX: this.keyPrefix,
@@ -207,6 +211,10 @@ export class RedisVectorStore extends VectorStore {
         [this.contentKey]: documents[idx].pageContent,
         [this.metadataKey]: this.escapeSpecialChars(JSON.stringify(metadata)),
       });
+
+      if (this.ttl) {
+        multi.expire(key, this.ttl);
+      }
 
       // write batch
       if (idx % batchSize === 0) {


### PR DESCRIPTION
hi team, want to address this [ask](https://github.com/langchain-ai/langchainjs/discussions/7632). It's a tiny change and python already supported it.  In addition, I also tested it in local redis stack. 

