### PR TITLE
fix(google-common): Fix warning about system message in Vertex Anthropic

### DIFF
--- a/libs/langchain-google-common/src/utils/anthropic.ts
+++ b/libs/langchain-google-common/src/utils/anthropic.ts
@@ -618,6 +618,9 @@ export function getAnthropicAPI(config?: AnthropicAPIConfig): GoogleAIAPI {
         return aiMessageToAnthropicMessage(base as AIMessage);
       case "tool":
         return toolMessageToAnthropicMessage(base as ToolMessage);
+      case "system":
+        //  System messages are handled in formatSystem()
+        return undefined;
       default:
         console.warn(`Unknown BaseMessage type: ${type}`, base);
         return undefined;

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -720,6 +720,25 @@ describe.each(testAnthropicModelNames)(
       console.log(aiMessage.lc_kwargs);
     });
 
+    test.only("system", async () => {
+      const consoleWarn = jest.spyOn(console, 'warn');
+      const model = new ChatVertexAI({
+        modelName,
+        callbacks,
+      });
+
+      const messages = [
+        new SystemMessage('Answer only in italian'),
+        new HumanMessage('What is the moon?')
+      ];
+
+      const res = await model.invoke(messages);
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      expect(consoleWarn).not.toHaveBeenCalled();
+    })
+
     test("stream", async () => {
       const model = new ChatVertexAI({
         modelName,

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -721,15 +721,15 @@ describe.each(testAnthropicModelNames)(
     });
 
     test.only("system", async () => {
-      const consoleWarn = jest.spyOn(console, 'warn');
+      const consoleWarn = jest.spyOn(console, "warn");
       const model = new ChatVertexAI({
         modelName,
         callbacks,
       });
 
       const messages = [
-        new SystemMessage('Answer only in italian'),
-        new HumanMessage('What is the moon?')
+        new SystemMessage("Answer only in italian"),
+        new HumanMessage("What is the moon?"),
       ];
 
       const res = await model.invoke(messages);
@@ -737,7 +737,7 @@ describe.each(testAnthropicModelNames)(
       expect(res._getType()).toEqual("ai");
 
       expect(consoleWarn).not.toHaveBeenCalled();
-    })
+    });
 
     test("stream", async () => {
       const model = new ChatVertexAI({

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -695,6 +695,11 @@ describe.each(testAnthropicModelNames)(
       callbacks = [recorder, new GoogleRequestLogger()];
     });
 
+    afterEach(() => {
+      // restore any spy created with spyOn
+      jest.restoreAllMocks();
+    });
+
     test("invoke", async () => {
       const model = new ChatVertexAI({
         modelName,
@@ -720,7 +725,7 @@ describe.each(testAnthropicModelNames)(
       console.log(aiMessage.lc_kwargs);
     });
 
-    test.only("system", async () => {
+    test("system", async () => {
       const consoleWarn = jest.spyOn(console, "warn");
       const model = new ChatVertexAI({
         modelName,


### PR DESCRIPTION
System Message types aren't supposed to be handled in `baseToAnthropicMessage()`, but they were generating a warning there. Make sure there isn't a warning and add a test to confirm.

Fixes #8011 
