### PR TITLE
fix(docs): fix broken links across documentation

### DIFF
--- a/docs/core_docs/docs/concepts/streaming.mdx
+++ b/docs/core_docs/docs/concepts/streaming.mdx
@@ -78,7 +78,7 @@ When using `stream()` with chat models, the output is streamed as [`AIMessageChu
 
 [LangGraph](/docs/concepts/architecture#langgraph) compiled graphs are [Runnables](/docs/concepts/runnables) and support the standard streaming APIs.
 
-When using the _stream_ and methods with LangGraph, you can **one or more** [streaming mode](https://langchain-ai.github.io/langgraphjs/reference/classes/langgraph_pregel.Pregel.html#streamMode) which allow you to control the type of output that is streamed. The available streaming modes are:
+When using the _stream_ and methods with LangGraph, you can **one or more** [streaming mode](https://langchain-ai.github.io/langgraphjs/reference/classes/langgraph.Pregel.html#streamMode) which allow you to control the type of output that is streamed. The available streaming modes are:
 
 - **"values"**: Emit all values of the [state](https://langchain-ai.github.io/langgraphjs/concepts/low_level/) for each step.
 - **"updates"**: Emit only the node name(s) and updates that were returned by the node(s) after each step.

--- a/docs/core_docs/docs/how_to/generative_ui.mdx
+++ b/docs/core_docs/docs/how_to/generative_ui.mdx
@@ -1,6 +1,6 @@
 # How to build an LLM generated UI
 
-This guide will walk through some high level concepts and code snippets for building generative UI's using LangChain.js. To see the full code for generative UI, [click here to visit our official LangChain Next.js template](https://github.com/langchain-ai/langchain-nextjs-template/blob/main/app/generative_ui/README.md).
+This guide will walk through some high level concepts and code snippets for building generative UI's using LangChain.js. To see the full code for generative UI, [click here to visit our official LangChain Next.js template](https://github.com/langchain-ai/langchain-nextjs-template/blob/7f764d558682214d50b064f4293667123a31e6fe/app/generative_ui/README.md).
 
 The sample implements a tool calling agent, which outputs an interactive UI element when streaming intermediate outputs of tool calls to the client.
 

--- a/docs/core_docs/docs/how_to/index.mdx
+++ b/docs/core_docs/docs/how_to/index.mdx
@@ -305,7 +305,7 @@ LangSmith allows you to closely trace, monitor and evaluate your LLM application
 It seamlessly integrates with LangChain and LangGraph.js, and you can use it to inspect and debug individual steps of your chains as you build.
 
 LangSmith documentation is hosted on a separate site.
-You can peruse [LangSmith how-to guides here](https://docs.smith.langchain.com/how_to_guides/), but we'll highlight a few sections that are particularly
+You can peruse [LangSmith how-to guides here](https://docs.smith.langchain.com/observability/how_to_guides), but we'll highlight a few sections that are particularly
 relevant to LangChain below:
 
 ### Evaluation
@@ -315,7 +315,7 @@ relevant to LangChain below:
 Evaluating performance is a vital part of building LLM-powered applications.
 LangSmith helps with every step of the process from creating a dataset to defining metrics to running evaluators.
 
-To learn more, check out the [LangSmith evaluation how-to guides](https://docs.smith.langchain.com/how_to_guides#evaluation).
+To learn more, check out the [LangSmith evaluation how-to guides](https://docs.smith.langchain.com/evaluation/how_to_guides).
 
 ### Tracing
 

--- a/docs/core_docs/docs/how_to/vectorstore_retriever.mdx
+++ b/docs/core_docs/docs/how_to/vectorstore_retriever.mdx
@@ -33,7 +33,7 @@ import IntegrationInstallTooltip from "@mdx_components/integration_install_toolt
 npm install @langchain/openai @langchain/core
 ```
 
-You can download the `state_of_the_union.txt` file [here](https://github.com/langchain-ai/langchain/blob/master/docs/docs/modules/state_of_the_union.txt).
+You can download the `state_of_the_union.txt` file [here](https://github.com/langchain-ai/langchain/blob/master/docs/docs/how_to/state_of_the_union.txt).
 
 import RetrievalQAExample from "@examples/chains/retrieval_qa.ts";
 

--- a/docs/core_docs/docs/integrations/chat/minimax.mdx
+++ b/docs/core_docs/docs/integrations/chat/minimax.mdx
@@ -12,7 +12,7 @@ This example demonstrates using LangChain.js to interact with Minimax.
 
 ## Setup
 
-To use Minimax models, you'll need a [Minimax account](https://api.minimax.chat), an [API key](https://api.minimax.chat/user-center/basic-information/interface-key), and a [Group ID](https://api.minimax.chat/user-center/basic-information)
+To use Minimax models, you'll need a Minimax account, an API key, and a Group ID.
 
 import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
 

--- a/docs/core_docs/docs/integrations/chat/premai.mdx
+++ b/docs/core_docs/docs/integrations/chat/premai.mdx
@@ -8,7 +8,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 ## Setup
 
-1. Create a Prem AI account and get your API key [here](https://app.premai.io/accounts/signup/).
+1. Create a Prem AI account and get your API key [here](https://studio.premai.io/sign-up).
 2. Export or set your API key inline. The ChatPrem class defaults to `process.env.PREM_API_KEY`.
 
 ```bash

--- a/docs/core_docs/docs/integrations/llms/prompt_layer_openai.mdx
+++ b/docs/core_docs/docs/integrations/llms/prompt_layer_openai.mdx
@@ -10,7 +10,7 @@ This module has been deprecated and is no longer supported. The documentation be
 
 LangChain integrates with PromptLayer for logging and debugging prompts and responses. To add support for PromptLayer:
 
-1. Create a PromptLayer account here: [https://promptlayer.com](https://promptlayer.com).
+1. Create a PromptLayer account here: [https://promptlayer.com](https://www.promptlayer.com/).
 2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPTLAYER_API_KEY` environment variable.
 
 ```typescript

--- a/docs/core_docs/docs/integrations/retrievers/dria.mdx
+++ b/docs/core_docs/docs/integrations/retrievers/dria.mdx
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # Dria Retriever
 
-The [Dria](https://dria.co/profile) retriever allows an agent to perform a text-based search across a comprehensive knowledge hub.
+The [Dria](https://dria.co/) retriever allows an agent to perform a text-based search across a comprehensive knowledge hub.
 
 ## Setup
 
@@ -16,7 +16,7 @@ npm install dria
 
 You need to provide two things to the retriever:
 
-- **API Key**: you can get yours at your [profile page](https://dria.co/profile) when you create an account.
+- **API Key**: you can get yours at your [profile page](https://dria.co/) when you create an account.
 - **Contract ID**: accessible at the top of the page when viewing a knowledge or in its URL.
   For example, the Bitcoin whitepaper is uploaded on Dria at https://dria.co/knowledge/2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0, so its contract ID is `2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0`.
   Contract ID can be omitted during instantiation, and later be set via `dria.contractId = "your-contract"`

--- a/docs/core_docs/docs/integrations/retrievers/zep-retriever.mdx
+++ b/docs/core_docs/docs/integrations/retrievers/zep-retriever.mdx
@@ -14,7 +14,7 @@ This example shows how to use the Zep Retriever in a retrieval chain to retrieve
 
 ## Installation
 
-Follow the [Zep Open Source Quickstart Guide](https://docs.getzep.com/deployment/quickstart/) to install and get started with Zep.
+Follow the [Zep Open Source Quickstart Guide](https://help.getzep.com/quickstart) to install and get started with Zep.
 
 ## Setup
 

--- a/docs/core_docs/docs/integrations/text_embedding/minimax.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/minimax.mdx
@@ -4,7 +4,7 @@ The `MinimaxEmbeddings` class uses the Minimax API to generate embeddings for a 
 
 # Setup
 
-To use Minimax model, you'll need a [Minimax account](https://api.minimax.chat), an [API key](https://api.minimax.chat/user-center/basic-information/interface-key), and a [Group ID](https://api.minimax.chat/user-center/basic-information)
+To use Minimax model, you'll need a Minimax account, an API key, and a Group ID.
 
 # Usage
 

--- a/docs/core_docs/docs/integrations/text_embedding/premai.mdx
+++ b/docs/core_docs/docs/integrations/text_embedding/premai.mdx
@@ -8,7 +8,7 @@ The `PremEmbeddings` class uses the Prem AI API to generate embeddings for a giv
 
 ## Setup
 
-In order to use the Prem API you'll need an API key. You can sign up for a Prem account and create an API key [here](https://app.premai.io/accounts/signup/).
+In order to use the Prem API you'll need an API key. You can sign up for a Prem account and create an API key [here](https://studio.premai.io/sign-up).
 
 You'll first need to install the [`@langchain/community`](https://www.npmjs.com/package/@langchain/community) package:
 

--- a/docs/core_docs/docs/integrations/toolkits/connery.mdx
+++ b/docs/core_docs/docs/integrations/toolkits/connery.mdx
@@ -49,7 +49,7 @@ npm install @langchain/openai @langchain/community @langchain/core
 
 In the example below, we create an agent that uses two Connery Actions to summarize a public webpage and send the summary by email:
 
-1. **Summarize public webpage** action from the [Summarization](https://github.com/connery-io/summarization-plugin) plugin.
+1. **Summarize public webpage** action from the Summarization plugin.
 2. **Send email** action from the [Gmail](https://github.com/connery-io/gmail) plugin.
 
 :::info

--- a/docs/core_docs/docs/integrations/tools/zapier_agent.mdx
+++ b/docs/core_docs/docs/integrations/tools/zapier_agent.mdx
@@ -24,7 +24,7 @@ User-facing (Oauth): for production scenarios where you are deploying an end-use
 
 Attach NLA credentials via either an environment variable (`ZAPIER_NLA_OAUTH_ACCESS_TOKEN` or `ZAPIER_NLA_API_KEY`) or refer to the params argument in the API reference for `ZapierNLAWrapper`.
 
-Review [auth docs](https://nla.zapier.com/docs/authentication/) for more details.
+Review [auth docs](https://docs.zapier.com/platform/build/auth) for more details.
 
 The example below demonstrates how to use the Zapier integration as an Agent:
 

--- a/docs/core_docs/docs/integrations/vectorstores/googlevertexai.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/googlevertexai.mdx
@@ -19,7 +19,7 @@ to as vector similarity-matching or an approximate nearest neighbor (ANN) servic
 :::caution
 This module expects an endpoint and deployed index already created as the
 creation time takes close to one hour. To learn more, see the LangChain python
-documentation [Create Index and deploy it to an Endpoint](https://python.langchain.com/docs/integrations/vectorstores/matchingengine#create-index-and-deploy-it-to-an-endpoint).
+documentation [Create Index and deploy it to an Endpoint](https://python.langchain.com/docs/integrations/vectorstores/google_vertex_ai_vector_search/#deploy-index-to-the-endpoint).
 :::
 
 Before running this code, you should make sure the Vertex AI API is

--- a/docs/core_docs/docs/integrations/vectorstores/rockset.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/rockset.mdx
@@ -6,8 +6,8 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Rockset
 
-[Rockset](https://rockset.com) is a real-time analyitics SQL database that runs in the cloud.
-Rockset provides vector search capabilities, in the form of [SQL functions](https://rockset.com/docs/vector-functions/#vector-distance-functions), to support AI applications that rely on text similarity.
+Rockset (acquired by OpenAI) is a real-time analyitics SQL database that runs in the cloud.
+Rockset provides vector search capabilities, in the form of SQL functions, to support AI applications that rely on text similarity.
 
 ## Setup
 

--- a/docs/core_docs/docs/integrations/vectorstores/zep.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/zep.mdx
@@ -25,11 +25,11 @@ for Retrieval Augmented Generation applications as it re-ranks results to ensure
 
 ## Installation
 
-Follow the [Zep Open Source Quickstart Guide](https://docs.getzep.com/deployment/quickstart/) to install and get started with Zep.
+Follow the [Zep Open Source Quickstart Guide](https://help.getzep.com/quickstart) to install and get started with Zep.
 
 ## Usage
 
-You'll need your Zep API URL and optionally an API key to use the Zep VectorStore. See the [Zep docs](https://docs.getzep.com) for more information.
+You'll need your Zep API URL and optionally an API key to use the Zep VectorStore. See the [Zep docs](https://help.getzep.com/welcome) for more information.
 
 In the examples below, we're using Zep's auto-embedding feature which automatically embed documents on the Zep server using
 low-latency embedding models. Since LangChain requires passing in a `Embeddings` instance, we pass in `FakeEmbeddings`.

--- a/docs/core_docs/docs/tutorials/index.mdx
+++ b/docs/core_docs/docs/tutorials/index.mdx
@@ -39,7 +39,12 @@ LangSmith allows you to closely trace, monitor and evaluate your LLM application
 It seamlessly integrates with LangChain, and you can use it to inspect and debug individual steps of your chains as you build.
 
 LangSmith documentation is hosted on a separate site.
-You can peruse [LangSmith tutorials here](https://docs.smith.langchain.com/tutorials/).
+
+You can peruse LangSmith tutorials for:
+- [Observability](https://docs.smith.langchain.com/observability/tutorials)
+- [Evaluation](https://docs.smith.langchain.com/evaluation/tutorials)
+- [Prompt Engineering](https://docs.smith.langchain.com/prompt_engineering/tutorials)
+- [Administration](https://docs.smith.langchain.com/administration/tutorials)
 
 ### Evaluation
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

## Description

This PR fixes multiple broken links discovered throughout the LangChain.js documentation. The changes include:

- **LangGraph references**: Fixed broken URL to LangGraph Pregel class reference
- **LangSmith documentation**: Updated outdated paths for how-to guides, evaluation guides, and tutorials
- **External service URLs**: Corrected links to various integration services (Minimax, PremAI, PromptLayer, Dria, Zep, Zapier, etc.)
- **GitHub template links**: Updated LangChain Next.js template link with specific commit hash
- **Vector store documentation**: Fixed links to Google Vertex AI and other vector store documentation
- **File references**: Corrected broken file path references within the repository
- **Tutorial organization**: Restructured LangSmith tutorial links into organized categories

## Context

These changes were discovered as part of a broader effort to move the `check-broken-links` script into a dedicated infrastructure package. While I'm still preparing that larger refactoring PR, I wanted to proactively fix the broken links that were identified during the link checking process to improve the documentation experience for users immediately.

The broken links were causing 404 errors and making it difficult for users to access referenced resources and documentation.

<!-- Remove if not applicable -->
<!-- No specific issue number - this addresses general documentation maintenance -->