### PR TITLE
fix(community): mark Azure blob storage connection string as secrets

### DIFF
--- a/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
+++ b/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
@@ -1,5 +1,6 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import { Document } from "@langchain/core/documents";
+import { Serializable } from "@langchain/core/load/serializable";
 import { BaseDocumentLoader } from "@langchain/core/document_loaders/base";
 import { AzureBlobStorageFileLoader } from "./azure_blob_storage_file.js";
 import { UnstructuredLoaderOptions } from "../fs/unstructured.js";
@@ -32,6 +33,13 @@ interface AzureBlobStorageContainerLoaderConfig {
  * Blob Storage container. It extends the BaseDocumentLoader class.
  */
 export class AzureBlobStorageContainerLoader extends BaseDocumentLoader {
+
+  get lc_secrets(): { [key: string]: string } {
+    return {
+      connectionString: "AZURE_BLOB_CONNECTION_STRING",
+    };
+  }
+
   private readonly connectionString: string;
 
   private readonly container: string;

--- a/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
+++ b/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
@@ -1,6 +1,5 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import { Document } from "@langchain/core/documents";
-import { Serializable } from "@langchain/core/load/serializable";
 import { BaseDocumentLoader } from "@langchain/core/document_loaders/base";
 import { AzureBlobStorageFileLoader } from "./azure_blob_storage_file.js";
 import { UnstructuredLoaderOptions } from "../fs/unstructured.js";

--- a/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
+++ b/libs/langchain-community/src/document_loaders/web/azure_blob_storage_container.ts
@@ -32,7 +32,6 @@ interface AzureBlobStorageContainerLoaderConfig {
  * Blob Storage container. It extends the BaseDocumentLoader class.
  */
 export class AzureBlobStorageContainerLoader extends BaseDocumentLoader {
-
   get lc_secrets(): { [key: string]: string } {
     return {
       connectionString: "AZURE_BLOB_CONNECTION_STRING",

--- a/libs/langchain-community/src/document_loaders/web/azure_blob_storage_file.ts
+++ b/libs/langchain-community/src/document_loaders/web/azure_blob_storage_file.ts
@@ -45,6 +45,13 @@ interface AzureBlobStorageFileLoaderConfig {
  * ```
  */
 export class AzureBlobStorageFileLoader extends BaseDocumentLoader {
+
+  get lc_secrets(): { [key: string]: string } {
+    return {
+      connectionString: "AZURE_BLOB_CONNECTION_STRING",
+    };
+  }
+
   private readonly connectionString: string;
 
   private readonly container: string;

--- a/libs/langchain-community/src/document_loaders/web/azure_blob_storage_file.ts
+++ b/libs/langchain-community/src/document_loaders/web/azure_blob_storage_file.ts
@@ -45,7 +45,6 @@ interface AzureBlobStorageFileLoaderConfig {
  * ```
  */
 export class AzureBlobStorageFileLoader extends BaseDocumentLoader {
-
   get lc_secrets(): { [key: string]: string } {
     return {
       connectionString: "AZURE_BLOB_CONNECTION_STRING",


### PR DESCRIPTION
Make sure connection string is hidden when serialization occurs