### PR TITLE
docs: fix typo in structured output guide

### DIFF
--- a/docs/core_docs/docs/how_to/structured_output.ipynb
+++ b/docs/core_docs/docs/how_to/structured_output.ipynb
@@ -20,7 +20,7 @@
         "<span data-heading-keywords=\"with_structured_output\"></span>\n",
         "```\n",
         "\n",
-        "It is often useful to have a model return output that matches some specific schema. One common use-case is extracting data from arbitrary text to insert into a traditional database or use with some other downstrem system. This guide will show you a few different strategies you can use to do this.\n",
+        "It is often useful to have a model return output that matches some specific schema. One common use-case is extracting data from arbitrary text to insert into a traditional database or use with some other downstream system. This guide will show you a few different strategies you can use to do this.\n",
         "\n",
         ":::info Prerequisites\n",
         "\n",


### PR DESCRIPTION
Fix a typo in the structured output guide documentation:
- Changed "downstrem" to "downstream" in the introduction paragraph