### PR TITLE
docs: broken link in chat models page

### DIFF
--- a/docs/core_docs/docs/concepts/chat_models.mdx
+++ b/docs/core_docs/docs/concepts/chat_models.mdx
@@ -19,7 +19,7 @@ LangChain provides a consistent interface for working with chat models from diff
 - Integrations with many chat model providers (e.g., Anthropic, OpenAI, Ollama, Microsoft Azure, Google Vertex, Amazon Bedrock, Hugging Face, Cohere, Groq). Please see [chat model integrations](/docs/integrations/chat/) for an up-to-date list of supported models.
 - Use either LangChain's [messages](/docs/concepts/messages) format or OpenAI format.
 - Standard [tool calling API](/docs/concepts/tool_calling): standard interface for binding tools to models, accessing tool call requests made by models, and sending tool results back to the model.
-- Standard API for structuring outputs (/docs/concepts/structured_outputs) via the `withStructuredOutput` method.
+- Standard API for [structuring outputs](/docs/concepts/structured_outputs) via the `withStructuredOutput` method.
 - Integration with [LangSmith](https://docs.smith.langchain.com) for monitoring and debugging production-grade applications based on LLMs.
 - Additional features like standardized [token usage](/docs/concepts/messages#token_usage), [rate limiting](#rate-limiting), [caching](#cache) and more.
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This PR fixes broken link on Chat models docs page.

<img width="839" alt="Zrzut ekranu 2025-03-8 o 22 11 52" src="https://github.com/user-attachments/assets/ed67dbd7-ce23-4477-9163-efaa3f3db21e" />