### PR TITLE
fix: don't drop tool input when converting messages to Anthropic payload

### DIFF
--- a/libs/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/langchain-anthropic/src/utils/message_inputs.ts
@@ -180,10 +180,12 @@ function _formatContent(content: MessageContent) {
 
         if ("input" in contentPartCopy) {
           // Anthropic tool use inputs should be valid objects, when applicable.
-          try {
-            contentPartCopy.input = JSON.parse(contentPartCopy.input);
-          } catch {
-            contentPartCopy.input = {};
+          if (typeof contentPartCopy.input === "string") {
+            try {
+              contentPartCopy.input = JSON.parse(contentPartCopy.input);
+            } catch {
+              contentPartCopy.input = {};
+            }
           }
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/langchain-ai/langchainjs/pull/7943#issuecomment-2807991300, Anthropic's tool use inputs are Javascript objects at this point rather than JSON strings, so we only need to parse the input if it's a string.

Without this change, the tool input is silently dropped when converting messages due to the try/catch.