### PR TITLE
fix(core): max event listeners error long running process

### DIFF
--- a/langchain-core/src/runnables/base.ts
+++ b/langchain-core/src/runnables/base.ts
@@ -931,8 +931,10 @@ export abstract class Runnable<
     // add each chunk to the output stream
     const outerThis = this;
     async function consumeRunnableStream() {
+      let signal;
+      let listener: (() => void) | null = null;
+
       try {
-        let signal;
         if (options?.signal) {
           if ("any" in AbortSignal) {
             // Use native AbortSignal.any() if available (Node 19+)
@@ -945,13 +947,12 @@ export abstract class Runnable<
             // Fallback for Node 18 and below - just use the provided signal
             signal = options.signal;
             // Ensure we still abort our controller when the parent signal aborts
-            options.signal.addEventListener(
-              "abort",
-              () => {
-                abortController.abort();
-              },
-              { once: true }
-            );
+
+            listener = () => {
+              abortController.abort();
+            };
+
+            options.signal.addEventListener("abort", listener, { once: true });
           }
         } else {
           signal = abortController.signal;
@@ -971,6 +972,10 @@ export abstract class Runnable<
         }
       } finally {
         await eventStreamer.finish();
+
+        if (signal && listener) {
+          signal.removeEventListener("abort", listener);
+        }
       }
     }
     const runnableStreamConsumePromise = consumeRunnableStream();


### PR DESCRIPTION
Fixes #7963

We are seeing this error on prod at Anara. 
We are using Vercel Fluid compute to optimize serverless execution.

This results in long running processes. The `addEventListener` is not being cleaned up when doing multiple executions.

This error also happened a year ago. Implemented a similar fix.
https://github.com/langchain-ai/langchainjs/issues/6461

> adds an abort listener to the passed options.signal, but never removes it manually.
> 
> When Runnable.stream() or streamEvents() is called repeatedly with the same signal (or multiple times in parallel), the listeners accumulate, eventually triggering:
> 
> (node:75561) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. MaxListeners is 10. Use events.setMaxListeners() to increase limit
> (Use node --trace-warnings ... to show where the warning was created)
> In long-running apps or with multiple concurrent streams, this can become problematic.
