### PR TITLE
fix(langchain): fix react agent quote handling in JSON parsing

### DIFF
--- a/langchain/src/agents/react/output_parser.ts
+++ b/langchain/src/agents/react/output_parser.ts
@@ -77,7 +77,7 @@ export class ReActSingleInputOutputParser extends AgentActionOutputParser {
 
       const action = actionMatch[1];
       const actionInput = actionMatch[2];
-      const toolInput = actionInput.trim().replace(/"/g, "");
+      const toolInput = actionInput.trim().replace(/^"|"$/g, "");
 
       return {
         tool: action,

--- a/langchain/src/tests/react_agent_output_parser.test.ts
+++ b/langchain/src/tests/react_agent_output_parser.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@jest/globals";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { AgentAction, AgentFinish } from "@langchain/core/agents.js";
+import { ReActSingleInputOutputParser } from "../agents/react/output_parser.js";
+
+
+test("React agent output parser", async () => {
+  const toolName = "AnyTool";
+  const outputParser = new ReActSingleInputOutputParser({ toolNames: [toolName] });
+  const response: AgentAction | AgentFinish = await outputParser.parse(`Action: ${toolName} Action Input: "["input1", "input2", "input3", "input4"]"`);
+
+  if (response.returnValues){
+    expect(response.returnValues).toBeNull();
+    return
+  }
+
+  const toolInputParsed = JSON.parse(response.toolInput);
+  expect(response.tool).toBe(toolName);
+  expect(toolInputParsed.length).toBe(4);
+});

--- a/langchain/src/tests/react_agent_output_parser.test.ts
+++ b/langchain/src/tests/react_agent_output_parser.test.ts
@@ -4,15 +4,18 @@ import { test, expect } from "@jest/globals";
 import { AgentAction, AgentFinish } from "@langchain/core/agents.js";
 import { ReActSingleInputOutputParser } from "../agents/react/output_parser.js";
 
-
 test("React agent output parser", async () => {
   const toolName = "AnyTool";
-  const outputParser = new ReActSingleInputOutputParser({ toolNames: [toolName] });
-  const response: AgentAction | AgentFinish = await outputParser.parse(`Action: ${toolName} Action Input: "["input1", "input2", "input3", "input4"]"`);
+  const outputParser = new ReActSingleInputOutputParser({
+    toolNames: [toolName],
+  });
+  const response: AgentAction | AgentFinish = await outputParser.parse(
+    `Action: ${toolName} Action Input: "["input1", "input2", "input3", "input4"]"`
+  );
 
-  if (response.returnValues){
+  if (response.returnValues) {
     expect(response.returnValues).toBeNull();
-    return
+    return;
   }
 
   const toolInputParsed = JSON.parse(response.toolInput);


### PR DESCRIPTION
react agent parser is replacing all '"' - in the text and this is incorrect, we can not parse a json

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)

E.g.

console.log('"hello world"'.replace(/^"|"$/g, ""));  // Output: hello world
console.log('"hello "world" "'.replace(/^"|"$/g, "")); // Output: hello "world" 
console.log('"hello"world"'.replace(/^"|"$/g, "")); // Output: hello"world
console.log('hello world'.replace(/^"|"$/g, ""));  // Output: hello world (unchanged)

