### PR TITLE
Google oauth support + fix tools for API v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ docs/api_refs/typedoc.json
 credentials.json
 **/typedoc.json
 .vercel
+
+bun.lock

--- a/docs/core_docs/docs/integrations/tools/gmail.mdx
+++ b/docs/core_docs/docs/integrations/tools/gmail.mdx
@@ -10,9 +10,16 @@ The Gmail Tool allows your agent to create and view messages from a linked email
 
 ## Setup
 
-You will need to get an API key from [Google here](https://developers.google.com/gmail/api/guides)
-and [enable the new Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com).
-Then, set the environment variables for `GMAIL_CLIENT_EMAIL`, and either `GMAIL_PRIVATE_KEY`, or `GMAIL_KEYFILE`.
+You can authenticate via two methods:
+
+1. Provide an access token, obtained via OAuth2 token exchange, to the credentials object.
+   This can be done using an Identity Provider that supports getting access tokens from federated connections.
+   This is the most secure method as the access and scope will be limited to the specific end user.
+   This method will be more appropriate when using the tool in an application that is meant to be used by end
+   users with their own Gmail account.
+2. You will need to get an API key from [Google here](https://developers.google.com/gmail/api/guides)
+   and [enable the new Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com).
+   Then, set the environment variables for `GMAIL_CLIENT_EMAIL`, and either `GMAIL_PRIVATE_KEY`, or `GMAIL_KEYFILE`.
 
 To use the Gmail Tool you need to install the following official peer dependency:
 

--- a/docs/core_docs/docs/integrations/tools/gmail.mdx
+++ b/docs/core_docs/docs/integrations/tools/gmail.mdx
@@ -13,6 +13,7 @@ The Gmail Tool allows your agent to create and view messages from a linked email
 You can authenticate via two methods:
 
 1. Provide an access token, obtained via OAuth2 token exchange, to the credentials object.
+   This can be a string or a function so that token expiry and validation can be handled.
    This can be done using an Identity Provider that supports getting access tokens from federated connections.
    This is the most secure method as the access and scope will be limited to the specific end user.
    This method will be more appropriate when using the tool in an application that is meant to be used by end

--- a/examples/src/tools/gmail.ts
+++ b/examples/src/tools/gmail.ts
@@ -20,10 +20,10 @@ export async function run() {
   //     credentials: {
   //       clientEmail: process.env.GMAIL_CLIENT_EMAIL,
   //       privateKey: process.env.GMAIL_PRIVATE_KEY,
-  //       // Either (privateKey + clientEmail) or access_token is required
-  //       access_token: process.env.GMAIL_ACCESS_TOKEN,
+  //       // Either (privateKey + clientEmail) or accessToken is required
+  //       accessToken: "your access token",
   //     },
-  //     scopes: ["https://mail.google.com/"], // Not required if using access_token
+  //     scopes: ["https://mail.google.com/"], // Not required if using access token
   //   };
 
   // For custom parameters, uncomment the code above, replace the values with your own, and pass it to the tools below

--- a/examples/src/tools/gmail.ts
+++ b/examples/src/tools/gmail.ts
@@ -20,8 +20,10 @@ export async function run() {
   //     credentials: {
   //       clientEmail: process.env.GMAIL_CLIENT_EMAIL,
   //       privateKey: process.env.GMAIL_PRIVATE_KEY,
+  //       // Either (privateKey + clientEmail) or access_token is required
+  //       access_token: process.env.GMAIL_ACCESS_TOKEN,
   //     },
-  //     scopes: ["https://mail.google.com/"],
+  //     scopes: ["https://mail.google.com/"], // Not required if using access_token
   //   };
 
   // For custom parameters, uncomment the code above, replace the values with your own, and pass it to the tools below

--- a/examples/src/tools/gmail.ts
+++ b/examples/src/tools/gmail.ts
@@ -21,7 +21,7 @@ export async function run() {
   //       clientEmail: process.env.GMAIL_CLIENT_EMAIL,
   //       privateKey: process.env.GMAIL_PRIVATE_KEY,
   //       // Either (privateKey + clientEmail) or accessToken is required
-  //       accessToken: "your access token",
+  //       accessToken: "an access token or function to get access token",
   //     },
   //     scopes: ["https://mail.google.com/"], // Not required if using access token
   //   };

--- a/libs/langchain-community/src/tools/gmail/base.ts
+++ b/libs/langchain-community/src/tools/gmail/base.ts
@@ -1,5 +1,4 @@
 import { gmail_v1, google } from "googleapis";
-import { z } from "zod";
 import { StructuredTool } from "@langchain/core/tools";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
@@ -9,92 +8,86 @@ export interface GmailBaseToolParams {
     privateKey?: string;
     keyfile?: string;
     subject?: string;
-    accessToken?: string;
+    // support string and async function to handle token validation and expiration
+    accessToken?: string | (() => Promise<string>);
   };
   scopes?: string[];
 }
 
 export abstract class GmailBaseTool extends StructuredTool {
-  private CredentialsSchema = z
-    .object({
-      clientEmail: z
-        .string()
-        .default(getEnvironmentVariable("GMAIL_CLIENT_EMAIL") ?? ""),
-      privateKey: z
-        .string()
-        .default(getEnvironmentVariable("GMAIL_PRIVATE_KEY") ?? ""),
-      keyfile: z
-        .string()
-        .default(getEnvironmentVariable("GMAIL_KEYFILE") ?? ""),
-      subject: z
-        .string()
-        .default(getEnvironmentVariable("GMAIL_SUBJECT") ?? ""),
-      accessToken: z.string().default(""),
-    })
-    .refine(
-      (credentials) =>
-        credentials.accessToken !== "" || credentials.clientEmail !== "",
-      {
-        message: "Missing GMAIL_CLIENT_EMAIL to interact with Gmail",
-      }
-    )
-    .refine(
-      (credentials) =>
-        credentials.privateKey !== "" ||
-        credentials.keyfile !== "" ||
-        credentials.accessToken !== "",
-      {
-        message:
-          "Missing GMAIL_PRIVATE_KEY or GMAIL_KEYFILE or accessToken to interact with Gmail",
-      }
-    );
-
-  private GmailBaseToolParamsSchema = z
-    .object({
-      credentials: this.CredentialsSchema.default({}),
-      scopes: z.array(z.string()).default(["https://mail.google.com/"]),
-    })
-    .default({});
-
   name = "Gmail";
 
   description = "A tool to send and view emails through Gmail";
 
-  protected gmail: gmail_v1.Gmail;
+  protected params: GmailBaseToolParams;
 
-  constructor(fields?: Partial<GmailBaseToolParams>) {
+  protected gmail?: gmail_v1.Gmail;
+
+  constructor(
+    { credentials, scopes }: GmailBaseToolParams = {
+      credentials: {
+        clientEmail: getEnvironmentVariable("GMAIL_CLIENT_EMAIL"),
+        privateKey: getEnvironmentVariable("GMAIL_PRIVATE_KEY"),
+        keyfile: getEnvironmentVariable("GMAIL_KEYFILE"),
+        subject: getEnvironmentVariable("GMAIL_SUBJECT"),
+      },
+      scopes: ["https://mail.google.com/"],
+    }
+  ) {
     super(...arguments);
 
-    const { credentials, scopes } =
-      this.GmailBaseToolParamsSchema.parse(fields);
+    if (!credentials) {
+      throw new Error("Missing credentials to authenticate to Gmail");
+    }
 
-    this.gmail = this.getGmail(
-      scopes,
-      credentials.clientEmail,
-      credentials.privateKey,
-      credentials.keyfile,
-      credentials.subject,
-      credentials.accessToken
-    );
+    if (!credentials.accessToken) {
+      if (!credentials.clientEmail) {
+        throw new Error("Missing GMAIL_CLIENT_EMAIL to interact with Gmail");
+      }
+
+      if (!credentials.privateKey && !credentials.keyfile) {
+        throw new Error(
+          "Missing GMAIL_PRIVATE_KEY or GMAIL_KEYFILE or accessToken to interact with Gmail"
+        );
+      }
+    }
+
+    this.params = { credentials, scopes };
   }
 
-  private getGmail(
-    scopes: string[],
-    email: string,
-    key?: string,
-    keyfile?: string,
-    subject?: string,
-    accessToken?: string
-  ) {
-    if (accessToken) {
+  async getGmailClient() {
+    const { credentials, scopes } = this.params;
+
+    if (credentials?.accessToken) {
+      // always return a new instance so that we don't end up using expired access tokens
       const auth = new google.auth.OAuth2();
-      auth.setCredentials({ access_token: accessToken });
+      const accessToken =
+        typeof credentials.accessToken === "function"
+          ? await credentials.accessToken()
+          : credentials.accessToken;
+
+      auth.setCredentials({
+        // get fresh access token if a function is provided
+        access_token: accessToken,
+      });
       return google.gmail({ version: "v1", auth });
     }
 
-    const auth = new google.auth.JWT(email, keyfile, key, scopes, subject);
+    // when not using access token its ok to use singleton instance
+    if (this.gmail) {
+      return this.gmail;
+    }
 
-    return google.gmail({ version: "v1", auth });
+    const auth = new google.auth.JWT(
+      credentials?.clientEmail,
+      credentials?.keyfile,
+      credentials?.privateKey,
+      scopes,
+      credentials?.subject
+    );
+
+    this.gmail = google.gmail({ version: "v1", auth });
+    return this.gmail;
   }
 
   parseHeaderAndBody(payload: gmail_v1.Schema$MessagePart | undefined) {

--- a/libs/langchain-community/src/tools/gmail/base.ts
+++ b/libs/langchain-community/src/tools/gmail/base.ts
@@ -9,7 +9,7 @@ export interface GmailBaseToolParams {
     privateKey?: string;
     keyfile?: string;
     subject?: string;
-    access_token?: string;
+    accessToken?: string;
   };
   scopes?: string[];
 }
@@ -29,11 +29,11 @@ export abstract class GmailBaseTool extends StructuredTool {
       subject: z
         .string()
         .default(getEnvironmentVariable("GMAIL_SUBJECT") ?? ""),
-      access_token: z.string().default(""),
+      accessToken: z.string().default(""),
     })
     .refine(
       (credentials) =>
-        credentials.access_token !== "" || credentials.clientEmail !== "",
+        credentials.accessToken !== "" || credentials.clientEmail !== "",
       {
         message: "Missing GMAIL_CLIENT_EMAIL to interact with Gmail",
       }
@@ -42,10 +42,10 @@ export abstract class GmailBaseTool extends StructuredTool {
       (credentials) =>
         credentials.privateKey !== "" ||
         credentials.keyfile !== "" ||
-        credentials.access_token !== "",
+        credentials.accessToken !== "",
       {
         message:
-          "Missing GMAIL_PRIVATE_KEY or GMAIL_KEYFILE or access_token to interact with Gmail",
+          "Missing GMAIL_PRIVATE_KEY or GMAIL_KEYFILE or accessToken to interact with Gmail",
       }
     );
 
@@ -74,7 +74,7 @@ export abstract class GmailBaseTool extends StructuredTool {
       credentials.privateKey,
       credentials.keyfile,
       credentials.subject,
-      credentials.access_token
+      credentials.accessToken
     );
   }
 
@@ -84,11 +84,11 @@ export abstract class GmailBaseTool extends StructuredTool {
     key?: string,
     keyfile?: string,
     subject?: string,
-    access_token?: string
+    accessToken?: string
   ) {
-    if (access_token) {
+    if (accessToken) {
       const auth = new google.auth.OAuth2();
-      auth.setCredentials({ access_token });
+      auth.setCredentials({ access_token: accessToken });
       return google.gmail({ version: "v1", auth });
     }
 

--- a/libs/langchain-community/src/tools/gmail/create_draft.ts
+++ b/libs/langchain-community/src/tools/gmail/create_draft.ts
@@ -56,7 +56,9 @@ export class GmailCreateDraft extends GmailBaseTool {
       bcc
     );
 
-    const response = await this.gmail.users.drafts.create({
+    const gmail = await this.getGmailClient();
+
+    const response = await gmail.users.drafts.create({
       userId: "me",
       requestBody: create_message,
     });

--- a/libs/langchain-community/src/tools/gmail/descriptions.ts
+++ b/libs/langchain-community/src/tools/gmail/descriptions.ts
@@ -78,42 +78,37 @@ Example Output:
 "Message sent. Message Id: unique_message_id_string"
 `;
 
-export const SEARCH_DESCRIPTION = `A tool for searching email messages or threads in Gmail using a specific query. It offers the flexibility to choose between messages and threads as the search resource.
+export const SEARCH_DESCRIPTION = `A tool for searching Gmail messages or threads using a specific query. Offers the flexibility to choose between messages and threads as the search resource.
 
-INPUT example:
+INPUT:
 {
-  "query": "specific search query",
+  "query": "search query",
   "maxResults": 10, // Optional: number of results to return
   "resource": "messages" // Optional: can be "messages" or "threads"
 }
 
 OUTPUT:
-The output is a JSON list of either email messages or threads, depending on the specified resource, that matches the search query. For 'messages', the output includes details like the message ID, thread ID, snippet, body, subject, and sender of each message. For 'threads', it includes the thread ID, snippet, body, subject, and sender of the first message in each thread. If no data is returned, or if the specified resource is invalid, the tool throws an error with a relevant message.
+JSON list of matching email messages or threads based on the specified resource. If no data is returned, or if the specified resource is invalid, throw error with a relevant message.
 
-Example Output for 'messages':
-"Result for the query 'specific search query':
-[
-  {
-    'id': 'message_id',
-    'threadId': 'thread_id',
-    'snippet': 'message snippet',
-    'body': 'message body',
-    'subject': 'message subject',
-    'sender': 'sender's email'
-  },
-  ... (other messages matching the query)
+Example result for messages:
+"[{
+  'id': 'message_id',
+  'threadId': 'thread_id',
+  'snippet': 'message snippet',
+  'body': 'message body',
+  'subject': 'message subject',
+  'sender': 'message sender'
+}, 
+... (other messages matching the query)
 ]"
 
-Example Output for 'threads':
-"Result for the query 'specific search query':
-[
-  {
-    'id': 'thread_id',
-    'snippet': 'thread snippet',
-    'body': 'first message body',
-    'subject': 'first message subject',
-    'sender': 'first message sender'
-  },
-  ... (other threads matching the query)
-]"
-`;
+Example result for threads:
+"[{
+  'id': 'thread_id',
+  'snippet': 'thread snippet',
+  'body': 'first message body',
+  'subject': 'first message subject',
+  'sender': 'first message sender'
+},
+... (other threads matching the query)
+]"`;

--- a/libs/langchain-community/src/tools/gmail/get_message.ts
+++ b/libs/langchain-community/src/tools/gmail/get_message.ts
@@ -18,7 +18,9 @@ export class GmailGetMessage extends GmailBaseTool {
   async _call(arg: z.output<typeof this.schema>) {
     const { messageId } = arg;
 
-    const { data } = await this.gmail.users.messages.get({
+    const gmail = await this.getGmailClient();
+
+    const { data } = await gmail.users.messages.get({
       userId: "me",
       format: "full",
 

--- a/libs/langchain-community/src/tools/gmail/get_message.ts
+++ b/libs/langchain-community/src/tools/gmail/get_message.ts
@@ -18,12 +18,12 @@ export class GmailGetMessage extends GmailBaseTool {
   async _call(arg: z.output<typeof this.schema>) {
     const { messageId } = arg;
 
-    const message = await this.gmail.users.messages.get({
+    const { data } = await this.gmail.users.messages.get({
       userId: "me",
+      format: "full",
+
       id: messageId,
     });
-
-    const { data } = message;
 
     if (!data) {
       throw new Error("No data returned from Gmail");
@@ -41,21 +41,17 @@ export class GmailGetMessage extends GmailBaseTool {
       throw new Error("No headers returned from Gmail");
     }
 
-    const subject = headers.find((header) => header.name === "Subject");
+    const { subject, sender, body } = this.parseHeaderAndBody(payload);
 
     if (!subject) {
       throw new Error("No subject returned from Gmail");
     }
 
-    const body = headers.find((header) => header.name === "Body");
-
     if (!body) {
       throw new Error("No body returned from Gmail");
     }
 
-    const from = headers.find((header) => header.name === "From");
-
-    if (!from) {
+    if (!sender) {
       throw new Error("No from returned from Gmail");
     }
 
@@ -81,8 +77,8 @@ export class GmailGetMessage extends GmailBaseTool {
 
     return `Result for the prompt ${messageId} \n${JSON.stringify({
       subject: subject.value,
-      body: body.value,
-      from: from.value,
+      body,
+      from: sender.value,
       to: to.value,
       date: date.value,
       messageId: messageIdHeader.value,

--- a/libs/langchain-community/src/tools/gmail/get_thread.ts
+++ b/libs/langchain-community/src/tools/gmail/get_thread.ts
@@ -18,7 +18,9 @@ export class GmailGetThread extends GmailBaseTool {
   async _call(arg: z.output<typeof this.schema>) {
     const { threadId } = arg;
 
-    const { data } = await this.gmail.users.threads.get({
+    const gmail = await this.getGmailClient();
+
+    const { data } = await gmail.users.threads.get({
       userId: "me",
       format: "full",
 

--- a/libs/langchain-community/src/tools/gmail/get_thread.ts
+++ b/libs/langchain-community/src/tools/gmail/get_thread.ts
@@ -18,12 +18,12 @@ export class GmailGetThread extends GmailBaseTool {
   async _call(arg: z.output<typeof this.schema>) {
     const { threadId } = arg;
 
-    const thread = await this.gmail.users.threads.get({
+    const { data } = await this.gmail.users.threads.get({
       userId: "me",
+      format: "full",
+
       id: threadId,
     });
-
-    const { data } = thread;
 
     if (!data) {
       throw new Error("No data returned from Gmail");
@@ -49,21 +49,17 @@ export class GmailGetThread extends GmailBaseTool {
           throw new Error("No headers returned from Gmail");
         }
 
-        const subject = headers.find((header) => header.name === "Subject");
+        const { subject, sender, body } = this.parseHeaderAndBody(payload);
 
         if (!subject) {
           throw new Error("No subject returned from Gmail");
         }
 
-        const body = headers.find((header) => header.name === "Body");
-
         if (!body) {
           throw new Error("No body returned from Gmail");
         }
 
-        const from = headers.find((header) => header.name === "From");
-
-        if (!from) {
+        if (!sender) {
           throw new Error("No from returned from Gmail");
         }
 
@@ -89,8 +85,8 @@ export class GmailGetThread extends GmailBaseTool {
 
         return {
           subject: subject.value,
-          body: body.value,
-          from: from.value,
+          body,
+          from: sender.value,
           to: to.value,
           date: date.value,
           messageId: messageIdHeader.value,

--- a/libs/langchain-community/src/tools/gmail/search.ts
+++ b/libs/langchain-community/src/tools/gmail/search.ts
@@ -21,35 +21,41 @@ export class GmailSearch extends GmailBaseTool {
   async _call(arg: z.output<typeof this.schema>) {
     const { query, maxResults = 10, resource = "messages" } = arg;
 
-    const response = await this.gmail.users.messages.list({
-      userId: "me",
-      q: query,
-      maxResults,
-    });
+    try {
+      const response = await this.gmail.users.messages.list({
+        userId: "me",
+        q: query,
+        maxResults,
+      });
 
-    const { data } = response;
+      const { data } = response;
 
-    if (!data) {
-      throw new Error("No data returned from Gmail");
+      if (!data) {
+        throw new Error("No data returned from Gmail");
+      }
+
+      const { messages } = data;
+
+      if (!messages) {
+        throw new Error("No messages returned from Gmail");
+      }
+
+      if (resource === "messages") {
+        const parsedMessages = await this.parseMessages(messages);
+        return `Result for the query ${query}:\n${JSON.stringify(
+          parsedMessages
+        )}`;
+      } else if (resource === "threads") {
+        const parsedThreads = await this.parseThreads(messages);
+        return `Result for the query ${query}:\n${JSON.stringify(
+          parsedThreads
+        )}`;
+      }
+
+      throw new Error(`Invalid resource: ${resource}`);
+    } catch (error) {
+      throw new Error(`Error while searching Gmail: ${error}`);
     }
-
-    const { messages } = data;
-
-    if (!messages) {
-      throw new Error("No messages returned from Gmail");
-    }
-
-    if (resource === "messages") {
-      const parsedMessages = await this.parseMessages(messages);
-      return `Result for the query ${query}:\n${JSON.stringify(
-        parsedMessages
-      )}`;
-    } else if (resource === "threads") {
-      const parsedThreads = await this.parseThreads(messages);
-      return `Result for the query ${query}:\n${JSON.stringify(parsedThreads)}`;
-    }
-
-    throw new Error(`Invalid resource: ${resource}`);
   }
 
   async parseMessages(
@@ -57,71 +63,61 @@ export class GmailSearch extends GmailBaseTool {
   ): Promise<gmail_v1.Schema$Message[]> {
     const parsedMessages = await Promise.all(
       messages.map(async (message) => {
-        const messageData = await this.gmail.users.messages.get({
-          userId: "me",
-          format: "raw",
-          id: message.id ?? "",
-        });
+        try {
+          const { data } = await this.gmail.users.messages.get({
+            userId: "me",
+            format: "full",
+            id: message.id ?? "",
+          });
 
-        const headers = messageData.data.payload?.headers || [];
+          const { payload } = data;
 
-        const subject = headers.find((header) => header.name === "Subject");
-        const sender = headers.find((header) => header.name === "From");
+          const { subject, sender, body } = this.parseHeaderAndBody(payload);
 
-        let body = "";
-        if (messageData.data.payload?.parts) {
-          body = messageData.data.payload.parts
-            .map((part) => part.body?.data ?? "")
-            .join("");
-        } else if (messageData.data.payload?.body?.data) {
-          body = messageData.data.payload.body.data;
+          return {
+            id: message.id,
+            threadId: message.threadId,
+            snippet: data.snippet,
+            body,
+            subject,
+            sender,
+          };
+        } catch (error) {
+          throw new Error(`Error while fetching message: ${error}`);
         }
-
-        return {
-          id: message.id,
-          threadId: message.threadId,
-          snippet: message.snippet,
-          body,
-          subject,
-          sender,
-        };
       })
     );
     return parsedMessages;
   }
 
   async parseThreads(
-    threads: gmail_v1.Schema$Thread[]
+    messages: gmail_v1.Schema$Message[]
   ): Promise<gmail_v1.Schema$Thread[]> {
     const parsedThreads = await Promise.all(
-      threads.map(async (thread) => {
-        const threadData = await this.gmail.users.threads.get({
-          userId: "me",
-          format: "raw",
-          id: thread.id ?? "",
-        });
+      messages.map(async (message) => {
+        try {
+          const {
+            data: { messages },
+          } = await this.gmail.users.threads.get({
+            userId: "me",
+            format: "full",
+            id: message.threadId ?? "",
+          });
 
-        const headers = threadData.data.messages?.[0]?.payload?.headers || [];
+          const { subject, sender, body } = this.parseHeaderAndBody(
+            messages?.[0]?.payload
+          );
 
-        const subject = headers.find((header) => header.name === "Subject");
-        const sender = headers.find((header) => header.name === "From");
-
-        let body = "";
-        if (threadData.data.messages?.[0]?.payload?.parts) {
-          body = threadData.data.messages[0].payload.parts
-            .map((part) => part.body?.data ?? "")
-            .join("");
-        } else if (threadData.data.messages?.[0]?.payload?.body?.data) {
-          body = threadData.data.messages[0].payload.body.data;
+          return {
+            id: message.threadId,
+            snippet: messages?.[0]?.snippet,
+            body,
+            subject,
+            sender,
+          };
+        } catch (error) {
+          throw new Error(`Error while fetching thread: ${error}`);
         }
-
-        return {
-          id: thread.id,
-          snippet: thread.snippet,
-          body,
-          subject,
-          sender,
-        };
       })
     );
     return parsedThreads;

--- a/libs/langchain-community/src/tools/gmail/send_message.ts
+++ b/libs/langchain-community/src/tools/gmail/send_message.ts
@@ -61,7 +61,9 @@ export class GmailSendMessage extends GmailBaseTool {
     });
 
     try {
-      const response = await this.gmail.users.messages.send({
+      const gmail = await this.getGmailClient();
+
+      const response = await gmail.users.messages.send({
         userId: "me",
         requestBody: {
           raw: rawMessage,

--- a/libs/langchain-community/src/tools/tests/gmail.test.ts
+++ b/libs/langchain-community/src/tools/tests/gmail.test.ts
@@ -22,10 +22,10 @@ describe("GmailBaseTool using GmailGetMessage", () => {
     expect(instance.name).toBe("gmail_get_message");
   });
 
-  it("should be setup with only access_token", async () => {
+  it("should be setup with only accessToken", async () => {
     const params = {
       credentials: {
-        access_token: "access_token",
+        accessToken: "access_token",
       },
       scopes: ["gmail_scope1"],
     };
@@ -33,7 +33,7 @@ describe("GmailBaseTool using GmailGetMessage", () => {
     expect(instance.name).toBe("gmail_get_message");
   });
 
-  it("should throw an error if access_token, privateKey and keyfile are missing", async () => {
+  it("should throw an error if accessToken, privateKey and keyfile are missing", async () => {
     const params = {
       credentials: {},
       scopes: ["gmail_scope1"],

--- a/libs/langchain-community/src/tools/tests/gmail.test.ts
+++ b/libs/langchain-community/src/tools/tests/gmail.test.ts
@@ -22,10 +22,21 @@ describe("GmailBaseTool using GmailGetMessage", () => {
     expect(instance.name).toBe("gmail_get_message");
   });
 
-  it("should be setup with only accessToken", async () => {
+  it("should be setup with only accessToken string", async () => {
     const params = {
       credentials: {
         accessToken: "access_token",
+      },
+      scopes: ["gmail_scope1"],
+    };
+    const instance = new GmailGetMessage(params);
+    expect(instance.name).toBe("gmail_get_message");
+  });
+
+  it("should be setup with only accessToken function", async () => {
+    const params = {
+      credentials: {
+        accessToken: () => Promise.resolve("access_token"),
       },
       scopes: ["gmail_scope1"],
     };

--- a/libs/langchain-community/src/tools/tests/gmail.test.ts
+++ b/libs/langchain-community/src/tools/tests/gmail.test.ts
@@ -22,7 +22,18 @@ describe("GmailBaseTool using GmailGetMessage", () => {
     expect(instance.name).toBe("gmail_get_message");
   });
 
-  it("should throw an error if both privateKey and keyfile are missing", async () => {
+  it("should be setup with only access_token", async () => {
+    const params = {
+      credentials: {
+        access_token: "access_token",
+      },
+      scopes: ["gmail_scope1"],
+    };
+    const instance = new GmailGetMessage(params);
+    expect(instance.name).toBe("gmail_get_message");
+  });
+
+  it("should throw an error if access_token, privateKey and keyfile are missing", async () => {
     const params = {
       credentials: {},
       scopes: ["gmail_scope1"],


### PR DESCRIPTION
- Adds support for OAuth access tokens. This is a much better option for use in applications for end users to use their own email account via federated Oauth token exchange using IdPs supporting the feature
- Fixes the search, get message and get thread tools to work properly with google gmail API v1
