### PR TITLE
feature(community): Enable using chat and llms without providing project/space/development id (lightweight engine IBM)

### DIFF
--- a/docs/core_docs/docs/integrations/chat/ibm.ipynb
+++ b/docs/core_docs/docs/integrations/chat/ibm.ipynb
@@ -171,7 +171,8 @@
         "  version: \"YYYY-MM-DD\",\n",
         "  serviceUrl: process.env.API_URL,\n",
         "  projectId: \"<PROJECT_ID>\",\n",
-        "  spaceId: \"<SPACE_ID>\",\n",
+        "  // spaceId: \"<SPACE_ID>\",\n",
+        "  // idOrName: \"<DEPLOYMENT_ID>\",\n",
         "  model: \"<MODEL_ID>\",\n",
         "  ...props\n",
         "});"
@@ -184,7 +185,7 @@
       "source": [
         "Note:\n",
         "\n",
-        "- You must provide `spaceId` or `projectId` in order to proceed.\n",
+        "- You must provide `spaceId`, `projectId` or `idOrName`(deployment id) unless you use lighweight engine which works without specifying either (refer to [watsonx.ai docs](https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=install-choosing-installation-mode))\n",
         "- Depending on the region of your provisioned service instance, use correct serviceUrl."
       ]
     },

--- a/docs/core_docs/docs/integrations/llms/ibm.ipynb
+++ b/docs/core_docs/docs/integrations/llms/ibm.ipynb
@@ -171,8 +171,8 @@
         "  version: \"YYYY-MM-DD\",\n",
         "  serviceUrl: process.env.API_URL,\n",
         "  projectId: \"<PROJECT_ID>\",\n",
-        "  spaceId: \"<SPACE_ID>\",\n",
-        "  idOrName: \"<DEPLOYMENT_ID>\",\n",
+        "  // spaceId: \"<SPACE_ID>\",\n",
+        "  // idOrName: \"<DEPLOYMENT_ID>\",\n",
         "  model: \"<MODEL_ID>\",\n",
         "  ...props,\n",
         "});"
@@ -185,7 +185,7 @@
       "source": [
         "Note:\n",
         "\n",
-        "- You must provide `spaceId`, `projectId` or `idOrName`(deployment id) in order to proceed.\n",
+        "- You must provide `spaceId`, `projectId` or `idOrName`(deployment id) unless you use lighweight engine which works without specifying either (refer to [watsonx.ai docs](https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=install-choosing-installation-mode))\n",
         "- Depending on the region of your provisioned service instance, use correct serviceUrl.\n",
         "- You need to specify the model you want to use for inferencing through model_id."
       ]

--- a/libs/langchain-community/src/chat_models/ibm.ts
+++ b/libs/langchain-community/src/chat_models/ibm.ts
@@ -465,11 +465,6 @@ export class ChatWatsonx<
     )
       throw new Error("Maximum 1 id type can be specified per instance");
 
-    if (!("projectId" in fields || "spaceId" in fields || "idOrName" in fields))
-      throw new Error(
-        "No id specified! At least id of 1 type has to be specified"
-      );
-
     if ("model" in fields) {
       this.projectId = fields?.projectId;
       this.spaceId = fields?.spaceId;
@@ -564,13 +559,18 @@ export class ChatWatsonx<
   scopeId():
     | { idOrName: string }
     | { projectId: string; modelId: string }
-    | { spaceId: string; modelId: string } {
+    | { spaceId: string; modelId: string }
+    | { modelId: string } {
     if (this.projectId && this.model)
       return { projectId: this.projectId, modelId: this.model };
     else if (this.spaceId && this.model)
       return { spaceId: this.spaceId, modelId: this.model };
     else if (this.idOrName) return { idOrName: this.idOrName };
-    else throw new Error("No scope id provided");
+    else if (this.model)
+      return {
+        modelId: this.model,
+      };
+    else throw new Error("No id or model provided!");
   }
 
   async completionWithRetry<T>(

--- a/libs/langchain-community/src/chat_models/tests/ibm.test.ts
+++ b/libs/langchain-community/src/chat_models/tests/ibm.test.ts
@@ -141,24 +141,22 @@ describe("LLM unit tests", () => {
 
       testProperties(instance, testProps);
     });
-  });
 
-  describe("Negative tests", () => {
     test("Missing id", async () => {
       const testProps: ChatWatsonxInput = {
         model: "mistralai/mistral-large",
         version: "2024-05-31",
         serviceUrl: process.env.WATSONX_AI_SERVICE_URL as string,
       };
-      expect(
-        () =>
-          new ChatWatsonx({
-            ...testProps,
-            ...fakeAuthProp,
-          })
-      ).toThrowError();
+      const intance = new ChatWatsonx({
+        ...testProps,
+        ...fakeAuthProp,
+      });
+      expect(intance).toBeDefined();
     });
+  });
 
+  describe("Negative tests", () => {
     test("Missing other props", async () => {
       // @ts-expect-error Intentionally passing not enough parameters
       const testPropsProjectId: ChatWatsonxInput = {

--- a/libs/langchain-community/src/llms/ibm.ts
+++ b/libs/langchain-community/src/llms/ibm.ts
@@ -184,11 +184,6 @@ export class WatsonxLLM<
     )
       throw new Error("Maximum 1 id type can be specified per instance");
 
-    if (!("projectId" in fields || "spaceId" in fields || "idOrName" in fields))
-      throw new Error(
-        "No id specified! At least id of 1 type has to be specified"
-      );
-
     this.serviceUrl = fields?.serviceUrl;
     const {
       watsonxAIApikey,
@@ -281,7 +276,7 @@ export class WatsonxLLM<
       return { spaceId: this.spaceId, modelId: this.model };
     else if (this.idOrName)
       return { idOrName: this.idOrName, modelId: this.model };
-    else return { spaceId: this.spaceId, modelId: this.model };
+    else return { modelId: this.model };
   }
 
   async listModels() {

--- a/libs/langchain-community/src/llms/tests/ibm.test.ts
+++ b/libs/langchain-community/src/llms/tests/ibm.test.ts
@@ -125,24 +125,21 @@ describe("LLM unit tests", () => {
 
       testProperties(instance, testProps);
     });
-  });
-
-  describe("Negative tests", () => {
     test("Missing id", async () => {
       const testProps: WatsonxInputLLM = {
         model: "ibm/granite-13b-chat-v2",
         version: "2024-05-31",
         serviceUrl: process.env.WATSONX_AI_SERVICE_URL as string,
       };
-      expect(
-        () =>
-          new WatsonxLLM({
-            ...testProps,
-            ...fakeAuthProp,
-          })
-      ).toThrowError();
+      const instance = new WatsonxLLM({
+        ...testProps,
+        ...fakeAuthProp,
+      });
+      expect(instance).toBeDefined();
     });
+  });
 
+  describe("Negative tests", () => {
     test("Missing other props", async () => {
       // @ts-expect-error Intentionally passing not enough parameters
       const testPropsProjectId: WatsonxInputLLM = {
@@ -153,17 +150,6 @@ describe("LLM unit tests", () => {
         () =>
           new WatsonxLLM({
             ...testPropsProjectId,
-            ...fakeAuthProp,
-          })
-      ).toThrowError();
-      // @ts-expect-error Intentionally passing not enough parameters
-      const testPropsServiceUrl: WatsonxInputLLM = {
-        serviceUrl: process.env.WATSONX_AI_SERVICE_URL as string,
-      };
-      expect(
-        () =>
-          new WatsonxLLM({
-            ...testPropsServiceUrl,
             ...fakeAuthProp,
           })
       ).toThrowError();


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Providing small changes in order to allow user to use inference methods in both LLM and chat class 
