### PR TITLE
fix(langchain): vertex ai model name pulled from hub

### DIFF
--- a/langchain/src/hub/base.ts
+++ b/langchain/src/hub/base.ts
@@ -106,7 +106,7 @@ export function generateModelImportMap(
       importMapKey = "chat_models__anthropic";
     } else if (modelLcName === "ChatAzureOpenAI") {
       importMapKey = "chat_models__openai";
-    } else if (modelLcName === "ChatGoogleVertexAI") {
+    } else if (modelLcName === "ChatVertexAI") {
       importMapKey = "chat_models__vertexai";
     } else if (modelLcName === "ChatGoogleGenerativeAI") {
       importMapKey = "chat_models__google_genai";

--- a/langchain/src/hub/node.ts
+++ b/langchain/src/hub/node.ts
@@ -41,7 +41,7 @@ export async function pull<T extends Runnable>(
         modelClass = (await import("@langchain/anthropic")).ChatAnthropic;
       } else if (modelName === "ChatAzureOpenAI") {
         modelClass = (await import("@langchain/openai")).AzureChatOpenAI;
-      } else if (modelName === "ChatGoogleVertexAI") {
+      } else if (modelName === "ChatVertexAI") {
         modelClass = (await import("@langchain/google-vertexai")).ChatVertexAI;
       } else if (modelName === "ChatGoogleGenerativeAI") {
         modelClass = (await import("@langchain/google-genai"))

--- a/libs/langchain-google-vertexai-web/src/chat_models.ts
+++ b/libs/langchain-google-vertexai-web/src/chat_models.ts
@@ -17,7 +17,7 @@ export interface ChatVertexAIInput extends ChatGoogleInput {}
  * export GOOGLE_VERTEX_AI_WEB_CREDENTIALS={"type":"service_account","project_id":"YOUR_PROJECT-12345",...}
  * ```
  *
- * ## [Constructor args](https://api.js.langchain.com/classes/langchain_community_chat_models_googlevertexai_web.ChatGoogleVertexAI.html#constructor)
+ * ## [Constructor args](https://api.js.langchain.com/classes/_langchain_google_vertexai_web.index.ChatVertexAI.html#constructor)
  *
  * ## [Runtime args](https://api.js.langchain.com/interfaces/langchain_google_common_types.GoogleAIBaseLanguageModelCallOptions.html)
  *

--- a/libs/langchain-google-vertexai/src/chat_models.ts
+++ b/libs/langchain-google-vertexai/src/chat_models.ts
@@ -17,7 +17,7 @@ export interface ChatVertexAIInput extends ChatGoogleInput {}
  * export GOOGLE_APPLICATION_CREDENTIALS="path/to/credentials"
  * ```
  *
- * ## [Constructor args](https://api.js.langchain.com/classes/langchain_community_chat_models_googlevertexai_web.ChatGoogleVertexAI.html#constructor)
+ * ## [Constructor args](https://api.js.langchain.com/classes/_langchain_google_vertexai.index.ChatVertexAI.html#constructor.new_ChatVertexAI)
  *
  * ## [Runtime args](https://api.js.langchain.com/interfaces/langchain_google_common_types.GoogleAIBaseLanguageModelCallOptions.html)
  *


### PR DESCRIPTION
Fixes # (https://github.com/langchain-ai/langchainjs/issues/8136)

1. `ChatGoogleVertexAI` was incorrect and should be `ChatVertexAI`
2. Fixed langchain doc urls
