### PR TITLE
fix(community): adding structured output parser for Google Calendar

### DIFF
--- a/libs/langchain-community/src/tools/google_calendar/commands/run-create-events.ts
+++ b/libs/langchain-community/src/tools/google_calendar/commands/run-create-events.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { calendar_v3 } from "googleapis";
 import type { GaxiosResponse } from "googleapis-common";
 import { PromptTemplate } from "@langchain/core/prompts";
@@ -5,7 +6,6 @@ import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { BaseLanguageModel } from "@langchain/core/language_models/base";
 import { CREATE_EVENT_PROMPT } from "../prompts/index.js";
 import { getTimezoneOffsetInHours } from "../utils/get-timezone-offset-in-hours.js";
-import { z } from "zod";
 
 const eventSchema = z.object({
   event_summary: z.string(),

--- a/libs/langchain-community/src/tools/google_calendar/commands/run-view-events.ts
+++ b/libs/langchain-community/src/tools/google_calendar/commands/run-view-events.ts
@@ -2,10 +2,20 @@ import { calendar_v3 } from "googleapis";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { BaseLanguageModel } from "@langchain/core/language_models/base";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
-import { StringOutputParser } from "@langchain/core/output_parsers";
+import { StructuredOutputParser } from "@langchain/core/output_parsers";
+import { z } from "zod";
 
 import { VIEW_EVENTS_PROMPT } from "../prompts/index.js";
 import { getTimezoneOffsetInHours } from "../utils/get-timezone-offset-in-hours.js";
+
+const eventSchema = z.object({
+  time_min: z.string(),
+  time_max: z.string(),
+  user_timezone: z.string(),
+  max_results: z.number(),
+  search_query: z.string().optional(),
+});
+const parser = StructuredOutputParser.fromZodSchema(eventSchema);
 
 type RunViewEventParams = {
   calendarId: string;
@@ -23,7 +33,7 @@ const runViewEvents = async (
     inputVariables: ["date", "query", "u_timezone", "dayName"],
   });
 
-  const viewEventsChain = prompt.pipe(model).pipe(new StringOutputParser());
+  const viewEventsChain = prompt.pipe(model).pipe(parser);
 
   const date = new Date().toISOString();
   const u_timezone = getTimezoneOffsetInHours();
@@ -38,12 +48,11 @@ const runViewEvents = async (
     },
     runManager?.getChild()
   );
-  const loaded = JSON.parse(output);
 
   try {
     const response = await calendar.events.list({
       calendarId,
-      ...loaded,
+      ...output,
     });
 
     const curatedItems =


### PR DESCRIPTION
Adding a structured output parser for Google Calendar view and event creation. This removes the possibility that the LLM returns more than just the formatted JSON and causes a JSON parsing error.
