### PR TITLE
docs: Fix the broken link

### DIFF
--- a/docs/core_docs/docs/how_to/sequence.ipynb
+++ b/docs/core_docs/docs/how_to/sequence.ipynb
@@ -36,7 +36,7 @@
         "\n",
         "## The pipe method\n",
         "\n",
-        "To show off how this works, let's go through an example. We'll walk through a common pattern in LangChain: using a [prompt template](/docs/concepts/prompt_templates) to format input into a [chat model](/docs/concepts/chat_models), and finally converting the chat message output into a string with an [output parser](/docs/concepts/output_parsers.\n",
+        "To show off how this works, let's go through an example. We'll walk through a common pattern in LangChain: using a [prompt template](/docs/concepts/prompt_templates) to format input into a [chat model](/docs/concepts/chat_models), and finally converting the chat message output into a string with an [output parser](/docs/concepts/output_parsers).\n",
         "\n",
         "```{=mdx}\n",
         "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",

--- a/docs/core_docs/docs/tutorials/rag.ipynb
+++ b/docs/core_docs/docs/tutorials/rag.ipynb
@@ -372,7 +372,7 @@
     "\n",
     "- [Docs](/docs/concepts/document_loaders): Detailed documentation on how to use\n",
     "- [Integrations](/docs/integrations/document_loaders/)\n",
-    "- [Interface](https:/api.js.langchain.com/classes/langchain.document_loaders_base.BaseDocumentLoader.html): API reference for the base interface.\n",
+    "- [Interface](https://api.js.langchain.com/classes/langchain.document_loaders_base.BaseDocumentLoader.html): API reference for the base interface.\n",
     "\n",
     "### Splitting documents\n",
     "\n",


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
There is a broken link when the user click on that it redirect to page not found instead taking the user to api reference.