### PR TITLE
fix(openai): allow streaming o1 responses

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -1917,7 +1917,6 @@ export class ChatOpenAI<
     this.maxTokens = fields?.maxCompletionTokens ?? fields?.maxTokens;
     this.useResponsesApi = fields?.useResponsesApi ?? this.useResponsesApi;
     this.disableStreaming = fields?.disableStreaming ?? this.disableStreaming;
-    if (this.model === "o1") this.disableStreaming = true;
 
     this.streaming = fields?.streaming ?? false;
     if (this.disableStreaming) this.streaming = false;

--- a/libs/langchain-openai/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models.int.test.ts
@@ -1188,7 +1188,7 @@ test("Can stream o1-mini requests", async () => {
   expect(numChunks).toBeGreaterThan(3);
 });
 
-test("Doesn't stream o1 requests", async () => {
+test("Can stream o1 requests", async () => {
   const model = new ChatOpenAI({
     model: "o1",
   });
@@ -1212,7 +1212,7 @@ test("Doesn't stream o1 requests", async () => {
     expect(finalMsg.content.length).toBeGreaterThanOrEqual(1);
   }
 
-  expect(numChunks).toBe(1);
+  expect(numChunks).toBeGreaterThan(3);
 });
 
 test("Allows developer messages with o1", async () => {


### PR DESCRIPTION
I had streaming of o1 up and running until I upgraded to `@langchain/openai` version 0.5.3, which introduced the change this PR is reverting: #7503.

I'm not sure whether all deployments of o1 support streaming yet, but at least it is working on my deployment of o1 version 2024-12-17 in Azure, swedencentral, Data zone standard :)