### PR TITLE
patch(openai): upgrade sdk & defer zdr handling to openai

### DIFF
--- a/langchain/src/chains/openai_functions/openapi.ts
+++ b/langchain/src/chains/openai_functions/openapi.ts
@@ -488,7 +488,7 @@ export async function createOpenAPIChain(
     );
   }
   const {
-    llm = new ChatOpenAI({ modelName: "gpt-3.5-turbo-0613" }),
+    llm = new ChatOpenAI({ model: "gpt-3.5-turbo-0613" }),
     prompt = ChatPromptTemplate.fromMessages([
       HumanMessagePromptTemplate.fromTemplate(
         "Use the provided API's to respond to this user query:\n\n{query}"

--- a/langchain/src/experimental/openai_assistant/index.ts
+++ b/langchain/src/experimental/openai_assistant/index.ts
@@ -103,9 +103,9 @@ export class OpenAIAssistantRunnable<
     if (this.asAgent && input.steps && input.steps.length > 0) {
       const parsedStepsInput = await this._parseStepsInput(input);
       run = await this.client.beta.threads.runs.submitToolOutputs(
-        parsedStepsInput.threadId,
         parsedStepsInput.runId,
         {
+          thread_id: parsedStepsInput.threadId,
           tool_outputs: parsedStepsInput.toolOutputs,
         }
       );
@@ -137,13 +137,10 @@ export class OpenAIAssistantRunnable<
     } else {
       // Submitting tool outputs to an existing run, outside the AgentExecutor
       // framework.
-      run = await this.client.beta.threads.runs.submitToolOutputs(
-        input.threadId,
-        input.runId,
-        {
-          tool_outputs: input.toolOutputs,
-        }
-      );
+      run = await this.client.beta.threads.runs.submitToolOutputs(input.runId, {
+        thread_id: input.threadId,
+        tool_outputs: input.toolOutputs,
+      });
     }
 
     return this._getResponse(run.id, run.thread_id);
@@ -156,7 +153,7 @@ export class OpenAIAssistantRunnable<
    * @returns {Promise<AssistantDeleted>}
    */
   public async deleteAssistant() {
-    return await this.client.beta.assistants.del(this.assistantId);
+    return await this.client.beta.assistants.delete(this.assistantId);
   }
 
   /**
@@ -268,7 +265,9 @@ export class OpenAIAssistantRunnable<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let run = {} as any;
     while (inProgress) {
-      run = await this.client.beta.threads.runs.retrieve(threadId, runId);
+      run = await this.client.beta.threads.runs.retrieve(runId, {
+        thread_id: threadId,
+      });
       inProgress = ["in_progress", "queued"].includes(run.status);
       if (inProgress) {
         await sleep(this.pollIntervalMs);

--- a/langchain/src/experimental/openai_files/index.ts
+++ b/langchain/src/experimental/openai_files/index.ts
@@ -53,7 +53,7 @@ export class OpenAIFiles extends Serializable {
     fileId: string;
     options?: OpenAIClient.RequestOptions;
   }) {
-    return this.oaiClient.files.del(fileId, options);
+    return this.oaiClient.files.delete(fileId, options);
   }
 
   /**
@@ -109,6 +109,6 @@ export class OpenAIFiles extends Serializable {
     fileId: string;
     options?: OpenAIClient.RequestOptions;
   }) {
-    return this.oaiClient.files.retrieveContent(fileId, options);
+    return this.oaiClient.files.retrieve(fileId, options);
   }
 }

--- a/libs/langchain-openai/package.json
+++ b/libs/langchain-openai/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "js-tiktoken": "^1.0.12",
-    "openai": "^4.96.0",
+    "openai": "^5.3.0",
     "zod": "3.25.32"
   },
   "peerDependencies": {

--- a/libs/langchain-openai/src/azure/chat_models.ts
+++ b/libs/langchain-openai/src/azure/chat_models.ts
@@ -18,6 +18,7 @@ import {
   OpenAIChatInput,
   OpenAICoreRequestOptions,
 } from "../types.js";
+import { normalizeHeaders } from "../utils/headers.js";
 
 export type { AzureOpenAIInput };
 
@@ -541,7 +542,9 @@ export class AzureChatOpenAI extends ChatOpenAI {
     return params;
   }
 
-  protected _getClientOptions(options: OpenAICoreRequestOptions | undefined) {
+  protected _getClientOptions(
+    options: OpenAICoreRequestOptions | undefined
+  ): OpenAICoreRequestOptions {
     if (!this.client) {
       const openAIEndpointConfig: OpenAIEndpointConfig = {
         azureOpenAIApiDeploymentName: this.azureOpenAIApiDeploymentName,
@@ -575,12 +578,12 @@ export class AzureChatOpenAI extends ChatOpenAI {
         env = `(${env}/${process.version}; ${process.platform}; ${process.arch})`;
       }
 
-      const specifiedUserAgent = params.defaultHeaders?.["User-Agent"];
+      const defaultHeaders = normalizeHeaders(params.defaultHeaders);
       params.defaultHeaders = {
         ...params.defaultHeaders,
-        "User-Agent": `langchainjs-azure-openai/2.0.0 (${env})${
-          specifiedUserAgent ? ` ${specifiedUserAgent}` : ""
-        }`,
+        "User-Agent": defaultHeaders["User-Agent"]
+          ? `langchainjs-azure-openai/2.0.0 (${env})${defaultHeaders["User-Agent"]}`
+          : `langchainjs-azure-openai/2.0.0 (${env})`,
       };
 
       this.client = new AzureOpenAIClient({

--- a/libs/langchain-openai/src/azure/llms.ts
+++ b/libs/langchain-openai/src/azure/llms.ts
@@ -8,6 +8,7 @@ import type {
   AzureOpenAIInput,
   OpenAICoreRequestOptions,
 } from "../types.js";
+import { normalizeHeaders } from "../utils/headers.js";
 
 export class AzureOpenAI extends OpenAI {
   azureOpenAIApiVersion?: string;
@@ -94,7 +95,9 @@ export class AzureOpenAI extends OpenAI {
     }
   }
 
-  protected _getClientOptions(options: OpenAICoreRequestOptions | undefined) {
+  protected _getClientOptions(
+    options: OpenAICoreRequestOptions | undefined
+  ): OpenAICoreRequestOptions {
     if (!this.client) {
       const openAIEndpointConfig: OpenAIEndpointConfig = {
         azureOpenAIApiDeploymentName: this.azureOpenAIApiDeploymentName,
@@ -122,10 +125,11 @@ export class AzureOpenAI extends OpenAI {
         delete params.baseURL;
       }
 
+      const defaultHeaders = normalizeHeaders(params.defaultHeaders);
       params.defaultHeaders = {
         ...params.defaultHeaders,
-        "User-Agent": params.defaultHeaders?.["User-Agent"]
-          ? `${params.defaultHeaders["User-Agent"]}: langchainjs-azure-openai-v2`
+        "User-Agent": defaultHeaders["User-Agent"]
+          ? `${defaultHeaders["User-Agent"]}: langchainjs-azure-openai-v2`
           : `langchainjs-azure-openai-v2`,
       };
 

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -818,7 +818,7 @@ function _convertOpenAIResponsesDeltaToBaseMessageChunk(
       text: chunk.delta,
       index: chunk.content_index,
     });
-  } else if (chunk.type === "response.output_text.annotation.added") {
+  } else if (chunk.type === "response.output_text_annotation.added") {
     content.push({
       type: "text",
       text: "",
@@ -2992,11 +2992,11 @@ export class ChatOpenAI<
     request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
     options?: OpenAICoreRequestOptions
     // Avoid relying importing a beta type with no official entrypoint
-  ): Promise<ReturnType<OpenAIClient["beta"]["chat"]["completions"]["parse"]>> {
+  ): Promise<ReturnType<OpenAIClient["chat"]["completions"]["parse"]>> {
     const requestOptions = this._getClientOptions(options);
     return this.caller.call(async () => {
       try {
-        const res = await this.client.beta.chat.completions.parse(
+        const res = await this.client.chat.completions.parse(
           request,
           requestOptions
         );
@@ -3008,7 +3008,9 @@ export class ChatOpenAI<
     });
   }
 
-  protected _getClientOptions(options: OpenAICoreRequestOptions | undefined) {
+  protected _getClientOptions(
+    options: OpenAICoreRequestOptions | undefined
+  ): OpenAICoreRequestOptions {
     if (!this.client) {
       const openAIEndpointConfig: OpenAIEndpointConfig = {
         baseURL: this.clientConfig.baseURL,

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -439,18 +439,18 @@ function _convertReasoningSummaryToOpenAIResponsesParams(
 
 function _convertMessagesToOpenAIResponsesParams(
   messages: BaseMessage[],
-  model?: string,
-  zdrEnabled?: boolean
+  model?: string
 ): ResponsesInputItem[] {
-  const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
-  const lastAIMessageId = lastAIMessage?.response_metadata?.id;
-  const newMessages =
-    lastAIMessageId && lastAIMessageId.startsWith("resp_") && !zdrEnabled
-      ? messages.slice(messages.indexOf(lastAIMessage) + 1)
-      : messages;
-
-  return newMessages.flatMap(
+  return messages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
+      const additional_kwargs = lcMsg.additional_kwargs as
+        | BaseMessageFields["additional_kwargs"] & {
+            [_FUNCTION_CALL_IDS_MAP_KEY]?: Record<string, string>;
+            reasoning?: OpenAIClient.Responses.ResponseReasoningItem;
+            type?: string;
+            refusal?: string;
+          };
+
       let role = messageToOpenAIRole(lcMsg);
       if (role === "system" && isReasoningModel(model)) role = "developer";
 
@@ -462,7 +462,7 @@ function _convertMessagesToOpenAIResponsesParams(
         const toolMessage = lcMsg as ToolMessage;
 
         // Handle computer call output
-        if (toolMessage.additional_kwargs?.type === "computer_call_output") {
+        if (additional_kwargs?.type === "computer_call_output") {
           const output = (() => {
             if (typeof toolMessage.content === "string") {
               return {
@@ -517,7 +517,6 @@ function _convertMessagesToOpenAIResponsesParams(
       if (role === "assistant") {
         // if we have the original response items, just reuse them
         if (
-          !zdrEnabled &&
           lcMsg.response_metadata.output != null &&
           Array.isArray(lcMsg.response_metadata.output) &&
           lcMsg.response_metadata.output.length > 0 &&
@@ -531,43 +530,29 @@ function _convertMessagesToOpenAIResponsesParams(
         const input: ResponsesInputItem[] = [];
 
         // reasoning items
-        if (!zdrEnabled && lcMsg.additional_kwargs.reasoning != null) {
-          type FindType<T, TType extends string> = T extends { type: TType }
-            ? T
-            : never;
-          type ReasoningItem = FindType<ResponsesInputItem, "reasoning">;
-
-          const isReasoningItem = (item: unknown): item is ReasoningItem =>
-            typeof item === "object" &&
-            item != null &&
-            "type" in item &&
-            item.type === "reasoning";
-
-          if (isReasoningItem(lcMsg.additional_kwargs.reasoning)) {
-            const reasoningItem =
-              _convertReasoningSummaryToOpenAIResponsesParams(
-                lcMsg.additional_kwargs.reasoning
-              );
-            input.push(reasoningItem);
-          }
+        if (additional_kwargs?.reasoning) {
+          const reasoningItem = _convertReasoningSummaryToOpenAIResponsesParams(
+            additional_kwargs.reasoning
+          );
+          input.push(reasoningItem);
         }
 
         // ai content
         let { content } = lcMsg;
-        if (lcMsg.additional_kwargs.refusal != null) {
+        if (additional_kwargs?.refusal) {
           if (typeof content === "string") {
             content = [{ type: "output_text", text: content, annotations: [] }];
           }
           content = [
             ...content,
-            { type: "refusal", refusal: lcMsg.additional_kwargs.refusal },
+            { type: "refusal", refusal: additional_kwargs.refusal },
           ];
         }
 
         input.push({
           type: "message",
           role: "assistant",
-          ...(lcMsg.id && !zdrEnabled ? { id: lcMsg.id } : {}),
+          ...(lcMsg.id ? { id: lcMsg.id } : {}),
           content:
             typeof content === "string"
               ? content
@@ -589,12 +574,7 @@ function _convertMessagesToOpenAIResponsesParams(
                 }),
         });
 
-        // function tool calls and computer use tool calls
-        const functionCallIds =
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          lcMsg.additional_kwargs[_FUNCTION_CALL_IDS_MAP_KEY] as
-            | Record<string, string>
-            | undefined;
+        const functionCallIds = additional_kwargs?.[_FUNCTION_CALL_IDS_MAP_KEY];
 
         if (isAIMessage(lcMsg) && !!lcMsg.tool_calls?.length) {
           input.push(
@@ -604,18 +584,18 @@ function _convertMessagesToOpenAIResponsesParams(
                 name: toolCall.name,
                 arguments: JSON.stringify(toolCall.args),
                 call_id: toolCall.id!,
-                ...(zdrEnabled ? { id: functionCallIds?.[toolCall.id!] } : {}),
+                id: functionCallIds?.[toolCall.id!],
               })
             )
           );
-        } else if (lcMsg.additional_kwargs.tool_calls != null) {
+        } else if (additional_kwargs?.tool_calls) {
           input.push(
-            ...lcMsg.additional_kwargs.tool_calls.map(
+            ...additional_kwargs.tool_calls.map(
               (toolCall): ResponsesInputItem => ({
                 type: "function_call",
                 name: toolCall.function.name,
                 call_id: toolCall.id,
-                ...(zdrEnabled ? { id: functionCallIds?.[toolCall.id] } : {}),
+                id: functionCallIds?.[toolCall.id],
                 arguments: toolCall.function.arguments,
               })
             )
@@ -626,7 +606,7 @@ function _convertMessagesToOpenAIResponsesParams(
           lcMsg.response_metadata.output as Array<ResponsesInputItem>
         )?.length
           ? lcMsg.response_metadata.output
-          : lcMsg.additional_kwargs.tool_outputs;
+          : additional_kwargs.tool_outputs;
 
         let computerCalls: Array<ResponsesInputItem> = [];
 
@@ -2359,22 +2339,11 @@ export class ChatOpenAI<
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     if (this._useResponseApi(options)) {
-      const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
-      const lastAIMessageId = lastAIMessage?.response_metadata?.id;
       const streamIterable = await this.responseApiWithRetry(
         {
           ...this.invocationParams<"responses">(options, { streaming: true }),
-          input: _convertMessagesToOpenAIResponsesParams(
-            messages,
-            this.model,
-            this.zdrEnabled
-          ),
+          input: _convertMessagesToOpenAIResponsesParams(messages, this.model),
           stream: true,
-          ...(lastAIMessageId &&
-          lastAIMessageId.startsWith("resp_") &&
-          !this.zdrEnabled
-            ? { previous_response_id: lastAIMessageId }
-            : {}),
         },
         options
       );
@@ -2537,22 +2506,11 @@ export class ChatOpenAI<
       };
     }
 
-    const lastAIMessage = messages.filter((m) => isAIMessage(m)).pop();
-    const lastAIMessageId = lastAIMessage?.response_metadata?.id;
-    const input = _convertMessagesToOpenAIResponsesParams(
-      messages,
-      this.model,
-      this.zdrEnabled
-    );
+    const input = _convertMessagesToOpenAIResponsesParams(messages, this.model);
     const data = await this.responseApiWithRetry(
       {
         input,
         ...invocationParams,
-        ...(lastAIMessageId &&
-        lastAIMessageId.startsWith("resp_") &&
-        !this.zdrEnabled
-          ? { previous_response_id: lastAIMessageId }
-          : {}),
       },
       { signal: options?.signal, ...options?.options }
     );

--- a/libs/langchain-openai/src/embeddings.ts
+++ b/libs/langchain-openai/src/embeddings.ts
@@ -216,8 +216,7 @@ export class OpenAIEmbeddings
 
       this.client = new OpenAIClient(params);
     }
-    const requestOptions: OpenAICoreRequestOptions<OpenAIClient.EmbeddingCreateParams> =
-      {};
+    const requestOptions: OpenAICoreRequestOptions = {};
     return this.caller.call(async () => {
       try {
         const res = await this.client.embeddings.create(

--- a/libs/langchain-openai/src/llms.ts
+++ b/libs/langchain-openai/src/llms.ts
@@ -458,7 +458,9 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
    * @param options Optional configuration for the API call.
    * @returns The response from the OpenAI API.
    */
-  protected _getClientOptions(options: OpenAICoreRequestOptions | undefined) {
+  protected _getClientOptions(
+    options: OpenAICoreRequestOptions | undefined
+  ): OpenAICoreRequestOptions {
     if (!this.client) {
       const openAIEndpointConfig: OpenAIEndpointConfig = {
         baseURL: this.clientConfig.baseURL,

--- a/libs/langchain-openai/src/types.ts
+++ b/libs/langchain-openai/src/types.ts
@@ -1,5 +1,4 @@
 import type { OpenAI as OpenAIClient } from "openai";
-import type { RequestOptions as _OpenAICoreRequestOptions } from "openai/core";
 import type {
   ResponseFormatText,
   ResponseFormatJSONObject,
@@ -101,8 +100,7 @@ export declare interface OpenAIBaseInput {
   apiKey?: string;
 }
 
-export type OpenAICoreRequestOptions<Req = Record<string, unknown>> =
-  _OpenAICoreRequestOptions<Req>;
+export type OpenAICoreRequestOptions = OpenAIClient.RequestOptions;
 
 export interface OpenAICallOptions extends BaseLanguageModelCallOptions {
   /**

--- a/libs/langchain-openai/src/utils/headers.ts
+++ b/libs/langchain-openai/src/utils/headers.ts
@@ -1,0 +1,45 @@
+type HeaderValue = string | undefined | null;
+export type HeadersLike =
+  | Headers
+  | readonly HeaderValue[][]
+  | Record<string, HeaderValue | readonly HeaderValue[]>
+  | undefined
+  | null
+  // NullableHeaders
+  | { values: Headers; [key: string]: unknown };
+
+const iife = <T>(fn: () => T) => fn();
+
+export function normalizeHeaders(
+  headers: HeadersLike
+): Record<string, HeaderValue | readonly HeaderValue[]> {
+  const output = iife(() => {
+    // If headers is a Headers instance
+    if (headers instanceof Headers) {
+      return headers;
+    }
+    // If headers is an array of [key, value] pairs
+    else if (Array.isArray(headers)) {
+      return new Headers(headers);
+    }
+    // If headers is a NullableHeaders-like object (has 'values' property that is a Headers)
+    else if (
+      typeof headers === "object" &&
+      headers !== null &&
+      "values" in headers &&
+      headers.values instanceof Headers
+    ) {
+      return headers.values;
+    }
+    // If headers is a plain object
+    else if (typeof headers === "object" && headers !== null) {
+      const entries: [string, string][] = Object.entries(headers)
+        .filter(([, v]) => typeof v === "string")
+        .map(([k, v]) => [k, v as string]);
+      return new Headers(entries);
+    }
+    return new Headers();
+  });
+
+  return Object.fromEntries(output.entries());
+}

--- a/libs/langchain-openai/src/utils/headers.ts
+++ b/libs/langchain-openai/src/utils/headers.ts
@@ -10,12 +10,21 @@ export type HeadersLike =
 
 const iife = <T>(fn: () => T) => fn();
 
+export function isHeaders(headers: unknown): headers is Headers {
+  return (
+    typeof Headers !== "undefined" &&
+    headers !== null &&
+    typeof headers === "object" &&
+    Object.prototype.toString.call(headers) === "[object Headers]"
+  );
+}
+
 export function normalizeHeaders(
   headers: HeadersLike
 ): Record<string, HeaderValue | readonly HeaderValue[]> {
   const output = iife(() => {
     // If headers is a Headers instance
-    if (headers instanceof Headers) {
+    if (isHeaders(headers)) {
       return headers;
     }
     // If headers is an array of [key, value] pairs
@@ -27,7 +36,7 @@ export function normalizeHeaders(
       typeof headers === "object" &&
       headers !== null &&
       "values" in headers &&
-      headers.values instanceof Headers
+      isHeaders(headers.values)
     ) {
       return headers.values;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8492,7 +8492,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     js-tiktoken: ^1.0.12
-    openai: ^4.96.0
+    openai: ^5.3.0
     prettier: ^2.8.3
     release-it: ^18.1.2
     rimraf: ^5.0.1
@@ -29621,7 +29621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:*, openai@npm:^4.32.1, openai@npm:^4.41.1, openai@npm:^4.96.0":
+"openai@npm:*, openai@npm:^4.32.1, openai@npm:^4.41.1":
   version: 4.96.0
   resolution: "openai@npm:4.96.0"
   dependencies:
@@ -29662,6 +29662,23 @@ __metadata:
   bin:
     openai: bin/cli
   checksum: bc572c9ac2a149722193d9f8e88a95fc2da021be9d18e36d5e840ce673dab78943f5b406e2a20d1044453fb259c7d1e10d2e2e34a92d94d73afc24832a183249
+  languageName: node
+  linkType: hard
+
+"openai@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "openai@npm:5.3.0"
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: c85db58ede53356bdc0b7a3cd68784102fb9825df271393bc8131db5b274028829b257d3b2550eff5d1265c9eeddb07aa932bbcd3a918e79f099388a68af158b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Some strange behavior I noticed with ChatOpenAI is that it would assume it should use an existing responses call when it was passed a previously generated AIMessage (containing `response_metadata.id`) unless `zdrEnabled: true` was provided in the constructor params, meaning even if you wanted to selectively involve context (e.g. trimming messages) it would still use an existing responses call if it could find it on a passed in message. (context is [existing messages on openai's side] U [messages passed in on invoke] if an `AIMessage` contained an openai ID)

```ts
const model = new ChatModel({ model: "o4-mini" });

const firstResponse = await model.invoke("hello")
await model.invoke([firstResponse, "hello"])
await model.invoke([firstResponse, "hello"])

const output = await model.invoke([firstResponse, "How many messages are in this conversation?"]);
// response would be something like:
// "We've had 7 messages so far (not including this one). 4 from you and 3 from me."
```

[Zero data retention](https://platform.openai.com/docs/guides/your-data#zero-data-retention) doesn't make any mention of needing to modify the request to accommodate it, just that `store: false` gets passed into the params to flag that data shouldn't be retained. This upgrades the sdk to the latest version and drops the extra zdr logic we had that pins responses like this.