### PR TITLE
fix(google-genai): Fix Google Genai usage token

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -905,21 +905,21 @@ export class ChatGoogleGenerativeAI
         options.streamUsage !== false
       ) {
         const genAIUsageMetadata = response.usageMetadata as {
-          promptTokenCount: number;
-          candidatesTokenCount: number;
-          totalTokenCount: number;
+          promptTokenCount: number | undefined;
+          candidatesTokenCount: number | undefined;
+          totalTokenCount: number | undefined;
         };
         if (!usageMetadata) {
           usageMetadata = {
-            input_tokens: genAIUsageMetadata.promptTokenCount,
-            output_tokens: genAIUsageMetadata.candidatesTokenCount,
-            total_tokens: genAIUsageMetadata.totalTokenCount,
+            input_tokens: genAIUsageMetadata.promptTokenCount ?? 0,
+            output_tokens: genAIUsageMetadata.candidatesTokenCount ?? 0,
+            total_tokens: genAIUsageMetadata.totalTokenCount ?? 0,
           };
         } else {
           // Under the hood, LangChain combines the prompt tokens. Google returns the updated
           // total each time, so we need to find the difference between the tokens.
           const outputTokenDiff =
-            genAIUsageMetadata.candidatesTokenCount -
+            (genAIUsageMetadata.candidatesTokenCount ?? 0) -
             usageMetadata.output_tokens;
           usageMetadata = {
             input_tokens: 0,


### PR DESCRIPTION
Fix corrupted token count (output & total) for Google Genai provider in streaming mode.

Problem was that when using streaming mode we assume `candidatesTokenCount` and `totalTokenCount` are present. They are not initially so the value gets corrupted (`NaN`) and this error carries forward.

Fixes #7444 
