### PR TITLE
Use the config value semanticConfigurationName in AzureAISearchVectorStore

### DIFF
--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -484,7 +484,7 @@ export class AzureAISearchVectorStore extends VectorStore {
       top: k,
       queryType: "semantic",
       semanticSearchOptions: {
-        configurationName: "semantic-search-config",
+        configurationName: this.options.semanticConfigurationName,
       },
     });
 
@@ -663,7 +663,7 @@ export class AzureAISearchVectorStore extends VectorStore {
         defaultConfigurationName: "semantic-search-config",
         configurations: [
           {
-            name: "semantic-search-config",
+            name: this.options.semanticConfigurationName,
             prioritizedFields: {
               contentFields: [
                 {


### PR DESCRIPTION
`semanticConfigurationName` is an argument that AzureAISearchVectorStore takes at the initialization, but in contrast to what you would expect from the argument's name, it is not used anywhere, and it's confusing. This PR includes the change to use the parameter as the semantic configuration name for Azure AI Search instead of the static text. 

Here is the interface for the option parameter. 

```ts
export interface AzureAISearchQueryOptions {
  readonly type?: AzureAISearchQueryType;
  readonly semanticConfigurationName?: string;
}
```