### PR TITLE
feat(google-genai): Add baseUrl property to embeddings

### DIFF
--- a/libs/langchain-google-genai/src/embeddings.ts
+++ b/libs/langchain-google-genai/src/embeddings.ts
@@ -48,6 +48,11 @@ export interface GoogleGenerativeAIEmbeddingsParams extends EmbeddingsParams {
    * Google API key to use
    */
   apiKey?: string;
+
+  /**
+   * Google API base URL to use
+   */
+  baseUrl?: string;
 }
 
 /**
@@ -120,9 +125,14 @@ export class GoogleGenerativeAIEmbeddings
       );
     }
 
-    this.client = new GoogleGenerativeAI(this.apiKey).getGenerativeModel({
-      model: this.model,
-    });
+    this.client = new GoogleGenerativeAI(this.apiKey).getGenerativeModel(
+      {
+        model: this.model,
+      },
+      {
+        baseUrl: fields?.baseUrl,
+      }
+    );
   }
 
   private _convertToContent(text: string): EmbedContentRequest {

--- a/libs/langchain-google-genai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-genai/src/tests/embeddings.int.test.ts
@@ -28,3 +28,33 @@ test("Test GooglePalmEmbeddings.embedDocuments", async () => {
     expect(typeof r[0]).toBe("number");
   });
 });
+
+test("Test GooglePalmEmbeddings.embedQuery with baseUrl set", async () => {
+  const embeddings = new GoogleGenerativeAIEmbeddings({
+    maxRetries: 1,
+    baseUrl: "https://generativelanguage.googleapis.com",
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  // console.log(res);
+  expect(typeof res[0]).toBe("number");
+});
+
+test("Test GooglePalmEmbeddings.embedDocuments with baseUrl set", async () => {
+  const embeddings = new GoogleGenerativeAIEmbeddings({
+    maxRetries: 1,
+    baseUrl: "https://generativelanguage.googleapis.com",
+  });
+  const res = await embeddings.embedDocuments([
+    "Hello world",
+    "Bye bye",
+    "we need",
+    "at least",
+    "six documents",
+    "to test pagination",
+  ]);
+  // console.log(res);
+  expect(res).toHaveLength(6);
+  res.forEach((r) => {
+    expect(typeof r[0]).toBe("number");
+  });
+});


### PR DESCRIPTION
Small addition of the baseUrl property that already exists on the google-genai chat model to the embeddings. This should enable the use of proxies / custom base urls as it's already supported on the chat model.