### PR TITLE
tests(google-vertex,webauth): Verify code works with gemini-2.0-flash-lite-001

### DIFF
--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -66,6 +66,7 @@ const testGeminiModelNames = [
   ["gemini-1.5-pro-002"],
   ["gemini-1.5-flash-002"],
   ["gemini-2.0-flash-001"],
+  ["gemini-2.0-flash-lite-001"],
   // ["gemini-2.0-flash-thinking-exp-1219"],
 ];
 
@@ -167,6 +168,8 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   });
 
   test("function", async () => {
+    // gemini-2.0-flash-001: Test occasionally fails due to model regression
+    // gemini-2.0-flash-lite-001: Not supported
     const tools: GeminiTool[] = [
       {
         functionDeclarations: [
@@ -560,6 +563,7 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   });
 
   test("Supports GoogleSearchRetrievalTool", async () => {
+    // gemini-2.0-flash-lite-001: Not supported
     const searchRetrievalTool = {
       googleSearchRetrieval: {
         dynamicRetrievalConfig: {
@@ -579,6 +583,7 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   });
 
   test("Supports GoogleSearchTool", async () => {
+    // gemini-2.0-flash-lite-001: Not supported
     const searchTool: GeminiTool = {
       googleSearch: {},
     };
@@ -593,6 +598,7 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
   });
 
   test("Can stream GoogleSearchRetrievalTool", async () => {
+    // gemini-2.0-flash-lite-001: Not supported
     const searchRetrievalTool = {
       googleSearchRetrieval: {
         dynamicRetrievalConfig: {

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -303,6 +303,12 @@ const testGeminiModelNames = [
     apiVersion: "v1beta",
   },
   { modelName: "gemini-2.0-flash-001", platformType: "gcp", apiVersion: "v1" },
+  {
+    modelName: "gemini-2.0-flash-lite-001",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  { modelName: "gemini-2.0-flash-lite-001", platformType: "gcp", apiVersion: "v1" },
 
   // Flash Thinking doesn't have functions or other features
   // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},
@@ -427,6 +433,8 @@ describe.each(testGeminiModelNames)(
     });
 
     test("function", async () => {
+      // gemini-2.0-flash-001: Test occasionally fails due to model regression
+      // gemini-2.0-flash-lite-001: Not supported
       const tools: GeminiTool[] = [
         {
           functionDeclarations: [
@@ -809,6 +817,7 @@ describe.each(testGeminiModelNames)(
     });
 
     test("Supports GoogleSearchRetrievalTool", async () => {
+      // gemini-2.0-flash-lite-001: Not supported
       const searchRetrievalTool = {
         googleSearchRetrieval: {
           dynamicRetrievalConfig: {
@@ -830,6 +839,7 @@ describe.each(testGeminiModelNames)(
     });
 
     test("Supports GoogleSearchTool", async () => {
+      // gemini-2.0-flash-lite-001: Not supported
       const searchTool: GeminiTool = {
         googleSearch: {},
       };
@@ -847,6 +857,7 @@ describe.each(testGeminiModelNames)(
     });
 
     test("Can stream GoogleSearchRetrievalTool", async () => {
+      // gemini-2.0-flash-lite-001: Not supported
       const searchRetrievalTool = {
         googleSearchRetrieval: {
           dynamicRetrievalConfig: {

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -308,7 +308,11 @@ const testGeminiModelNames = [
     platformType: "gai",
     apiVersion: "v1beta",
   },
-  { modelName: "gemini-2.0-flash-lite-001", platformType: "gcp", apiVersion: "v1" },
+  {
+    modelName: "gemini-2.0-flash-lite-001",
+    platformType: "gcp",
+    apiVersion: "v1",
+  },
 
   // Flash Thinking doesn't have functions or other features
   // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},


### PR DESCRIPTION
No code changes - just tests.

Verify code works with gemini-2.0-flash-lite-001 (or that failures are documented and understood).

(Flash Lite doesn't support every feature, and these are documented.)

