### PR TITLE
fix(trimmer): consider last message on partial trim

### DIFF
--- a/langchain-core/src/messages/transformers.ts
+++ b/langchain-core/src/messages/transformers.ts
@@ -4,10 +4,10 @@ import { Runnable, RunnableLambda } from "../runnables/base.js";
 import { AIMessage, AIMessageChunk, AIMessageChunkFields } from "./ai.js";
 import {
   BaseMessage,
-  MessageType,
   BaseMessageChunk,
   BaseMessageFields,
   isBaseMessageChunk,
+  MessageType,
 } from "./base.js";
 import {
   ChatMessage,
@@ -745,7 +745,7 @@ async function _firstMaxTokens(
       break;
     }
   }
-  if (idx < messagesCopy.length - 1 && partialStrategy) {
+  if (idx < messagesCopy.length && partialStrategy) {
     let includedPartial = false;
     if (Array.isArray(messagesCopy[idx].content)) {
       const excluded = messagesCopy[idx];


### PR DESCRIPTION
Hello team! 👋 

While consuming the `messageTrimmer` abstraction, I've noticed that for the following example:

```javascript
const messages = [
  new SystemMessage(ENTITY_SUMMARIZER_PROMPT),
  new HumanMessage(
    `Please analyze this entity data: ${JSON.stringify(entity)}`
  ),
];

const trimmedMessages = await trimMessages({
  maxTokens: 128_000 * 0.9,
  strategy: 'first',
  allowPartial: true,
  textSplitter,
  tokenCounter,
}).invoke(messages, config);
```

The `trimmedMessages` would always strip away the `HumanMessage` completely – even though `allowPartial` is `true`, and we provided a `textSplitter` which splits text into 500-character chunks.

Looking at the `_firstMaxTokens` code plus the [equivalent Python algorithm](https://github.com/langchain-ai/langchain/blob/5bf89628bf82a5ddf9d0dd4bc0926e61ccc4657d/libs/core/langchain_core/messages/utils.py#L1333), I saw a discrepancy in the way we're iterating. This PR fixes the issue by just navigating the entire array (including the last message).
