### PR TITLE
fix(openai): Fix stop sequence passing in constructor for text completion models

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -1492,7 +1492,7 @@ export class ChatOpenAI<
     this.n = fields?.n ?? this.n;
     this.logitBias = fields?.logitBias;
     this.stop = fields?.stopSequences ?? fields?.stop;
-    this.stopSequences = this?.stop;
+    this.stopSequences = this.stop;
     this.user = fields?.user;
     this.__includeRawResponse = fields?.__includeRawResponse;
     this.audio = fields?.audio;

--- a/libs/langchain-openai/src/llms.ts
+++ b/libs/langchain-openai/src/llms.ts
@@ -182,7 +182,7 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
     this.bestOf = fields?.bestOf ?? this.bestOf;
     this.logitBias = fields?.logitBias;
     this.stop = fields?.stopSequences ?? fields?.stop;
-    this.stopSequences = fields?.stopSequences;
+    this.stopSequences = this.stop;
     this.user = fields?.user;
 
     this.streaming = fields?.streaming ?? false;


### PR DESCRIPTION
Fixes #7747