### PR TITLE
fix(core): Fix JSDom check for recent Node versions

### DIFF
--- a/langchain-core/src/utils/env.ts
+++ b/langchain-core/src/utils/env.ts
@@ -22,9 +22,7 @@ export const isWebWorker = () =>
 
 export const isJsDom = () =>
   (typeof window !== "undefined" && window.name === "nodejs") ||
-  (typeof navigator !== "undefined" &&
-    (navigator.userAgent.includes("Node.js") ||
-      navigator.userAgent.includes("jsdom")));
+  (typeof navigator !== "undefined" && navigator.userAgent.includes("jsdom"));
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property


### PR DESCRIPTION
Node 21 added the navigator interface, so the JSDom check in env.ts will always return true for recent Node versions:

https://developer.mozilla.org/en-US/docs/Web/API/Navigator#browser_compatibility

JSDom's default user agent contains the string "jsdom" so it still should be fine:

https://github.com/jsdom/jsdom?tab=readme-ov-file#advanced-configuration

Same fix as https://github.com/langchain-ai/langsmith-sdk/pull/1784