### PR TITLE
docs: add unreachable node docs

### DIFF
--- a/docs/core_docs/docs/troubleshooting/errors/UNREACHABLE_NODE.mdx
+++ b/docs/core_docs/docs/troubleshooting/errors/UNREACHABLE_NODE.mdx
@@ -1,0 +1,54 @@
+# UNREACHABLE_NODE
+
+LangGraph cannot identify an incoming edge to one of your nodes. Check to ensure you have added sufficient edges when constructing your graph.
+
+Alternatively, if you are returning [`Command`](/docs/how_to/command/) instances from your nodes to make your graphs edgeless, you will need to add an additional `ends` parameter when calling `addNode` to help LangGraph determine the destinations for your node.
+
+Here's an example:
+
+```typescript
+import { Annotation, Command } from "@langchain/langgraph";
+
+const StateAnnotation = Annotation.Root({
+  foo: Annotation<string>,
+});
+
+const nodeA = async (_state: typeof StateAnnotation.State) => {
+  const goto = Math.random() > 0.5 ? "nodeB" : "nodeC";
+  return new Command({
+    update: { foo: "a" },
+    goto,
+  });
+};
+
+const nodeB = async (state: typeof StateAnnotation.State) => {
+  return {
+    foo: state.foo + "|b",
+  };
+};
+
+const nodeC = async (state: typeof StateAnnotation.State) => {
+  return {
+    foo: state.foo + "|c",
+  };
+};
+
+import { StateGraph } from "@langchain/langgraph";
+
+// NOTE: there are no edges between nodes A, B and C!
+const graph = new StateGraph(StateAnnotation)
+  .addNode("nodeA", nodeA, {
+    // Explicitly specify "nodeB" and "nodeC" as potential destinations for nodeA
+    ends: ["nodeB", "nodeC"],
+  })
+  .addNode("nodeB", nodeB)
+  .addNode("nodeC", nodeC)
+  .addEdge("__start__", "nodeA")
+  .compile();
+```
+
+## Troubleshooting
+
+- Make sure that you have not forgotten to add edges between some of your nodes.
+
+- If you are returning Commands from your nodes, make sure that you're passing an ends array with the names of potential destination nodes as shown above.


### PR DESCRIPTION
I got this error when I forgot to add an edge to my StateGraph:

<img width="969" alt="image" src="https://github.com/user-attachments/assets/bd8e7c48-7c74-4f73-9cb1-082df6e13fd0" />

But this page does not exits: https://js.langchain.com/docs/troubleshooting/errors/UNREACHABLE_NODE/

### Copilot summary

This pull request adds a new troubleshooting guide for the `UNREACHABLE_NODE` error in the LangGraph documentation. The guide explains the error, provides an example of how to resolve it using the `ends` parameter, and offers additional troubleshooting tips.

Documentation changes:

* [`docs/core_docs/docs/troubleshooting/errors/UNREACHABLE_NODE.mdx`](diffhunk://#diff-69c71c84cab1adc24094bfbc5166dbc96d4e6907c3c66ac4e941d52851ca6e77R1-R54): Added a detailed explanation of the `UNREACHABLE_NODE` error, including an example of using the `ends` parameter in the `addNode` method to specify potential destinations for edgeless graphs. Also included general troubleshooting advice for ensuring proper graph construction.
