### PR TITLE
test(google): Gemini 2.5

### DIFF
--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -339,6 +339,17 @@ const testGeminiModelNames = [
     platformType: "gcp",
     apiVersion: "v1",
   },
+  {
+    modelName: "gemini-2.5-pro-exp-03-25",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  // Gemini 2.5 not available on Vertex yet
+  // {
+  //   modelName: "gemini-2.5-pro-exp-03-25",
+  //   platformType: "gai",
+  //   apiVersion: "v1beta",
+  // },
 
   // Flash Thinking doesn't have functions or other features
   // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},
@@ -352,6 +363,7 @@ const testGeminiModelNames = [
 const testGeminiModelDelay: Record<string, number> = {
   "gemini-2.0-flash-exp": 10000,
   "gemini-2.0-flash-thinking-exp-1219": 10000,
+  "gemini-2.5-pro-exp-03-25": 10000,
 };
 
 describe.each(testGeminiModelNames)(
@@ -659,7 +671,6 @@ describe.each(testGeminiModelNames)(
     test("Stream token count usage_metadata", async () => {
       const model = newChatGoogle({
         temperature: 0,
-        maxOutputTokens: 10,
       });
       let res: AIMessageChunk | null = null;
       for await (const chunk of await model.stream(
@@ -705,7 +716,6 @@ describe.each(testGeminiModelNames)(
     test("Invoke token count usage_metadata", async () => {
       const model = newChatGoogle({
         temperature: 0,
-        maxOutputTokens: 10,
       });
       const res = await model.invoke("Why is the sky blue? Be concise.");
       // console.log(res);
@@ -722,7 +732,6 @@ describe.each(testGeminiModelNames)(
 
     test("Streaming true constructor param will stream", async () => {
       const modelWithStreaming = newChatGoogle({
-        maxOutputTokens: 50,
         streaming: true,
       });
 
@@ -912,68 +921,69 @@ describe.each(testGeminiModelNames)(
       expect(finalMsg.content as string).toContain("Dodgers");
     });
 
-    const testMultimodalModelNames = [
-      {
-        modelName: "gemini-2.0-flash-exp-image-generation",
-        platformType: "gai",
-        apiVersion: "v1beta",
-      },
-      // Multimodal in Vertex AI is private preview currently
-    ];
+  }
+);
 
-    describe.each(testMultimodalModelNames)(
-      "Webauth ($platformType) Gemini Multimodal ($modelName)",
-      ({ modelName, platformType, apiVersion }) => {
-        let recorder: GoogleRequestRecorder;
-        let callbacks: BaseCallbackHandler[];
+const testMultimodalModelNames = [
+  {
+    modelName: "gemini-2.0-flash-exp-image-generation",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  // Multimodal in Vertex AI is private preview currently
+];
 
-        function newChatGoogle(fields?: ChatGoogleInput): ChatGoogle {
-          // const logger = new GoogleRequestLogger();
-          recorder = new GoogleRequestRecorder();
-          callbacks = [recorder, new GoogleRequestLogger()];
+describe.each(testMultimodalModelNames)(
+  "Webauth ($platformType) Gemini Multimodal ($modelName)",
+  ({ modelName, platformType, apiVersion }) => {
+    let recorder: GoogleRequestRecorder;
+    let callbacks: BaseCallbackHandler[];
 
-          const apiKey =
-            platformType === "gai"
-              ? getEnvironmentVariable("TEST_API_KEY")
-              : undefined;
+    function newChatGoogle(fields?: ChatGoogleInput): ChatGoogle {
+      // const logger = new GoogleRequestLogger();
+      recorder = new GoogleRequestRecorder();
+      callbacks = [recorder, new GoogleRequestLogger()];
 
-          return new ChatGoogle({
-            modelName,
-            platformType: platformType as GooglePlatformType,
-            apiVersion,
-            callbacks,
-            apiKey,
-            ...(fields ?? {}),
-          });
-        }
+      const apiKey =
+        platformType === "gai"
+          ? getEnvironmentVariable("TEST_API_KEY")
+          : undefined;
 
-        test("image output", async () => {
-          const model = newChatGoogle({
-            responseModalities: ["TEXT", "IMAGE"],
-          });
-          const res = await model.invoke(
-            "Draw an image of a red triangle on top of a blue box."
-          );
+      return new ChatGoogle({
+        modelName,
+        platformType: platformType as GooglePlatformType,
+        apiVersion,
+        callbacks,
+        apiKey,
+        ...(fields ?? {}),
+      });
+    }
 
-          const content = res?.content;
-          expect(typeof content).toEqual("object");
-          expect(Array.isArray(content)).toEqual(true);
-          expect(content).toHaveLength(1);
+    test("image output", async () => {
+      const model = newChatGoogle({
+        responseModalities: ["TEXT", "IMAGE"],
+      });
+      const res = await model.invoke(
+        "Draw an image of a red triangle on top of a blue box."
+      );
 
-          const content0 = content[0];
-          expect(typeof content0).not.toEqual("string");
+      const content = res?.content;
+      expect(typeof content).toEqual("object");
+      expect(Array.isArray(content)).toEqual(true);
+      expect(content).toHaveLength(1);
 
-          const mc = content0 as MessageContentImageUrl;
-          expect(mc).toHaveProperty("type");
-          expect(mc.type).toEqual("image_url");
-          expect(mc).toHaveProperty("image_url");
-          const url = (mc as MessageContentImageUrl).image_url as string;
-          expect(url).toMatch(/^data:image\/png;base64,/);
+      const content0 = content[0];
+      expect(typeof content0).not.toEqual("string");
 
-          console.log(recorder.response);
-          console.log(JSON.stringify(res.content, null, 1));
-        });
-      }
-    );
+      const mc = content0 as MessageContentImageUrl;
+      expect(mc).toHaveProperty("type");
+      expect(mc.type).toEqual("image_url");
+      expect(mc).toHaveProperty("image_url");
+      const url = (mc as MessageContentImageUrl).image_url as string;
+      expect(url).toMatch(/^data:image\/png;base64,/);
+
+      console.log(recorder.response);
+      console.log(JSON.stringify(res.content, null, 1));
+    });
   }
 );

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -920,7 +920,6 @@ describe.each(testGeminiModelNames)(
       }
       expect(finalMsg.content as string).toContain("Dodgers");
     });
-
   }
 );
 


### PR DESCRIPTION
* Add Gemini 2.5 Pro Experimental to test runs against AI Studio
* Adjust tests to remove Max Token setting for streaming tests since it was triggering no output on "thinking" model. 
* Fix bug in placement of multimodal output testing.

Note that tests weren't done against Vertex since it isn't supported there yet.

No code changes.
**No need for new release.**