### PR TITLE
feat(core): add `orchestratorAbortBehavior` option to `RunnableConfig`

### DIFF
--- a/langchain-core/src/runnables/index.ts
+++ b/langchain-core/src/runnables/index.ts
@@ -19,12 +19,13 @@ export {
   type RunnableToolLikeArgs,
 } from "./base.js";
 export {
+  type OrchestratorAbortBehavior,
   type RunnableBatchOptions,
+  type RunnableConfig,
   type RunnableInterface,
   type RunnableIOSchema,
 } from "./types.js";
 export {
-  type RunnableConfig,
   getCallbackManagerForConfig,
   patchConfig,
   ensureConfig,

--- a/langchain-core/src/utils/signal.ts
+++ b/langchain-core/src/utils/signal.ts
@@ -1,11 +1,38 @@
+import {
+  OrchestratorAbortBehavior,
+  RunnableConfig,
+} from "../runnables/types.js";
+
+/**
+ * Helper function to race a promise with an abort signal (used for timeouts). If
+ * {@link RunnableConfig.orchestratorAbortBehavior} is
+ * {@link OrchestratorAbortBehavior.THROW_IMMEDIATELY}, the promise will throw if the signal is
+ * aborted. Otherwise this is a no-op and the original promise is returned.
+ *
+ * @param promise - The promise to race with the signal
+ * @param config - The config object containing the signal and orchestratorAbortBehavior property
+ * @param defaultOrchestratorAbortBehavior - The default behavior to use if config.orchestratorAbortBehavior is `undefined` (defaults to {@link OrchestratorAbortBehavior.THROW_IMMEDIATELY})
+ *
+ * @internal
+ */
 export async function raceWithSignal<T>(
   promise: Promise<T>,
-  signal?: AbortSignal
+  config?: Partial<RunnableConfig>,
+  defaultOrchestratorAbortBehavior: OrchestratorAbortBehavior = OrchestratorAbortBehavior.THROW_IMMEDIATELY
 ): Promise<T> {
-  if (signal === undefined) {
+  const { signal, orchestratorAbortBehavior } = config ?? {};
+
+  const resolvedOrchestratorAbortBehavior =
+    orchestratorAbortBehavior ?? defaultOrchestratorAbortBehavior;
+
+  if (
+    signal === undefined ||
+    resolvedOrchestratorAbortBehavior !==
+      OrchestratorAbortBehavior.THROW_IMMEDIATELY
+  ) {
     return promise;
   }
-  let listener: () => void;
+
   return Promise.race([
     promise.catch<T>((err) => {
       if (!signal?.aborted) {
@@ -14,15 +41,59 @@ export async function raceWithSignal<T>(
         return undefined as T;
       }
     }),
+
     new Promise<never>((_, reject) => {
-      listener = () => {
-        reject(new Error("Aborted"));
+      const listener = () => {
+        try {
+          signal.throwIfAborted();
+        } catch (e) {
+          // it's a bit odd to try/catch and reject here rather than throwing directly,
+          // but it's necessary to make sure that we reject with the correct error type
+          reject(e);
+        }
       };
-      signal.addEventListener("abort", listener);
       // Must be here inside the promise to avoid a race condition
       if (signal.aborted) {
-        reject(new Error("Aborted"));
+        listener();
       }
+      signal.addEventListener("abort", listener, { once: true });
     }),
-  ]).finally(() => signal.removeEventListener("abort", listener));
+  ]);
+}
+
+/**
+ * Helper function for handling abort signals.
+ *
+ * @internal
+ *
+ * Behavior depends on the value of config.orchestratorAbortBehavior:
+ *
+ * - If {@link RunnableConfig.orchestratorAbortBehavior} is
+ *   {@link OrchestratorAbortBehavior.PASSTHROUGH}, the function will not throw and will not check
+ *   the signal.
+ * - If {@link RunnableConfig.orchestratorAbortBehavior} is
+ *   {@link OrchestratorAbortBehavior.COMPLETE_PENDING}, the function will return `true` if the
+ *   signal is aborted, and the caller must wait for in-progress promises to complete, and call
+ *   {@link AbortSignal.throwIfAborted} to throw instead of starting new promises.
+ * - If {@link RunnableConfig.orchestratorAbortBehavior} is
+ *   {@link OrchestratorAbortBehavior.THROW_IMMEDIATELY} or `undefined`, the function will throw.
+ *
+ * @param config - An object containing an optional `signal` and `orchestratorAbortBehavior` property
+ * @param defaultBehavior - The default behavior to use if config.orchestratorAbortBehavior is `undefined` (defaults to {@link OrchestratorAbortBehavior.THROW_IMMEDIATELY})
+ * @returns `true` if the signal is aborted, `false` otherwise
+ * @throws If config.orchestratorAbortBehavior is OrchestratorAbortBehavior.THROW_IMMEDIATELY or undefined
+ */
+export function checkAbortSignal(
+  config: Partial<RunnableConfig> | undefined,
+  defaultBehavior: OrchestratorAbortBehavior = OrchestratorAbortBehavior.THROW_IMMEDIATELY
+): boolean {
+  const resolvedBehavior = config?.orchestratorAbortBehavior ?? defaultBehavior;
+  if (resolvedBehavior === OrchestratorAbortBehavior.THROW_IMMEDIATELY) {
+    config?.signal?.throwIfAborted();
+    return false;
+  }
+  if (resolvedBehavior === OrchestratorAbortBehavior.COMPLETE_PENDING) {
+    return config?.signal?.aborted ?? false;
+  }
+  return false;
 }


### PR DESCRIPTION
This feature allows the consumer of a `Runnable` to define how the orchestration layer (i.e. the LangChain core generic `Runnable` implementations, like `RunnableLambda`, and LangGraph's task execution logic) behaves when the abort signal is fired.

This is necessary because JavaScript doesn't provide any mechanism for forcibly terminating an asynchronous task. The best you can do is hand the task itself an `AbortSignal` and allow it to decide when to abort. The only alternative to this would be to simply abandon the promise instead of blocking until it settles.

Prior to this change, (and by default under this change) the execution layer in LangChain will abandon a `Promise` and throw under most circumstances when the `AbortSignal` is triggered. This means that asynchronous work in progress that does not monitor the `AbortSignal` will continue to execute, but the result of that work will not be captured.

The change introduced by this feature allows the consumer of a runnable to specify how eagerly the execution runtime should handle aborts. The options are:

- `"throw_immediately"` (default): The execution runtime will abandon an active asynchronous task and throw when `RunnableConfig.signal` requests an abort.
- `"complete_pending"`: The execution runtime will *not* abandon active asynchronous tasks. Instead, the `AbortSignal` is checked before starting additional asynchronous tasks, and the execution runtime throws on abort only if it would otherwise start new asynchronous work.
- `"passthrough"`: The execution runtime will *not* check the `AbortSignal` at all in this case, but the signal will be passed through to the asynchronous tasks as per usual. This mode delegates the responsibility for early termination entirely to the asynchronous tasks themselves. This mode also makes it possible for execution runtimes external to LangChain core (like LangGraph) can request an abort while still allowing in-progress chains to complete so their state can be captured and replayed on resume.