### PR TITLE
Ensure the GithubRepoLoader path is URI Encoded when fetching repo files

### DIFF
--- a/libs/langchain-community/src/document_loaders/web/github.ts
+++ b/libs/langchain-community/src/document_loaders/web/github.ts
@@ -647,7 +647,7 @@ export class GithubRepoLoader
    * @returns A promise that resolves to an array of GithubFile instances.
    */
   private async fetchRepoFiles(path: string): Promise<GithubFile[]> {
-    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`;
+    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
     return this.caller.call(async () => {
       this.log(`Fetching ${url}`);
       const response = await fetch(url, { headers: this.headers });


### PR DESCRIPTION
Currently, if you are processing a GithubRepo with a file or directory name with characters like `%5F` (which is allowed by Github) this loader will return 404. Instead, we need to URI Encode the path to ensure it can be reached.