### PR TITLE
fix chroma query param error

### DIFF
--- a/libs/langchain-community/src/vectorstores/chroma.ts
+++ b/libs/langchain-community/src/vectorstores/chroma.ts
@@ -361,7 +361,7 @@ export class Chroma extends VectorStore {
     // similaritySearchVectorWithScore supports one query vector at a time
     // chroma supports multiple query vectors at a time
     const result = await collection.query({
-      queryEmbeddings: query,
+      queryEmbeddings: [query],
       nResults: k,
       where,
     });


### PR DESCRIPTION
In the collection.query method, the parameter queryEmbeddings should accept a number[][] instead of a number[]. Multiple query conditions are required.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes #8314
