### PR TITLE
fix(docs): fix parameter casing for useResponsesAPI -> useResponsesApi

### DIFF
--- a/docs/core_docs/docs/integrations/chat/openai.ipynb
+++ b/docs/core_docs/docs/integrations/chat/openai.ipynb
@@ -679,7 +679,7 @@
         "\n",
         "OpenAI supports a [Responses](https://platform.openai.com/docs/guides/responses-vs-chat-completions) API that is oriented toward building [agentic](/docs/concepts/agents/) applications. It includes a suite of [built-in tools](https://platform.openai.com/docs/guides/tools?api-mode=responses), including web and file search. It also supports management of [conversation state](https://platform.openai.com/docs/guides/conversation-state?api-mode=responses), allowing you to continue a conversational thread without explicitly passing in previous messages.\n",
         "\n",
-        "`ChatOpenAI` will route to the Responses API if one of these features is used. You can also specify `useResponsesAPI: true` when instantiating `ChatOpenAI`.\n",
+        "`ChatOpenAI` will route to the Responses API if one of these features is used. You can also specify `useResponsesApi: true` when instantiating `ChatOpenAI`.\n",
         "\n",
         "### Built-in tools\n",
         "\n",


### PR DESCRIPTION
useResponsesAPI was used where it should be useResponsesApi, small but important b/c it's enough to be throwing off AI tooling, but also is where docs are generated from, and threw me (as a soft carbon based lifeform) off as well when reading it with my old school eyes/manual coding process (shame, I know...). 