### PR TITLE
fix(openapi): add global flag to replaceAll in getCleanedOperationId

### DIFF
--- a/langchain/src/util/openapi.ts
+++ b/langchain/src/util/openapi.ts
@@ -190,15 +190,15 @@ export class OpenAPISpec {
   ) {
     let { operationId } = operation;
     if (operationId === undefined) {
-      const updatedPath = path.replaceAll(/[^a-zA-Z0-9]/, "_");
+      const updatedPath = path.replaceAll(/[^a-zA-Z0-9]/g, "_");
       operationId = `${
         updatedPath.startsWith("/") ? updatedPath.slice(1) : updatedPath
       }_${method}`;
     }
     return operationId
-      .replaceAll("-", "_")
-      .replaceAll(".", "_")
-      .replaceAll("/", "_");
+      .replaceAll(/-/g, "_")
+      .replaceAll(/\./g, "_")
+      .replaceAll(/\//g, "_");
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION

**fix(openapi): add global flag to `replaceAll` in `getCleanedOperationId`**

### Summary  
This update amends the `getCleanedOperationId` utility so that each call to `String.prototype.replaceAll` uses a **global** regular expression, preventing a `TypeError` when invoked with a non-global `RegExp`.

### Motivation  
The ECMAScript 2021 specification requires that any `RegExp` passed to `replaceAll` must include the `/g` flag, or the method will throw a `TypeError`. In practice, the previous implementation omitted this flag, causing runtime failures when sanitizing operation IDs.

### Specification Compliance  
- Aligns with ECMAScript 2021 §22.1.3.27: `String.prototype.replaceAll` must be called with a global regex.  
- Restores the intended behavior of replacing **all** matches without altering the sanitization logic.

### References  
- MDN Web Docs: [String.prototype.replaceAll](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll)  

*Labels:* `type: bug`, `good first issue`  
