### PR TITLE
feat(google-common): Add tokenUsage to llmOutput of google-genai

### DIFF
--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -340,6 +340,13 @@ export function mapGenerateContentResultToChatResult(
 
   return {
     generations: [generation],
+    llmOutput: {
+      tokenUsage: {
+        promptTokens: extra?.usageMetadata?.input_tokens,
+        completionTokens: extra?.usageMetadata?.output_tokens,
+        totalTokens: extra?.usageMetadata?.total_tokens,
+      },
+    },
   };
 }
 


### PR DESCRIPTION
In callbacks of google-genai chat models, the `llmOutput` doesn't contain a `tokenUsage` key, only `generations`, while the usage is known and computed at this point. This PR makes the llmOutput consistent with openai chat models.

Context: Trying to use [`UpstashRatelimitHandler`](https://js.langchain.com/docs/integrations/callbacks/upstash_ratelimit_callback/) with google-genai models raises this error:

```
Failed to log token usage for Upstash rate limit. It could be because the LLM returns the token usage in a different format than expected. See UpstashRatelimitHandler parameters. Got error: TypeError: Cannot read properties of undefined (reading 'promptTokens')
```