### PR TITLE
feat(anthropic): Add image url support to anthropic

### DIFF
--- a/libs/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/langchain-anthropic/src/utils/message_inputs.ts
@@ -26,20 +26,39 @@ import {
 function _formatImage(imageUrl: string) {
   const regex = /^data:(image\/.+);base64,(.+)$/;
   const match = imageUrl.match(regex);
-  if (match === null) {
+
+  // Check if the imageUrl is a data URI
+  if (match) {
+    return {
+      type: "base64",
+      media_type: match[1] ?? "",
+      data: match[2] ?? "",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+
+  // Check if the imageUrl is a URL
+  try {
+    // Check if the imageUrl is a valid URL.
+    // If it is, then we assume it is a URL reference.
+    // We don't need to check the media type here.
+    // https://docs.anthropic.com/en/api/messages-examples#vision
+    new URL(imageUrl);
+    return {
+      type: "url",
+      url: imageUrl,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  } catch (e) {
+    // If it's not a valid URL, throw an error
     throw new Error(
       [
-        "Anthropic only supports base64-encoded images currently.",
-        "Example: data:image/png;base64,/9j/4AAQSk...",
+        "Anthropic only supports base64-encoded images or image URLs.",
+        "Example base64: data:image/png;base64,/9j/4AAQSk...",
+        "Example URL: https://example.com/image.png",
       ].join("\n\n")
     );
   }
-  return {
-    type: "base64",
-    media_type: match[1] ?? "",
-    data: match[2] ?? "",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
 }
 
 function _ensureMessageContents(


### PR DESCRIPTION
This PR updates the `langchain-anthropic` package to support image inputs provided as URLs, in addition to the existing base64 encoding support.

According to the latest [Anthropic documentation](https://docs.anthropic.com/en/api/messages-examples#vision), Claude 3 models can accept image inputs via a URL source: `{"type": "image", "source": {"type": "url", "url": "..."}}`.

This change modifies the `_formatImage` utility function in `libs/langchain-anthropic/src/utils/message_inputs.ts` to detect if the input string is a valid URL. If it is, it formats the message payload accordingly; otherwise, it falls back to the base64 parsing logic.

This resolves the limitation where LangchainJS previously only accepted base64-encoded images, allowing users to leverage the full capabilities of the Anthropic API for multimodal inputs more easily.

```
Test Suites: 1 skipped, 56 passed, 56 of 57 total
Tests:       12 skipped, 323 passed, 335 total
Snapshots:   39 passed, 39 total
Time:        5.396 s
Ran all test suites.
```