### PR TITLE
fix[openai]: avoid sending auto-generated tool ID

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -499,7 +499,7 @@ function _convertMessagesToOpenAIResponsesParams(
         return {
           type: "function_call_output",
           call_id: toolMessage.tool_call_id,
-          id: toolMessage.id,
+          id: toolMessage.id?.startsWith("fc_") ? toolMessage.id : undefined,
           output:
             typeof toolMessage.content !== "string"
               ? JSON.stringify(toolMessage.content)


### PR DESCRIPTION
In LangGraph if a message does not have an ID, it will persist with auto-generated UUID instead. This ID is considered incorrect by Responses API, but Responses API still permits submitting runs with `call_id` instead, so rely on this for now.
