### PR TITLE
feat(google-common): Gemini 2.5 flash

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -190,6 +190,8 @@ export abstract class ChatGoogleBase<AuthOptions>
 
   maxOutputTokens: number;
 
+  maxReasoningTokens: number;
+
   topP: number;
 
   topK: number;

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -516,6 +516,104 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(caught).toBeTruthy();
   });
 
+  test("1. Reasoning - default off", async() => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+    });
+    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig).not.toHaveProperty("thinkingConfig");
+  });
+
+  test("1. Reasoning - standard settings", async() => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      maxReasoningTokens: 100,
+    });
+    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig).toHaveProperty("thinkingConfig");
+    const { thinkingConfig } = data.generationConfig;
+    expect(thinkingConfig).toHaveProperty("thinkingBudget");
+    expect(thinkingConfig.thinkingBudget).toEqual(100);
+  });
+
+
+  test("1. Reasoning - google settings", async() => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      thinkingBudget: 120,
+    });
+    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig).toHaveProperty("thinkingConfig");
+    const { thinkingConfig } = data.generationConfig;
+    expect(thinkingConfig).toHaveProperty("thinkingBudget");
+    expect(thinkingConfig.thinkingBudget).toEqual(120);
+  });
+
+  test("1. Reasoning - openAI settings", async() => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.5-flex-preview-04-17",
+      reasoningEffort: "low",
+    });
+    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig).toHaveProperty("thinkingConfig");
+    const { thinkingConfig } = data.generationConfig;
+    expect(thinkingConfig).toHaveProperty("thinkingBudget");
+    expect(thinkingConfig.thinkingBudget).toEqual(8192);
+  });
+
   test("2. Safety - settings", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -531,7 +531,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(caught).toBeTruthy();
   });
 
-  test("1. Reasoning - default off", async() => {
+  test("1. Reasoning - default off", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
     const authOptions: MockClientAuthInfo = {
@@ -542,7 +542,9 @@ describe("Mock ChatGoogle - Gemini", () => {
     const model = new ChatGoogle({
       authOptions,
     });
-    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
 
     expect(record.opts).toBeDefined();
     expect(record.opts.data).toBeDefined();
@@ -552,7 +554,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(data.generationConfig).not.toHaveProperty("thinkingConfig");
   });
 
-  test("1. Reasoning - standard settings", async() => {
+  test("1. Reasoning - standard settings", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
     const authOptions: MockClientAuthInfo = {
@@ -564,7 +566,9 @@ describe("Mock ChatGoogle - Gemini", () => {
       authOptions,
       maxReasoningTokens: 100,
     });
-    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
 
     expect(record.opts).toBeDefined();
     expect(record.opts.data).toBeDefined();
@@ -577,8 +581,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(thinkingConfig.thinkingBudget).toEqual(100);
   });
 
-
-  test("1. Reasoning - google settings", async() => {
+  test("1. Reasoning - google settings", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
     const authOptions: MockClientAuthInfo = {
@@ -590,7 +593,9 @@ describe("Mock ChatGoogle - Gemini", () => {
       authOptions,
       thinkingBudget: 120,
     });
-    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
 
     expect(record.opts).toBeDefined();
     expect(record.opts.data).toBeDefined();
@@ -603,7 +608,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(thinkingConfig.thinkingBudget).toEqual(120);
   });
 
-  test("1. Reasoning - openAI settings", async() => {
+  test("1. Reasoning - openAI settings", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
     const authOptions: MockClientAuthInfo = {
@@ -616,7 +621,9 @@ describe("Mock ChatGoogle - Gemini", () => {
       modelName: "gemini-2.5-flex-preview-04-17",
       reasoningEffort: "low",
     });
-    await model.invoke("You roll two dice. What’s the probability they add up to 7?");
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
 
     expect(record.opts).toBeDefined();
     expect(record.opts.data).toBeDefined();

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -84,6 +84,21 @@ describe("Mock ChatGoogle - Gemini", () => {
       });
       expect(model).toBeNull(); // For linting. Should never reach.
     }).toThrowError(/topK/);
+
+    expect(() => {
+      const model = new ChatGoogle({
+        maxReasoningTokens: -1000,
+      });
+      expect(model).toBeNull(); // For linting. Should never reach.
+    }).toThrowError(/maxReasoningTokens.*non-negative/);
+
+    expect(() => {
+      const model = new ChatGoogle({
+        maxOutputTokens: 500,
+        maxReasoningTokens: 1000,
+      });
+      expect(model).toBeNull(); // For linting. Should never reach.
+    }).toThrowError(/maxOutputTokens.*maxReasoningTokens/);
   });
 
   test("user agent header", async () => {

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -148,7 +148,6 @@ export interface GoogleAIModelParams {
    */
   maxOutputTokens?: number;
 
-
   /**
    * The maximum number of the output tokens that will be used
    * for the "thinking" or "reasoning" stages.

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -125,6 +125,11 @@ export type GoogleAIResponseMimeType = "text/plain" | "application/json";
 
 export type GoogleAIModelModality = "TEXT" | "IMAGE" | "AUDIO" | string;
 
+export interface GoogleThinkingConfig {
+  thinkingBudget?: number;
+  includeThoughts?: boolean;
+}
+
 export interface GoogleAIModelParams {
   /** Model to use */
   model?: string;
@@ -139,8 +144,26 @@ export interface GoogleAIModelParams {
 
   /**
    * Maximum number of tokens to generate in the completion.
+   * This may include reasoning tokens (for backwards compatibility).
    */
   maxOutputTokens?: number;
+
+
+  /**
+   * The maximum number of the output tokens that will be used
+   * for the "thinking" or "reasoning" stages.
+   */
+  maxReasoningTokens?: number;
+
+  /**
+   * An alias for "maxReasoningTokens"
+   */
+  thinkingBudget?: number;
+
+  /**
+   * An OpenAI compatible parameter that will map to "maxReasoningTokens"
+   */
+  reasoningEffort?: "low" | "medium" | "high";
 
   /**
    * Top-p changes how the model selects tokens for output.
@@ -535,6 +558,7 @@ export interface GeminiGenerationConfig {
   responseLogprobs?: boolean;
   logprobs?: number;
   responseModalities?: GoogleAIModelModality[];
+  thinkingConfig?: GoogleThinkingConfig;
 }
 
 export interface GeminiRequest {

--- a/libs/langchain-google-common/src/utils/common.ts
+++ b/libs/langchain-google-common/src/utils/common.ts
@@ -118,6 +118,19 @@ export function convertToGeminiTools(tools: GoogleAIToolType[]): GeminiTool[] {
   return geminiTools;
 }
 
+function reasoningEffortToReasoningTokens(_modelName?: string, effort?: string): number | undefined {
+  if (effort === undefined) {
+    return undefined;
+  }
+  const maxEffort = 24 * 1024;  // Max for Gemini 2.5 Flash
+  switch (effort) {
+    case "low": return maxEffort / 3;
+    case "medium": return (2 * maxEffort) / 3;
+    case "high": return maxEffort;
+    default: return undefined;
+  }
+}
+
 export function copyAIModelParamsInto(
   params: GoogleAIModelParams | undefined,
   options: GoogleAIBaseLanguageModelCallOptions | undefined,
@@ -134,6 +147,16 @@ export function copyAIModelParamsInto(
     options?.maxOutputTokens ??
     params?.maxOutputTokens ??
     target.maxOutputTokens;
+  ret.maxReasoningTokens =
+    options?.maxReasoningTokens ??
+      params?.maxReasoningTokens ??
+      target?.maxReasoningTokens ??
+      options?.thinkingBudget ??
+      params?.thinkingBudget ??
+      target?.thinkingBudget ??
+      reasoningEffortToReasoningTokens(ret.modelName, params?.reasoningEffort) ??
+      reasoningEffortToReasoningTokens(ret.modelName, target?.reasoningEffort) ??
+      reasoningEffortToReasoningTokens(ret.modelName, options?.reasoningEffort);
   ret.topP = options?.topP ?? params?.topP ?? target.topP;
   ret.topK = options?.topK ?? params?.topK ?? target.topK;
   ret.presencePenalty =

--- a/libs/langchain-google-common/src/utils/common.ts
+++ b/libs/langchain-google-common/src/utils/common.ts
@@ -118,16 +118,23 @@ export function convertToGeminiTools(tools: GoogleAIToolType[]): GeminiTool[] {
   return geminiTools;
 }
 
-function reasoningEffortToReasoningTokens(_modelName?: string, effort?: string): number | undefined {
+function reasoningEffortToReasoningTokens(
+  _modelName?: string,
+  effort?: string
+): number | undefined {
   if (effort === undefined) {
     return undefined;
   }
-  const maxEffort = 24 * 1024;  // Max for Gemini 2.5 Flash
+  const maxEffort = 24 * 1024; // Max for Gemini 2.5 Flash
   switch (effort) {
-    case "low": return maxEffort / 3;
-    case "medium": return (2 * maxEffort) / 3;
-    case "high": return maxEffort;
-    default: return undefined;
+    case "low":
+      return maxEffort / 3;
+    case "medium":
+      return (2 * maxEffort) / 3;
+    case "high":
+      return maxEffort;
+    default:
+      return undefined;
   }
 }
 
@@ -149,14 +156,14 @@ export function copyAIModelParamsInto(
     target.maxOutputTokens;
   ret.maxReasoningTokens =
     options?.maxReasoningTokens ??
-      params?.maxReasoningTokens ??
-      target?.maxReasoningTokens ??
-      options?.thinkingBudget ??
-      params?.thinkingBudget ??
-      target?.thinkingBudget ??
-      reasoningEffortToReasoningTokens(ret.modelName, params?.reasoningEffort) ??
-      reasoningEffortToReasoningTokens(ret.modelName, target?.reasoningEffort) ??
-      reasoningEffortToReasoningTokens(ret.modelName, options?.reasoningEffort);
+    params?.maxReasoningTokens ??
+    target?.maxReasoningTokens ??
+    options?.thinkingBudget ??
+    params?.thinkingBudget ??
+    target?.thinkingBudget ??
+    reasoningEffortToReasoningTokens(ret.modelName, params?.reasoningEffort) ??
+    reasoningEffortToReasoningTokens(ret.modelName, target?.reasoningEffort) ??
+    reasoningEffortToReasoningTokens(ret.modelName, options?.reasoningEffort);
   ret.topP = options?.topP ?? params?.topP ?? target.topP;
   ret.topK = options?.topK ?? params?.topK ?? target.topK;
   ret.presencePenalty =

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1240,7 +1240,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       ret.thinkingConfig = {
         thinkingBudget: parameters.maxReasoningTokens,
         includeThoughts: true,
-      }
+      };
     }
 
     // Remove any undefined properties, so we don't send them
@@ -1447,7 +1447,9 @@ export function validateGeminiParams(params: GoogleAIModelParams): void {
     }
     if (typeof params.maxOutputTokens !== "undefined") {
       if (params.maxReasoningTokens >= params.maxOutputTokens) {
-        throw new Error("`maxOutputTokens` must be greater than `maxReasoningTokens`");
+        throw new Error(
+          "`maxOutputTokens` must be greater than `maxReasoningTokens`"
+        );
       }
     }
   }

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1441,6 +1441,16 @@ export function validateGeminiParams(params: GoogleAIModelParams): void {
   if (params.maxOutputTokens && params.maxOutputTokens < 0) {
     throw new Error("`maxOutputTokens` must be a positive integer");
   }
+  if (typeof params.maxReasoningTokens !== "undefined") {
+    if (params.maxReasoningTokens < 0) {
+      throw new Error("`maxReasoningTokens` must be non-negative integer");
+    }
+    if (typeof params.maxOutputTokens !== "undefined") {
+      if (params.maxReasoningTokens >= params.maxOutputTokens) {
+        throw new Error("`maxOutputTokens` must be greater than `maxReasoningTokens`");
+      }
+    }
+  }
 
   if (
     params.temperature &&

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1235,6 +1235,14 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       }
     }
 
+    // Add thinking configuration if explicitly set
+    if (typeof parameters.maxReasoningTokens !== "undefined") {
+      ret.thinkingConfig = {
+        thinkingBudget: parameters.maxReasoningTokens,
+        includeThoughts: true,
+      }
+    }
+
     // Remove any undefined properties, so we don't send them
     let attribute: keyof GeminiGenerationConfig;
     for (attribute in ret) {

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -930,6 +930,32 @@ describe.each(testGeminiModelNames)(
       }
       expect(finalMsg.content as string).toContain("Dodgers");
     });
+
+    test("reasoning", async () => {
+      const model = newChatGoogle({
+        maxReasoningTokens: 12000,
+      });
+      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      console.log(res);
+      expect(res.content).toMatch(/^1\/6/);
+    });
+
+    test("reasoning default", async () => {
+      const model = newChatGoogle({
+      });
+      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      console.log(res);
+      expect(res.content).toMatch(/^1\/6/);
+    });
+
+    test("reasoning off", async () => {
+      const model = newChatGoogle({
+        maxReasoningTokens: 0,
+      });
+      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      console.log(res);
+      expect(res.content).toMatch(/^1\/6/);
+    });
   }
 );
 

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -340,6 +340,16 @@ const testGeminiModelNames = [
     apiVersion: "v1",
   },
   {
+    modelName: "gemini-2.5-flash-preview-04-17",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  {
+    modelName: "gemini-2.5-flash-preview-04-17",
+    platformType: "gcp",
+    apiVersion: "v1",
+  },
+  {
     modelName: "gemini-2.5-pro-exp-03-25",
     platformType: "gai",
     apiVersion: "v1beta",
@@ -363,6 +373,7 @@ const testGeminiModelDelay: Record<string, number> = {
   "gemini-2.0-flash-exp": 10000,
   "gemini-2.0-flash-thinking-exp-1219": 10000,
   "gemini-2.5-pro-exp-03-25": 10000,
+  "gemini-2.5-flash-preview-04-17": 10000,
 };
 
 describe.each(testGeminiModelNames)(

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -935,15 +935,18 @@ describe.each(testGeminiModelNames)(
       const model = newChatGoogle({
         maxReasoningTokens: 12000,
       });
-      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      const res = await model.invoke(
+        "You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain."
+      );
       console.log(res);
       expect(res.content).toMatch(/^1\/6/);
     });
 
     test("reasoning default", async () => {
-      const model = newChatGoogle({
-      });
-      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      const model = newChatGoogle({});
+      const res = await model.invoke(
+        "You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain."
+      );
       console.log(res);
       expect(res.content).toMatch(/^1\/6/);
     });
@@ -952,7 +955,9 @@ describe.each(testGeminiModelNames)(
       const model = newChatGoogle({
         maxReasoningTokens: 0,
       });
-      const res = await model.invoke("You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.");
+      const res = await model.invoke(
+        "You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain."
+      );
       console.log(res);
       expect(res.content).toMatch(/^1\/6/);
     });


### PR DESCRIPTION
Initial support for Gemini 2.5 Flash
* Adds support for the "thinking budget" through a "maxReasoningTokens" parameter
* Also supports a "thinkingBudget" and "reasoningEffort" for compatibility
* Tests for everything

Fixes #8038 

I'd like to get this out ASAP, even if there are some pending issues.

Some notes:
* Gemini 2.5 Flash defaults to using "thinking tokens" unless you set this off by setting the budget to 0. We don't do anything specific about this.
* Specifying the "maxReasoningTokens" for models that don't support reasoning causes an error. We can discuss if / how we want to address this.

Still pending, but I'd like to get this release out asap while I add these:
* Documentation (where should we document this, exactly?)
* Information in `OutputTokenDetails`
  * Google has a bug causing inconsistent values for "output tokens" vs "thinking tokens" between the two platforms so we should wait on this till they standardize their format