### PR TITLE
feat: add `ls_structured_output_format` tracing

### DIFF
--- a/langchain-core/src/language_models/base.ts
+++ b/langchain-core/src/language_models/base.ts
@@ -208,7 +208,26 @@ export interface BaseLanguageModelParams
   cache?: BaseCache | boolean;
 }
 
-export interface BaseLanguageModelCallOptions extends RunnableConfig {
+export interface BaseLanguageModelTracingCallOptions {
+  /**
+   * Describes the format of structured outputs.
+   * This should be provided if an output is considered to be structured
+   */
+  ls_structured_output_format?: {
+    /**
+     * An object containing the method used for structured output (e.g., "jsonMode").
+     */
+    kwargs: { method: string };
+    /**
+     * The JSON schema describing the expected output structure.
+     */
+    schema?: JSONSchema;
+  };
+}
+
+export interface BaseLanguageModelCallOptions
+  extends RunnableConfig,
+    BaseLanguageModelTracingCallOptions {
   /**
    * Stop tokens to use for this call.
    * If not provided, the default stop tokens for the model will be used.

--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -1171,6 +1171,10 @@ export class ChatAnthropicMessages<
 
       llm = this.withConfig({
         tools,
+        ls_structured_output_format: {
+          kwargs: { method: "functionCalling" },
+          schema: toJsonSchema(schema),
+        },
       } as Partial<CallOptions>);
 
       const raiseIfNoToolCalls = (message: AIMessageChunk) => {
@@ -1187,6 +1191,10 @@ export class ChatAnthropicMessages<
         tool_choice: {
           type: "tool",
           name: functionName,
+        },
+        ls_structured_output_format: {
+          kwargs: { method: "functionCalling" },
+          schema: toJsonSchema(schema),
         },
       } as Partial<CallOptions>);
     }

--- a/libs/langchain-ollama/src/chat_models.ts
+++ b/libs/langchain-ollama/src/chat_models.ts
@@ -858,6 +858,10 @@ export class ChatOllama
         },
       ]).withConfig({
         format: "json",
+        ls_structured_output_format: {
+          kwargs: { method: "jsonSchema" },
+          schema: toJsonSchema(outputSchema),
+        },
       });
       const outputParser = outputSchemaIsZod
         ? StructuredOutputParser.fromZodSchema(outputSchema)

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -28,6 +28,7 @@ import {
   BaseChatModelsTestsFields,
   RecordStringAny,
 } from "../base.js";
+import { TestCallbackHandler } from "../utils.js";
 
 // Placeholder data for content block tests
 const TEST_IMAGE_URL =
@@ -898,6 +899,13 @@ export abstract class ChatModelIntegrationTests<
       );
     }
 
+    // Setup and bind a callback handler to test the output params
+    const handler = new TestCallbackHandler();
+    const callOptionsWithHandler = {
+      ...callOptions,
+      callbacks: [handler],
+    };
+
     // Create a new model instance with structured output capability
     const modelWithTools = model.withStructuredOutput(adderSchema, {
       name: "math_addition",
@@ -908,7 +916,7 @@ export abstract class ChatModelIntegrationTests<
       {
         toolName: "math_addition",
       },
-      callOptions
+      callOptionsWithHandler
     );
 
     // Verify that the 'a' field is present and is a number
@@ -918,6 +926,17 @@ export abstract class ChatModelIntegrationTests<
     // Verify that the 'b' field is present and is a number
     expect(result.b).toBeDefined();
     expect(typeof result.b).toBe("number");
+
+    // Verify that details to describe the structured output
+    // is emitted in tracing
+    expect(handler.extraParams).toEqual(
+      expect.objectContaining({
+        ls_structured_output_format: {
+          kwargs: { method: "jsonMode" },
+          schema: toJsonSchema(adderSchema),
+        },
+      })
+    );
   }
 
   /**
@@ -955,6 +974,13 @@ export abstract class ChatModelIntegrationTests<
       );
     }
 
+    // Setup and bind a callback handler to test the output params
+    const handler = new TestCallbackHandler();
+    const callOptionsWithHandler = {
+      ...callOptions,
+      callbacks: [handler],
+    };
+
     // Create a new model instance with structured output capability, including raw output
     const modelWithTools = model.withStructuredOutput(adderSchema, {
       includeRaw: true,
@@ -966,7 +992,7 @@ export abstract class ChatModelIntegrationTests<
       {
         toolName: "math_addition",
       },
-      callOptions
+      callOptionsWithHandler
     );
 
     // Verify that the raw output is of the expected type
@@ -979,6 +1005,17 @@ export abstract class ChatModelIntegrationTests<
     // Verify that the parsed 'b' field is present and is a number
     expect(result.parsed.b).toBeDefined();
     expect(typeof result.parsed.b).toBe("number");
+
+    // Verify that details to describe the structured output
+    // is emitted in tracing
+    expect(handler.extraParams).toEqual(
+      expect.objectContaining({
+        ls_structured_output_format: {
+          kwargs: { method: "jsonMode" },
+          schema: toJsonSchema(adderSchema),
+        },
+      })
+    );
   }
 
   /**

--- a/libs/langchain-standard-tests/src/utils.ts
+++ b/libs/langchain-standard-tests/src/utils.ts
@@ -1,0 +1,51 @@
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import { Serialized } from "@langchain/core/load/serializable";
+import { BaseMessage } from "@langchain/core/messages";
+
+/**
+ * A test callback handler for capturing extra parameters passed to chat model runs.
+ *
+ * This handler is primarily used in tests to collect and expose any extra parameters
+ * provided to chat model calls, such as structured output format details.
+ *
+ * This class should be extended as the needs of the standard tests change.
+ *
+ * @example
+ * const handler = new TestCallbackHandler();
+ * // Pass handler in call options to a model invocation
+ * model.invoke(input, { callbacks: [handler] });
+ * // After invocation, access handler.extraParams for collected params
+ */
+export class TestCallbackHandler extends BaseCallbackHandler {
+  name = "TestCallbackHandler";
+
+  /**
+   * Internal array to store extra parameters from each chat model start event.
+   * @internal
+   */
+  _extraParams: Array<Record<string, unknown>> = [];
+
+  /**
+   * Returns a single object containing all accumulated extra parameters,
+   * merged together. If multiple runs provide extra parameters, later
+   * values will overwrite earlier ones for the same keys.
+   *
+   * @returns {Record<string, unknown>} The merged extra parameters.
+   */
+  get extraParams(): Record<string, unknown> {
+    return this._extraParams.reduce(Object.assign, {});
+  }
+
+  handleChatModelStart(
+    _llm: Serialized,
+    _messages: BaseMessage[][],
+    _runId: string,
+    _parentRunId?: string,
+    extraParams?: Record<string, unknown>,
+    _tags?: string[],
+    _metadata?: Record<string, unknown>,
+    _runName?: string
+  ) {
+    if (extraParams) this._extraParams.push(extraParams);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -29428,17 +29428,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:*, openai@npm:^4.32.1, openai@npm:^4.41.1":
-  version: 4.96.0
-  resolution: "openai@npm:4.96.0"
-  dependencies:
-    "@types/node": ^18.11.18
-    "@types/node-fetch": ^2.6.4
-    abort-controller: ^3.0.0
-    agentkeepalive: ^4.2.1
-    form-data-encoder: 1.7.2
-    formdata-node: ^4.3.2
-    node-fetch: ^2.6.7
+"openai@npm:*, openai@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "openai@npm:5.3.0"
   peerDependencies:
     ws: ^8.18.0
     zod: ^3.23.8
@@ -29449,7 +29441,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: d54ba62c4ad298ce3ea4ccc124f6fef0a81c2121ec830a363a1bec7ab909fa2a0e768c5decd738fe2db4f7fd0f5bbed8c8200debf52dd3ca4b9ba58aa1c11860
+  checksum: c85db58ede53356bdc0b7a3cd68784102fb9825df271393bc8131db5b274028829b257d3b2550eff5d1265c9eeddb07aa932bbcd3a918e79f099388a68af158b
   languageName: node
   linkType: hard
 
@@ -29472,9 +29464,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "openai@npm:5.3.0"
+"openai@npm:^4.32.1, openai@npm:^4.41.1":
+  version: 4.96.0
+  resolution: "openai@npm:4.96.0"
+  dependencies:
+    "@types/node": ^18.11.18
+    "@types/node-fetch": ^2.6.4
+    abort-controller: ^3.0.0
+    agentkeepalive: ^4.2.1
+    form-data-encoder: 1.7.2
+    formdata-node: ^4.3.2
+    node-fetch: ^2.6.7
   peerDependencies:
     ws: ^8.18.0
     zod: ^3.23.8
@@ -29485,7 +29485,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: c85db58ede53356bdc0b7a3cd68784102fb9825df271393bc8131db5b274028829b257d3b2550eff5d1265c9eeddb07aa932bbcd3a918e79f099388a68af158b
+  checksum: d54ba62c4ad298ce3ea4ccc124f6fef0a81c2121ec830a363a1bec7ab909fa2a0e768c5decd738fe2db4f7fd0f5bbed8c8200debf52dd3ca4b9ba58aa1c11860
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #8144 

The change in python was to replace the structured_output_format config option, but here we never had one to begin with! Any items that aren't a model or runnable param get passed through to `options` in the trace, so we're relying on the integration package to provide it rather than trying to transform that in core

before trace: https://smith.langchain.com/public/82b3d21d-28a6-4abf-b2b9-1d429af84948/r
after trace: https://smith.langchain.com/public/7560ef8e-b839-494c-8de1-2a5fd1197c0e/r