### PR TITLE
feat(openai): Response API support for reasoning summaries, stateful conversations, and Zero Data Retention

### DIFF
--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "js-tiktoken": "^1.0.12",
-    "openai": "^4.93.0",
+    "openai": "^4.96.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.3"
   },

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -5,7 +5,6 @@ import type {
   ChatCompletionContentPartInputAudio,
   ChatCompletionContentPart,
 } from "openai/resources/chat/completions";
-
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import {
   AIMessage,
@@ -77,11 +76,12 @@ import type {
   ResponseFormatJSONObject,
   ResponseFormatJSONSchema,
 } from "openai/resources/shared";
-import type {
-  OpenAICallOptions,
-  OpenAIChatInput,
-  OpenAICoreRequestOptions,
-  ChatOpenAIResponseFormat,
+import {
+  type OpenAICallOptions,
+  type OpenAIChatInput,
+  type OpenAICoreRequestOptions,
+  type ChatOpenAIResponseFormat,
+  ChatOpenAIReasoningSummary,
 } from "./types.js";
 import { type OpenAIEndpointConfig, getEndpoint } from "./utils/azure.js";
 import {
@@ -400,11 +400,49 @@ export function _convertMessagesToOpenAIParams(
 
 const _FUNCTION_CALL_IDS_MAP_KEY = "__openai_function_call_ids__";
 
+function _convertReasoningSummaryToOpenAIResponsesParams(
+  reasoning: ChatOpenAIReasoningSummary
+): OpenAIClient.Responses.ResponseReasoningItem {
+  // combine summary parts that have the the same index and then remove the indexes
+  const summary = (
+    reasoning.summary.length > 1
+      ? reasoning.summary.reduce(
+          (acc, curr) => {
+            const last = acc.at(-1);
+
+            if (last!.index === curr.index) {
+              last!.text += curr.text;
+            } else {
+              acc.push(curr);
+            }
+            return acc;
+          },
+          [{ ...reasoning.summary[0] }]
+        )
+      : reasoning.summary
+  ).map((s) =>
+    Object.fromEntries(Object.entries(s).filter(([k]) => k !== "index"))
+  ) as OpenAIClient.Responses.ResponseReasoningItem.Summary[];
+
+  return {
+    ...reasoning,
+    summary,
+  } as OpenAIClient.Responses.ResponseReasoningItem;
+}
+
 function _convertMessagesToOpenAIResponsesParams(
   messages: BaseMessage[],
-  model?: string
+  model?: string,
+  zdrEnabled?: boolean
 ): ResponsesInputItem[] {
-  return messages.flatMap(
+  const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
+  const lastAIMessageId = lastAIMessage?.response_metadata?.id;
+  const newMessages =
+    lastAIMessageId && lastAIMessageId.startsWith("resp_") && !zdrEnabled
+      ? messages.slice(messages.indexOf(lastAIMessage) + 1)
+      : messages;
+
+  return newMessages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
       let role = messageToOpenAIRole(lcMsg);
       if (role === "system" && isReasoningModel(model)) role = "developer";
@@ -470,6 +508,20 @@ function _convertMessagesToOpenAIResponsesParams(
       }
 
       if (role === "assistant") {
+        // if we have the original response items, just reuse them
+        if (
+          lcMsg.response_metadata.output != null &&
+          Array.isArray(lcMsg.response_metadata.output) &&
+          lcMsg.response_metadata.output.length > 0 &&
+          lcMsg.response_metadata.output.every(
+            (item) => "type" in item && "id" in item
+          )
+        ) {
+          return lcMsg.response_metadata.output;
+        }
+
+        // otherwise, try to reconstruct the response from what we have
+
         const input: ResponsesInputItem[] = [];
 
         // reasoning items
@@ -486,7 +538,11 @@ function _convertMessagesToOpenAIResponsesParams(
             item.type === "reasoning";
 
           if (isReasoningItem(lcMsg.additional_kwargs.reasoning)) {
-            input.push(lcMsg.additional_kwargs.reasoning);
+            const reasoningItem =
+              _convertReasoningSummaryToOpenAIResponsesParams(
+                lcMsg.additional_kwargs.reasoning
+              );
+            input.push(reasoningItem);
           }
         }
 
@@ -505,6 +561,7 @@ function _convertMessagesToOpenAIResponsesParams(
         input.push({
           type: "message",
           role: "assistant",
+          ...(lcMsg.id ? { id: lcMsg.id } : {}),
           content:
             typeof content === "string"
               ? content
@@ -565,20 +622,14 @@ function _convertMessagesToOpenAIResponsesParams(
           ? lcMsg.response_metadata.output
           : lcMsg.additional_kwargs.tool_outputs;
 
+        let computerCalls: Array<ResponsesInputItem> = [];
+
         if (toolOutputs != null) {
           const castToolOutputs = toolOutputs as Array<ResponsesInputItem>;
-          const reasoningCalls = castToolOutputs?.filter(
-            (item) => item.type === "reasoning"
-          );
 
-          const computerCalls = castToolOutputs?.filter(
+          computerCalls = castToolOutputs?.filter(
             (item) => item.type === "computer_call"
           );
-
-          // NOTE: Reasoning outputs must be passed to the model BEFORE computer calls.
-          if (reasoningCalls.length > 0 && computerCalls.length > 0) {
-            input.push(...reasoningCalls);
-          }
 
           if (computerCalls.length > 0) input.push(...computerCalls);
         }
@@ -667,7 +718,7 @@ function _convertOpenAIResponsesMessageToBaseMessage(
   const additional_kwargs: {
     [key: string]: unknown;
     refusal?: string;
-    reasoning?: unknown;
+    reasoning?: OpenAIClient.Responses.ResponseReasoningItem;
     tool_outputs?: unknown[];
     parsed?: unknown;
     [_FUNCTION_CALL_IDS_MAP_KEY]?: Record<string, string>;
@@ -748,7 +799,10 @@ function _convertOpenAIResponsesDeltaToBaseMessageChunk(
   let usage_metadata: UsageMetadata | undefined;
   const tool_call_chunks: ToolCallChunk[] = [];
   const response_metadata: Record<string, unknown> = {};
-  const additional_kwargs: Record<string, unknown> = {};
+  const additional_kwargs: {
+    [key: string]: unknown;
+    reasoning?: Partial<ChatOpenAIReasoningSummary>;
+  } = {};
   let id: string | undefined;
   if (chunk.type === "response.output_text.delta") {
     content.push({
@@ -823,6 +877,39 @@ function _convertOpenAIResponsesDeltaToBaseMessageChunk(
     };
   } else if (chunk.type === "response.refusal.done") {
     additional_kwargs.refusal = chunk.refusal;
+  } else if (
+    chunk.type === "response.output_item.added" &&
+    "item" in chunk &&
+    chunk.item.type === "reasoning"
+  ) {
+    const summary: ChatOpenAIReasoningSummary["summary"] | undefined = chunk
+      .item.summary
+      ? chunk.item.summary.map((s, index) => ({
+          ...s,
+          index,
+        }))
+      : undefined;
+
+    additional_kwargs.reasoning = {
+      // We only capture ID in the first chunk or else the concatenated result of all chunks will
+      // have an ID field that is repeated once per chunk. There is special handling for the `type`
+      // field that prevents this, however.
+      id: chunk.item.id,
+      type: chunk.item.type,
+      ...(summary ? { summary } : {}),
+    };
+  } else if (chunk.type === "response.reasoning_summary_part.added") {
+    additional_kwargs.reasoning = {
+      type: "reasoning",
+      summary: [{ ...chunk.part, index: chunk.summary_index }],
+    };
+  } else if (chunk.type === "response.reasoning_summary_text.delta") {
+    additional_kwargs.reasoning = {
+      type: "reasoning",
+      summary: [
+        { text: chunk.delta, type: "summary_text", index: chunk.summary_index },
+      ],
+    };
   } else {
     return null;
   }
@@ -858,10 +945,7 @@ type ResponsesToolChoice = Exclude<
   undefined
 >;
 
-type ResponsesInputItem = Exclude<
-  ResponsesCreateParams["input"],
-  string | undefined
->[number];
+type ResponsesInputItem = OpenAIClient.Responses.ResponseInputItem;
 
 type ResponsesCreateInvoke = ExcludeController<
   Awaited<ReturnType<ResponsesCreate>>
@@ -927,11 +1011,7 @@ function _convertChatOpenAIToolTypeToOpenAITool(
 }
 
 function isReasoningModel(model?: string) {
-  return (
-    model?.startsWith("o1") ||
-    model?.startsWith("o3") ||
-    model?.startsWith("o4")
-  );
+  return model && /^o\d/.test(model);
 }
 
 // TODO: Use the base structured output options param in next breaking release.
@@ -1024,28 +1104,50 @@ export interface ChatOpenAICallOptions
   /**
    * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
    * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+   *
+   * @deprecated Use {@link reasoning} object instead.
    */
   reasoning_effort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
 
   /**
+   * Options for reasoning models.
+   *
+   * Note that some options, like reasoning summaries, are only available when using the responses
+   * API. If these options are set, the responses API will be used to fulfill the request.
+   *
+   * These options will be ignored when not using a reasoning model.
+   */
+  reasoning?: OpenAIClient.Reasoning;
+
+  /**
    * Configuration options for a text response from the model. Can be plain text or
    * structured JSON data.
+   *
+   * If set, the Responses API will be used to fulfill the request.
    */
   text?: ResponsesCreateParams["text"];
 
   /**
    * The truncation strategy to use for the model response.
+   *
+   * If set, the Responses API will be used to fulfill the request.
    */
   truncation?: ResponsesCreateParams["truncation"];
 
   /**
    * Specify additional output data to include in the model response.
+   *
+   * If set, the Responses API will be used to fulfill the request.
    */
   include?: ResponsesCreateParams["include"];
 
   /**
-   * The unique ID of the previous response to the model. Use this to create
-   * multi-turn conversations.
+   * The unique ID of the previous response to the model. Use this to create multi-turn
+   * conversations. Will be set automatically if {@link ChatOpenAI.zdrEnabled} is `false`, provided
+   * that AIMessages included in the request have a `response_metadata.id` property. Ignored unless
+   * {@link ChatOpenAI.useResponsesApi} is `true`.
+   *
+   * If set, the Responses API will be used to fulfill the request.
    */
   previous_response_id?: ResponsesCreateParams["previous_response_id"];
 }
@@ -1054,6 +1156,11 @@ export interface ChatOpenAIFields
   extends Partial<OpenAIChatInput>,
     BaseChatModelParams {
   configuration?: ClientOptions;
+
+  /**
+   * Whether to use the responses API for all requests. If `false` the responses API will be used
+   * only when required in order to fulfill the request.
+   */
   useResponsesApi?: boolean;
 }
 
@@ -1674,6 +1781,9 @@ export class ChatOpenAI<
       "tags",
       "metadata",
       "disableStreaming",
+      "useResponsesApi",
+      "zdrEnabled",
+      "reasoning",
     ];
   }
 
@@ -1736,9 +1846,27 @@ export class ChatOpenAI<
 
   modalities?: Array<OpenAIClient.Chat.ChatCompletionModality>;
 
+  /**
+   * @deprecated Use {@link reasoning} object instead.
+   */
   reasoningEffort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
 
+  /**
+   * Options for reasoning models.
+   */
+  reasoning?: OpenAIClient.Reasoning;
+
+  /**
+   * Whether to use the responses API for all requests. If `false` the responses API will be used
+   * only when required in order to fulfill the request.
+   */
   useResponsesApi = false;
+
+  /**
+   * Should be set to `true` in tenancies with Zero Data Retention
+   * @default false
+   */
+  zdrEnabled?: boolean | undefined;
 
   constructor(fields?: ChatOpenAIFields) {
     super(fields ?? {});
@@ -1772,7 +1900,12 @@ export class ChatOpenAI<
     this.__includeRawResponse = fields?.__includeRawResponse;
     this.audio = fields?.audio;
     this.modalities = fields?.modalities;
-    this.reasoningEffort = fields?.reasoningEffort;
+    this.reasoningEffort = fields?.reasoningEffort ?? fields?.reasoning?.effort;
+    this.reasoning =
+      fields?.reasoning ??
+      (fields?.reasoningEffort
+        ? { effort: fields.reasoningEffort }
+        : undefined);
     this.maxTokens = fields?.maxCompletionTokens ?? fields?.maxTokens;
     this.useResponsesApi = fields?.useResponsesApi ?? this.useResponsesApi;
     this.disableStreaming = fields?.disableStreaming ?? this.disableStreaming;
@@ -1796,6 +1929,8 @@ export class ChatOpenAI<
     if (fields?.supportsStrictToolCalling !== undefined) {
       this.supportsStrictToolCalling = fields.supportsStrictToolCalling;
     }
+
+    this.zdrEnabled = fields?.zdrEnabled ?? false;
   }
 
   getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {
@@ -1856,6 +1991,44 @@ export class ChatOpenAI<
       | ResponseFormatJSONObject
       | ResponseFormatJSONSchema
       | undefined;
+  }
+
+  private getReasoningParams(
+    options?: this["ParsedCallOptions"]
+  ): OpenAIClient.Reasoning | undefined {
+    if (!isReasoningModel(this.model)) {
+      return;
+    }
+
+    let reasoning: OpenAIClient.Reasoning | undefined;
+
+    // apply reasoning options in reverse order of priority without else blocks so that highest priority overrides lowest priority
+    if (this.reasoningEffort !== undefined) {
+      reasoning = { effort: this.reasoningEffort };
+    }
+
+    if (this.reasoning !== undefined) {
+      reasoning = {
+        ...reasoning,
+        ...this.reasoning,
+      };
+    }
+
+    if (options?.reasoning_effort !== undefined) {
+      reasoning = {
+        ...reasoning,
+        effort: options.reasoning_effort,
+      };
+    }
+
+    if (options?.reasoning !== undefined) {
+      reasoning = {
+        ...reasoning,
+        ...options.reasoning,
+      };
+    }
+
+    return reasoning;
   }
 
   /**
@@ -1940,9 +2113,10 @@ export class ChatOpenAI<
         ...this.modelKwargs,
       };
 
-      const reasoningEffort = options?.reasoning_effort ?? this.reasoningEffort;
-      if (reasoningEffort !== undefined) {
-        params.reasoning = { effort: reasoningEffort };
+      const reasoning = this.getReasoningParams(options);
+
+      if (reasoning !== undefined) {
+        params.reasoning = reasoning;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1995,9 +2169,9 @@ export class ChatOpenAI<
     if (options?.prediction !== undefined) {
       params.prediction = options.prediction;
     }
-    const reasoningEffort = options?.reasoning_effort ?? this.reasoningEffort;
-    if (reasoningEffort !== undefined) {
-      params.reasoning_effort = reasoningEffort;
+    const reasoning = this.getReasoningParams(options);
+    if (reasoning !== undefined && reasoning.effort !== undefined) {
+      params.reasoning_effort = reasoning.effort;
     }
     if (isReasoningModel(params.model)) {
       params.max_completion_tokens =
@@ -2170,11 +2344,22 @@ export class ChatOpenAI<
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     if (this._useResponseApi(options)) {
+      const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
+      const lastAIMessageId = lastAIMessage?.response_metadata?.id;
       const streamIterable = await this.responseApiWithRetry(
         {
           ...this.invocationParams<"responses">(options, { streaming: true }),
-          input: _convertMessagesToOpenAIResponsesParams(messages, this.model),
+          input: _convertMessagesToOpenAIResponsesParams(
+            messages,
+            this.model,
+            this.zdrEnabled
+          ),
           stream: true,
+          ...(lastAIMessageId &&
+          lastAIMessageId.startsWith("resp_") &&
+          !this.zdrEnabled
+            ? { previous_response_id: lastAIMessageId }
+            : {}),
         },
         options
       );
@@ -2337,9 +2522,23 @@ export class ChatOpenAI<
       };
     }
 
-    const input = _convertMessagesToOpenAIResponsesParams(messages, this.model);
+    const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
+    const lastAIMessageId = lastAIMessage?.response_metadata?.id;
+    const input = _convertMessagesToOpenAIResponsesParams(
+      messages,
+      this.model,
+      this.zdrEnabled
+    );
     const data = await this.responseApiWithRetry(
-      { input, ...invocationParams },
+      {
+        input,
+        ...invocationParams,
+        ...(lastAIMessageId &&
+        lastAIMessageId.startsWith("resp_") &&
+        !this.zdrEnabled
+          ? { previous_response_id: lastAIMessageId }
+          : {}),
+      },
       { signal: options?.signal, ...options?.options }
     );
 
@@ -2363,13 +2562,24 @@ export class ChatOpenAI<
     };
   }
 
+  /**
+   * Determines whether the responses API should be used for the given request.
+   *
+   * @internal
+   *
+   * @param options The parsed call options for the request.
+   * @returns `true` if the responses API should be used, either because it is explicitly enabled,
+   * or because the request requires it.
+   */
   protected _useResponseApi(options: this["ParsedCallOptions"] | undefined) {
     const usesBuiltInTools = options?.tools?.some(isBuiltInTool);
     const hasResponsesOnlyKwargs =
       options?.previous_response_id != null ||
       options?.text != null ||
       options?.truncation != null ||
-      options?.include != null;
+      options?.include != null ||
+      options?.reasoning?.summary != null ||
+      this.reasoning?.summary != null;
 
     return this.useResponsesApi || usesBuiltInTools || hasResponsesOnlyKwargs;
   }

--- a/libs/langchain-openai/src/tools/dalle.ts
+++ b/libs/langchain-openai/src/tools/dalle.ts
@@ -173,44 +173,46 @@ export class DallEAPIWrapper extends Tool {
   ): MessageContentImageUrl[] {
     if (this.dallEResponseFormat === "url") {
       return response.flatMap((res) => {
-        const imageUrlContent = res.data
-          .flatMap((item) => {
-            if (!item.url) return [];
-            return {
-              type: "image_url" as const,
-              image_url: item.url,
-            };
-          })
-          .filter(
-            (item) =>
-              item !== undefined &&
-              item.type === "image_url" &&
-              typeof item.image_url === "string" &&
-              item.image_url !== undefined
-          );
+        const imageUrlContent =
+          res.data
+            ?.flatMap((item) => {
+              if (!item.url) return [];
+              return {
+                type: "image_url" as const,
+                image_url: item.url,
+              };
+            })
+            .filter(
+              (item) =>
+                item !== undefined &&
+                item.type === "image_url" &&
+                typeof item.image_url === "string" &&
+                item.image_url !== undefined
+            ) ?? [];
         return imageUrlContent;
       });
     } else {
       return response.flatMap((res) => {
-        const b64Content = res.data
-          .flatMap((item) => {
-            if (!item.b64_json) return [];
-            return {
-              type: "image_url" as const,
-              image_url: {
-                url: item.b64_json,
-              },
-            };
-          })
-          .filter(
-            (item) =>
-              item !== undefined &&
-              item.type === "image_url" &&
-              typeof item.image_url === "object" &&
-              "url" in item.image_url &&
-              typeof item.image_url.url === "string" &&
-              item.image_url.url !== undefined
-          );
+        const b64Content =
+          res.data
+            ?.flatMap((item) => {
+              if (!item.b64_json) return [];
+              return {
+                type: "image_url" as const,
+                image_url: {
+                  url: item.b64_json,
+                },
+              };
+            })
+            .filter(
+              (item) =>
+                item !== undefined &&
+                item.type === "image_url" &&
+                typeof item.image_url === "object" &&
+                "url" in item.image_url &&
+                typeof item.image_url.url === "string" &&
+                item.image_url.url !== undefined
+            ) ?? [];
         return b64Content;
       });
     }
@@ -243,13 +245,16 @@ export class DallEAPIWrapper extends Tool {
 
     let data = "";
     if (this.dallEResponseFormat === "url") {
-      [data] = response.data
-        .map((item) => item.url)
-        .filter((url): url is string => url !== "undefined");
+      [data] =
+        response.data
+          ?.map((item) => item.url)
+          .filter((url): url is string => url !== "undefined") ?? [];
     } else {
-      [data] = response.data
-        .map((item) => item.b64_json)
-        .filter((b64_json): b64_json is string => b64_json !== "undefined");
+      [data] =
+        response.data
+          ?.map((item) => item.b64_json)
+          .filter((b64_json): b64_json is string => b64_json !== "undefined") ??
+        [];
     }
     return data;
   }

--- a/libs/langchain-openai/src/types.ts
+++ b/libs/langchain-openai/src/types.ts
@@ -174,8 +174,26 @@ export interface OpenAIChatInput extends OpenAIBaseInput {
   /**
    * Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high.
    * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
+   *
+   * @deprecated Use the {@link reasoning} object instead.
    */
   reasoningEffort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
+
+  /**
+   * Options for reasoning models.
+   *
+   * Note that some options, like reasoning summaries, are only available when using the responses
+   * API. This option is ignored when not using a reasoning model.
+   */
+  reasoning?: OpenAIClient.Reasoning;
+
+  /**
+   * Should be set to `true` in tenancies with Zero Data Retention
+   * @see https://platform.openai.com/docs/guides/your-data
+   *
+   * @default false
+   */
+  zdrEnabled?: boolean;
 }
 
 export declare interface AzureOpenAIInput {
@@ -257,6 +275,23 @@ type ChatOpenAIResponseFormatJSONSchema = Omit<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     schema: Record<string, any> | z.ZodObject<any, any, any, any>;
   };
+};
+
+/**
+ * The summary of a model's reasoning step.
+ */
+export type ChatOpenAIReasoningSummary = Omit<
+  OpenAIClient.Responses.ResponseReasoningItem,
+  "summary"
+> & {
+  /**
+   * The summary of the reasoning step. The index field will be populated if the response was
+   * streamed. This allows LangChain to recompose the reasoning summary output correctly when the
+   * AIMessage is used as an input for future generation requests.
+   */
+  summary: Array<
+    OpenAIClient.Responses.ResponseReasoningItem.Summary & { index?: number }
+  >;
 };
 
 export type ChatOpenAIResponseFormat =

--- a/yarn.lock
+++ b/yarn.lock
@@ -8419,7 +8419,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.12
-    openai: ^4.93.0
+    openai: ^4.96.0
     prettier: ^2.8.3
     release-it: ^18.1.2
     rimraf: ^5.0.1
@@ -28461,9 +28461,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:*, openai@npm:^4.32.1, openai@npm:^4.41.1, openai@npm:^4.93.0":
-  version: 4.93.0
-  resolution: "openai@npm:4.93.0"
+"openai@npm:*, openai@npm:^4.32.1, openai@npm:^4.41.1, openai@npm:^4.96.0":
+  version: 4.96.0
+  resolution: "openai@npm:4.96.0"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
@@ -28482,7 +28482,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: 39fa6635475590c05c5fcb1fd07708c8f23d430dad36037c49fe25020ada0a4a36801e5c443669acd8f947d52005e3b7cf0215ca4b76262007f9b1ea3c916a68
+  checksum: d54ba62c4ad298ce3ea4ccc124f6fef0a81c2121ec830a363a1bec7ab909fa2a0e768c5decd738fe2db4f7fd0f5bbed8c8200debf52dd3ca4b9ba58aa1c11860
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Includes the following changes:

- Updates to latest OpenAI SDK version
- Adds `zdrEnabled` constructor option to `ChatOpenAI`, which to disables automatic `ChatOpenAI` features that depend on OpenAI data storage
- Populates [`previous_response_id`](https://platform.openai.com/docs/guides/conversation-state?api-mode=responses#openai-apis-for-conversation-state) automatically by default, unless ZDR is enabled.
- Populates the ID of previous message items when using the Responses API, unless ZDR is enabled.
- Deprecates `reasoningEffort` and `reasoning_effort` parameters in favor of the forwarded OpenAI `reasoning` object
  - These deprecated parameters are still respected if they are provided
- Adds missing fields to the `lc_serializable_keys` property
- Improves API docs to detail cases when the responses API will or won't be used.
  
Fixes #8088.