### PR TITLE
test(mongodb): add more comprehensive testing to MongoDB integration 

### DIFF
--- a/libs/langchain-mongodb/src/tests/chat_history.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/chat_history.int.test.ts
@@ -14,52 +14,152 @@ beforeAll(async () => {
   collection = await client.db("langchain").createCollection("memory");
 });
 
+beforeEach(async () => {
+  await collection.deleteMany({});
+});
+
 afterAll(async () => {
   await client.close();
 });
 
-test("Test MongoDB history store", async () => {
+test("nothing is inserted into the database until messages are added", async () => {
   const sessionId = new ObjectId().toString();
-  const chatHistory = new MongoDBChatMessageHistory({
+  // we explicitly test that there are no side effects
+  // eslint-disable-next-line no-new
+  new MongoDBChatMessageHistory({
     collection,
     sessionId,
   });
-
-  const blankResult = await chatHistory.getMessages();
-  expect(blankResult).toStrictEqual([]);
-
-  await chatHistory.addUserMessage("Who is the best vocalist?");
-  await chatHistory.addAIChatMessage("Ozzy Osbourne");
-
-  const expectedMessages = [
-    new HumanMessage("Who is the best vocalist?"),
-    new AIMessage("Ozzy Osbourne"),
-  ];
-
-  const resultWithHistory = await chatHistory.getMessages();
-  expect(resultWithHistory).toEqual(expectedMessages);
+  expect(await collection.findOne({ sessionId })).toBeNull();
 });
 
-test("Test clear MongoDB history store", async () => {
+test("addMessage() upserts if the document does not exist", async () => {
   const sessionId = new ObjectId().toString();
   const chatHistory = new MongoDBChatMessageHistory({
     collection,
     sessionId,
   });
 
-  await chatHistory.addUserMessage("Who is the best vocalist?");
-  await chatHistory.addAIChatMessage("Ozzy Osbourne");
+  expect((await collection.find().toArray()).length).toBe(0);
 
-  const expectedMessages = [
+  const message = new HumanMessage("Who is the best vocalist?");
+  await chatHistory.addMessage(message);
+
+  const [
+    {
+      messages: [
+        {
+          data: { content },
+        },
+      ],
+    },
+  ] = await collection.find().toArray();
+
+  expect(content).toEqual("Who is the best vocalist?");
+});
+
+test("addMessage() appends to the document if it exists", async () => {
+  const sessionId = new ObjectId().toString();
+  const chatHistory = new MongoDBChatMessageHistory({
+    collection,
+    sessionId,
+  });
+  expect((await collection.find().toArray()).length).toBe(0);
+
+  const message = new HumanMessage("Who is the best vocalist?");
+  await chatHistory.addMessage(message);
+  const message2 = new AIMessage("Ozzy Osbourne");
+  await chatHistory.addMessage(message2);
+  const [
+    {
+      messages: [
+        {
+          data: { content },
+        },
+        {
+          data: { content: content2 },
+        },
+      ],
+    },
+  ] = await collection.find().toArray();
+
+  expect(content).toEqual("Who is the best vocalist?");
+  expect(content2).toEqual("Ozzy Osbourne");
+});
+
+test("clear() removes all messages for a given sessionId", async () => {
+  const sessionId = new ObjectId().toString();
+  const chatHistory = new MongoDBChatMessageHistory({
+    collection,
+    sessionId,
+  });
+  const message = new HumanMessage("Who is the best vocalist?");
+  await chatHistory.addMessage(message);
+  expect((await collection.find().toArray()).length).toBe(1);
+  await chatHistory.clear();
+  expect((await collection.find().toArray()).length).toBe(0);
+});
+
+test("clear() only removes messages for the given sessionId", async () => {
+  const sessionId1 = new ObjectId().toString();
+  const sessionId2 = new ObjectId().toString();
+  const chatHistory1 = new MongoDBChatMessageHistory({
+    collection,
+    sessionId: sessionId1,
+  });
+  const chatHistory2 = new MongoDBChatMessageHistory({
+    collection,
+    sessionId: sessionId2,
+  });
+  const message1 = new HumanMessage("Who is the best vocalist?");
+  await chatHistory1.addMessage(message1);
+  await chatHistory2.addMessage(message1);
+
+  expect((await collection.find().toArray()).length).toBe(2);
+  await chatHistory1.clear();
+
+  expect(await collection.findOne({ sessionId: sessionId1 })).toBeNull();
+  expect(await collection.findOne({ sessionId: sessionId2 })).not.toBeNull();
+});
+
+test("getMessages() returns [] if no messages exist", async () => {
+  const sessionId = new ObjectId().toString();
+
+  const chatHistory = new MongoDBChatMessageHistory({
+    collection,
+    sessionId,
+  });
+  expect(await chatHistory.getMessages()).toStrictEqual([]);
+});
+
+test("getMessages() messages when messages exist", async () => {
+  const sessionId = new ObjectId().toString();
+  const chatHistory = new MongoDBChatMessageHistory({
+    collection,
+    sessionId,
+  });
+  await chatHistory.addMessage(new HumanMessage("Who is the best vocalist?"));
+  expect(await chatHistory.getMessages()).toStrictEqual([
+    new HumanMessage("Who is the best vocalist?"),
+  ]);
+});
+
+test("getMessages() returns messages in the order they were added", async () => {
+  const sessionId = new ObjectId().toString();
+  const chatHistory = new MongoDBChatMessageHistory({
+    collection,
+    sessionId,
+  });
+
+  await chatHistory.addMessage(new HumanMessage("Who is the best vocalist?"));
+  await chatHistory.addMessage(new AIMessage("Ozzy Osbourne"));
+  await chatHistory.addMessage(new HumanMessage("Who is the best guitarist?"));
+  await chatHistory.addMessage(new AIMessage("Jimmy Page"));
+
+  expect(await chatHistory.getMessages()).toStrictEqual([
     new HumanMessage("Who is the best vocalist?"),
     new AIMessage("Ozzy Osbourne"),
-  ];
-
-  const resultWithHistory = await chatHistory.getMessages();
-  expect(resultWithHistory).toEqual(expectedMessages);
-
-  await chatHistory.clear();
-
-  const blankResult = await chatHistory.getMessages();
-  expect(blankResult).toStrictEqual([]);
+    new HumanMessage("Who is the best guitarist?"),
+    new AIMessage("Jimmy Page"),
+  ]);
 });

--- a/libs/langchain-mongodb/src/tests/setup.ts
+++ b/libs/langchain-mongodb/src/tests/setup.ts
@@ -33,7 +33,7 @@ class ReadyWhenMongotEstablished extends StartupCheckStrategy {
   private async tryCreateSearchIndex() {
     let client;
     try {
-      client = new MongoClient(uri());
+      client = new MongoClient(uri(), { serverSelectionTimeoutMS: 1_000 });
       await client.connect();
 
       const namespace = "vectorstore.test";

--- a/libs/langchain-mongodb/src/tests/storage.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/storage.int.test.ts
@@ -182,8 +182,11 @@ describe("mset()", () => {
 
     const [document] = await collection.find().limit(1).toArray();
 
-    // @ts-expect-error asdf
-    expect((document._id as string).startsWith("customNamespace/")).toBe(true);
+    // By default, mongodb's collection is an ObjectId.  But the store
+    // automatically inserts _id as a string, unless a custom primaryKey is set.
+    expect(
+      (document._id as unknown as string).startsWith("customNamespace/")
+    ).toBe(true);
   });
 
   test("populates the store with the primaryKey set when `primaryKey` is set to a non-default value", async () => {

--- a/libs/langchain-mongodb/src/tests/storage.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/storage.int.test.ts
@@ -14,153 +14,360 @@ beforeAll(async () => {
       strict: true,
       deprecationErrors: true,
     },
+    monitorCommands: true,
   });
   await client.connect();
   collection = await client.db("langchain").createCollection("storage");
+});
+
+afterEach(async () => {
+  await collection.deleteMany({});
 });
 
 afterAll(async () => {
   await client.close();
 });
 
-test("MongoDBStore can set and retrieve", async () => {
-  const store = new MongoDBStore({
-    collection,
+describe("mget()", () => {
+  test("returns [] when no keys are specified", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    await store.mset(makeTestDocuments(10));
+    const result = await store.mget([]);
+    expect(result).toEqual([]);
   });
-  expect(store).toBeDefined();
 
-  try {
-    const docs = [
-      [uuidv4(), "Dogs are tough."],
-      [uuidv4(), "Cats are tough."],
-    ];
-    const encoder = new TextEncoder();
-    const decoder = new TextDecoder();
-    const docsAsKVPairs: Array<[string, Uint8Array]> = docs.map((doc) => [
-      doc[0],
-      encoder.encode(doc[1]),
+  test("returns an array of undefined when no specified keys exist in the store", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    await store.mset(makeTestDocuments(10));
+    const result = await store.mget(["nonexistent_key_1", "nonexistent_key_2"]);
+    expect(result).toEqual([undefined, undefined]);
+  });
+
+  test("returns matches when specified keys exist in the store", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const keysToGet = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedValues = documents.slice(0, 2).map((doc) => doc[1]);
+    const result = await store.mget(keysToGet);
+    expect(result).toEqual(expectedValues);
+  });
+
+  test("returns a sparse array when some specified keys exist in the store", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const keysToGet = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedValues = documents.slice(0, 2).map((doc) => doc[1]);
+    const result = await store.mget([
+      keysToGet[0],
+      "nonexistent_key_1",
+      keysToGet[1],
+      "nonexistent_key_2",
     ]);
-    await store.mset(docsAsKVPairs);
+    expect(result).toEqual([
+      expectedValues[0],
+      undefined,
+      expectedValues[1],
+      undefined,
+    ]);
+  });
 
-    const keysToRetrieve = docs.map((doc) => doc[0]);
-    keysToRetrieve.unshift("nonexistent_key_0");
-    keysToRetrieve.push("nonexistent_key_3");
+  test("returns matching documents when `primaryKey` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      primaryKey: "customPrimaryKey",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const keysToGet = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedValues = documents.slice(0, 2).map((doc) => doc[1]);
+    const result = await store.mget(keysToGet);
+    expect(result).toEqual(expectedValues);
+  });
 
-    const retrievedDocs = await store.mget(keysToRetrieve);
-    expect(retrievedDocs.length).toBe(keysToRetrieve.length);
-    // Check that the first item is undefined (nonexistent_key_0)
-    expect(retrievedDocs[0]).toBeUndefined();
-
-    // Check that the second and third items match the original docs
-    expect(decoder.decode(retrievedDocs[1])).toBe(docs[0][1]);
-    expect(decoder.decode(retrievedDocs[2])).toBe(docs[1][1]);
-
-    // Check that the last item is undefined (nonexistent_key_1)
-    expect(retrievedDocs[retrievedDocs.length - 1]).toBeUndefined();
-  } finally {
-    const keys = store.yieldKeys();
-    const yieldedKeys = [];
-    for await (const key of keys) {
-      yieldedKeys.push(key);
-    }
-    await store.mdelete(yieldedKeys);
-  }
+  test("returns matching documents when `namespace` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      namespace: "customNamespace",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const keysToGet = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedValues = documents.slice(0, 2).map((doc) => doc[1]);
+    const result = await store.mget(keysToGet);
+    expect(result).toEqual(expectedValues);
+  });
 });
 
-test("MongoDBStore can delete", async () => {
-  const store = new MongoDBStore({
-    collection,
+describe("mset()", () => {
+  test("throws an error when no kv pairs are specified", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const error = await store.mset([]).catch((e) => e);
+    expect(error.message).toEqual(
+      "Invalid BulkOperation, Batch cannot be empty"
+    );
   });
 
-  try {
-    const docs = [
-      [uuidv4(), "Dogs are tough."],
-      [uuidv4(), "Cats are tough."],
+  test("upserts kv pairs if they don't exist in the db", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    expect(await collection.countDocuments()).toEqual(0);
+
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const yieldedKeys = await arrayFromAsyncGenerator(store.yieldKeys());
+    expect(new Set(yieldedKeys)).toEqual(
+      new Set(documents.map((doc) => doc[0]))
+    );
+  });
+
+  test("updates kv pairs if they do exist in the db", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const updatedDocuments: Array<[string, Uint8Array]> = documents.map(
+      (doc) => [doc[0], new TextEncoder().encode("updated value")]
+    );
+    await store.mset(updatedDocuments);
+
+    expect(await collection.countDocuments()).toEqual(10);
+
+    const values = await store.mget(documents.map((doc) => doc[0]));
+    expect(new Set(values)).toEqual(
+      new Set(updatedDocuments.map((doc) => doc[1]))
+    );
+  });
+
+  test("invalid utf8 data is replaced with replacement character", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+
+    // meta - we must ensure that the data is not valid utf8 and will throw if a textdecoder is
+    const invalidUtf8Data = new Uint8Array([0xff, 0xfe, 0xfd]);
+    expect(() =>
+      new TextDecoder("utf-8", { fatal: true }).decode(invalidUtf8Data)
+    ).toThrow();
+
+    const documents: Array<[string, Uint8Array]> = [
+      [uuidv4(), invalidUtf8Data],
     ];
-    const encoder = new TextEncoder();
-    const docsAsKVPairs: Array<[string, Uint8Array]> = docs.map((doc) => [
-      doc[0],
-      encoder.encode(doc[1]),
-    ]);
-    await store.mset(docsAsKVPairs);
+    await store.mset(documents);
 
-    const docIds = docs.map((doc) => doc[0]);
-    await store.mdelete(docIds);
+    const result = await store.mget([documents[0][0]]);
+    expect(result[0]).toEqual(new TextEncoder().encode("\uFFFD\uFFFD\uFFFD"));
+  });
 
-    const retrievedDocs = await store.mget(docs.map((doc) => doc[0]));
+  test("populates the store with a namespaced key when `namespace` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      namespace: "customNamespace",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
 
-    expect(retrievedDocs.length).toBe(2);
-    const everyValueUndefined = retrievedDocs.every((v) => v === undefined);
-    expect(everyValueUndefined).toBe(true);
-  } finally {
-    const keys = store.yieldKeys();
-    const yieldedKeys = [];
-    for await (const key of keys) {
-      yieldedKeys.push(key);
-    }
-    await store.mdelete(yieldedKeys);
-  }
+    const [document] = await collection.find().limit(1).toArray();
+
+    // @ts-expect-error asdf
+    expect((document._id as string).startsWith("customNamespace/")).toBe(true);
+  });
+
+  test("populates the store with the primaryKey set when `primaryKey` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      primaryKey: "customPrimaryKey",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+
+    const [document] = await collection.find().limit(1).toArray();
+
+    expect(document.customPrimaryKey).toBeDefined();
+  });
 });
 
-test("MongoDBStore can yield keys", async () => {
-  const store = new MongoDBStore({
-    collection,
+describe("mdelete()", () => {
+  test("deletes nothing when no keys are specified", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    await store.mset(makeTestDocuments(10));
+    await store.mdelete([]);
+
+    expect(await collection.countDocuments()).toEqual(10);
+  });
+  test("deletes only matching keys", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+    const keysToDelete = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedRemainingKeys = documents.slice(2).map((doc) => doc[0]);
+    await store.mdelete(keysToDelete);
+    const yieldedKeys = await arrayFromAsyncGenerator(store.yieldKeys());
+    expect(new Set(yieldedKeys)).toEqual(new Set(expectedRemainingKeys));
+  });
+  test("deletes keys with prefix when `namespace` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      namespace: "customNamespace",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+
+    const keysToDelete = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedRemainingKeys = documents.slice(2).map((doc) => doc[0]);
+
+    await store.mdelete(keysToDelete);
+    const yieldedKeys = await arrayFromAsyncGenerator(store.yieldKeys());
+    expect(new Set(yieldedKeys)).toEqual(new Set(expectedRemainingKeys));
+  });
+  test("deletes keys with primaryKey when `primaryKey` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      primaryKey: "customPrimaryKey",
+    });
+    const documents = makeTestDocuments(10);
+    await store.mset(documents);
+
+    const keysToDelete = documents.slice(0, 2).map((doc) => doc[0]);
+    const expectedRemainingKeys = documents.slice(2).map((doc) => doc[0]);
+
+    await store.mdelete(keysToDelete);
+    const yieldedKeys = await arrayFromAsyncGenerator(store.yieldKeys());
+    expect(new Set(yieldedKeys)).toEqual(new Set(expectedRemainingKeys));
+  });
+});
+
+describe("yieldKeys()", () => {
+  test("yields all keys when no prefix is specified", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    const expectedKeys = documents.map((doc) => doc[0]);
+    await store.mset(documents);
+    const keys = store.yieldKeys();
+    const yieldedKeys = await arrayFromAsyncGenerator(keys);
+    expect(new Set(yieldedKeys)).toEqual(new Set(expectedKeys));
   });
 
-  const docs = [
-    [uuidv4(), "Dogs are tough."],
-    [uuidv4(), "Cats are tough."],
-  ];
+  test("yields only matching keys when a prefix is specified", async () => {
+    const store = new MongoDBStore({
+      collection,
+    });
+    const documents = makeTestDocuments(10);
+    documents[0][0] = "prefix_1";
+    documents[1][0] = "prefix_2";
+    documents[2][0] = "prefix_3";
+
+    await store.mset(documents);
+    const keys = store.yieldKeys("prefix");
+    const yieldedKeys = await arrayFromAsyncGenerator(keys);
+    expect(new Set(yieldedKeys)).toEqual(
+      new Set(["prefix_1", "prefix_2", "prefix_3"])
+    );
+  });
+
+  test("yields only matching keys when `primaryKey` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      primaryKey: "customPrimaryKey",
+    });
+    const documents = makeTestDocuments(10);
+    documents[0][0] = "prefix_1";
+    documents[1][0] = "prefix_2";
+    documents[2][0] = "prefix_3";
+
+    await store.mset(documents);
+    const keys = store.yieldKeys("prefix");
+    const yieldedKeys = await arrayFromAsyncGenerator(keys);
+    expect(new Set(yieldedKeys)).toEqual(
+      new Set(["prefix_1", "prefix_2", "prefix_3"])
+    );
+  });
+  test("yields only matching keys when `namespace` is set to a non-default value", async () => {
+    const store = new MongoDBStore({
+      collection,
+      namespace: "customNamespace",
+    });
+    const documents = makeTestDocuments(10);
+    documents[0][0] = "prefix_1";
+    documents[1][0] = "prefix_2";
+    documents[2][0] = "prefix_3";
+
+    await store.mset(documents);
+    const keys = store.yieldKeys("prefix");
+    const yieldedKeys = await arrayFromAsyncGenerator(keys);
+    expect(new Set(yieldedKeys)).toEqual(
+      new Set(["prefix_1", "prefix_2", "prefix_3"])
+    );
+  });
+
+  test("batches are fetched in batches of `yieldKeysScanBatchSize`", async () => {
+    const events: { batchSize: number; command: "find" | "getMore" }[] = [];
+    client.on("commandStarted", (event) => {
+      if (["find", "getMore"].includes(event.commandName))
+        events.push({
+          batchSize: event.command.batchSize,
+          command: event.commandName as unknown as "find" | "getMore",
+        });
+    });
+
+    const store = new MongoDBStore({
+      collection,
+      yieldKeysScanBatchSize: 2,
+    });
+    const documents = makeTestDocuments(5);
+    await store.mset(documents);
+    const keys = store.yieldKeys();
+    await arrayFromAsyncGenerator(keys);
+
+    expect(events).toEqual([
+      {
+        batchSize: 2,
+        command: "find",
+      },
+      {
+        batchSize: 2,
+        command: "getMore",
+      },
+      {
+        batchSize: 2,
+        command: "getMore",
+      },
+    ]);
+  });
+});
+
+async function arrayFromAsyncGenerator<T>(gen: AsyncGenerator<T>) {
+  const arr: T[] = [];
+  for await (const item of gen) {
+    arr.push(item);
+  }
+  return arr;
+}
+
+function makeTestDocuments(n: number) {
+  const docs: Array<[string, Uint8Array]> = [];
   const encoder = new TextEncoder();
-  const docsAsKVPairs: Array<[string, Uint8Array]> = docs.map((doc) => [
-    doc[0],
-    encoder.encode(doc[1]),
-  ]);
-  await store.mset(docsAsKVPairs);
-
-  const keys = store.yieldKeys();
-
-  const yieldedKeys = [];
-  for await (const key of keys) {
-    yieldedKeys.push(key);
+  for (let i = 0; i < n; i += 1) {
+    docs.push([uuidv4(), encoder.encode(`Dogs are tough ${i}.`)]);
   }
-
-  expect(yieldedKeys.sort()).toEqual(docs.map((doc) => doc[0]).sort());
-
-  // delete
-  await store.mdelete(yieldedKeys);
-});
-
-test("MongoDBStore can yield keys with prefix", async () => {
-  const store = new MongoDBStore({
-    collection,
-  });
-
-  try {
-    const docs = [
-      ["dis_one", "Dogs are tough."],
-      ["not_dis_one", "Cats are tough."],
-    ];
-    const encoder = new TextEncoder();
-    const docsAsKVPairs: Array<[string, Uint8Array]> = docs.map((doc) => [
-      doc[0],
-      encoder.encode(doc[1]),
-    ]);
-    await store.mset(docsAsKVPairs);
-
-    const keys = store.yieldKeys("dis_one");
-
-    const yieldedKeys = [];
-    for await (const key of keys) {
-      yieldedKeys.push(key);
-    }
-    expect(yieldedKeys).toEqual(["dis_one"]);
-  } finally {
-    const keys = store.yieldKeys();
-    const yieldedKeys = [];
-    for await (const key of keys) {
-      yieldedKeys.push(key);
-    }
-    await store.mdelete(yieldedKeys);
-  }
-});
+  return docs;
+}

--- a/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-process-env */
 /* eslint-disable no-promise-executor-return */
 
-import { test, expect } from "@jest/globals";
+import { expect, jest, test } from "@jest/globals";
 import { Collection, MongoClient } from "mongodb";
 import { setTimeout } from "timers/promises";
 import { OpenAIEmbeddings } from "@langchain/openai";
@@ -240,8 +240,429 @@ test("MongoDBAtlasVectorSearch upsert", async () => {
     "Sandwich",
     1
   );
-  // console.log(results2);
 
   expect(results2.length).toEqual(1);
   expect(results2[0].pageContent).not.toContain("sandwich");
+});
+
+// Setup and teardown code would be here
+
+describe("MongoDBAtlasVectorSearch Constructor", () => {
+  test("initializes with minimal configuration", () => {
+    const vectorStore = new MongoDBAtlasVectorSearch(new OpenAIEmbeddings(), {
+      collection,
+    });
+    expect(vectorStore).toBeDefined();
+  });
+
+  test("initializes with custom index name", () => {
+    const customIndexName = "custom_index";
+    const vectorStore = new MongoDBAtlasVectorSearch(new OpenAIEmbeddings(), {
+      collection,
+      indexName: customIndexName,
+    });
+    expect(vectorStore).toBeDefined();
+    // @ts-expect-error: Testing private property
+    expect(vectorStore.indexName).toEqual(customIndexName);
+  });
+
+  test("initializes with custom field names", () => {
+    const vectorStore = new MongoDBAtlasVectorSearch(new OpenAIEmbeddings(), {
+      collection,
+      textKey: "content",
+      embeddingKey: "vector",
+      primaryKey: "docId",
+    });
+    expect(vectorStore).toBeDefined();
+    // @ts-expect-error: Testing private properties
+    expect(vectorStore.textKey).toEqual("content");
+    // @ts-expect-error: Testing private properties
+    expect(vectorStore.embeddingKey).toEqual("vector");
+    // @ts-expect-error: Testing private properties
+    expect(vectorStore.primaryKey).toEqual("docId");
+  });
+
+  test("initializes AsyncCaller with custom parameters", () => {
+    const vectorStore = new MongoDBAtlasVectorSearch(new OpenAIEmbeddings(), {
+      collection,
+      maxConcurrency: 5,
+      maxRetries: 3,
+    });
+    expect(vectorStore).toBeDefined();
+    // @ts-expect-error: Testing private property
+    expect(vectorStore.caller.maxConcurrency).toEqual(5);
+    // @ts-expect-error: Testing private property
+    expect(vectorStore.caller.maxRetries).toEqual(3);
+  });
+});
+
+describe("addVectors method", () => {
+  test("stores vectors and documents correctly", async () => {
+    const vectorStore = new PatchedVectorStore(new OpenAIEmbeddings(), {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const vectors = [Array(1536).fill(0.1), Array(1536).fill(0.2)];
+    const documents = [
+      new Document({ pageContent: "test 1", metadata: { source: "source1" } }),
+      new Document({ pageContent: "test 2", metadata: { source: "source2" } }),
+    ];
+
+    await vectorStore.addVectors(vectors, documents);
+
+    const results = await collection.find({}).toArray();
+    expect(results.length).toBe(2);
+    expect(results[0].text).toBe("test 1");
+    expect(results[0].embedding).toEqual(Array(1536).fill(0.1));
+    expect(results[0].source).toBe("source1");
+    expect(results[1].text).toBe("test 2");
+    expect(results[1].embedding).toEqual(Array(1536).fill(0.2));
+    expect(results[1].source).toBe("source2");
+  });
+
+  test("with custom ids performs upsert correctly", async () => {
+    const vectorStore = new PatchedVectorStore(new OpenAIEmbeddings(), {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const vectors = [Array(1536).fill(0.1), Array(1536).fill(0.2)];
+    const documents = [
+      new Document({ pageContent: "test 1", metadata: { source: "source1" } }),
+      new Document({ pageContent: "test 2", metadata: { source: "source2" } }),
+    ];
+    const ids = ["id1", "id2"];
+
+    await vectorStore.addVectors(vectors, documents, { ids });
+
+    // Check if documents were inserted
+    const results = await collection.find({}).toArray();
+    expect(results.length).toBe(2);
+    expect(results.find((r) => r._id === "id1")).toBeDefined();
+    expect(results.find((r) => r._id === "id2")).toBeDefined();
+
+    // Test upsert with updated data
+    const updatedVectors = [Array(1536).fill(0.3), Array(1536).fill(0.4)];
+    const updatedDocuments = [
+      new Document({
+        pageContent: "updated 1",
+        metadata: { source: "updated1" },
+      }),
+      new Document({
+        pageContent: "updated 2",
+        metadata: { source: "updated2" },
+      }),
+    ];
+
+    await vectorStore.addVectors(updatedVectors, updatedDocuments, { ids });
+
+    const updatedResults = await collection.find({}).toArray();
+    expect(updatedResults.length).toBe(2);
+    const doc1 = updatedResults.find((r) => r._id === "id1");
+    const doc2 = updatedResults.find((r) => r._id === "id2");
+
+    expect(doc1.text).toBe("updated 1");
+    expect(doc1.embedding).toEqual(Array(1536).fill(0.3));
+    expect(doc1.source).toBe("updated1");
+    expect(doc2.text).toBe("updated 2");
+    expect(doc2.embedding).toEqual(Array(1536).fill(0.4));
+    expect(doc2.source).toBe("updated2");
+  });
+
+  test("throws error when ids length doesn't match vectors length", async () => {
+    const vectorStore = new PatchedVectorStore(new OpenAIEmbeddings(), {
+      collection,
+    });
+
+    const vectors = [Array(1536).fill(0.1), Array(1536).fill(0.2)];
+    const documents = [
+      new Document({ pageContent: "test 1", metadata: {} }),
+      new Document({ pageContent: "test 2", metadata: {} }),
+    ];
+    const ids = ["id1"]; // Only one ID for two vectors
+
+    await expect(
+      vectorStore.addVectors(vectors, documents, { ids })
+    ).rejects.toThrow(
+      'If provided, "options.ids" must be an array with the same length as "vectors".'
+    );
+  });
+});
+
+describe("addDocuments method", () => {
+  test("correctly embeds and stores documents", async () => {
+    const embeddings = {
+      embedDocuments: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue([Array(1536).fill(0.1), Array(1536).fill(0.2)]),
+      embedQuery: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue(Array(1536).fill(0.1)),
+    };
+
+    // @ts-expect-error: Mock embeddings
+    const vectorStore = new PatchedVectorStore(embeddings, {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const documents = [
+      new Document({ pageContent: "test 1", metadata: { source: "source1" } }),
+      new Document({ pageContent: "test 2", metadata: { source: "source2" } }),
+    ];
+
+    await vectorStore.addDocuments(documents);
+
+    expect(embeddings.embedDocuments).toHaveBeenCalledWith([
+      "test 1",
+      "test 2",
+    ]);
+
+    const results = await collection.find({}).toArray();
+    expect(results.length).toBe(2);
+    expect(results[0].text).toBe("test 1");
+    expect(results[0].embedding).toEqual(Array(1536).fill(0.1));
+    expect(results[1].text).toBe("test 2");
+    expect(results[1].embedding).toEqual(Array(1536).fill(0.2));
+  });
+
+  test("with custom ids performs upsert correctly", async () => {
+    const embeddings = {
+      embedDocuments: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue([Array(1536).fill(0.1), Array(1536).fill(0.2)]),
+      embedQuery: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue(Array(1536).fill(0.1)),
+    };
+
+    // @ts-expect-error: Mock embeddings
+    const vectorStore = new PatchedVectorStore(embeddings, {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const documents = [
+      new Document({ pageContent: "test 1", metadata: { source: "source1" } }),
+      new Document({ pageContent: "test 2", metadata: { source: "source2" } }),
+    ];
+
+    await vectorStore.addDocuments(documents, { ids: ["id1", "id2"] });
+
+    const results = await collection.find({}).toArray();
+    expect(results.length).toBe(2);
+    expect(results.find((r) => r._id === "id1")).toBeDefined();
+    expect(results.find((r) => r._id === "id2")).toBeDefined();
+  });
+
+  test("correctly handles documents with special characters", async () => {
+    const embeddings = {
+      embedDocuments: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue([Array(1536).fill(0.1)]),
+      embedQuery: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue(Array(1536).fill(0.1)),
+    };
+
+    // @ts-expect-error: Mock embeddings
+    const vectorStore = new PatchedVectorStore(embeddings, {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const documents = [
+      new Document({
+        pageContent: "test !@#$%^&*()",
+        metadata: { source: "special" },
+      }),
+    ];
+
+    await vectorStore.addDocuments(documents);
+
+    const results = await collection.find({}).toArray();
+    expect(results.length).toBe(1);
+    expect(results[0].text).toBe("test !@#$%^&*()");
+    expect(results[0].embedding).toEqual(Array(1536).fill(0.1));
+    expect(results[0].source).toBe("special");
+  });
+});
+
+describe("similaritySearchVectorWithScore method", () => {
+  beforeEach(async () => {
+    const embeddings = {
+      embedDocuments: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue([
+          Array(1536).fill(0.1),
+          Array(1536).fill(0.2),
+          Array(1536).fill(0.3),
+          Array(1536).fill(0.4),
+        ]),
+      embedQuery: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue(Array(1536).fill(0.1)),
+    };
+
+    // @ts-expect-error: Mock embeddings
+    const vectorStore = new PatchedVectorStore(embeddings, {
+      collection,
+    });
+
+    await collection.deleteMany({});
+
+    const documents = [
+      new Document({ pageContent: "cat", metadata: { animal: true, id: 1 } }),
+      new Document({ pageContent: "dog", metadata: { animal: true, id: 2 } }),
+      new Document({
+        pageContent: "fish",
+        metadata: { animal: true, id: 3, aquatic: true },
+      }),
+      new Document({ pageContent: "car", metadata: { vehicle: true, id: 4 } }),
+    ];
+
+    await vectorStore.addDocuments(documents);
+  });
+
+  test("returns correct documents and scores", async () => {
+    // Test basic similarity search with scores
+  });
+
+  test("with preFilter applies filters correctly", async () => {
+    // Test preFilter functionality
+  });
+
+  test("with postFilterPipeline applies pipeline correctly", async () => {
+    // Test postFilterPipeline functionality
+  });
+
+  test("with includeEmbeddings returns embeddings", async () => {
+    // Test includeEmbeddings functionality
+  });
+
+  test("handles complex combined filters", async () => {
+    // Test combination of filter types
+  });
+});
+
+describe("maxMarginalRelevanceSearch method", () => {
+  let embeddings: {
+    embedQuery: jest.Mock<() => Promise<number[][]>>;
+    embedDocuments: jest.Mock;
+  };
+
+  beforeEach(() => {
+    // Mock embeddings with controlled values for deterministic MMR testing
+    embeddings = {
+      embedQuery: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue(Array(1536).fill(0.1)),
+      embedDocuments: jest
+        .fn<() => Promise<number[][]>>()
+        .mockResolvedValue([
+          Array(1536).fill(0.1),
+          Array(1536).fill(0.2),
+          Array(1536).fill(0.3),
+        ]),
+    };
+  });
+
+  test("returns diverse results", async () => {
+    // Test basic MMR functionality
+  });
+
+  test("with different lambda values affects diversity", async () => {
+    // Test impact of lambda parameter
+  });
+
+  test("with fetchK parameter retrieves correct number of candidates", async () => {
+    // Test fetchK parameter
+  });
+
+  test("with filter correctly applies filtering", async () => {
+    // Test filtered MMR search
+  });
+
+  test("respects includeEmbeddings flag", async () => {
+    // Test that embeddings are included/excluded based on flag
+  });
+});
+
+describe("delete method", () => {
+  beforeEach(async () => {
+    // Setup test data
+    await collection.deleteMany({});
+    await collection.insertMany([
+      { _id: "id1", text: "doc1" },
+      { _id: "id2", text: "doc2" },
+      { _id: "id3", text: "doc3" },
+      { _id: "id4", text: "doc4" },
+      { _id: "id5", text: "doc5" },
+    ]);
+  });
+
+  test("removes documents by ids", async () => {
+    const vectorStore = new PatchedVectorStore(new OpenAIEmbeddings(), {
+      collection,
+    });
+
+    await vectorStore.delete({ ids: ["id1", "id3"] });
+
+    const remaining = await collection
+      .find({})
+      .map(({ _id }) => _id)
+      .toArray();
+    expect(remaining.length).toBe(3);
+    expect(remaining).toEqual(["id2", "id4", "id5"]);
+  });
+
+  test("handles large number of ids by chunking", async () => {
+    // Test chunking for large deletions
+  });
+
+  test("ignores non-existent ids", async () => {
+    const vectorStore = new PatchedVectorStore(new OpenAIEmbeddings(), {
+      collection,
+    });
+
+    await vectorStore.delete({ ids: ["nonexistent1", "nonexistent2", "id1"] });
+
+    const remaining = await collection
+      .find({})
+      .map(({ _id }) => _id)
+      .toArray();
+    expect(remaining).toEqual(["id2", "id3", "id4", "id5"]);
+  });
+});
+
+describe("Static Methods", () => {
+  describe("fromTexts", () => {
+    test("creates instance with correct documents from strings", async () => {
+      // Test fromTexts factory method
+    });
+
+    test("with array of metadata assigns correct metadata to each document", async () => {
+      // Test metadata handling in fromTexts
+    });
+
+    test("with single metadata object applies to all documents", async () => {
+      // Test single metadata object behavior
+    });
+  });
+
+  describe("fromDocuments", () => {
+    test("creates instance with documents preserved", async () => {
+      // Test fromDocuments factory method
+    });
+
+    test("with custom ids performs upsert behavior", async () => {
+      // Test fromDocuments with custom ids
+    });
+  });
 });


### PR DESCRIPTION
We (MongoDB) have started running the langchainjs MongoDB integration periodically in our own CI to get early alerting if something were to break.  We'd like to also make sure the tests provide good coverage of the integration.

This PR updates the existing MongoDB integration test suite to more exhaustively test the integration.
