### PR TITLE
feat(community): make convertOpenAPISpecToOpenAIFunctions available for imports

### DIFF
--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -98,4 +98,5 @@ export {
 export {
   type OpenAPIChainOptions,
   createOpenAPIChain,
+  convertOpenAPISpecToOpenAIFunctions,
 } from "./openai_functions/openapi.js";

--- a/langchain/src/chains/openai_functions/openapi.ts
+++ b/langchain/src/chains/openai_functions/openapi.ts
@@ -210,7 +210,7 @@ export function convertOpenAPISchemaToJSONSchema(
  * @param spec The OpenAPI specification to convert.
  * @returns An object containing the OpenAI functions derived from the OpenAPI specification and a default execution method.
  */
-function convertOpenAPISpecToOpenAIFunctions(spec: OpenAPISpec): {
+export function convertOpenAPISpecToOpenAIFunctions(spec: OpenAPISpec): {
   openAIFunctions: OpenAIClient.Chat.ChatCompletionCreateParams.Function[];
   defaultExecutionMethod?: OpenAPIExecutionMethod;
 } {


### PR DESCRIPTION
Make function `convertOpenAPISpecToOpenAIFunctions` available for imports. It's pretty useful function outside of the library, and helps to save a lot of time in API management with LLM