### PR TITLE
fix(community): Optional google cloud storage options for GCS doc loader

### DIFF
--- a/docs/core_docs/docs/integrations/document_loaders/web_loaders/google_cloud_storage.mdx
+++ b/docs/core_docs/docs/integrations/document_loaders/web_loaders/google_cloud_storage.mdx
@@ -27,6 +27,8 @@ npm install @langchain/community @langchain/core @google-cloud/storage
 
 Once Unstructured is configured, you can use the Google Cloud Storage loader to load files and then convert them into a Document.
 
+In addition, you can optionally provide a `storageOptions` parameter to specify not only your storage options but also other authentication ways if you don't want Application Default Credentials(ADC) as default manner.
+
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/document_loaders/google_cloud_storage.ts";
 

--- a/libs/langchain-community/src/document_loaders/web/google_cloud_storage.ts
+++ b/libs/langchain-community/src/document_loaders/web/google_cloud_storage.ts
@@ -19,7 +19,7 @@ export type GcsLoaderConfig = {
   bucket: string;
   file: string;
   unstructuredLoaderOptions: UnstructuredLoaderOptions;
-  storageOptions: StorageOptions;
+  storageOptions?: StorageOptions;
 };
 
 /**
@@ -46,7 +46,7 @@ export class GoogleCloudStorageLoader extends BaseDocumentLoader {
 
   private file: string;
 
-  private storageOptions: StorageOptions;
+  private storageOptions: StorageOptions | undefined;
 
   private _fs: typeof fsDefault;
 


### PR DESCRIPTION
A quick fix for https://github.com/langchain-ai/langchainjs/pull/7740#discussion_r1976549027