### PR TITLE
feat(google): Assorted updates and tests from recent announcements

### DIFF
--- a/libs/langchain-google-common/src/chat_models.ts
+++ b/libs/langchain-google-common/src/chat_models.ts
@@ -196,6 +196,8 @@ export abstract class ChatGoogleBase<AuthOptions>
 
   topK: number;
 
+  seed: number;
+
   presencePenalty: number;
 
   frequencyPenalty: number;

--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -165,11 +165,24 @@ export abstract class GoogleHostConnection<
     super(caller, client, streaming);
     this.caller = caller;
 
-    this.platformType = fields?.platformType;
+    this.platformType = this.fieldPlatformType(fields);
     this._endpoint = fields?.endpoint;
     this._location = fields?.location;
     this._apiVersion = fields?.apiVersion;
     this.client = client;
+  }
+
+  fieldPlatformType(fields: GoogleConnectionParams<any> | undefined): GooglePlatformType | undefined {
+    if (typeof fields === "undefined") {
+      return undefined;
+    }
+    if (typeof fields.platformType !== "undefined") {
+      return fields.platformType;
+    }
+    if (fields.vertexai === true) {
+      return "gcp";
+    }
+    return undefined;
   }
 
   get platform(): GooglePlatformType {
@@ -296,6 +309,18 @@ export abstract class GoogleAIConnection<
 
   get isApiKey(): boolean {
     return this.client.clientType === "apiKey";
+  }
+
+
+  fieldPlatformType(fields: GoogleConnectionParams<any> | undefined): GooglePlatformType | undefined {
+    const ret = super.fieldPlatformType(fields);
+    if (typeof ret !== "undefined") {
+      return ret;
+    }
+    if (fields?.vertexai === false) {
+      return "gai";
+    }
+    return undefined;
   }
 
   get computedPlatformType(): GooglePlatformType {

--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -201,7 +201,11 @@ export abstract class GoogleHostConnection<
   }
 
   get computedEndpoint(): string {
-    return `${this.location}-aiplatform.googleapis.com`;
+    if (this.location === 'global') {
+      return "aiplatform.googleapis.com";
+    } else {
+      return `${this.location}-aiplatform.googleapis.com`;
+    }
   }
 
   buildMethod(): GoogleAbstractedClientOpsMethod {

--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -172,7 +172,9 @@ export abstract class GoogleHostConnection<
     this.client = client;
   }
 
-  fieldPlatformType(fields: GoogleConnectionParams<any> | undefined): GooglePlatformType | undefined {
+  fieldPlatformType(
+    fields: GoogleConnectionParams<any> | undefined
+  ): GooglePlatformType | undefined {
     if (typeof fields === "undefined") {
       return undefined;
     }
@@ -214,7 +216,7 @@ export abstract class GoogleHostConnection<
   }
 
   get computedEndpoint(): string {
-    if (this.location === 'global') {
+    if (this.location === "global") {
       return "aiplatform.googleapis.com";
     } else {
       return `${this.location}-aiplatform.googleapis.com`;
@@ -311,8 +313,9 @@ export abstract class GoogleAIConnection<
     return this.client.clientType === "apiKey";
   }
 
-
-  fieldPlatformType(fields: GoogleConnectionParams<any> | undefined): GooglePlatformType | undefined {
+  fieldPlatformType(
+    fields: GoogleConnectionParams<any> | undefined
+  ): GooglePlatformType | undefined {
     const ret = super.fieldPlatformType(fields);
     if (typeof ret !== "undefined") {
       return ret;

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -173,6 +173,37 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(model.platform).toEqual("gai");
   });
 
+  test("platform vertexai true", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      apiKey: "test",
+      vertexai: true,
+    });
+
+    expect(model.platform).toEqual("gcp");
+  });
+
+  test("platform vertexai false", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      vertexai: false,
+    });
+
+    expect(model.platform).toEqual("gai");
+  });
+
   test("platform endpoint - gcp", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -197,6 +197,56 @@ describe("Mock ChatGoogle - Gemini", () => {
     );
   });
 
+  test("platform endpoint - gcp location", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gcp",
+      location: "luna-central1"
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://luna-central1-aiplatform.googleapis.com/v1/projects/${projectId}/locations/luna-central1/publishers/google/models/gemini-pro:generateContent`
+    );
+  });
+
+  test("platform endpoint - gcp global", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gcp",
+      location: "global",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/global/publishers/google/models/gemini-pro:generateContent`
+    );
+  });
+
   test("platform endpoint - gai", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -669,6 +669,53 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(caught).toBeTruthy();
   });
 
+  test("1. seed - default off", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+    });
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig).not.toHaveProperty("seed");
+  });
+
+  test("1. seed - value", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      seed: 6,
+    });
+    await model.invoke(
+      "You roll two dice. What’s the probability they add up to 7?"
+    );
+
+    expect(record.opts).toBeDefined();
+    expect(record.opts.data).toBeDefined();
+    const { data } = record.opts;
+
+    expect(data).toHaveProperty("generationConfig");
+    expect(data.generationConfig.seed).toEqual(6);
+  });
+
   test("1. Reasoning - default off", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-common/src/tests/chat_models.test.ts
@@ -239,7 +239,7 @@ describe("Mock ChatGoogle - Gemini", () => {
     const model = new ChatGoogle({
       authOptions,
       platformType: "gcp",
-      location: "luna-central1"
+      location: "luna-central1",
     });
     const messages: BaseMessageLike[] = [
       new HumanMessage("Flip a coin and tell me H for heads and T for tails"),

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -187,6 +187,11 @@ export interface GoogleAIModelParams {
   topK?: number;
 
   /**
+   * Seed used in decoding. If not set, the request uses a randomly generated seed.
+   */
+  seed?: number;
+
+  /**
    * Presence penalty applied to the next token's logprobs
    * if the token has already been seen in the response.
    * This penalty is binary on/off and not dependant on the
@@ -551,6 +556,7 @@ export interface GeminiGenerationConfig {
   temperature?: number;
   topP?: number;
   topK?: number;
+  seed?: number;
   presencePenalty?: number;
   frequencyPenalty?: number;
   responseMimeType?: GoogleAIResponseMimeType;

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -55,6 +55,12 @@ export interface GoogleConnectionParams<AuthOptions>
    * the "platform" getter.
    */
   platformType?: GooglePlatformType;
+
+  /**
+   * For compatibility with Google's libraries, should this use Vertex?
+   * The "platformType" parmeter takes precedence.
+   */
+  vertexai?: boolean;
 }
 
 export const GoogleAISafetyCategory = {

--- a/libs/langchain-google-common/src/utils/common.ts
+++ b/libs/langchain-google-common/src/utils/common.ts
@@ -166,6 +166,7 @@ export function copyAIModelParamsInto(
     reasoningEffortToReasoningTokens(ret.modelName, options?.reasoningEffort);
   ret.topP = options?.topP ?? params?.topP ?? target.topP;
   ret.topK = options?.topK ?? params?.topK ?? target.topK;
+  ret.seed = options?.seed ?? params?.seed ?? target.seed;
   ret.presencePenalty =
     options?.presencePenalty ??
     params?.presencePenalty ??

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -1405,6 +1405,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       temperature: parameters.temperature,
       topK: parameters.topK,
       topP: parameters.topP,
+      seed: parameters.seed,
       presencePenalty: parameters.presencePenalty,
       frequencyPenalty: parameters.frequencyPenalty,
       maxOutputTokens: parameters.maxOutputTokens,

--- a/libs/langchain-google-common/src/utils/gemini.ts
+++ b/libs/langchain-google-common/src/utils/gemini.ts
@@ -889,6 +889,9 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
 
       const input_token_details: InputTokenDetails = {};
       addModalityCounts(usageMetadata.promptTokensDetails, input_token_details);
+      if (typeof usageMetadata?.cachedContentTokenCount === "number") {
+        input_token_details.cache_read = usageMetadata.cachedContentTokenCount;
+      }
 
       const output_token_details: OutputTokenDetails = {};
       addModalityCounts(

--- a/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -67,8 +67,8 @@ const testGeminiModelNames = [
   ["gemini-1.5-flash-002"],
   ["gemini-2.0-flash-001"],
   ["gemini-2.0-flash-lite-001"],
-  // ["gemini-2.0-flash-thinking-exp-1219"],
-  ["gemini-2.5-pro-exp-03-25"],
+  ["gemini-2.5-flash-preview-04-17"],
+  ["gemini-2.5-pro-preview-05-06"],
 ];
 
 /*
@@ -76,9 +76,9 @@ const testGeminiModelNames = [
  * For those models, set how long (in millis) to wait in between each test.
  */
 const testGeminiModelDelay: Record<string, number> = {
-  "gemini-2.0-flash-exp": 5000,
-  "gemini-2.0-flash-thinking-exp-1219": 5000,
   "gemini-2.5-pro-exp-03-25": 5000,
+  "gemini-2.5-pro-preview-05-06": 5000,
+  "gemini-2.5-flash-preview-04-17": 5000,
 };
 
 describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
@@ -106,6 +106,29 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
 
     expect(recorder?.request?.connection?.url).toMatch(
       /https:\/\/.+-aiplatform.googleapis.com/
+    );
+
+    expect(res).toBeDefined();
+    expect(res._getType()).toEqual("ai");
+
+    const aiMessage = res as AIMessageChunk;
+    expect(aiMessage.content).toBeDefined();
+
+    expect(typeof aiMessage.content).toBe("string");
+    const text = aiMessage.content as string;
+    expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
+  });
+
+  test("invoke global", async () => {
+    const model = new ChatVertexAI({
+      callbacks,
+      modelName,
+      location: "global",
+    });
+    const res = await model.invoke("What is 1 + 1?");
+
+    expect(recorder?.request?.connection?.url).toMatch(
+      /https:\/\/aiplatform.googleapis.com/
     );
 
     expect(res).toBeDefined();

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -133,7 +133,6 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
       expect(aiMessage.content).toBeDefined();
       expect(aiMessage.content.length).toBeGreaterThan(0);
       expect(aiMessage.content[0]).toBeDefined();
-
     } catch (e) {
       console.error(e);
       throw e;
@@ -321,13 +320,12 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
   });
 
   test("image_url image data", async () => {
-    const model = newChatGoogle({
-    });
+    const model = newChatGoogle({});
 
     const dataPath = "src/tests/data/blue-square.png";
     const dataType = "image/png";
     const data = await fs.readFile(dataPath);
-    const data64 = data.toString('base64');
+    const data64 = data.toString("base64");
     const dataUri = `data:${dataType};base64,${data64}`;
 
     const message: MessageContentComplex[] = [
@@ -360,7 +358,9 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
       const text = aiMessage.content as string;
       expect(text).toMatch(/blue/);
 
-      expect(aiMessage?.usage_metadata?.input_token_details?.image).toBeGreaterThan(0);
+      expect(
+        aiMessage?.usage_metadata?.input_token_details?.image
+      ).toBeGreaterThan(0);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
@@ -371,13 +371,12 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
   });
 
   test("implicit caching", async () => {
-    const model = newChatGoogle({
-    });
+    const model = newChatGoogle({});
 
     const dataPath = "src/tests/data/rainbow.mp4";
     const dataType = "video/mp4";
     const data = await fs.readFile(dataPath);
-    const data64 = data.toString('base64');
+    const data64 = data.toString("base64");
     const dataUri = `data:${dataType};base64,${data64}`;
 
     const message1: MessageContentComplex[] = [
@@ -402,27 +401,25 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
     const message2: MessageContentComplex[] = [
       {
         type: "text",
-        text: "Does the camera pan from left to right or right to left?"
-      }
-    ]
+        text: "Does the camera pan from left to right or right to left?",
+      },
+    ];
 
     messages.push(res1);
-    messages.push(new HumanMessageChunk({content: message2}));
+    messages.push(new HumanMessageChunk({ content: message2 }));
     const res2 = await model.invoke(messages);
     console.log(res2);
     const response2 = recorder.response;
 
-    console.log('response1', JSON.stringify(response1, null, 1));
-    console.log('response2', JSON.stringify(response2, null, 1));
+    console.log("response1", JSON.stringify(response1, null, 1));
+    console.log("response2", JSON.stringify(response2, null, 1));
 
     const cached2 = res2?.usage_metadata?.input_token_details?.cache_read;
     // expect(cached2).toEqual(size1); // Why isn't this true?
     expect(cached2).toBeGreaterThan(0);
     expect(cached2).toBeLessThanOrEqual(size1);
     // Results are highly inconsistent. Sometimes it won't cache.
-
   }, 90000); // Increase timeout
-
 });
 
 const weatherTool = tool((_) => "no-op", {
@@ -1126,13 +1123,12 @@ describe.each(testGeminiModelNames)(
     });
 
     test("image_url image data", async () => {
-      const model = newChatGoogle({
-      });
+      const model = newChatGoogle({});
 
       const dataPath = "src/tests/data/blue-square.png";
       const dataType = "image/png";
       const data = await fs.readFile(dataPath);
-      const data64 = data.toString('base64');
+      const data64 = data.toString("base64");
       const dataUri = `data:${dataType};base64,${data64}`;
 
       const message: MessageContentComplex[] = [
@@ -1165,7 +1161,9 @@ describe.each(testGeminiModelNames)(
         const text = aiMessage.content as string;
         expect(text).toMatch(/blue/);
 
-        expect(aiMessage?.usage_metadata?.input_token_details?.image).toBeGreaterThan(0);
+        expect(
+          aiMessage?.usage_metadata?.input_token_details?.image
+        ).toBeGreaterThan(0);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
@@ -1176,13 +1174,12 @@ describe.each(testGeminiModelNames)(
     });
 
     test("image_url video data", async () => {
-      const model = newChatGoogle({
-      });
+      const model = newChatGoogle({});
 
       const dataPath = "src/tests/data/rainbow.mp4";
       const dataType = "video/mp4";
       const data = await fs.readFile(dataPath);
-      const data64 = data.toString('base64');
+      const data64 = data.toString("base64");
       const dataUri = `data:${dataType};base64,${data64}`;
 
       const message: MessageContentComplex[] = [
@@ -1216,8 +1213,12 @@ describe.each(testGeminiModelNames)(
         expect(text).toMatch(/rainbow/);
 
         // Gemini 1.5 does not include audio
-        expect(aiMessage?.usage_metadata?.input_token_details?.video).toBeGreaterThan(1024);
-        expect(aiMessage?.usage_metadata?.input_token_details?.audio).toBeGreaterThan(0);
+        expect(
+          aiMessage?.usage_metadata?.input_token_details?.video
+        ).toBeGreaterThan(1024);
+        expect(
+          aiMessage?.usage_metadata?.input_token_details?.audio
+        ).toBeGreaterThan(0);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
@@ -1228,13 +1229,12 @@ describe.each(testGeminiModelNames)(
     });
 
     test("implicit caching", async () => {
-      const model = newChatGoogle({
-      });
+      const model = newChatGoogle({});
 
       const dataPath = "src/tests/data/rainbow.mp4";
       const dataType = "video/mp4";
       const data = await fs.readFile(dataPath);
-      const data64 = data.toString('base64');
+      const data64 = data.toString("base64");
       const dataUri = `data:${dataType};base64,${data64}`;
 
       const message1: MessageContentComplex[] = [
@@ -1259,25 +1259,24 @@ describe.each(testGeminiModelNames)(
       const message2: MessageContentComplex[] = [
         {
           type: "text",
-          text: "Does the camera pan from left to right or right to left?"
-        }
-      ]
+          text: "Does the camera pan from left to right or right to left?",
+        },
+      ];
 
       messages.push(res1);
-      messages.push(new HumanMessageChunk({content: message2}));
+      messages.push(new HumanMessageChunk({ content: message2 }));
       const res2 = await model.invoke(messages);
       console.log(res2);
       const response2 = recorder.response;
 
-      console.log('response1', JSON.stringify(response1, null, 1));
-      console.log('response2', JSON.stringify(response2, null, 1));
+      console.log("response1", JSON.stringify(response1, null, 1));
+      console.log("response2", JSON.stringify(response2, null, 1));
 
       const cached2 = res2?.usage_metadata?.input_token_details?.cache_read;
       // expect(cached2).toEqual(size1); // Why isn't this true?
       expect(cached2).toBeGreaterThan(0);
       expect(cached2).toBeLessThanOrEqual(size1);
       // Results are highly inconsistent. Sometimes it won't cache.
-
     }, 90000); // Increase timeout
 
     test("reasoning", async () => {
@@ -1371,8 +1370,8 @@ describe.each(testMultimodalModelNames)(
       expect(content.length).toBeGreaterThanOrEqual(1);
 
       let imageCount = 0;
-      (content as MessageContentComplex[]).forEach(mc => {
-        if (mc?.type === 'image_url') {
+      (content as MessageContentComplex[]).forEach((mc) => {
+        if (mc?.type === "image_url") {
           const fn = `/tmp/${platformType}-${modelName}-${imageCount}.png`;
           console.log(`(Content saved to ${fn})`);
           imageCount += 1;
@@ -1384,7 +1383,7 @@ describe.each(testMultimodalModelNames)(
         } else {
           console.log("Content", mc);
         }
-      })
+      });
 
       expect(imageCount).toEqual(1);
 

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -294,6 +294,56 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
       throw e;
     }
   });
+
+  test("image_url data", async () => {
+    const model = newChatGoogle({
+    });
+
+    const dataPath = "src/tests/data/blue-square.png";
+    const dataType = "image/png";
+    const data = await fs.readFile(dataPath);
+    const data64 = data.toString('base64');
+    const dataUri = `data:${dataType};base64,${data64}`;
+
+    const message: MessageContentComplex[] = [
+      {
+        type: "text",
+        text: "What is in this image?",
+      },
+      {
+        type: "image_url",
+        image_url: dataUri,
+      },
+    ];
+
+    const messages: BaseMessage[] = [
+      new HumanMessageChunk({ content: message }),
+    ];
+
+    try {
+      const res = await model.invoke(messages);
+
+      // console.log(res);
+
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      const aiMessage = res as AIMessageChunk;
+      expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/blue/);
+
+      expect(aiMessage?.usage_metadata?.input_token_details?.image).toBeGreaterThan(0);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      console.error(e);
+      console.error(JSON.stringify(e.details, null, 1));
+      throw e;
+    }
+  });
 });
 
 const weatherTool = tool((_) => "no-op", {

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -118,6 +118,28 @@ describe.each(apiKeyModelNames)("Google APIKey Chat (%s)", (modelName) => {
     }
   });
 
+  test("invoke seed", async () => {
+    const model = newChatGoogle({
+      seed: 6,
+    });
+    try {
+      const res = await model.invoke("What is 1 + 1?");
+      console.log(res);
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      const aiMessage = res as AIMessageChunk;
+      console.log(aiMessage);
+      expect(aiMessage.content).toBeDefined();
+      expect(aiMessage.content.length).toBeGreaterThan(0);
+      expect(aiMessage.content[0]).toBeDefined();
+
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  });
+
   test("generate", async () => {
     const model = newChatGoogle();
     try {
@@ -566,6 +588,23 @@ describe.each(testGeminiModelNames)(
       // available tokens, this should be the case for how we're doing Gemini.
       expect(propSum(usage.input_token_details)).toEqual(usage.input_tokens);
       expect(propSum(usage.output_token_details)).toEqual(usage.output_tokens);
+    });
+
+    test("invoke seed", async () => {
+      const model = newChatGoogle({
+        seed: 6,
+      });
+      const res = await model.invoke("What is 1 + 1?");
+
+      expect(res).toBeDefined();
+      expect(res._getType()).toEqual("ai");
+
+      const aiMessage = res as AIMessageChunk;
+      expect(aiMessage.content).toBeDefined();
+
+      expect(typeof aiMessage.content).toBe("string");
+      const text = aiMessage.content as string;
+      expect(text).toMatch(/(1 + 1 (equals|is|=) )?2.? ?/);
     });
 
     test(`generate`, async () => {


### PR DESCRIPTION
From May 1-10, Google has announced a variety of updates to Gemini. This adds support for many of those features, including:
* Implicit caching. Cache results now included in token count. (Fixes #8146)
* Vertex "global" region support
* "seed" is now a valid parameter
* Added "vertexai" parameter for compatibility with Google's "genai" library as alias for "platformType" functionality

Added tests against the latest model names and announced features. Including:
* Gemini image generation model publicly available in Vertex
* Gemma on AI Studio now supports images
