### PR TITLE
feat(google-common), feat(core): Improve token counting

### DIFF
--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -46,6 +46,11 @@ export type InputTokenDetails = {
    * Since there was a cache miss, the cache was created from these tokens.
    */
   cache_creation?: number;
+
+  /**
+   * Other, arbitrary, token types can be set with their count
+   */
+  [key: string]: number | undefined;
 };
 
 /**
@@ -66,6 +71,11 @@ export type OutputTokenDetails = {
    * OpenAI's o1 models) that are not returned as part of model output.
    */
   reasoning?: number;
+
+  /**
+   * Other, arbitrary, token types can be set with their count
+   */
+  [key: string]: number | undefined;
 };
 
 /**

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -48,7 +48,7 @@ export type ModalitiesTokenDetails = {
    * e.g. PDF
    */
   document?: number;
-}
+};
 
 /**
  * Breakdown of input token counts.

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -21,17 +21,41 @@ export type AIMessageFields = BaseMessageFields & {
   usage_metadata?: UsageMetadata;
 };
 
+export type ModalitiesTokenDetails = {
+  /**
+   * Text tokens.
+   * Does not need to be reported, but some models will do so.
+   */
+  text?: number;
+
+  /**
+   * Image (non-video) tokens.
+   */
+  image?: number;
+
+  /**
+   * Audio tokens.
+   */
+  audio?: number;
+
+  /**
+   * Video tokens.
+   */
+  video?: number;
+
+  /**
+   * Document tokens.
+   * e.g. PDF
+   */
+  document?: number;
+}
+
 /**
  * Breakdown of input token counts.
  *
  * Does not *need* to sum to full input token count. Does *not* need to have all keys.
  */
-export type InputTokenDetails = {
-  /**
-   * Audio input tokens.
-   */
-  audio?: number;
-
+export type InputTokenDetails = ModalitiesTokenDetails & {
   /**
    * Input tokens that were cached and there was a cache hit.
    *
@@ -46,11 +70,6 @@ export type InputTokenDetails = {
    * Since there was a cache miss, the cache was created from these tokens.
    */
   cache_creation?: number;
-
-  /**
-   * Other, arbitrary, token types can be set with their count
-   */
-  [key: string]: number | undefined;
 };
 
 /**
@@ -58,12 +77,7 @@ export type InputTokenDetails = {
  *
  * Does *not* need to sum to full output token count. Does *not* need to have all keys.
  */
-export type OutputTokenDetails = {
-  /**
-   * Audio output tokens
-   */
-  audio?: number;
-
+export type OutputTokenDetails = ModalitiesTokenDetails & {
   /**
    * Reasoning output tokens.
    *
@@ -71,11 +85,6 @@ export type OutputTokenDetails = {
    * OpenAI's o1 models) that are not returned as part of model output.
    */
   reasoning?: number;
-
-  /**
-   * Other, arbitrary, token types can be set with their count
-   */
-  [key: string]: number | undefined;
 };
 
 /**

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -596,10 +596,39 @@ interface GeminiResponsePromptFeedback {
   safetyRatings: GeminiSafetyRating[];
 }
 
+export type ModalityEnum =
+  | "TEXT"
+  | "IMAGE"
+  | "VIDEO"
+  | "AUDIO"
+  | "DOCUMENT"
+  | string;
+
+export interface ModalityTokenCount {
+  modality: ModalityEnum;
+  tokenCount: number;
+}
+
+export interface GenerateContentResponseUsageMetadata {
+  promptTokenCount: number;
+  toolUsePromptTokenCount: number;
+  cachedContentTokenCount: number;
+  thoughtsTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
+
+  promptTokensDetails: ModalityTokenCount[];
+  toolUsePromptTokensDetails: ModalityTokenCount[];
+  cacheTokensDetails: ModalityTokenCount[];
+  candidatesTokensDetails: ModalityTokenCount[];
+
+  [key: string]: unknown;
+}
+
 export interface GenerateContentResponseData {
   candidates: GeminiResponseCandidate[];
   promptFeedback: GeminiResponsePromptFeedback;
-  usageMetadata: Record<string, unknown>;
+  usageMetadata: GenerateContentResponseUsageMetadata;
 }
 
 export type GoogleLLMModelFamily = null | "palm" | "gemini" | "gemma";

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -20,7 +20,8 @@ import {
   isDataContentBlock,
   convertToProviderContentBlock,
   InputTokenDetails,
-  OutputTokenDetails, ModalitiesTokenDetails,
+  OutputTokenDetails,
+  ModalitiesTokenDetails,
 } from "@langchain/core/messages";
 import {
   ChatGeneration,
@@ -864,7 +865,8 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   ): void {
     modalityTokenCounts?.forEach((modalityTokenCount) => {
       const { modality, tokenCount } = modalityTokenCount;
-      const modalityLc: keyof ModalitiesTokenDetails = modality.toLowerCase() as keyof ModalitiesTokenDetails;
+      const modalityLc: keyof ModalitiesTokenDetails =
+        modality.toLowerCase() as keyof ModalitiesTokenDetails;
       const currentCount = details[modalityLc] ?? 0;
       // eslint-disable-next-line no-param-reassign
       details[modalityLc] = currentCount + tokenCount;

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -20,7 +20,7 @@ import {
   isDataContentBlock,
   convertToProviderContentBlock,
   InputTokenDetails,
-  OutputTokenDetails,
+  OutputTokenDetails, ModalitiesTokenDetails,
 } from "@langchain/core/messages";
 import {
   ChatGeneration,
@@ -864,7 +864,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   ): void {
     modalityTokenCounts?.forEach((modalityTokenCount) => {
       const { modality, tokenCount } = modalityTokenCount;
-      const modalityLc = modality.toLowerCase();
+      const modalityLc: keyof ModalitiesTokenDetails = modality.toLowerCase() as keyof ModalitiesTokenDetails;
       const currentCount = details[modalityLc] ?? 0;
       // eslint-disable-next-line no-param-reassign
       details[modalityLc] = currentCount + tokenCount;
@@ -893,7 +893,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         usageMetadata?.candidatesTokensDetails,
         output_token_details
       );
-      if (usageMetadata?.thoughtsTokenCount) {
+      if (typeof usageMetadata?.thoughtsTokenCount === "number") {
         output_token_details.reasoning = usageMetadata.thoughtsTokenCount;
       }
 

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -19,6 +19,8 @@ import {
   parseBase64DataUrl,
   isDataContentBlock,
   convertToProviderContentBlock,
+  InputTokenDetails,
+  OutputTokenDetails,
 } from "@langchain/core/messages";
 import {
   ChatGeneration,
@@ -47,6 +49,7 @@ import type {
   GeminiLogprobsResult,
   GeminiLogprobsResultCandidate,
   GeminiLogprobsTopCandidate,
+  ModalityTokenCount,
 } from "../types.js";
 import { GoogleAISafetyError } from "./safety.js";
 import { MediaBlob } from "../experimental/utils/media_core.js";
@@ -855,6 +858,57 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     };
   }
 
+  function addModalityCounts(
+    modalityTokenCounts: ModalityTokenCount[],
+    details: InputTokenDetails | OutputTokenDetails
+  ): void {
+    modalityTokenCounts?.forEach((modalityTokenCount) => {
+      const { modality, tokenCount } = modalityTokenCount;
+      const modalityLc = modality.toLowerCase();
+      const currentCount = details[modalityLc] ?? 0;
+      // eslint-disable-next-line no-param-reassign
+      details[modalityLc] = currentCount + tokenCount;
+    });
+  }
+
+  function responseToUsageMetadata(
+    response: GoogleLLMResponse
+  ): UsageMetadata | undefined {
+    if ("usageMetadata" in response.data) {
+      const data: GenerateContentResponseData = response?.data;
+      const usageMetadata = data?.usageMetadata;
+
+      const input_tokens = usageMetadata.promptTokenCount ?? 0;
+      const candidatesTokenCount = usageMetadata.candidatesTokenCount ?? 0;
+      const thoughtsTokenCount = usageMetadata.thoughtsTokenCount ?? 0;
+      const output_tokens = candidatesTokenCount + thoughtsTokenCount;
+      const total_tokens =
+        usageMetadata.totalTokenCount ?? input_tokens + output_tokens;
+
+      const input_token_details: InputTokenDetails = {};
+      addModalityCounts(usageMetadata.promptTokensDetails, input_token_details);
+
+      const output_token_details: OutputTokenDetails = {};
+      addModalityCounts(
+        usageMetadata?.candidatesTokensDetails,
+        output_token_details
+      );
+      if (usageMetadata?.thoughtsTokenCount) {
+        output_token_details.reasoning = usageMetadata.thoughtsTokenCount;
+      }
+
+      const ret: UsageMetadata = {
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        input_token_details,
+        output_token_details,
+      };
+      return ret;
+    }
+    return undefined;
+  }
+
   function responseToGenerationInfo(response: GoogleLLMResponse) {
     const data =
       // eslint-disable-next-line no-nested-ternary
@@ -890,11 +944,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     // Only add the usage_metadata on the last chunk
     // sent while streaming (see issue 8102).
     if (typeof finish_reason === "string") {
-      ret.usage_metadata = {
-        prompt_token_count: data.usageMetadata?.promptTokenCount,
-        candidates_token_count: data.usageMetadata?.candidatesTokenCount,
-        total_token_count: data.usageMetadata?.totalTokenCount,
-      };
+      ret.usage_metadata = responseToUsageMetadata(response);
     }
 
     return ret;
@@ -1115,15 +1165,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     const lastContent = gen.content[gen.content.length - 1];
 
     // Add usage metadata
-    let usageMetadata: UsageMetadata | undefined;
-    if ("usageMetadata" in response.data) {
-      usageMetadata = {
-        input_tokens: response.data.usageMetadata.promptTokenCount as number,
-        output_tokens: response.data.usageMetadata
-          .candidatesTokenCount as number,
-        total_tokens: response.data.usageMetadata.totalTokenCount as number,
-      };
-    }
+    const usage_metadata = responseToUsageMetadata(response);
 
     // Add thinking / reasoning
     // if (gen.reasoning && gen.reasoning.length > 0) {
@@ -1134,7 +1176,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     const message = new AIMessageChunk({
       content: combinedContent,
       additional_kwargs: kwargs,
-      usage_metadata: usageMetadata,
+      usage_metadata,
       tool_calls: combinedToolCalls.tool_calls,
       invalid_tool_calls: combinedToolCalls.invalid_tool_calls,
     });

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -39,8 +39,10 @@ import { ChatGoogle, ChatGoogleInput } from "../chat_models.js";
 import { BlobStoreAIStudioFile } from "../media.js";
 import MockedFunction = jest.MockedFunction;
 
-function propSum(o: Record<string,number>): number {
-  return Object.keys(o).map(key => o[key]).reduce((acc, val) => acc+val);
+function propSum(o: Record<string, number>): number {
+  return Object.keys(o)
+    .map((key) => o[key])
+    .reduce((acc, val) => acc + val);
 }
 
 class WeatherTool extends StructuredTool {

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -39,6 +39,10 @@ import { ChatGoogle, ChatGoogleInput } from "../chat_models.js";
 import { BlobStoreAIStudioFile } from "../media.js";
 import MockedFunction = jest.MockedFunction;
 
+function propSum(o: Record<string,number>): number {
+  return Object.keys(o).map(key => o[key]).reduce((acc, val) => acc+val);
+}
+
 class WeatherTool extends StructuredTool {
   schema = z.object({
     locations: z
@@ -442,10 +446,16 @@ describe.each(testGeminiModelNames)(
       expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
 
       expect(res).toHaveProperty("response_metadata");
-      expect(res.response_metadata).not.toHaveProperty("groundingMetadata");
-      expect(res.response_metadata).not.toHaveProperty("groundingSupport");
+      const meta = res.response_metadata;
+      expect(meta).not.toHaveProperty("groundingMetadata");
+      expect(meta).not.toHaveProperty("groundingSupport");
+      expect(meta).toHaveProperty("usage_metadata");
+      const usage = meta.usage_metadata;
 
-      console.log(recorder);
+      // Although LangChainJS doesn't require that the details sum to the
+      // available tokens, this should be the case for how we're doing Gemini.
+      expect(propSum(usage.input_token_details)).toEqual(usage.input_tokens);
+      expect(propSum(usage.output_token_details)).toEqual(usage.output_tokens);
     });
 
     test(`generate`, async () => {
@@ -883,6 +893,21 @@ describe.each(testGeminiModelNames)(
 
       expect(typeof response.content).toBe("string");
       expect((response.content as string).length).toBeGreaterThan(15);
+
+      expect(response).toHaveProperty("response_metadata");
+      const meta = response.response_metadata;
+      expect(meta).not.toHaveProperty("groundingMetadata");
+      expect(meta).not.toHaveProperty("groundingSupport");
+      expect(meta).toHaveProperty("usage_metadata");
+      const usage = meta.usage_metadata;
+
+      // Although LangChainJS doesn't require that the details sum to the
+      // available tokens, this should be the case for how we're doing Gemini.
+      expect(propSum(usage.input_token_details)).toEqual(usage.input_tokens);
+      expect(propSum(usage.output_token_details)).toEqual(usage.output_tokens);
+      expect(usage.input_token_details).toHaveProperty("audio");
+
+      console.log(response);
     });
 
     test("Supports GoogleSearchRetrievalTool", async () => {


### PR DESCRIPTION
***Note that this includes changes in langchain-core***

Done:
* Changes to `InputTokenDetails` and `OutputTokenDetails` that split out the common modalities field into a new type. Added several modalities based on those available from Gemini.
* Changes in Gemini output processing to handle "thinking" token count, which is not included in the output token count.
* Add the modalities/details from Gemini to the token details
* Tests
  * Note that some tests fail because of a bug in the AI Studio API. I'm working with Google to resolve.

Fixes #8127 
