### PR TITLE
fix(core): Add typing in ChatMessagePromptTemplate.fromTemplate

### DIFF
--- a/langchain-core/src/prompts/chat.ts
+++ b/langchain-core/src/prompts/chat.ts
@@ -336,13 +336,13 @@ export class ChatMessagePromptTemplate<
     return new ChatMessage(await this.prompt.format(values), this.role);
   }
 
-  static fromTemplate(
-    template: string,
-    role: string,
-    options?: { templateFormat?: TemplateFormat }
-  ) {
+  static fromTemplate<
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    RunInput extends InputValues = Symbol,
+    T extends string = string
+  >(template: T, role: string, options?: { templateFormat?: TemplateFormat }) {
     return new this(
-      PromptTemplate.fromTemplate(template, {
+      PromptTemplate.fromTemplate<RunInput, T>(template, {
         templateFormat: options?.templateFormat,
       }),
       role


### PR DESCRIPTION
When using the static method fromTemplate, this PR allows the type of the input to be strictly enforced.

When using the following example :

```typescript
  const chatPrompt = ChatPromptTemplate.fromTemplate<{foo: string, bar: string}>("Hello {foo}, I'm {bar}");
  const messages = await chatPrompt.formatPromptValue({
    foo: "Foo",
    bar: "Bar",
  });
```

If an input is missing you got a type error `Property 'foo' is missing in type '{ bar: string; }' but required in type 'TypedPromptInputValues<{ foo: string; bar: string; }>'`

<img width="837" alt="Screenshot 2025-03-21 at 18 19 32" src="https://github.com/user-attachments/assets/4c72d6a1-e33a-45f6-a4f3-bd18f032edfc" />

I have reused the declarations found in `PromptTemplate.fromTemplate` with the eslint-disabled for the banned type `Symbol` to stay consistent.

Let me know if you have any feedback.

Thanks for the great work !