### PR TITLE
feat(community): Return document ids when querying opensearch vector store

### DIFF
--- a/libs/langchain-community/src/vectorstores/opensearch.ts
+++ b/libs/langchain-community/src/vectorstores/opensearch.ts
@@ -233,6 +233,7 @@ export class OpenSearchVectorStore extends VectorStore {
       new Document({
         pageContent: hit._source[this.textFieldName],
         metadata: hit._source[this.metadataFieldName],
+        id: hit._id,
       }),
       hit._score,
     ]);


### PR DESCRIPTION
Currently the ids are not returned when querying an opensearch vector store. This adds them to the returned document.

Related to https://github.com/langchain-ai/langchainjs/pull/6963