### PR TITLE
Add support for GPT-4.1 token counting and max output tokens

### DIFF
--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -37,7 +37,7 @@
     "ansi-styles": "^5.0.0",
     "camelcase": "6",
     "decamelize": "1.2.0",
-    "js-tiktoken": "^1.0.12",
+    "js-tiktoken": "^1.0.20",
     "langsmith": "^0.3.29",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",

--- a/langchain-core/src/language_models/base.ts
+++ b/langchain-core/src/language_models/base.ts
@@ -44,6 +44,10 @@ export const getModelNameForTiktoken = (modelName: string): TiktokenModel => {
     return "gpt-4o";
   }
 
+  if (modelName.startsWith("gpt-4.1")) {
+    return "gpt-4.1";
+  }
+
   return modelName as TiktokenModel;
 };
 
@@ -66,6 +70,8 @@ export const getModelContextSize = (modelName: string): number => {
       return 32768;
     case "gpt-4":
       return 8192;
+    case "gpt-4.1":
+      return 32768;
     case "text-davinci-003":
       return 4097;
     case "text-curie-001":

--- a/langchain-core/src/language_models/tests/count_tokens.test.ts
+++ b/langchain-core/src/language_models/tests/count_tokens.test.ts
@@ -22,6 +22,9 @@ test("properly calculates correct max tokens", async () => {
   expect(await calculateMaxTokens({ prompt: "", modelName: "gpt-4-32k" })).toBe(
     32768
   );
+  expect(await calculateMaxTokens({ prompt: "", modelName: "gpt-4.1" })).toBe(
+    32768
+  );
 });
 
 test("properly gets model context size", async () => {
@@ -30,4 +33,5 @@ test("properly gets model context size", async () => {
   expect(await getModelContextSize("gpt-3.5-turbo")).toBe(4096);
   expect(await getModelContextSize("gpt-4")).toBe(8192);
   expect(await getModelContextSize("gpt-4-32k")).toBe(32768);
+  expect(await getModelContextSize("gpt-4.1")).toBe(32768);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7826,7 +7826,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
-    js-tiktoken: ^1.0.12
+    js-tiktoken: ^1.0.20
     langsmith: ^0.3.29
     ml-matrix: ^6.10.4
     mustache: ^4.2.0
@@ -25910,6 +25910,15 @@ __metadata:
   dependencies:
     base64-js: ^1.5.1
   checksum: 07a0e9cd5cb05f304696ac74e76d48f960d62b0443b65f0d09adf79dc903d2fba82d2cff2907491259bbf8b59842c20f89fd1879d2c0249706e7c84507c687fd
+  languageName: node
+  linkType: hard
+
+"js-tiktoken@npm:^1.0.20":
+  version: 1.0.20
+  resolution: "js-tiktoken@npm:1.0.20"
+  dependencies:
+    base64-js: ^1.5.1
+  checksum: 29106a6faa65c85d13ead291ce17b007ef7c16918fdd570d4636b74da33e54b72af66f9d5dd963f2979733f70d4221e4a9655d236395719c5cc04620d9f1e2cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I encountered an error when trying to use GPT-4.1:
culate number of tokens, falling back to approximate count Error: Unknown model

This PR adds support for GPT-4.1 by updating the token counting logic and setting the correct max output token size (32768), based on the official documentation:
https://platform.openai.com/docs/models/gpt-4.1

Let me know if any further changes are needed!