### PR TITLE
chore(community): use distance_metric in turbopuffer call

### DIFF
--- a/libs/langchain-community/src/vectorstores/turbopuffer.ts
+++ b/libs/langchain-community/src/vectorstores/turbopuffer.ts
@@ -210,6 +210,7 @@ export class TurbopufferVectorStore extends VectorStore {
       const data = {
         ids: batchIds,
         vectors: batchVectors,
+        distance_metric: this.distanceMetric,
         attributes,
       };
 


### PR DESCRIPTION
Fixes #8362 
