### PR TITLE
chore(genai): fix code sample in README

### DIFF
--- a/libs/langchain-google-genai/README.md
+++ b/libs/langchain-google-genai/README.md
@@ -50,6 +50,7 @@ Then initialize
 
 ```typescript
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { HumanMessage } from "@langchain/core/messages";
 
 const model = new ChatGoogleGenerativeAI({
   modelName: "gemini-pro",


### PR DESCRIPTION
Added missing HumanMessage import for `@langchain/google-genai` readme


