### PR TITLE
fix(langchain): Fix typo in error message for SqlDatabase options

### DIFF
--- a/langchain/src/sql_db.ts
+++ b/langchain/src/sql_db.ts
@@ -57,7 +57,7 @@ export class SqlDatabase
     this.appDataSource = fields.appDataSource;
     this.appDataSourceOptions = fields.appDataSource.options;
     if (fields?.includesTables && fields?.ignoreTables) {
-      throw new Error("Cannot specify both include_tables and ignoreTables");
+      throw new Error("Cannot specify both includeTables and ignoreTables");
     }
     this.includesTables = fields?.includesTables ?? [];
     this.ignoreTables = fields?.ignoreTables ?? [];


### PR DESCRIPTION
An error message in SqlDatabase incorrectly uses "include_tables" instead of "includeTables" when both includeTables and ignoreTables are specified. This commit fixes the typo to maintain consistent camelCase naming convention throughout the codebase and to avoid confusing anyone.

Fixes #7974
