### PR TITLE
feat(tavily): use chunks per source arg

### DIFF
--- a/libs/langchain-tavily/src/tavily-search.ts
+++ b/libs/langchain-tavily/src/tavily-search.ts
@@ -118,6 +118,13 @@ export type TavilySearchAPIRetrieverFields = ToolParams & {
    * ignored.
    */
   apiWrapper?: TavilySearchAPIWrapper;
+
+  /**
+   * The number of content chunks to retrieve from each source. Each chunk's length is maximum 500 characters. Available only when search_depth is advanced.
+   *
+   * @default 3
+   */
+  chunksPerSource?: number;
 };
 
 function generateSuggestions(params: Record<string, unknown>): string[] {
@@ -299,6 +306,8 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
 
   timeRange?: TimeRange;
 
+  chunksPerSource?: number;
+
   handleToolError = true;
 
   apiWrapper: TavilySearchAPIWrapper;
@@ -341,6 +350,7 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
     this.includeAnswer = params.includeAnswer ?? false;
     this.includeRawContent = params.includeRawContent ?? false;
     this.includeImageDescriptions = params.includeImageDescriptions ?? false;
+    this.chunksPerSource = params.chunksPerSource ?? 3;
   }
 
   async _call(
@@ -378,6 +388,7 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
         includeAnswer: this.includeAnswer,
         includeRawContent: this.includeRawContent,
         includeImageDescriptions: this.includeImageDescriptions,
+        chunksPerSource: this.chunksPerSource,
       });
 
       if (

--- a/libs/langchain-tavily/src/tavily-search.ts
+++ b/libs/langchain-tavily/src/tavily-search.ts
@@ -120,7 +120,7 @@ export type TavilySearchAPIRetrieverFields = ToolParams & {
   apiWrapper?: TavilySearchAPIWrapper;
 
   /**
-   * The number of content chunks to retrieve from each source. Each chunk's length is maximum 500 characters. Available only when search_depth is advanced.
+   * The number of content chunks to retrieve from each source. Each chunk's length is maximum 500 characters. Available only when searchDepth is advanced. See https://docs.tavily.com/docs/rest-api/api-reference
    *
    * @default 3
    */

--- a/libs/langchain-tavily/src/utils.ts
+++ b/libs/langchain-tavily/src/utils.ts
@@ -291,48 +291,24 @@ abstract class BaseTavilyAPIWrapper {
   }
 
   /**
-   * Maps from camelCase parameter names to snake_case API parameter names
-   */
-  protected readonly camelToSnakeMap: Record<
-    keyof TavilySearchParams | keyof TavilyExtractParams,
-    string
-  > = {
-    query: "query",
-    topic: "topic",
-    searchDepth: "search_depth",
-    chunksPerSource: "chunks_per_source",
-    maxResults: "max_results",
-    timeRange: "time_range",
-    days: "days",
-    includeAnswer: "include_answer",
-    includeRawContent: "include_raw_content",
-    includeDomains: "include_domains",
-    excludeDomains: "exclude_domains",
-    includeImages: "include_images",
-    includeImageDescriptions: "include_image_descriptions",
-    urls: "urls",
-    extractDepth: "extract_depth",
-  };
-
-  /**
    * Converts camelCase keys to snake_case for API compatibility
    * @param params The parameters with camelCase keys
    * @returns The parameters with snake_case keys
    */
   protected convertCamelToSnakeCase(
-    params: Record<
-      keyof TavilySearchParams | keyof TavilyExtractParams,
-      unknown
-    >
-  ) {
+    params: Record<string, unknown>
+  ): Record<string, unknown> {
     return Object.entries(params).reduce((result, [key, value]) => {
       if (value === undefined) {
         return result;
       }
-      // Use explicit mapping for known keys, fall back to generic default key
-      const newKey = this.camelToSnakeMap[key] || key;
+      // Convert camelCase key to snake_case
+      // Handle potential leading capital letter first
+      let newKey = key.replace(/^[A-Z]/, (letter) => letter.toLowerCase());
+      // Then handle subsequent capital letters
+      newKey = newKey.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
       return { ...result, [newKey]: value };
-    }, {} as Record<keyof TavilySearchParams | keyof TavilyExtractParams, unknown>);
+    }, {} as Record<string, unknown>);
   }
 }
 


### PR DESCRIPTION
Adds missing `chunks_per_source` parameter in the latest tavily search class