### PR TITLE
fix(google-common): Eliminate hard-coded default values in favor of model-based defaults

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -181,13 +181,13 @@ export abstract class ChatGoogleBase<AuthOptions>
 
   modelName = "gemini-pro";
 
-  temperature = 0.7;
+  temperature: number;
 
-  maxOutputTokens = 1024;
+  maxOutputTokens: number;
 
-  topP = 0.8;
+  topP: number;
 
-  topK = 40;
+  topK: number;
 
   presencePenalty: number;
 

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -218,6 +218,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     };
     const model = new ChatGoogle({
       authOptions,
+      temperature: 0.8,
     });
     const messages: BaseMessageLike[] = [
       new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
@@ -229,6 +230,13 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(record.opts).toBeDefined();
     expect(record.opts.data).toBeDefined();
     const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    const { generationConfig } = data;
+    expect(generationConfig).toHaveProperty("temperature");
+    expect(generationConfig.temperature).toEqual(0.8);
+    expect(generationConfig).not.toHaveProperty("topP")
+
     expect(data.contents).toBeDefined();
     expect(data.contents.length).toEqual(3);
     expect(data.contents[0].role).toEqual("user");

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -235,7 +235,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     const { generationConfig } = data;
     expect(generationConfig).toHaveProperty("temperature");
     expect(generationConfig.temperature).toEqual(0.8);
-    expect(generationConfig).not.toHaveProperty("topP")
+    expect(generationConfig).not.toHaveProperty("topP");
 
     expect(data.contents).toBeDefined();
     expect(data.contents.length).toEqual(3);

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1102,6 +1102,14 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       }
     }
 
+    // Remove any undefined properties, so we don't send them
+    let attribute: keyof GeminiGenerationConfig;
+    for (attribute in ret) {
+      if (ret[attribute] === undefined) {
+        delete ret[attribute];
+      }
+    }
+
     return ret;
   }
 


### PR DESCRIPTION
This eliminates the hard coded default values for:
* temperature
* maxOutputTokens
* topP
* topK
and makes sure that values that aren't set aren't even sent in the request.
