### PR TITLE
fix(core): Fix issue in .d.ts typing for TextEncoder

### DIFF
--- a/langchain-core/src/output_parsers/bytes.ts
+++ b/langchain-core/src/output_parsers/bytes.ts
@@ -13,9 +13,7 @@ export class BytesOutputParser extends BaseTransformOutputParser<Uint8Array> {
 
   lc_serializable = true;
 
-  // TODO: Figure out why explicit typing is needed
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected textEncoder: any = new TextEncoder();
+  protected textEncoder: InstanceType<typeof TextEncoder> = new TextEncoder();
 
   parse(text: string): Promise<Uint8Array> {
     return Promise.resolve(this.textEncoder.encode(text));


### PR DESCRIPTION
Fixes #7247 without loosing the typing

This pull request makes a small but important change to the `BytesOutputParser` class in the `langchain-core` package. The change involves updating the type of the `textEncoder` property to use a more specific type.

`globalThis.TextEncoder` (when not imported from `node:util`) is a value, not a type. In this case, the type is actually `InstanceType<typeof TextEncoder>`.

* [`langchain-core/src/output_parsers/bytes.ts`](diffhunk://#diff-d38c7f72b0e15d5088141cc1fcbaa2dfb397a6107d941ce71e780e972e05529bL16-R16): Updated the `textEncoder` property to use `InstanceType<typeof TextEncoder>` instead of `any` for better type safety.
