### PR TITLE
fix(docs): fix a typo

### DIFF
--- a/docs/core_docs/docs/tutorials/rag.ipynb
+++ b/docs/core_docs/docs/tutorials/rag.ipynb
@@ -22,7 +22,7 @@
     "complexity.\n",
     "\n",
     "If you're already familiar with basic retrieval, you might also be interested in\n",
-    "this [high-level overview of different retrieval techinques](/docs/concepts/retrieval).\n",
+    "this [high-level overview of different retrieval techniques](/docs/concepts/retrieval).\n",
     "\n",
     "**Note**: Here we focus on Q&A for unstructured data. If you are interested for RAG over structured data, check out our tutorial on doing [question/answering over SQL data](/docs/tutorials/sql_qa).\n",
     "\n",


### PR DESCRIPTION
Fix a typo while reading the RAG part1 tutorial
