### PR TITLE
release(aws): 0.1.5

### DIFF
--- a/libs/langchain-aws/package.json
+++ b/libs/langchain-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/aws",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "LangChain AWS integration",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Updates `@langchain/aws` to support Claude 3.7 with extended thinking mode on bedrock.
