### PR TITLE
chore(community): fix docs typo in tavily_search_community

### DIFF
--- a/docs/core_docs/docs/integrations/tools/tavily_search_community.ipynb
+++ b/docs/core_docs/docs/integrations/tools/tavily_search_community.ipynb
@@ -50,7 +50,7 @@
         "<IntegrationInstallTooltip></IntegrationInstallTooltip>\n",
         "\n",
         "<Npm2Yarn>\n",
-        "  @langchain/communityv @langchain/core\n",
+        "  @langchain/community @langchain/core\n",
         "</Npm2Yarn>\n",
         "```\n",
         "\n",


### PR DESCRIPTION


Fixes #8198
