### PR TITLE
fix(google-genai): Add support for supervisor author name

### DIFF
--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -62,6 +62,7 @@ export function convertAuthorToRole(
      *  Note: Gemini currently is not supporting system messages
      *  we will convert them to human messages and merge with following
      * */
+    case "supervisor":
     case "ai":
     case "model": // getMessageAuthor returns message.name. code ex.: return message.name ?? type;
       return "model";


### PR DESCRIPTION
The invocation of a multi-level agent fails when using Gemini models and passing it messages from a previous run (either by using checkpointer/MemorySaver or by passing the messages directly). However, it works perfectly when using another model, such as OpenAI. It works with gemini models when adding the `supervisor` case to `convertAuthorToRole()`.

Fixes #7979 

Also see the bug report for reproducer code.