### PR TITLE
feat(community): move `api_key` from body to header for Tavily tool

### DIFF
--- a/libs/langchain-community/src/tools/tavily_search.ts
+++ b/libs/langchain-community/src/tools/tavily_search.ts
@@ -244,7 +244,7 @@ export class TavilySearchResults extends Tool {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "authorization": `Bearer ${this.apiKey}`,
+        authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify({ ...body, ...this.kwargs }),
     });

--- a/libs/langchain-community/src/tools/tavily_search.ts
+++ b/libs/langchain-community/src/tools/tavily_search.ts
@@ -229,7 +229,6 @@ export class TavilySearchResults extends Tool {
     const body: Record<string, unknown> = {
       query: input,
       max_results: this.maxResults,
-      api_key: this.apiKey,
       include_images: this.includeImages,
       include_image_descriptions: this.includeImageDescriptions,
       include_answer: this.includeAnswer,
@@ -245,6 +244,7 @@ export class TavilySearchResults extends Tool {
       method: "POST",
       headers: {
         "content-type": "application/json",
+        "authorization": `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify({ ...body, ...this.kwargs }),
     });


### PR DESCRIPTION
As far as I can see, the authorization in Tavily moved from request body to `Authorization` header: https://docs.tavily.com/documentation/api-reference/endpoint/search#authorization-authorization

This change makes it easier to proxy requests together with `apiUrl`, because the proxy service would only need to rewrite headers and not change request bodies.