### PR TITLE
fix(google): Using .nullish() in zod.

### DIFF
--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -661,6 +661,7 @@ export interface GoogleAISafetyParams {
 export type GeminiJsonSchema = Record<string, unknown> & {
   properties?: Record<string, GeminiJsonSchema>;
   type: GeminiFunctionSchemaType;
+  nullable?: boolean;
 };
 
 export interface GeminiJsonSchemaDirty extends GeminiJsonSchema {

--- a/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
+++ b/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
@@ -21,12 +21,25 @@ export function removeAdditionalProperties(
     }
 
     if (Array.isArray(obj.type)) {
-      // Gemini requires type be a string, so we use the first defined one
-      newObj.type = obj?.type[0];
-
-      // If type contains "null", which isn't allowed, set "nullable" to true
-      if (obj.type.includes("null")) {
+      const len = obj.type.length;
+      const nullIndex = obj.type.indexOf("null");
+      if (len === 2 && nullIndex >= 0) {
+        // There are only two values set for the type, and one of them is "null".
+        // Set the type to the other one and set nullable to true.
+        const typeIndex = nullIndex === 0 ? 1 : 0;
+        newObj.type = obj.type[typeIndex];
         newObj.nullable = true;
+      } else if (len === 1 && nullIndex === 0) {
+        // This is nullable only without a type, which doesn't
+        // make sense for Gemini
+        throw new Error("zod_to_gemini_parameters: Gemini cannot handle null type");
+      } else if (len === 1) {
+        // Although an array, it has only one value.
+        // So set it to the string to match what Gemini expects.
+        newObj.type = obj?.type[0];
+      } else {
+        // Anything else could be a union type, so reject it.
+        throw new Error("zod_to_gemini_parameters: Gemini cannot handle union types");
       }
     }
 

--- a/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
+++ b/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
@@ -32,14 +32,18 @@ export function removeAdditionalProperties(
       } else if (len === 1 && nullIndex === 0) {
         // This is nullable only without a type, which doesn't
         // make sense for Gemini
-        throw new Error("zod_to_gemini_parameters: Gemini cannot handle null type");
+        throw new Error(
+          "zod_to_gemini_parameters: Gemini cannot handle null type"
+        );
       } else if (len === 1) {
         // Although an array, it has only one value.
         // So set it to the string to match what Gemini expects.
         newObj.type = obj?.type[0];
       } else {
         // Anything else could be a union type, so reject it.
-        throw new Error("zod_to_gemini_parameters: Gemini cannot handle union types");
+        throw new Error(
+          "zod_to_gemini_parameters: Gemini cannot handle union types"
+        );
       }
     }
 

--- a/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
+++ b/libs/langchain-google-common/src/utils/zod_to_gemini_parameters.ts
@@ -20,6 +20,16 @@ export function removeAdditionalProperties(
       delete newObj.additionalProperties;
     }
 
+    if (Array.isArray(obj.type)) {
+      // Gemini requires type be a string, so we use the first defined one
+      newObj.type = obj?.type[0];
+
+      // If type contains "null", which isn't allowed, set "nullable" to true
+      if (obj.type.includes("null")) {
+        newObj.nullable = true;
+      }
+    }
+
     for (const key in newObj) {
       if (key in newObj) {
         if (Array.isArray(newObj[key])) {
@@ -47,6 +57,8 @@ export function schemaToGeminiParameters<
 ): GeminiFunctionSchema {
   // Gemini doesn't accept either the $schema or additionalProperties
   // attributes, so we need to explicitly remove them.
+  // Zod sometimes also makes an array of type (because of .nullish()),
+  // which needs cleaning up.
   const jsonSchema = removeAdditionalProperties(
     isZodSchema(schema) ? zodToJsonSchema(schema) : schema
   );


### PR DESCRIPTION
See #8162 for detailed analysis.
Resolved the issue by using the existing `removeAdditionalProperties()` function in zod_to_gemini_parameters.ts to cleanup the `type` property and possibly add the `nullable` property.

Fixes #8162 
