### PR TITLE
feat(community): enable browser usage for OpenAI client in Prexplexity

### DIFF
--- a/libs/langchain-community/src/chat_models/perplexity.ts
+++ b/libs/langchain-community/src/chat_models/perplexity.ts
@@ -168,6 +168,7 @@ export class ChatPerplexity
     this.client = new OpenAI({
       apiKey: this.apiKey,
       baseURL: "https://api.perplexity.ai",
+      dangerouslyAllowBrowser: true,
     });
   }
 


### PR DESCRIPTION
enable browser usage for OpenAI client in prexplexity to match other chat providers