### PR TITLE
fix(mcp-adatpors): Provide cwd when calling into StdioClientTransport

### DIFF
--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -559,7 +559,7 @@ export class MultiServerMCPClient {
     serverName: string,
     connection: ResolvedStdioConnection
   ): Promise<void> {
-    const { command, args, env, restart, stderr } = connection;
+    const { command, args, env, restart, stderr, cwd } = connection;
 
     getDebugLog()(
       `DEBUG: Creating stdio transport for server "${serverName}" with command: ${command} ${args.join(
@@ -572,6 +572,7 @@ export class MultiServerMCPClient {
       args,
       env,
       stderr,
+      cwd
     });
 
     this._transportInstances[serverName] = transport;


### PR DESCRIPTION

When we add the `cwd` as a config option when creating mcp server config objects, this property does not get properly passed into the ``StdioClientTransport``.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # 
