### PR TITLE
fix(community): Azure AI Search - similaritySearch return description is incorrect

### DIFF
--- a/libs/langchain-community/src/vectorstores/azure_aisearch.ts
+++ b/libs/langchain-community/src/vectorstores/azure_aisearch.ts
@@ -344,7 +344,7 @@ export class AzureAISearchVectorStore extends VectorStore {
    * @param query Query text for the similarity search.
    * @param k=4 Number of nearest neighbors to return.
    * @param filter Optional filter options for the documents.
-   * @returns Promise that resolves to a list of documents and their corresponding similarity scores.
+   * @returns Promise that resolves to a list of documents.
    */
   async similaritySearch(
     query: string,


### PR DESCRIPTION
The description of the return argument for similarity search is incorrect. 

@dfberry

Fixes #7866
