### PR TITLE
fix: handle subgraph nesting better in graph_mermaid

### DIFF
--- a/langchain-core/src/runnables/graph_mermaid.ts
+++ b/langchain-core/src/runnables/graph_mermaid.ts
@@ -97,20 +97,36 @@ export function drawMermaid(
 
   const seenSubgraphs = new Set<string>();
 
+  // sort prefixes by path length for correct nesting
+  function sortPrefixesByDepth(prefixes: string[]): string[] {
+    return [...prefixes].sort((a, b) => {
+      return a.split(":").length - b.split(":").length;
+    });
+  }
+
   function addSubgraph(edges: Edge[], prefix: string): void {
     const selfLoop = edges.length === 1 && edges[0].source === edges[0].target;
     if (prefix && !selfLoop) {
       const subgraph = prefix.split(":").pop()!;
-      if (seenSubgraphs.has(subgraph)) {
-        throw new Error(
-          `Found duplicate subgraph '${subgraph}' -- this likely means that ` +
-            "you're reusing a subgraph node with the same name. " +
-            "Please adjust your graph to have subgraph nodes with unique names."
-        );
+
+      if (seenSubgraphs.has(prefix)) {
+        return;
       }
 
-      seenSubgraphs.add(subgraph);
+      seenSubgraphs.add(prefix);
       mermaidGraph += `\tsubgraph ${subgraph}\n`;
+    }
+
+    // all nested prefixes for this level, sorted by depth
+    const nestedPrefixes = sortPrefixesByDepth(
+      Object.keys(edgeGroups).filter(
+        (nestedPrefix) =>
+          nestedPrefix.startsWith(`${prefix}:`) && nestedPrefix !== prefix
+      )
+    );
+
+    for (const nestedPrefix of nestedPrefixes) {
+      addSubgraph(edgeGroups[nestedPrefix], nestedPrefix);
     }
 
     for (const edge of edges) {
@@ -141,13 +157,6 @@ export function drawMermaid(
       )}${edgeLabel}${_escapeNodeLabel(target)};\n`;
     }
 
-    // Recursively add nested subgraphs
-    for (const nestedPrefix in edgeGroups) {
-      if (nestedPrefix.startsWith(`${prefix}:`) && nestedPrefix !== prefix) {
-        addSubgraph(edgeGroups[nestedPrefix], nestedPrefix);
-      }
-    }
-
     if (prefix && !selfLoop) {
       mermaidGraph += "\tend\n";
     }
@@ -156,7 +165,7 @@ export function drawMermaid(
   // Start with the top-level edges (no common prefix)
   addSubgraph(edgeGroups[""] ?? [], "");
 
-  // Add remaining subgraphs
+  // Add remaining top-level subgraphs
   for (const prefix in edgeGroups) {
     if (!prefix.includes(":") && prefix !== "") {
       addSubgraph(edgeGroups[prefix], prefix);

--- a/langchain-core/src/runnables/tests/graph_mermaid.test.ts
+++ b/langchain-core/src/runnables/tests/graph_mermaid.test.ts
@@ -1,0 +1,141 @@
+/* eslint-disable no-promise-executor-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { test, expect } from "@jest/globals";
+import { drawMermaid } from "../../runnables/graph_mermaid.js";
+import { Edge, Node, RunnableInterface } from "../../runnables/types.js";
+
+describe("drawMermaid", () => {
+  test("nests deep subgraphs correctly", () => {
+    const data = {} as RunnableInterface;
+
+    const nodes: Record<string, Node> = {
+      __start__: {
+        id: "__start__",
+        data,
+        name: "__start__",
+      },
+      collectTools: {
+        id: "collectTools",
+        data,
+        name: "collectTools",
+        metadata: {},
+      },
+      "fooTool:userVerification": {
+        id: "fooTool:userVerification",
+        data,
+        name: "userVerification",
+        metadata: {},
+      },
+      "fooTool:fooSearchSource:explainReasoning": {
+        id: "fooTool:fooSearchSource:explainReasoning",
+        data,
+        name: "explainReasoning",
+        metadata: {},
+      },
+      "fooTool:fooSearchSource:fooGenericSearch:promptForTools": {
+        id: "fooTool:fooSearchSource:fooGenericSearch:promptForTools",
+        data,
+        name: "promptForTools",
+        metadata: {},
+      },
+      "fooTool:fooSearchSource:fooGenericSearch:searchToolWithQuery": {
+        id: "fooTool:fooSearchSource:fooGenericSearch:searchToolWithQuery",
+        data,
+        name: "searchToolWithQuery",
+        metadata: {},
+      },
+      "fooTool:fooSearchSource:emitfooToolResults": {
+        id: "fooTool:fooSearchSource:emitfooToolResults",
+        data,
+        name: "emitfooToolResults",
+        metadata: {},
+      },
+      "fooTool:reportToolResults": {
+        id: "fooTool:reportToolResults",
+        data,
+        name: "reportToolResults",
+        metadata: {},
+      },
+      promptForAnswer: {
+        id: "promptForAnswer",
+        data,
+        name: "promptForAnswer",
+        metadata: {},
+      },
+      __end__: {
+        id: "__end__",
+        data,
+        name: "__end__",
+      },
+    };
+
+    const edges: Edge[] = [
+      {
+        source: "fooTool:fooSearchSource:fooGenericSearch:promptForTools",
+        target: "fooTool:fooSearchSource:fooGenericSearch:searchToolWithQuery",
+        conditional: false,
+      },
+      {
+        source: "fooTool:fooSearchSource:fooGenericSearch:searchToolWithQuery",
+        target: "fooTool:fooSearchSource:emitfooToolResults",
+        conditional: false,
+      },
+      {
+        source: "fooTool:fooSearchSource:explainReasoning",
+        target: "fooTool:fooSearchSource:fooGenericSearch:promptForTools",
+        conditional: false,
+      },
+      {
+        source: "fooTool:fooSearchSource:emitfooToolResults",
+        target: "fooTool:reportToolResults",
+        conditional: false,
+      },
+      {
+        source: "fooTool:userVerification",
+        target: "fooTool:fooSearchSource:explainReasoning",
+        conditional: true,
+      },
+      {
+        source: "__start__",
+        target: "collectTools",
+        conditional: false,
+      },
+      {
+        source: "fooTool:reportToolResults",
+        target: "promptForAnswer",
+        conditional: false,
+      },
+      {
+        source: "collectTools",
+        target: "fooTool:userVerification",
+        conditional: true,
+      },
+      {
+        source: "promptForAnswer",
+        target: "__end__",
+        conditional: true,
+      },
+    ];
+
+    const result = drawMermaid(nodes, edges);
+
+    expect(result).toContain("subgraph fooTool");
+    expect(result).toContain("subgraph fooSearchSource");
+    expect(result).toContain("subgraph fooGenericSearch");
+
+    // verify proper nested order of subgraphs
+    const nestedPattern = [
+      "subgraph fooTool",
+      "subgraph fooSearchSource",
+      "subgraph fooGenericSearch",
+      // ... inside fooGenericSearch
+      "end",
+      // ... inside fooSearchSource
+      "end",
+      // ... inside fooTool
+      "end",
+    ].join("[\\s\\S]*?");
+
+    expect(result).toMatch(new RegExp(nestedPattern));
+  });
+});


### PR DESCRIPTION
Currently, `graph_mermaid` can throw an error when subgraphs are deeply nested, due to its way of tracking subgraph names and its order of processing edges. We encountered this in production with a large graph which had a couple of levels of subgraphs and many edges.

See the nodes/edges fixture added in `graph_mermaid.test.ts`, which is a minimal reproduction of one part of our graph, and will throw the following error on main branch:

```
Found duplicate subgraph 'fooGenericSearch' -- this likely means that you're reusing a subgraph node with the same name. Please adjust your graph to have subgraph nodes with unique names
```

The graph (and original langgraph code that generated it) is valid, and doesn't have a duplicate subgraph, but the subgraph/prefix handling misrecognizes it as duplicate when traversing and tracking the set of subgraphs.

This PR fixes that, and can now render the graph correctly; and also pre-orders the edges so that subgraphs will appear in their correct nesting, which wasn't necessarily the case before.

Without the additional edge reordering, the test graph here was not properly nested:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/82ba960c-2435-459b-917b-ceb6796081c8" />

due to incorrect ordering of subgraphs (excerpt):
```
      subgraph fooTool
      subgraph fooGenericSearch
         ...
      end
      subgraph fooSearchSource
         ...
      end
        ...
      end
```

With the fix, it is, thanks to ordering edges by depth before traversal:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/2ac2ce1a-1baf-42d1-a3db-a334f5248b74" />

```
          subgraph fooTool
          subgraph fooSearchSource
          subgraph fooGenericSearch
              ...
          end
              ...
          end
              ...
          end
```

I was able to test this rendering on our very large application graph and there were no unintended side effects / regressions; would be happy to have even more test cases for example graphs if needed--this particular script had little in the way of existing tests. 