### PR TITLE
Fix param in langchain-google-genai README

### DIFF
--- a/libs/langchain-google-genai/README.md
+++ b/libs/langchain-google-genai/README.md
@@ -53,7 +53,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { HumanMessage } from "@langchain/core/messages";
 
 const model = new ChatGoogleGenerativeAI({
-  modelName: "gemini-pro",
+  model: "gemini-pro",
   maxOutputTokens: 2048,
 });
 const response = await model.invoke(new HumanMessage("Hello world!"));
@@ -73,7 +73,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { HumanMessage } from "@langchain/core/messages";
 
 const vision = new ChatGoogleGenerativeAI({
-  modelName: "gemini-pro-vision",
+  model: "gemini-pro-vision",
   maxOutputTokens: 2048,
 });
 const image = fs.readFileSync("./hotdog.jpg").toString("base64");


### PR DESCRIPTION
I was updating package '@langchain/google-genai' to 0.2.10 from 0.1.8 and noticed that docs are mentioning old param `modelName`. By looking at typings from `ChatGoogleGenerativeAI` i see that it has been renamed to `model`

`GoogleGenerativeAIEmbeddingsParams` has alias for both so this raises question should alias be supported for `ChatGoogleGenerativeAI` - if yes i would like to work on it