### PR TITLE
feat: chaining of methods

### DIFF
--- a/langchain-core/src/utils/testing/tests/binding-tools.test.ts
+++ b/langchain-core/src/utils/testing/tests/binding-tools.test.ts
@@ -1,0 +1,64 @@
+import * as z from "zod";
+import { tool } from "../../../tools/index.js";
+import { FakeChatModel } from "../index.js";
+import { BaseChatModelCallOptions, BindToolsInput } from "../../../language_models/chat_models.js";
+
+
+class FakeChatModelWithBindTools extends FakeChatModel {
+
+  override bindTools(
+      tools: BindToolsInput[],
+      kwargs?: Partial<BaseChatModelCallOptions>
+    ) {
+      return this.bind({
+        tools,
+        ...kwargs,
+      } as Partial<BaseChatModelCallOptions>);
+    }
+
+  override withConfig(
+    config: Partial<BaseChatModelCallOptions>
+  ) {
+    const configuredModel = super.withConfig(config);
+
+    // Add bindTools method to the configured model
+    if (!('bindTools' in configuredModel)) {
+      Object.defineProperty(configuredModel, 'bindTools',() => {
+          return this.withConfig(config);
+        });
+    }
+
+    return configuredModel;
+  }
+  }
+
+
+describe("binding tools", () => {
+  it("should bind tools to a function", async () => {
+    const model = new FakeChatModelWithBindTools({});
+
+    const echoTool = tool((input) => String(input), {
+      name: "echo",
+      description: "Echos the input",
+      schema: z.string(),
+    });
+    
+    const config = {
+      stop: ["stop"],
+    };
+    
+    const tools = [echoTool];
+
+    // @ts-expect-error Property 'bindTools' is being added through withConfig
+    const configuredBoundModel = model.withConfig(config).bindTools(tools);
+    const boundConfiguredModel = model.bindTools(tools).withConfig(config);
+  
+    const configuredBoundModelResult = await configuredBoundModel
+      .invoke("Any arbitrary input");
+    const boundConfiguredModelResult = await boundConfiguredModel
+      .invoke("Any arbitrary input");
+    
+    expect(configuredBoundModelResult.content).toEqual(boundConfiguredModelResult.content);
+
+  });
+});

--- a/langchain-core/src/utils/testing/tests/binding-tools.test.ts
+++ b/langchain-core/src/utils/testing/tests/binding-tools.test.ts
@@ -1,10 +1,19 @@
 import * as z from "zod";
 import { tool } from "../../../tools/index.js";
 import { FakeChatModel } from "../index.js";
-import { BaseChatModelCallOptions, BindToolsInput } from "../../../language_models/chat_models.js";
+import { BaseChatModelCallOptions, BaseChatModelParams, BindToolsInput } from "../../../language_models/chat_models.js";
+import { BaseLanguageModelInput } from "../../../language_models/base.js";
 
 
 class FakeChatModelWithBindTools extends FakeChatModel {
+  private _boundConfig?: Partial<BaseChatModelCallOptions>;
+
+  constructor(fields: BaseChatModelParams & { config?: Partial<BaseChatModelCallOptions> }) {
+    super(fields);
+    if (fields.config) {
+      this._boundConfig = { ...fields.config };
+    }
+  }
 
   override bindTools(
       tools: BindToolsInput[],
@@ -15,50 +24,103 @@ class FakeChatModelWithBindTools extends FakeChatModel {
         ...kwargs,
       } as Partial<BaseChatModelCallOptions>);
     }
+  // Implementation from BindingRunnable
+  // withConfig(
+  //   config: RunnableConfig
+  // ): Runnable<RunInput, RunOutput, CallOptions> {
+  //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //   return new (this.constructor as any)({
+  //     bound: this.bound,
+  //     kwargs: this.kwargs,
+  //     config: { ...this.config, ...config },
+  //   });
+  // }
 
-  override withConfig(
-    config: Partial<BaseChatModelCallOptions>
-  ) {
-    const configuredModel = super.withConfig(config);
-
-    // Add bindTools method to the configured model
-    if (!('bindTools' in configuredModel)) {
-      Object.defineProperty(configuredModel, 'bindTools',() => {
-          return this.withConfig(config);
-        });
-    }
-
-    return configuredModel;
+  // Returns new model of the same type, with the config merged
+  override withConfig(config: Partial<BaseChatModelCallOptions>) {
+    const mergedConfig = { ...(this._boundConfig ?? {}), ...config };
+    const newFields = { ...this, config: mergedConfig };
+    const newModel = new FakeChatModelWithBindTools(newFields);
+    newModel._boundConfig = mergedConfig;
+    return newModel;
   }
+
+  override async invoke(input: BaseLanguageModelInput, config?: Partial<BaseChatModelCallOptions>) {
+    const mergedConfig = { ...(this._boundConfig ?? {}), ...(config ?? {}) };
+
+    return super.invoke(input, mergedConfig);
   }
+}
 
 
 describe("binding tools", () => {
-  it("should bind tools to a function", async () => {
+  it("should bind tools to a function and store them in the model", () => {
+    // Arrange
     const model = new FakeChatModelWithBindTools({});
-
     const echoTool = tool((input) => String(input), {
       name: "echo",
       description: "Echos the input",
       schema: z.string(),
     });
-    
-    const config = {
-      stop: ["stop"],
-    };
-    
     const tools = [echoTool];
 
-    // @ts-expect-error Property 'bindTools' is being added through withConfig
+    // Act
+    const boundModel = model.bindTools(tools);
+
+    // Assert
+    // @ts-expect-error - types
+    expect(boundModel.kwargs?.tools).toBeDefined();
+    // @ts-expect-error - types
+    expect(boundModel.kwargs?.tools.length).toBe(1);
+    // @ts-expect-error - types
+    expect(boundModel.kwargs?.tools[0].name).toBe("echo");
+  });
+
+  it("should bind tools to a function and return same content result", async () => {
+    // Arrange
+    const model = new FakeChatModelWithBindTools({});
+    const echoTool = tool((input) => String(input), {
+      name: "echo",
+      description: "Echos the input",
+      schema: z.string(),
+    });
+    const config = { stop: ["stop"] };
+    const input = "Any arbitrary input";
+    const tools = [echoTool];
+
     const configuredBoundModel = model.withConfig(config).bindTools(tools);
     const boundConfiguredModel = model.bindTools(tools).withConfig(config);
-  
-    const configuredBoundModelResult = await configuredBoundModel
-      .invoke("Any arbitrary input");
-    const boundConfiguredModelResult = await boundConfiguredModel
-      .invoke("Any arbitrary input");
-    
-    expect(configuredBoundModelResult.content).toEqual(boundConfiguredModelResult.content);
 
+
+    // @ts-expect-error - types
+    expect(configuredBoundModel.kwargs?.tools).toBeDefined();
+    // @ts-expect-error - types
+    expect(configuredBoundModel.kwargs?.tools.length).toBe(1);
+    // @ts-expect-error - types
+    expect(configuredBoundModel.kwargs?.tools[0].name).toBe("echo");
+    // @ts-expect-error - types
+    expect(configuredBoundModel.kwargs?.tools[0].name).toEqual(boundConfiguredModel.kwargs?.tools[0].name);
+
+  });
+
+  it("should return the same content result regardless of bind/config order", async () => {
+    
+    const model = new FakeChatModelWithBindTools({});
+    const echoTool = tool((input) => String(input), {
+      name: "echo",
+      description: "Echos the input",
+      schema: z.string(),
+    });
+    const config = { stop: ["stop"] };
+    const input = "Any arbitrary input";
+    const tools = [echoTool];
+
+    const configuredBoundModel = model.withConfig(config).bindTools(tools);
+    const boundConfiguredModel = model.bindTools(tools).withConfig(config);
+
+    const configuredBoundModelResult = await configuredBoundModel.invoke(input);
+    const boundConfiguredModelResult = await boundConfiguredModel.invoke(input);
+
+    expect(configuredBoundModelResult.content).toEqual(boundConfiguredModelResult.content);
   });
 });

--- a/langchain-core/src/utils/testing/tests/binding-tools.test.ts
+++ b/langchain-core/src/utils/testing/tests/binding-tools.test.ts
@@ -29,17 +29,6 @@ class FakeChatModelWithBindTools extends FakeChatModel {
         ...kwargs,
       } as Partial<BaseChatModelCallOptions>);
     }
-  // Implementation from BindingRunnable
-  // withConfig(
-  //   config: RunnableConfig
-  // ): Runnable<RunInput, RunOutput, CallOptions> {
-  //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  //   return new (this.constructor as any)({
-  //     bound: this.bound,
-  //     kwargs: this.kwargs,
-  //     config: { ...this.config, ...config },
-  //   });
-  // }
 
   // Returns new model of the same type, with the config merged
   override withConfig(config: Partial<BaseChatModelCallOptions>) {

--- a/langchain-core/src/utils/testing/tests/binding-tools.test.ts
+++ b/langchain-core/src/utils/testing/tests/binding-tools.test.ts
@@ -49,7 +49,7 @@ class FakeChatModelWithBindTools extends FakeChatModel {
 
 
 describe("binding tools", () => {
-  it("should bind tools to a function and return same content result", async () => {
+  it("should bind tools and store them in the model regardless of bind/config order", async () => {
     const model = new FakeChatModelWithBindTools({});
     const echoTool = tool((input) => String(input), {
       name: "echo",
@@ -57,7 +57,6 @@ describe("binding tools", () => {
       schema: z.string(),
     });
     const config = { stop: ["stop"] };
-    const input = "Any arbitrary input";
     const tools = [echoTool];
 
     const configuredBoundModel = model.withConfig(config).bindTools(tools);

--- a/langchain-core/src/utils/testing/tests/binding-tools.test.ts
+++ b/langchain-core/src/utils/testing/tests/binding-tools.test.ts
@@ -36,11 +36,8 @@ class FakeChatModelWithBindTools extends FakeChatModel {
     const mergedConfig = this.mergeConfig(config);
     const newFields = { ...this, config: mergedConfig };
 
-    const newModel = new FakeChatModelWithBindTools(newFields);
-
-    newModel._boundConfig = mergedConfig;
-
-    return newModel;
+    // eslint-disable-next-line
+    return new (this.constructor as any)(newFields);
   }
 
   override async invoke(input: BaseLanguageModelInput, config?: Partial<BaseChatModelCallOptions>) {
@@ -52,30 +49,7 @@ class FakeChatModelWithBindTools extends FakeChatModel {
 
 
 describe("binding tools", () => {
-  it("should bind tools to a function and store them in the model", () => {
-    // Arrange
-    const model = new FakeChatModelWithBindTools({});
-    const echoTool = tool((input) => String(input), {
-      name: "echo",
-      description: "Echos the input",
-      schema: z.string(),
-    });
-    const tools = [echoTool];
-
-    // Act
-    const boundModel = model.bindTools(tools);
-
-    // Assert
-    // @ts-expect-error - types
-    expect(boundModel.kwargs?.tools).toBeDefined();
-    // @ts-expect-error - types
-    expect(boundModel.kwargs?.tools.length).toBe(1);
-    // @ts-expect-error - types
-    expect(boundModel.kwargs?.tools[0].name).toBe("echo");
-  });
-
   it("should bind tools to a function and return same content result", async () => {
-    // Arrange
     const model = new FakeChatModelWithBindTools({});
     const echoTool = tool((input) => String(input), {
       name: "echo",
@@ -90,13 +64,9 @@ describe("binding tools", () => {
     const boundConfiguredModel = model.bindTools(tools).withConfig(config);
 
 
-    // @ts-expect-error - types
     expect(configuredBoundModel.kwargs?.tools).toBeDefined();
-    // @ts-expect-error - types
     expect(configuredBoundModel.kwargs?.tools.length).toBe(1);
-    // @ts-expect-error - types
     expect(configuredBoundModel.kwargs?.tools[0].name).toBe("echo");
-    // @ts-expect-error - types
     expect(configuredBoundModel.kwargs?.tools[0].name).toEqual(boundConfiguredModel.kwargs?.tools[0].name);
 
   });


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

The core idea is to override methods like `withConfig` so they always return a new instance of model class they were invoked in, allowing us to chain model-specific methods and always have access to all model-specific functionality.
