### PR TITLE
fix(tavily): Fix unit tests 

### DIFF
--- a/libs/langchain-tavily/src/tests/search.test.ts
+++ b/libs/langchain-tavily/src/tests/search.test.ts
@@ -136,6 +136,7 @@ describe("TavilySearch", () => {
       includeAnswer: false,
       includeRawContent: false,
       includeImageDescriptions: false,
+      chunksPerSource: 3,
     });
 
     expect(result).toEqual(mockResult);
@@ -187,6 +188,7 @@ describe("TavilySearch", () => {
       includeAnswer: false,
       includeRawContent: false,
       includeImageDescriptions: false,
+      chunksPerSource: 3,
     });
   });
 
@@ -238,6 +240,7 @@ describe("TavilySearch", () => {
       includeAnswer: true,
       includeRawContent: true,
       includeImageDescriptions: false,
+      chunksPerSource: 3,
     });
   });
 

--- a/libs/langchain-tavily/src/utils.ts
+++ b/libs/langchain-tavily/src/utils.ts
@@ -293,22 +293,27 @@ abstract class BaseTavilyAPIWrapper {
   /**
    * Converts camelCase keys to snake_case for API compatibility
    * @param params The parameters with camelCase keys
-   * @returns The parameters with snake_case keys
+   * @returns The parameters with snake_case keys only
    */
   protected convertCamelToSnakeCase(
     params: Record<string, unknown>
   ): Record<string, unknown> {
-    return Object.entries(params).reduce((result, [key, value]) => {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(params)) {
       if (value === undefined) {
-        return result;
+        continue;
       }
       // Convert camelCase key to snake_case
       // Handle potential leading capital letter first
       let newKey = key.replace(/^[A-Z]/, (letter) => letter.toLowerCase());
       // Then handle subsequent capital letters
       newKey = newKey.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-      return { ...result, [newKey]: value };
-    }, {} as Record<string, unknown>);
+
+      result[newKey] = value;
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
When trying to create a release for tavily package, i've noticed that recent PR to the @langchain/tavily package created issues with tests: https://github.com/langchain-ai/langchainjs/pull/8081
- the default parameters were not updated with `chunksPerSource`
- adjustment in the camelCase conversion method created regression