### PR TITLE
fix(gemini-common): Allow reasoning to be turned off by setting maxReasoningTokens to 0.

### DIFF
--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1422,10 +1422,8 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     }
 
     // Add thinking configuration if explicitly set
-    if (
-      typeof parameters.maxReasoningTokens !== "undefined" &&
-      parameters.maxReasoningTokens !== 0
-    ) {
+    // Note that you cannot have thinkingBudget set to 0 and includeThoughts true
+    if (typeof parameters.maxReasoningTokens !== "undefined") {
       ret.thinkingConfig = {
         thinkingBudget: parameters.maxReasoningTokens,
         // TODO: Expose this configuration to the user once google fully supports it

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -357,12 +357,12 @@ const testGeminiModelNames = [
     apiVersion: "v1",
   },
   {
-    modelName: "gemini-2.5-pro-exp-03-25",
+    modelName: "gemini-2.5-pro-preview-05-06",
     platformType: "gai",
     apiVersion: "v1beta",
   },
   {
-    modelName: "gemini-2.5-pro-exp-03-25",
+    modelName: "gemini-2.5-pro-preview-05-06",
     platformType: "gcp",
     apiVersion: "v1",
   },
@@ -380,6 +380,7 @@ const testGeminiModelDelay: Record<string, number> = {
   "gemini-2.0-flash-exp": 10000,
   "gemini-2.0-flash-thinking-exp-1219": 10000,
   "gemini-2.5-pro-exp-03-25": 10000,
+  "gemini-2.5-pro-preview-05-06": 10000,
   "gemini-2.5-flash-preview-04-17": 10000,
 };
 
@@ -1007,6 +1008,11 @@ describe.each(testGeminiModelNames)(
       );
       console.log(res);
       expect(res.content).toMatch(/^1\/6/);
+      expect(res).toHaveProperty("usage_metadata");
+      expect(res.usage_metadata).toHaveProperty("output_token_details");
+      expect(res.usage_metadata!.output_token_details).not.toHaveProperty(
+        "reasoning"
+      );
     });
   }
 );


### PR DESCRIPTION
Fix logic check for when to include `thinkingConfig` in the generation config.
Add test to confirm reasoning can be turned off.
Change Gemini 2.5 Pro model to latest preview.

Fixes #8145 
