### PR TITLE
Issue 8303 - cp4d auth fix

### DIFF
--- a/libs/langchain-community/src/utils/ibm.ts
+++ b/libs/langchain-community/src/utils/ibm.ts
@@ -43,7 +43,8 @@ export const authenticateAndSetInstance = ({
       }),
     });
   } else if (watsonxAIAuthType === "cp4d" && watsonxAIUrl) {
-    if (watsonxAIUsername && watsonxAIPassword && watsonxAIApikey)
+    // cp4d auth requires username with either Password of ApiKey but not both.
+    if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey))
       return WatsonXAI.newInstance({
         version,
         serviceUrl,


### PR DESCRIPTION


<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

ref: https://github.com/langchain-ai/langchainjs/issues/8303

cp4d authentication requires username along with either `password` or `apiKey` but not both. 

Fixed condition that ensures above check.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # ([issue-8303](https://github.com/langchain-ai/langchainjs/issues/8303))
