### PR TITLE
fix(google-common): Default AI Studio ("gai") platform to use "v1beta" API Version

### DIFF
--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -154,7 +154,7 @@ export abstract class GoogleHostConnection<
 
   _location: string | undefined;
 
-  apiVersion = "v1";
+  _apiVersion: string | undefined;
 
   constructor(
     fields: GoogleConnectionParams<AuthOptions> | undefined,
@@ -168,7 +168,7 @@ export abstract class GoogleHostConnection<
     this.platformType = fields?.platformType;
     this._endpoint = fields?.endpoint;
     this._location = fields?.location;
-    this.apiVersion = fields?.apiVersion ?? this.apiVersion;
+    this._apiVersion = fields?.apiVersion;
     this.client = client;
   }
 
@@ -178,6 +178,14 @@ export abstract class GoogleHostConnection<
 
   get computedPlatformType(): GooglePlatformType {
     return "gcp";
+  }
+
+  get computedApiVersion(): string {
+    return "v1";
+  }
+
+  get apiVersion(): string {
+    return this._apiVersion ?? this.computedApiVersion;
   }
 
   get location(): string {
@@ -294,6 +302,15 @@ export abstract class GoogleAIConnection<
       return "gai";
     } else {
       return "gcp";
+    }
+  }
+
+  get computedApiVersion(): string {
+    switch (this.platform) {
+      case "gai":
+        return "v1beta";
+      default:
+        return "v1";
     }
   }
 

--- a/libs/langchain-google-common/src/experimental/media.ts
+++ b/libs/langchain-google-common/src/experimental/media.ts
@@ -579,7 +579,9 @@ export class AIStudioFileUploadConnection<
   AIStudioFileSaveResponse,
   AuthOptions
 > {
-  apiVersion = "v1beta";
+  get computedApiVersion(): string {
+    return "v1beta";
+  }
 
   async buildUrl(): Promise<string> {
     return `https://generativelanguage.googleapis.com/upload/${this.apiVersion}/files`;
@@ -605,8 +607,6 @@ export class AIStudioFileDownloadConnection<
 
   name: string;
 
-  apiVersion = "v1beta";
-
   constructor(
     fields: AIStudioFileDownloadConnectionParams<AuthOptions>,
     caller: AsyncCaller,
@@ -615,6 +615,10 @@ export class AIStudioFileDownloadConnection<
     super(fields, caller, client);
     this.method = fields.method;
     this.name = fields.name;
+  }
+
+  get computedApiVersion(): string {
+    return "v1beta";
   }
 
   buildMethod(): GoogleAbstractedClientOpsMethod {

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -143,6 +143,21 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(model.platform).toEqual("gcp");
   });
 
+  test("platform default key", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      apiKey: "test",
+    });
+
+    expect(model.platform).toEqual("gai");
+  });
+
   test("platform set", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();
@@ -156,6 +171,79 @@ describe("Mock ChatGoogle - Gemini", () => {
     });
 
     expect(model.platform).toEqual("gai");
+  });
+
+  test("platform endpoint - gcp", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gcp",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://us-central1-aiplatform.googleapis.com/v1/projects/${projectId}/locations/us-central1/publishers/google/models/gemini-pro:generateContent`
+    );
+  });
+
+  test("platform endpoint - gai", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gai",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent`
+    );
+  });
+
+  test("platform endpoint - gai apiVersion", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gai",
+      apiVersion: "v1alpha",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://generativelanguage.googleapis.com/v1alpha/models/gemini-pro:generateContent`
+    );
   });
 
   test("1. Basic request format", async () => {


### PR DESCRIPTION
This is an issue that has gotten raised a few times as people have tried to use `@langchain/google-webauth` instead of `@langchain/google-genai`. For calls to AI Studio, default to using the "v1beta" API Version.

(There is no change when using Vertex or if the user explicitly sets `apiVersion`.)
