### PR TITLE
fix(redis): handle both numDocs and num_docs in RedisVectorStore

### DIFF
--- a/libs/langchain-community/src/vectorstores/redis.ts
+++ b/libs/langchain-community/src/vectorstores/redis.ts
@@ -196,7 +196,7 @@ export class RedisVectorStore extends VectorStore {
     await this.createIndex(vectors[0].length);
 
     const info = await this.redisClient.ft.info(this.indexName);
-    const lastKeyCount = parseInt(info.numDocs, 10) || 0;
+    const lastKeyCount = parseInt(info.numDocs || info.num_docs, 10) || 0;
     const multi = this.redisClient.multi();
 
     vectors.map(async (vector, idx) => {

--- a/libs/langchain-redis/src/vectorstores.ts
+++ b/libs/langchain-redis/src/vectorstores.ts
@@ -193,7 +193,7 @@ export class RedisVectorStore extends VectorStore {
     await this.createIndex(vectors[0].length);
 
     const info = await this.redisClient.ft.info(this.indexName);
-    const lastKeyCount = parseInt(info.numDocs, 10) || 0;
+    const lastKeyCount = parseInt(info.numDocs || info.num_docs, 10) || 0;
     const multi = this.redisClient.multi();
 
     vectors.map(async (vector, idx) => {


### PR DESCRIPTION
The redis store do not use the correct name for the field numDocs

Some other redis conector may convert snake case to camelcase, so I keep the two syntax.

the official redis client use the snake case.

https://github.com/redis/node-redis/blob/bb7845dfe39e385d9e02966d54efb211addb79e0/packages/search/lib/commands/INFO.ts#L25

