### PR TITLE
feat: Query Embedding Caching

### DIFF
--- a/docs/core_docs/docs/how_to/caching_embeddings.mdx
+++ b/docs/core_docs/docs/how_to/caching_embeddings.mdx
@@ -20,13 +20,65 @@ The cache backed embedder is a wrapper around an embedder that caches embeddings
 
 The text is hashed and the hash is used as the key in the cache.
 
-The main supported way to initialized a `CacheBackedEmbeddings` is the `fromBytesStore` static method. This takes in the following parameters:
+The main supported way to initialize a `CacheBackedEmbeddings` is the `fromBytesStore` static method. This takes in the following parameters:
 
 - `underlyingEmbeddings`: The embeddings model to use.
-- `documentEmbeddingCache`: The cache to use for storing document embeddings.
+- `documentEmbeddingStore`: The cache to use for storing document embeddings.
 - `namespace`: (optional, defaults to "") The namespace to use for document cache. This namespace is used to avoid collisions with other caches. For example, you could set it to the name of the embedding model used.
+- `queryEmbeddingStore`: (optional) The cache to use for storing **query embeddings**. If provided, query embeddings will also be cached and reused.
+
+**Query embedding caching is optional:**  
+If you do not provide a `queryEmbeddingStore`, only document embeddings will be cached. If you want to cache query embeddings as well, pass a `queryEmbeddingStore` when initializing `CacheBackedEmbeddings`.
 
 **Attention:** Be sure to set the namespace parameter to avoid collisions of the same text embedded using different embeddings models.
+
+## Caching query embeddings
+
+You can cache both document and query embeddings by passing a `queryEmbeddingStore`:
+
+```typescript
+import { OpenAIEmbeddings } from "@langchain/openai";
+import { CacheBackedEmbeddings } from "@langchain/core/embeddings";
+import { InMemoryStore } from "@langchain/core/storage";
+
+const underlyingEmbeddings = new OpenAIEmbeddings();
+
+const cacheBackedEmbeddings = CacheBackedEmbeddings.fromBytesStore(
+  underlyingEmbeddings,
+  new InMemoryStore(), // document embedding cache
+  {
+    namespace: underlyingEmbeddings.modelName,
+    queryEmbeddingStore: new InMemoryStore(), // query embedding cache
+  }
+);
+
+// Now both document and query embeddings are cached!
+const docEmbedding = await cacheBackedEmbeddings.embedDocuments([
+  "Hello world",
+]);
+const queryEmbedding = await cacheBackedEmbeddings.embedQuery("What is AI?");
+```
+
+## Cache expiration and store management
+
+:::caution
+`CacheBackedEmbeddings` does **not** implement any cache expiration or eviction policy.  
+If you want cache entries to expire or be removed, you must configure this behavior in your underlying store (for example, using Redis TTL or a custom cleanup process).
+:::
+
+### Store separation recommendation
+
+We recommend using **separate stores** for document embeddings and query embeddings:
+
+- **Document embedding cache store**: Usually, you want to keep these embeddings for a long time, since documents rarely change. Only clear this cache if you permanently switch embedding models or update your document corpus.
+- **Query embedding cache store**: This cache may accumulate many entries from random or one-off queries. It's often helpful to periodically clear unused or old entries from this store to save space and keep your cache efficient.
+
+Keeping these stores separate allows you to manage their lifecycles independently and avoid accidentally deleting important document embeddings when cleaning up query caches.
+
+> **Note:**  
+> `documentEmbeddingStore` and `queryEmbeddingStore` are used only for caching embeddings by key (such as a hash of the text).  
+> They are **not** vector databases and are **not** used for similarity search or retrieval.  
+> For retrieval or similarity search, use a dedicated vector store or vector database.
 
 ## In-memory
 

--- a/langchain/src/embeddings/tests/cache.test.ts
+++ b/langchain/src/embeddings/tests/cache.test.ts
@@ -28,3 +28,69 @@ test("Basic embeddings cache", async () => {
   const result2 = await embeddingsCache.embedDocuments(documents);
   expect(result).toEqual(result2);
 });
+
+test("Query caching works correctly", async () => {
+  const queryStore = new InMemoryStore();
+  const embeddingsCache = CacheBackedEmbeddings.fromBytesStore(
+    new RandomEmbeddings({}),
+    new InMemoryStore(),
+    { queryEmbeddingStore: queryStore }
+  );
+
+  const query = "What is AI?";
+
+  // First call: Embed and cache
+  const firstEmbedding = await embeddingsCache.embedQuery(query);
+  expect(firstEmbedding.length).toBeGreaterThan(0);
+
+  // Second call: Retrieve from cache
+  const cachedEmbedding = await embeddingsCache.embedQuery(query);
+  expect(firstEmbedding).toEqual(cachedEmbedding);
+});
+
+test("Document and query caches remain separate", async () => {
+  const documentStore = new InMemoryStore();
+  const queryStore = new InMemoryStore();
+  const embeddingsCache = CacheBackedEmbeddings.fromBytesStore(
+    new RandomEmbeddings({}),
+    documentStore,
+    { queryEmbeddingStore: queryStore }
+  );
+
+  const document = "How does LangChain work?";
+  const query = "What is AI?";
+
+  // Store query embedding
+  const queryEmbedding = await embeddingsCache.embedQuery(query);
+
+  // Store document embedding
+  const documentEmbedding = await embeddingsCache.embedDocuments([document]);
+
+  // Retrieve again via embeddingsCache to ensure cache is used
+  const cachedQueryEmbedding = await embeddingsCache.embedQuery(query);
+  const cachedDocumentEmbedding = (
+    await embeddingsCache.embedDocuments([document])
+  )[0];
+
+  expect(cachedQueryEmbedding).toEqual(queryEmbedding);
+  expect(cachedDocumentEmbedding).toEqual(documentEmbedding[0]);
+});
+
+test("Cache handles missing values properly", async () => {
+  const queryStore = new InMemoryStore();
+  const embeddingsCache = CacheBackedEmbeddings.fromBytesStore(
+    new RandomEmbeddings({}),
+    new InMemoryStore(),
+    { queryEmbeddingStore: queryStore }
+  );
+
+  const query = "Explain embeddings";
+
+  // First call: should compute and cache the embedding
+  const embedding1 = await embeddingsCache.embedQuery(query);
+  expect(embedding1.length).toBeGreaterThan(0);
+
+  // Second call: should retrieve from cache (should be equal)
+  const embedding2 = await embeddingsCache.embedQuery(query);
+  expect(embedding2).toEqual(embedding1);
+});


### PR DESCRIPTION
This change brings the JS/TypeScript implementation for caching embeddings closer to feature parity with Python LangChain, while preserving backward compatibility for current users.

- Add support for caching query embeddings in `CacheBackedEmbeddings`.  This implementation adds an optional `queryEmbeddingStore` parameter to cache query embeddings separately from document embeddings.
- Update names for consistency: `documentEmbeddingStore`and `queryEmbeddingStore`.
- Add new tests.
- Update documentation to cover query embedding caching and provide additional clarifications.


_Python version features NOT included in this change:_
- Using UUID-based key encoding is not included since it would be a breaking change for existing cache stores.
- Batch process is not included as it requires changes outside the cache_backed related code.


Fixes https://github.com/langchain-ai/langchainjs/discussions/8149
