### PR TITLE
Removed unsupported media_type parameter for image upload when supply…

### DIFF
--- a/libs/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/langchain-anthropic/src/utils/message_inputs.ts
@@ -191,7 +191,6 @@ const standardContentBlockConverter: StandardContentBlockConverter<{
           source: {
             type: "url",
             url: block.url,
-            media_type: block.mime_type ?? "",
           },
           ...("cache_control" in (block.metadata ?? {})
             ? { cache_control: block.metadata!.cache_control }


### PR DESCRIPTION
The @langchain/anthropic package was edited to support url based file uploads in the following format:

```
{
    "type": "image",
    "url": "https://s3.ap-southeast-2.amazonaws.com/ch.dreamrea.public/whatsapp-images/d4390bb6-6430-4dfd-80e7-29599106d13f.jpg",
    "source_type": "url"
}
```

However the code adds a parameter to the Anthropic query `media_type` which is necessary for base64 encoded images but results in the following when an image is provided.

```
Error during agent streaming: BadRequestError: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.1.image.source.url.media_type: Extra inputs are not permitted"}}
```