### PR TITLE
fix(core): Skip delete operation if not necessary during incremental index

### DIFF
--- a/langchain-core/src/indexing/base.ts
+++ b/langchain-core/src/indexing/base.ts
@@ -348,9 +348,12 @@ export async function index(args: IndexArgs): Promise<IndexingResult> {
         before: indexStartDt,
         groupIds: sourceIds,
       });
-      await vectorStore.delete({ ids: uidsToDelete });
-      await recordManager.deleteKeys(uidsToDelete);
-      numDeleted += uidsToDelete.length;
+
+      if (uidsToDelete.length > 0) {
+        await vectorStore.delete({ ids: uidsToDelete });
+        await recordManager.deleteKeys(uidsToDelete);
+        numDeleted += uidsToDelete.length;
+      }
     }
   }
 


### PR DESCRIPTION
While indexing with an incremental cleanup, a list of UIDs is generated, which is passed off to the vector store to be deleted.
https://github.com/langchain-ai/langchainjs/blob/d303e909d6b73da0bda4c0b7065ff974a980e5b0/langchain-core/src/indexing/base.ts#L343-L355

Sometimes, this list of UIDs is empty, and ChromaDB seems to have a problem with that:
```
InvalidArgumentError:
                You must provide either ids, where, or where_document to delete. If
                you want to delete all data in a collection you can delete the
                collection itself using the delete_collection method. Or alternatively,
                you can get() all the relevant ids and then delete them.
``` 

ChromaDB should probably just not do anything instead of throwing an error in such a scenario. Still, it's probably more efficient to skip performing the query than having the vector store take care of it anyway.

This is a simple PR that fixes this issue by ensuring the operation is only done when the list is not empty.