### PR TITLE
fix(aws): handle image_url object format in block type extraction

### DIFF
--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -297,7 +297,7 @@ function convertLangChainContentBlockToConverseContentBlock<
   }
 
   if (block.type === "image_url") {
-    return extractImageInfo(block.image_url);
+    return extractImageInfo(typeof block.image_url === "string" ? block.image_url : block.image_url.url);
   }
 
   if (block.type === "document" && block.document !== undefined) {

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -297,7 +297,11 @@ function convertLangChainContentBlockToConverseContentBlock<
   }
 
   if (block.type === "image_url") {
-    return extractImageInfo(typeof block.image_url === "string" ? block.image_url : block.image_url.url);
+    return extractImageInfo(
+      typeof block.image_url === "string"
+        ? block.image_url
+        : block.image_url.url
+    );
   }
 
   if (block.type === "document" && block.document !== undefined) {


### PR DESCRIPTION
It looks like with the current version, a small bug was introduced: after the recent refactoring, the handling of image_url was changed to assume it's always a string. However, image_url can also be an object with a url property, which seems to be causing errors. I'm reintroducing the previous logic to handle both cases properly