### PR TITLE
fix(aws): fix `Invalid reasoning content` exception on empty reasoning chunk

### DIFF
--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -563,7 +563,7 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
   | MessageContentReasoningBlockReasoningTextPartial
   | MessageContentReasoningBlockRedacted {
   const { text, redactedContent, signature } = reasoningContent;
-  if (text || typeof text === 'string') {
+  if (typeof text === 'string') {
     return {
       type: "reasoning_content",
       reasoningText: { text },

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -563,7 +563,7 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
   | MessageContentReasoningBlockReasoningTextPartial
   | MessageContentReasoningBlockRedacted {
   const { text, redactedContent, signature } = reasoningContent;
-  if (typeof text === 'string') {
+  if (typeof text === "string") {
     return {
       type: "reasoning_content",
       reasoningText: { text },

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -563,7 +563,7 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
   | MessageContentReasoningBlockReasoningTextPartial
   | MessageContentReasoningBlockRedacted {
   const { text, redactedContent, signature } = reasoningContent;
-  if (text) {
+  if (text || typeof text === 'string') {
     return {
       type: "reasoning_content",
       reasoningText: { text },


### PR DESCRIPTION
When invoking the DeeSeek R1 model on Bedrock, there exists a possibility that the model may generate reasoningContent with an  empty text string.

```json
{
  "reasoningContent": {
    "text": ""
  }
}
```

Modify the code to prevent the `Invalid reasoning content` exception from being thrown in this scenario.