### PR TITLE
feat(community): add deepseek to allowed bedrock models

### DIFF
--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -72,6 +72,7 @@ const ALLOWED_MODEL_PROVIDERS = [
   "cohere",
   "meta",
   "mistral",
+  "deepseek",
 ];
 
 const PRELUDE_TOTAL_LENGTH_BYTES = 4;

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -37,6 +37,7 @@ const ALLOWED_MODEL_PROVIDERS = [
   "cohere",
   "meta",
   "mistral",
+  "deepseek"
 ];
 
 const PRELUDE_TOTAL_LENGTH_BYTES = 4;

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -37,7 +37,7 @@ const ALLOWED_MODEL_PROVIDERS = [
   "cohere",
   "meta",
   "mistral",
-  "deepseek"
+  "deepseek",
 ];
 
 const PRELUDE_TOTAL_LENGTH_BYTES = 4;


### PR DESCRIPTION
See https://aws.amazon.com/blogs/aws/deepseek-r1-now-available-as-a-fully-managed-serverless-model-in-amazon-bedrock/

IMHO this validation of model providers is redundant. Bedrock will let the user know if the model is invalid. Strictly enforcing it in client libs makes no sense to me.