### PR TITLE
fix(google-genai): convertAuthorToRole: add support for agent names

### DIFF
--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -74,7 +74,9 @@ export function convertAuthorToRole(
     case "function":
       return "function";
     default:
-      throw new Error(`Unknown / unsupported author: ${author}`);
+      // When using supervisor or swarm, the author will be the name of the agent
+      // and the role must be "system"
+      return "system";
   }
 }
 


### PR DESCRIPTION
When using supervisor or swarm, the current implementation throws `Unknown / unsupported author: <agent_name>` because the author is the name of the agent.

https://github.com/langchain-ai/langchainjs/issues/8126