### PR TITLE
fix(prisma): filter on enum value

### DIFF
--- a/libs/langchain-community/src/vectorstores/prisma.ts
+++ b/libs/langchain-community/src/vectorstores/prisma.ts
@@ -455,7 +455,7 @@ export class PrismaVectorStore<
             case OpMap.isNotNull:
               return this.Prisma.sql`${colRaw} ${opRaw}`;
             default:
-              return this.Prisma.sql`${colRaw} ${opRaw} ${value}`;
+              return this.Prisma.sql`${colRaw}::text ${opRaw} ${value}`;
           }
         })
       ),


### PR DESCRIPTION
This PR fixes an issue where filtering on enum values using Prisma would fail due to a type mismatch. The fix ensures enum values are correctly cast to text in the default SQL query, allowing filters to work as expected for enums.

Context: When using where filters with enums in a vector store powered by Prisma, the generated SQL failed due to a type mismatch (enum vs. text). This cast to ::text resolves the issue.

Fixes #7953