### PR TITLE
fix(tavily): convert search/extract API parameters to snake_case in request body

### DIFF
--- a/libs/langchain-tavily/src/tests/search.test.ts
+++ b/libs/langchain-tavily/src/tests/search.test.ts
@@ -340,4 +340,57 @@ describe("TavilySearch", () => {
       error: "String error without message property",
     });
   });
+
+  test("converts camelCase parameters to snake_case in API requests", async () => {
+    // Mock fetch to intercept the actual API request
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn().mockImplementation(() => 
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ 
+          query: "test query",
+          results: [],
+          response_time: 0.5
+        }),
+      } as Response)
+    );
+    global.fetch = mockFetch as typeof fetch;
+
+    try {
+      // Create a wrapper with test API key
+      const wrapper = new TavilySearchAPIWrapper({ tavilyApiKey: "test-key" });
+      
+      // Call with camelCase parameters
+      await wrapper.rawResults({
+        query: "test query",
+        includeDomains: ["example.com"],
+        searchDepth: "advanced",
+        includeImages: true,
+        timeRange: "week",
+      } as any);
+
+      // Verify the parameters in the request body
+      expect(mockFetch).toHaveBeenCalled();
+      
+      // Get the body from the mock call
+      const requestInit = mockFetch.mock.calls[0][1] as RequestInit;
+      const bodyString = requestInit.body as string;
+      const requestBody = JSON.parse(bodyString);
+      
+      // Check that parameters were converted to snake_case
+      expect(requestBody.include_domains).toEqual(["example.com"]);
+      expect(requestBody.search_depth).toBe("advanced");
+      expect(requestBody.include_images).toBe(true);
+      expect(requestBody.time_range).toBe("week");
+      
+      // Original camelCase keys should not be present
+      expect(requestBody.includeDomains).toBeUndefined();
+      expect(requestBody.searchDepth).toBeUndefined();
+      expect(requestBody.includeImages).toBeUndefined();
+      expect(requestBody.timeRange).toBeUndefined();
+    } finally {
+      // Restore original fetch
+      global.fetch = originalFetch;
+    }
+  });
 });

--- a/libs/langchain-tavily/src/tests/search.test.ts
+++ b/libs/langchain-tavily/src/tests/search.test.ts
@@ -344,14 +344,15 @@ describe("TavilySearch", () => {
   test("converts camelCase parameters to snake_case in API requests", async () => {
     // Mock fetch to intercept the actual API request
     const originalFetch = global.fetch;
-    const mockFetch = jest.fn().mockImplementation(() => 
+    const mockFetch = jest.fn().mockImplementation(() =>
       Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ 
-          query: "test query",
-          results: [],
-          response_time: 0.5
-        }),
+        json: () =>
+          Promise.resolve({
+            query: "test query",
+            results: [],
+            response_time: 0.5,
+          }),
       } as Response)
     );
     global.fetch = mockFetch as typeof fetch;
@@ -359,7 +360,7 @@ describe("TavilySearch", () => {
     try {
       // Create a wrapper with test API key
       const wrapper = new TavilySearchAPIWrapper({ tavilyApiKey: "test-key" });
-      
+
       // Call with camelCase parameters
       await wrapper.rawResults({
         query: "test query",
@@ -367,22 +368,22 @@ describe("TavilySearch", () => {
         searchDepth: "advanced",
         includeImages: true,
         timeRange: "week",
-      } as any);
+      });
 
       // Verify the parameters in the request body
       expect(mockFetch).toHaveBeenCalled();
-      
+
       // Get the body from the mock call
       const requestInit = mockFetch.mock.calls[0][1] as RequestInit;
       const bodyString = requestInit.body as string;
       const requestBody = JSON.parse(bodyString);
-      
+
       // Check that parameters were converted to snake_case
       expect(requestBody.include_domains).toEqual(["example.com"]);
       expect(requestBody.search_depth).toBe("advanced");
       expect(requestBody.include_images).toBe(true);
       expect(requestBody.time_range).toBe("week");
-      
+
       // Original camelCase keys should not be present
       expect(requestBody.includeDomains).toBeUndefined();
       expect(requestBody.searchDepth).toBeUndefined();

--- a/libs/langchain-tavily/src/utils.ts
+++ b/libs/langchain-tavily/src/utils.ts
@@ -320,7 +320,10 @@ abstract class BaseTavilyAPIWrapper {
    * @returns The parameters with snake_case keys
    */
   protected convertCamelToSnakeCase(
-    params: Record<keyof TavilySearchParams | keyof TavilyExtractParams, any>
+    params: Record<
+      keyof TavilySearchParams | keyof TavilyExtractParams,
+      unknown
+    >
   ) {
     return Object.entries(params).reduce((result, [key, value]) => {
       if (value === undefined) {
@@ -329,7 +332,7 @@ abstract class BaseTavilyAPIWrapper {
       // Use explicit mapping for known keys, fall back to generic default key
       const newKey = this.camelToSnakeMap[key] || key;
       return { ...result, [newKey]: value };
-    }, {} as Record<keyof TavilySearchParams | keyof TavilyExtractParams, any>);
+    }, {} as Record<keyof TavilySearchParams | keyof TavilyExtractParams, unknown>);
   }
 }
 


### PR DESCRIPTION
# Summary
While using the TavilySearch tool, I noticed that the provided options were not being applied correctly. Upon investigation, I identified a mismatch between the camelCase keys used in the API wrapper and the snake_case format expected by the Tavily API.

## Changes

- Introduced an abstract base class to:
  - Unify apiKey handling for both search and extract wrappers.
  - Add a private utility method that converts camelCase option keys to snake_case before making API requests. This ensures compatibility with Tavily's expected format without introducing breaking changes.


 @michaelgriff if you have spare second, please take a look.