### PR TITLE
fix(community): Return raw response content when calling Bedrock Anthropic tools

### DIFF
--- a/libs/langchain-community/src/chat_models/tests/chatbedrock.int.test.ts
+++ b/libs/langchain-community/src/chat_models/tests/chatbedrock.int.test.ts
@@ -415,7 +415,7 @@ test.skip("withStructuredOutput", async () => {
   expect(response.city.toLowerCase()).toBe("san francisco");
 });
 
-test.skip(".bind tools", async () => {
+test(".bind tools", async () => {
   const weatherTool = z
     .object({
       city: z.string().describe("The city to get the weather for"),
@@ -424,7 +424,7 @@ test.skip(".bind tools", async () => {
     .describe("Get the weather for a city");
   const model = new BedrockChatWeb({
     region: process.env.BEDROCK_AWS_REGION,
-    model: "anthropic.claude-3-sonnet-20240229-v1:0",
+    model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
     maxRetries: 0,
     credentials: {
       secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
@@ -441,14 +441,16 @@ test.skip(".bind tools", async () => {
     ],
   });
   const response = await modelWithTools.invoke(
-    "Whats the weather like in san francisco?"
+    "Whats the weather like in san francisco? Always explain your reasoning as you call a proper tool."
   );
-  // console.log(response);
   if (!response.tool_calls?.[0]) {
     throw new Error("No tool calls found in response");
   }
   const { tool_calls } = response;
   expect(tool_calls[0].name.toLowerCase()).toBe("weather_tool");
+  expect(Array.isArray(response.content)).toBe(true);
+  expect((response.content[0] as any).type).toBe("text");
+  expect((response.content[0] as any).text.length).toBeGreaterThan(0);
 });
 
 test.skip(".bindTools with openai tool format", async () => {

--- a/libs/langchain-community/src/utils/bedrock/index.ts
+++ b/libs/langchain-community/src/utils/bedrock/index.ts
@@ -465,13 +465,12 @@ function parseMessage(responseBody: any, asChunk?: boolean): ChatGeneration {
       generationInfo,
     });
   } else {
-    // TODO: we are throwing away here the text response, as the interface of this method returns only one
     const toolCalls = extractToolCalls(responseBody.content);
 
     if (toolCalls.length > 0) {
       return {
         message: new AIMessage({
-          content: "",
+          content: responseBody.content,
           additional_kwargs: { id },
           tool_calls: toolCalls,
         }),


### PR DESCRIPTION
Satisfies old TODO before we supported complex message content types properly

Fixes #7942 