### PR TITLE
fix: Amazon Bedrock  Error (thinking: Extra inputs are not permitted)

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -815,7 +815,6 @@ export class ChatAnthropicMessages<
       max_tokens: this.maxTokens,
       tools: this.formatStructuredToolToAnthropic(options?.tools),
       tool_choice,
-      thinking: this.thinking,
       ...this.invocationKwargs,
     };
   }


### PR DESCRIPTION
When using Amazon Bedrock to invoke Anthropic models that do not support extended-thinking (such as anthropic.claude-3-sonnet-v2), Bedrock validates the input parameters, resulting in the following error:

```
error: {
    status: 500,
    data: 'thinking: Extra inputs are not permitted (Service: BedrockRuntime, Status Code: 400, Request ID: 4784b6ca-2bd4-4bc8-9e4b-7c8595ab48c5)'
}
```

The solution proposed in this PR is to avoid passing the thinking field to the server when thinking is not enabled, ensuring compatibility while eliminating the error.

