### PR TITLE
fix(core): add custom key encoder and deprecate insecureHash

### DIFF
--- a/docs/core_docs/docs/troubleshooting/errors/index.mdx
+++ b/docs/core_docs/docs/troubleshooting/errors/index.mdx
@@ -10,3 +10,9 @@ Errors referenced below will have an `lc_error_code` property corresponding to o
 - [MODEL_NOT_FOUND](/docs/troubleshooting/errors/MODEL_NOT_FOUND)
 - [MODEL_RATE_LIMIT](/docs/troubleshooting/errors/MODEL_RATE_LIMIT)
 - [OUTPUT_PARSING_FAILURE](/docs/troubleshooting/errors/OUTPUT_PARSING_FAILURE)
+
+## Warnings & other notices
+
+Below is a reference to all current warnings that you may encounter while building with LangChain.
+
+- [Insecure Cache Algorithims](/docs/troubleshooting/warnings/insecure-cache-algorithm)

--- a/docs/core_docs/docs/troubleshooting/warnings/insecure-cache-algorithm.mdx
+++ b/docs/core_docs/docs/troubleshooting/warnings/insecure-cache-algorithm.mdx
@@ -1,0 +1,29 @@
+# Insecure Cache Algorithms
+
+> **Warning: Insecure Cache Key Algorithm (SHA-1)**
+
+LangChain's default cache key encoder uses the SHA-1 hashing algorithm to generate cache keys for prompt/LLM pairs. While this is generally acceptable for most cache scenarios, **SHA-1 is _not_ collision-resistant**. This means that a motivated attacker could potentially craft two different payloads that result in the same cache key, leading to possible cache poisoning or unexpected cache hits.
+
+SHA-1 is now deprecated for cache key generation in LangChain. However, to maintain compatibility with existing deployments, the transition away from SHA-1 is opt-in rather than automatic. In later versions, SHA-1 will be replaced as the default by a more secure hashing algorithm.
+
+### Why does this matter?
+
+- **Security Risk:** If your application is exposed to untrusted input, an attacker could intentionally generate two different prompts or LLM keys that hash to the same value, causing one to overwrite the other's cache entry.
+- **Data Integrity:** Collisions could result in incorrect generations being returned from the cache, which may be problematic in sensitive or high-integrity environments.
+
+### When should you care?
+
+- If your application is public-facing or handles sensitive data.
+- If cache integrity is critical to your workflow.
+- If you have compliance or security requirements that prohibit the use of weak hash functions.
+
+### How to mitigate
+
+You can supply a stronger hash function (such as SHA-256 or SHA-3) for cache key encoding by using the `makeDefaultKeyEncoder()` method on your cache instance. For example:
+
+```ts
+import { sha256 } from "@langchain/core/utils/hash/sha256";
+
+const client = new CacheClient(...);
+client.makeDefaultKeyEncoder(sha256);
+```

--- a/langchain-core/.eslintrc.cjs
+++ b/langchain-core/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
     "src/utils/@cfworker",
     "src/utils/fast-json-patch",
     "src/utils/js-sha1",
+    "src/utils/js-sha256",
     "src/utils/sax-js",
     ".eslintrc.cjs",
     "scripts",

--- a/langchain-core/.gitignore
+++ b/langchain-core/.gitignore
@@ -206,6 +206,14 @@ utils/hash.cjs
 utils/hash.js
 utils/hash.d.ts
 utils/hash.d.cts
+utils/hash/insecure.cjs
+utils/hash/insecure.js
+utils/hash/insecure.d.ts
+utils/hash/insecure.d.cts
+utils/hash/sha256.cjs
+utils/hash/sha256.js
+utils/hash/sha256.d.ts
+utils/hash/sha256.d.cts
 utils/json_patch.cjs
 utils/json_patch.js
 utils/json_patch.d.ts

--- a/langchain-core/langchain.config.js
+++ b/langchain-core/langchain.config.js
@@ -64,6 +64,8 @@ export const config = {
     "utils/event_source_parse": "utils/event_source_parse",
     "utils/function_calling": "utils/function_calling",
     "utils/hash": "utils/hash",
+    "utils/hash/insecure": "utils/js-sha1/hash",
+    "utils/hash/sha256": "utils/js-sha256/hash",
     "utils/json_patch": "utils/json_patch",
     "utils/json_schema": "utils/json_schema",
     "utils/math": "utils/math",

--- a/langchain-core/package.json
+++ b/langchain-core/package.json
@@ -557,6 +557,24 @@
       "import": "./utils/hash.js",
       "require": "./utils/hash.cjs"
     },
+    "./utils/hash/insecure": {
+      "types": {
+        "import": "./utils/hash/insecure.d.ts",
+        "require": "./utils/hash/insecure.d.cts",
+        "default": "./utils/hash/insecure.d.ts"
+      },
+      "import": "./utils/hash/insecure.js",
+      "require": "./utils/hash/insecure.cjs"
+    },
+    "./utils/hash/sha256": {
+      "types": {
+        "import": "./utils/hash/sha256.d.ts",
+        "require": "./utils/hash/sha256.d.cts",
+        "default": "./utils/hash/sha256.d.ts"
+      },
+      "import": "./utils/hash/sha256.js",
+      "require": "./utils/hash/sha256.cjs"
+    },
     "./utils/json_patch": {
       "types": {
         "import": "./utils/json_patch.d.ts",
@@ -841,6 +859,14 @@
     "utils/hash.js",
     "utils/hash.d.ts",
     "utils/hash.d.cts",
+    "utils/hash/insecure.cjs",
+    "utils/hash/insecure.js",
+    "utils/hash/insecure.d.ts",
+    "utils/hash/insecure.d.cts",
+    "utils/hash/sha256.cjs",
+    "utils/hash/sha256.js",
+    "utils/hash/sha256.d.ts",
+    "utils/hash/sha256.d.cts",
     "utils/json_patch.cjs",
     "utils/json_patch.js",
     "utils/json_patch.d.ts",

--- a/langchain-core/src/caches/base.ts
+++ b/langchain-core/src/caches/base.ts
@@ -12,6 +12,9 @@ import { type StoredGeneration } from "../messages/base.js";
  * separate concerns and scale horizontally.
  *
  * TODO: Make cache key consistent across versions of LangChain.
+ * 
+ * @deprecated Use `makeDefaultKeyEncoder()` to create a custom key encoder.
+ * This function will be removed in a future version.
  */
 export const getCacheKey = (...strings: string[]): string =>
   insecureHash(strings.join("_"));
@@ -43,6 +46,22 @@ export function serializeGeneration(generation: Generation) {
  * Base class for all caches. All caches should extend this class.
  */
 export abstract class BaseCache<T = Generation[]> {
+  
+  // For backwards compatibility, we use a default key encoder
+  // that uses SHA-1 to hash the prompt and LLM key. This will also print a warning
+  // about the security implications of using SHA-1 as a cache key.
+  protected keyEncoder: (...strings: string[]) => string = getCacheKey;
+
+  /**
+   * Sets a custom key encoder function for the cache.
+   * This function should take a prompt and an LLM key and return a string
+   * that will be used as the cache key.
+   * @param keyEncoderFn The custom key encoder function.
+   */
+  makeDefaultKeyEncoder(keyEncoderFn: (...strings: string[]) => string): void {
+    this.keyEncoder = keyEncoderFn;
+  }
+
   abstract lookup(prompt: string, llmKey: string): Promise<T | null>;
 
   abstract update(prompt: string, llmKey: string, value: T): Promise<void>;
@@ -69,7 +88,7 @@ export class InMemoryCache<T = Generation[]> extends BaseCache<T> {
    * @returns The data corresponding to the prompt and LLM key, or null if not found.
    */
   lookup(prompt: string, llmKey: string): Promise<T | null> {
-    return Promise.resolve(this.cache.get(getCacheKey(prompt, llmKey)) ?? null);
+    return Promise.resolve(this.cache.get(this.keyEncoder(prompt, llmKey)) ?? null);
   }
 
   /**
@@ -79,7 +98,7 @@ export class InMemoryCache<T = Generation[]> extends BaseCache<T> {
    * @param value The data to be stored.
    */
   async update(prompt: string, llmKey: string, value: T): Promise<void> {
-    this.cache.set(getCacheKey(prompt, llmKey), value);
+    this.cache.set(this.keyEncoder(prompt, llmKey), value);
   }
 
   /**

--- a/langchain-core/src/caches/base.ts
+++ b/langchain-core/src/caches/base.ts
@@ -1,4 +1,4 @@
-import { insecureHash } from "../utils/hash.js";
+import { insecureHash, type HashKeyEncoder } from "../utils/hash.js";
 import type { Generation, ChatGeneration } from "../outputs.js";
 import { mapStoredMessageToChatMessage } from "../messages/utils.js";
 import { type StoredGeneration } from "../messages/base.js";
@@ -16,7 +16,7 @@ import { type StoredGeneration } from "../messages/base.js";
  * @deprecated Use `makeDefaultKeyEncoder()` to create a custom key encoder.
  * This function will be removed in a future version.
  */
-export const getCacheKey = (...strings: string[]): string =>
+export const getCacheKey: HashKeyEncoder = (...strings) =>
   insecureHash(strings.join("_"));
 
 export function deserializeStoredGeneration(
@@ -49,7 +49,7 @@ export abstract class BaseCache<T = Generation[]> {
   // For backwards compatibility, we use a default key encoder
   // that uses SHA-1 to hash the prompt and LLM key. This will also print a warning
   // about the security implications of using SHA-1 as a cache key.
-  protected keyEncoder: (...strings: string[]) => string = getCacheKey;
+  protected keyEncoder: HashKeyEncoder = getCacheKey;
 
   /**
    * Sets a custom key encoder function for the cache.
@@ -57,7 +57,7 @@ export abstract class BaseCache<T = Generation[]> {
    * that will be used as the cache key.
    * @param keyEncoderFn The custom key encoder function.
    */
-  makeDefaultKeyEncoder(keyEncoderFn: (...strings: string[]) => string): void {
+  makeDefaultKeyEncoder(keyEncoderFn: HashKeyEncoder): void {
     this.keyEncoder = keyEncoderFn;
   }
 

--- a/langchain-core/src/caches/base.ts
+++ b/langchain-core/src/caches/base.ts
@@ -12,7 +12,7 @@ import { type StoredGeneration } from "../messages/base.js";
  * separate concerns and scale horizontally.
  *
  * TODO: Make cache key consistent across versions of LangChain.
- * 
+ *
  * @deprecated Use `makeDefaultKeyEncoder()` to create a custom key encoder.
  * This function will be removed in a future version.
  */
@@ -46,7 +46,6 @@ export function serializeGeneration(generation: Generation) {
  * Base class for all caches. All caches should extend this class.
  */
 export abstract class BaseCache<T = Generation[]> {
-  
   // For backwards compatibility, we use a default key encoder
   // that uses SHA-1 to hash the prompt and LLM key. This will also print a warning
   // about the security implications of using SHA-1 as a cache key.
@@ -88,7 +87,9 @@ export class InMemoryCache<T = Generation[]> extends BaseCache<T> {
    * @returns The data corresponding to the prompt and LLM key, or null if not found.
    */
   lookup(prompt: string, llmKey: string): Promise<T | null> {
-    return Promise.resolve(this.cache.get(this.keyEncoder(prompt, llmKey)) ?? null);
+    return Promise.resolve(
+      this.cache.get(this.keyEncoder(prompt, llmKey)) ?? null
+    );
   }
 
   /**

--- a/langchain-core/src/caches/tests/in_memory_cache.test.ts
+++ b/langchain-core/src/caches/tests/in_memory_cache.test.ts
@@ -41,12 +41,7 @@ test("InMemoryCache works with complex message types", async () => {
 });
 
 test("InMemoryCache handles default key encoder", async () => {
-  // @ts-expect-error __printInsecureHashWarning is not defined in globalThis
-  globalThis.__printInsecureHashWarning = false;
   const cache = new InMemoryCache();
-  const consoleWarnSpy = jest
-    .spyOn(console, "warn")
-    .mockImplementation(() => {});
 
   await cache.update("prompt1", "key1", [
     {
@@ -58,20 +53,10 @@ test("InMemoryCache handles default key encoder", async () => {
   const result = await cache.lookup("prompt1", "key1");
 
   expect(result).toBeDefined();
-  if (!result) {
-    return;
-  }
-  expect(consoleWarnSpy).toHaveBeenCalled();
-  consoleWarnSpy.mockRestore();
 });
 
 test("InMemoryCache handles custom key encoder", async () => {
-  // @ts-expect-error __printInsecureHashWarning is not defined in globalThis
-  globalThis.__printInsecureHashWarning = false;
   const cache = new InMemoryCache();
-  const consoleWarnSpy = jest
-    .spyOn(console, "warn")
-    .mockImplementation(() => {});
 
   // use fancy hashing algorithm to encode the key :)
   cache.makeDefaultKeyEncoder((prompt, key) => `${prompt}###${key}`);
@@ -83,14 +68,10 @@ test("InMemoryCache handles custom key encoder", async () => {
     },
   ]);
 
-  expect(consoleWarnSpy).not.toHaveBeenCalled();
-
   const result1 = await cache.lookup("prompt1", "key1");
   expect(result1).toBeDefined();
   if (!result1) {
     return;
   }
   expect(result1[0].text).toBe("text1");
-
-  consoleWarnSpy.mockRestore();
 });

--- a/langchain-core/src/caches/tests/in_memory_cache.test.ts
+++ b/langchain-core/src/caches/tests/in_memory_cache.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, jest } from "@jest/globals";
+import { test, expect } from "@jest/globals";
 import { MessageContentComplex } from "../../messages/base.js";
 import { InMemoryCache } from "../base.js";
 

--- a/langchain-core/src/caches/tests/in_memory_cache.test.ts
+++ b/langchain-core/src/caches/tests/in_memory_cache.test.ts
@@ -41,6 +41,8 @@ test("InMemoryCache works with complex message types", async () => {
 });
 
 test("InMemoryCache handles default key encoder", async () => {
+  // @ts-expect-error __printInsecureHashWarning is not defined in globalThis
+  globalThis.__printInsecureHashWarning = false;
   const cache = new InMemoryCache();
   const consoleWarnSpy = jest
     .spyOn(console, "warn")
@@ -64,6 +66,8 @@ test("InMemoryCache handles default key encoder", async () => {
 });
 
 test("InMemoryCache handles custom key encoder", async () => {
+  // @ts-expect-error __printInsecureHashWarning is not defined in globalThis
+  globalThis.__printInsecureHashWarning = false;
   const cache = new InMemoryCache();
   const consoleWarnSpy = jest
     .spyOn(console, "warn")

--- a/langchain-core/src/caches/tests/in_memory_cache.test.ts
+++ b/langchain-core/src/caches/tests/in_memory_cache.test.ts
@@ -42,14 +42,16 @@ test("InMemoryCache works with complex message types", async () => {
 
 test("InMemoryCache handles default key encoder", async () => {
   const cache = new InMemoryCache();
-  const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  const consoleWarnSpy = jest
+    .spyOn(console, "warn")
+    .mockImplementation(() => {});
 
   await cache.update("prompt1", "key1", [
     {
       text: "text1",
     },
   ]);
-  
+
   // expect this to call console.warn about SHA-1 usage
   const result = await cache.lookup("prompt1", "key1");
 
@@ -61,14 +63,15 @@ test("InMemoryCache handles default key encoder", async () => {
   consoleWarnSpy.mockRestore();
 });
 
-
 test("InMemoryCache handles custom key encoder", async () => {
   const cache = new InMemoryCache();
-  const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-  
+  const consoleWarnSpy = jest
+    .spyOn(console, "warn")
+    .mockImplementation(() => {});
+
   // use fancy hashing algorithm to encode the key :)
   cache.makeDefaultKeyEncoder((prompt, key) => `${prompt}###${key}`);
-  
+
   // expect custom key encoder not to call console.warn
   await cache.update("prompt1", "key1", [
     {
@@ -86,5 +89,4 @@ test("InMemoryCache handles custom key encoder", async () => {
   expect(result1[0].text).toBe("text1");
 
   consoleWarnSpy.mockRestore();
-
 });

--- a/langchain-core/src/indexing/base.ts
+++ b/langchain-core/src/indexing/base.ts
@@ -61,9 +61,7 @@ export class _HashedDocument implements HashedDocumentInterface {
     this.metadata = fields.metadata;
   }
 
-  makeDefaultKeyEncoder(
-    keyEncoderFn: (...strings: string[]) => string
-  ): void {
+  makeDefaultKeyEncoder(keyEncoderFn: (...strings: string[]) => string): void {
     this.keyEncoder = keyEncoderFn;
   }
 

--- a/langchain-core/src/indexing/base.ts
+++ b/langchain-core/src/indexing/base.ts
@@ -1,7 +1,7 @@
 import { v5 as uuidv5 } from "uuid";
 import { VectorStore } from "../vectorstores.js";
 import { RecordManagerInterface, UUIDV5_NAMESPACE } from "./record_manager.js";
-import { insecureHash } from "../utils/hash.js";
+import { insecureHash, type HashKeyEncoder } from "../utils/hash.js";
 import { DocumentInterface, Document } from "../documents/document.js";
 import { BaseDocumentLoader } from "../document_loaders/base.js";
 
@@ -51,9 +51,10 @@ export class _HashedDocument implements HashedDocumentInterface {
 
   metadata: Metadata;
 
-  // backwards compatibility with old code that used SHA-1
-  // as a key encoder. This will also print a warning about the security implications of using
-  private keyEncoder: (...strings: string[]) => string = insecureHash;
+  // For backwards compatibility, we use a default key encoder
+  // that uses SHA-1 to hash the prompt and LLM key. This will also print a warning
+  // about the security implications of using SHA-1 as a key encoder.
+  private keyEncoder: HashKeyEncoder = insecureHash;
 
   constructor(fields: HashedDocumentArgs) {
     this.uid = fields.uid;
@@ -61,7 +62,7 @@ export class _HashedDocument implements HashedDocumentInterface {
     this.metadata = fields.metadata;
   }
 
-  makeDefaultKeyEncoder(keyEncoderFn: (...strings: string[]) => string): void {
+  makeDefaultKeyEncoder(keyEncoderFn: HashKeyEncoder): void {
     this.keyEncoder = keyEncoderFn;
   }
 

--- a/langchain-core/src/utils/hash.ts
+++ b/langchain-core/src/utils/hash.ts
@@ -1,1 +1,8 @@
 export { insecureHash } from "./js-sha1/hash.js";
+
+/**
+ * A function type for encoding hash keys.
+ * Accepts any number of string arguments (such as prompt and LLM key)
+ * and returns a single string to be used as the hash key.
+ */
+export type HashKeyEncoder = (...strings: string[]) => string;

--- a/langchain-core/src/utils/hash.ts
+++ b/langchain-core/src/utils/hash.ts
@@ -1,4 +1,5 @@
 export { insecureHash } from "./js-sha1/hash.js";
+export { sha256 } from "./js-sha256/hash.js";
 
 /**
  * A function type for encoding hash keys.

--- a/langchain-core/src/utils/js-sha1/hash.ts
+++ b/langchain-core/src/utils/js-sha1/hash.ts
@@ -417,14 +417,17 @@ Sha1.prototype.arrayBuffer = function () {
  * This function will be removed in a future version.
  */
 export const insecureHash = (message) => {
-  console.warn(
-    "Using default key encoder: SHA-1 is *not* collision-resistant. " +
-      "While acceptable for most cache scenarios, a motivated attacker " +
-      "can craft two different payloads that map to the same cache key. " +
-      "If that risk matters in your environment, supply a stronger " +
-      "encoder (e.g. SHA-3) by calling the `makeDefaultKeyEncoder()` method. " +
-      "If you change the key encoder, consider also creating a new cache, " +
-      "to avoid (the potential for) collisions with existing keys."
-  );
+  if (!globalThis.__printInsecureHashWarning) {
+    console.warn(
+      "Using default key encoder: SHA-1 is *not* collision-resistant. " +
+        "While acceptable for most cache scenarios, a motivated attacker " +
+        "can craft two different payloads that map to the same cache key. " +
+        "If that risk matters in your environment, supply a stronger " +
+        "encoder (e.g. SHA-3) by calling the `makeDefaultKeyEncoder()` method. " +
+        "If you change the key encoder, consider also creating a new cache, " +
+        "to avoid (the potential for) collisions with existing keys."
+    );
+    globalThis.__printInsecureHashWarning = true;
+  }
   return new Sha1(true).update(message)["hex"]();
 };

--- a/langchain-core/src/utils/js-sha1/hash.ts
+++ b/langchain-core/src/utils/js-sha1/hash.ts
@@ -412,12 +412,14 @@ Sha1.prototype.arrayBuffer = function () {
   return buffer;
 };
 
+let hasLoggedWarning = false;
+
 /**
  * @deprecated Use `makeDefaultKeyEncoder()` to create a custom key encoder.
  * This function will be removed in a future version.
  */
 export const insecureHash = (message) => {
-  if (!globalThis.__printInsecureHashWarning) {
+  if (!hasLoggedWarning) {
     console.warn(
       "Using default key encoder: SHA-1 is *not* collision-resistant. " +
         "While acceptable for most cache scenarios, a motivated attacker " +
@@ -427,7 +429,7 @@ export const insecureHash = (message) => {
         "If you change the key encoder, consider also creating a new cache, " +
         "to avoid (the potential for) collisions with existing keys."
     );
-    globalThis.__printInsecureHashWarning = true;
+    hasLoggedWarning = true;
   }
   return new Sha1(true).update(message)["hex"]();
 };

--- a/langchain-core/src/utils/js-sha1/hash.ts
+++ b/langchain-core/src/utils/js-sha1/hash.ts
@@ -412,6 +412,19 @@ Sha1.prototype.arrayBuffer = function () {
   return buffer;
 };
 
+/**
+ * @deprecated Use `makeDefaultKeyEncoder()` to create a custom key encoder.
+ * This function will be removed in a future version.
+ */
 export const insecureHash = (message) => {
+  console.warn(
+    "Using default key encoder: SHA-1 is *not* collision-resistant. " +
+      "While acceptable for most cache scenarios, a motivated attacker " +
+      "can craft two different payloads that map to the same cache key. " +
+      "If that risk matters in your environment, supply a stronger " +
+      "encoder (e.g. SHA-3) by calling the `makeDefaultKeyEncoder()` method. " +
+      "If you change the key encoder, consider also creating a new cache, " +
+      "to avoid (the potential for) collisions with existing keys."
+  );
   return new Sha1(true).update(message)["hex"]();
 };

--- a/langchain-core/src/utils/js-sha1/hash.ts
+++ b/langchain-core/src/utils/js-sha1/hash.ts
@@ -421,13 +421,15 @@ let hasLoggedWarning = false;
 export const insecureHash = (message) => {
   if (!hasLoggedWarning) {
     console.warn(
-      "Using default key encoder: SHA-1 is *not* collision-resistant. " +
-        "While acceptable for most cache scenarios, a motivated attacker " +
-        "can craft two different payloads that map to the same cache key. " +
-        "If that risk matters in your environment, supply a stronger " +
-        "encoder (e.g. SHA-3) by calling the `makeDefaultKeyEncoder()` method. " +
-        "If you change the key encoder, consider also creating a new cache, " +
-        "to avoid (the potential for) collisions with existing keys."
+      [
+        `The default method for hashing keys is insecure and will be replaced in a future version,`,
+        `but hasn't been replaced yet as to not break existing caches. It's recommended that you use`,
+        `a more secure hashing algorithm to avoid cache poisoning.`,
+        ``,
+        `See this page for more information:`,
+        `|`,
+        `└> https://js.langchain.com/docs/troubleshooting/warnings/insecure-cache-algorithm`,
+      ].join("\n")
     );
     hasLoggedWarning = true;
   }

--- a/langchain-core/src/utils/js-sha256/LICENSE.md
+++ b/langchain-core/src/utils/js-sha256/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2014-2025 Chen, Yi-Cyuan
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/langchain-core/src/utils/js-sha256/hash.ts
+++ b/langchain-core/src/utils/js-sha256/hash.ts
@@ -1,0 +1,506 @@
+// @ts-nocheck
+
+// Inlined to deal with portability issues with importing crypto module
+
+/**
+ * [js-sha256]{@link https://github.com/emn178/js-sha256}
+ *
+ * @version 0.11.1
+ * @author Chen, Yi-Cyuan [emn178@gmail.com]
+ * @copyright Chen, Yi-Cyuan 2014-2025
+ * @license MIT
+ */
+/*jslint bitwise: true */
+"use strict";
+
+import { type HashKeyEncoder } from "../hash.js";
+
+var HEX_CHARS = "0123456789abcdef".split("");
+var EXTRA = [-2147483648, 8388608, 32768, 128];
+var SHIFT = [24, 16, 8, 0];
+var K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+var OUTPUT_TYPES = ["hex", "array", "digest", "arrayBuffer"];
+
+var blocks = [];
+
+function Sha256(is224, sharedMemory) {
+  if (sharedMemory) {
+    blocks[0] =
+      blocks[16] =
+      blocks[1] =
+      blocks[2] =
+      blocks[3] =
+      blocks[4] =
+      blocks[5] =
+      blocks[6] =
+      blocks[7] =
+      blocks[8] =
+      blocks[9] =
+      blocks[10] =
+      blocks[11] =
+      blocks[12] =
+      blocks[13] =
+      blocks[14] =
+      blocks[15] =
+        0;
+    this.blocks = blocks;
+  } else {
+    this.blocks = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+  }
+
+  if (is224) {
+    this.h0 = 0xc1059ed8;
+    this.h1 = 0x367cd507;
+    this.h2 = 0x3070dd17;
+    this.h3 = 0xf70e5939;
+    this.h4 = 0xffc00b31;
+    this.h5 = 0x68581511;
+    this.h6 = 0x64f98fa7;
+    this.h7 = 0xbefa4fa4;
+  } else {
+    // 256
+    this.h0 = 0x6a09e667;
+    this.h1 = 0xbb67ae85;
+    this.h2 = 0x3c6ef372;
+    this.h3 = 0xa54ff53a;
+    this.h4 = 0x510e527f;
+    this.h5 = 0x9b05688c;
+    this.h6 = 0x1f83d9ab;
+    this.h7 = 0x5be0cd19;
+  }
+
+  this.block = this.start = this.bytes = this.hBytes = 0;
+  this.finalized = this.hashed = false;
+  this.first = true;
+  this.is224 = is224;
+}
+
+Sha256.prototype.update = function (message) {
+  if (this.finalized) {
+    return;
+  }
+  var notString,
+    type = typeof message;
+  if (type !== "string") {
+    if (type === "object") {
+      if (message === null) {
+        throw new Error(ERROR);
+      } else if (ARRAY_BUFFER && message.constructor === ArrayBuffer) {
+        message = new Uint8Array(message);
+      } else if (!Array.isArray(message)) {
+        if (!ARRAY_BUFFER || !ArrayBuffer.isView(message)) {
+          throw new Error(ERROR);
+        }
+      }
+    } else {
+      throw new Error(ERROR);
+    }
+    notString = true;
+  }
+  var code,
+    index = 0,
+    i,
+    length = message.length,
+    blocks = this.blocks;
+  while (index < length) {
+    if (this.hashed) {
+      this.hashed = false;
+      blocks[0] = this.block;
+      this.block =
+        blocks[16] =
+        blocks[1] =
+        blocks[2] =
+        blocks[3] =
+        blocks[4] =
+        blocks[5] =
+        blocks[6] =
+        blocks[7] =
+        blocks[8] =
+        blocks[9] =
+        blocks[10] =
+        blocks[11] =
+        blocks[12] =
+        blocks[13] =
+        blocks[14] =
+        blocks[15] =
+          0;
+    }
+
+    if (notString) {
+      for (i = this.start; index < length && i < 64; ++index) {
+        blocks[i >>> 2] |= message[index] << SHIFT[i++ & 3];
+      }
+    } else {
+      for (i = this.start; index < length && i < 64; ++index) {
+        code = message.charCodeAt(index);
+        if (code < 0x80) {
+          blocks[i >>> 2] |= code << SHIFT[i++ & 3];
+        } else if (code < 0x800) {
+          blocks[i >>> 2] |= (0xc0 | (code >>> 6)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+        } else if (code < 0xd800 || code >= 0xe000) {
+          blocks[i >>> 2] |= (0xe0 | (code >>> 12)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | ((code >>> 6) & 0x3f)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+        } else {
+          code =
+            0x10000 +
+            (((code & 0x3ff) << 10) | (message.charCodeAt(++index) & 0x3ff));
+          blocks[i >>> 2] |= (0xf0 | (code >>> 18)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | ((code >>> 12) & 0x3f)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | ((code >>> 6) & 0x3f)) << SHIFT[i++ & 3];
+          blocks[i >>> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+        }
+      }
+    }
+
+    this.lastByteIndex = i;
+    this.bytes += i - this.start;
+    if (i >= 64) {
+      this.block = blocks[16];
+      this.start = i - 64;
+      this.hash();
+      this.hashed = true;
+    } else {
+      this.start = i;
+    }
+  }
+  if (this.bytes > 4294967295) {
+    this.hBytes += (this.bytes / 4294967296) << 0;
+    this.bytes = this.bytes % 4294967296;
+  }
+  return this;
+};
+
+Sha256.prototype.finalize = function () {
+  if (this.finalized) {
+    return;
+  }
+  this.finalized = true;
+  var blocks = this.blocks,
+    i = this.lastByteIndex;
+  blocks[16] = this.block;
+  blocks[i >>> 2] |= EXTRA[i & 3];
+  this.block = blocks[16];
+  if (i >= 56) {
+    if (!this.hashed) {
+      this.hash();
+    }
+    blocks[0] = this.block;
+    blocks[16] =
+      blocks[1] =
+      blocks[2] =
+      blocks[3] =
+      blocks[4] =
+      blocks[5] =
+      blocks[6] =
+      blocks[7] =
+      blocks[8] =
+      blocks[9] =
+      blocks[10] =
+      blocks[11] =
+      blocks[12] =
+      blocks[13] =
+      blocks[14] =
+      blocks[15] =
+        0;
+  }
+  blocks[14] = (this.hBytes << 3) | (this.bytes >>> 29);
+  blocks[15] = this.bytes << 3;
+  this.hash();
+};
+
+Sha256.prototype.hash = function () {
+  var a = this.h0,
+    b = this.h1,
+    c = this.h2,
+    d = this.h3,
+    e = this.h4,
+    f = this.h5,
+    g = this.h6,
+    h = this.h7,
+    blocks = this.blocks,
+    j,
+    s0,
+    s1,
+    maj,
+    t1,
+    t2,
+    ch,
+    ab,
+    da,
+    cd,
+    bc;
+
+  for (j = 16; j < 64; ++j) {
+    // rightrotate
+    t1 = blocks[j - 15];
+    s0 = ((t1 >>> 7) | (t1 << 25)) ^ ((t1 >>> 18) | (t1 << 14)) ^ (t1 >>> 3);
+    t1 = blocks[j - 2];
+    s1 = ((t1 >>> 17) | (t1 << 15)) ^ ((t1 >>> 19) | (t1 << 13)) ^ (t1 >>> 10);
+    blocks[j] = (blocks[j - 16] + s0 + blocks[j - 7] + s1) << 0;
+  }
+
+  bc = b & c;
+  for (j = 0; j < 64; j += 4) {
+    if (this.first) {
+      if (this.is224) {
+        ab = 300032;
+        t1 = blocks[0] - 1413257819;
+        h = (t1 - 150054599) << 0;
+        d = (t1 + 24177077) << 0;
+      } else {
+        ab = 704751109;
+        t1 = blocks[0] - 210244248;
+        h = (t1 - 1521486534) << 0;
+        d = (t1 + 143694565) << 0;
+      }
+      this.first = false;
+    } else {
+      s0 =
+        ((a >>> 2) | (a << 30)) ^
+        ((a >>> 13) | (a << 19)) ^
+        ((a >>> 22) | (a << 10));
+      s1 =
+        ((e >>> 6) | (e << 26)) ^
+        ((e >>> 11) | (e << 21)) ^
+        ((e >>> 25) | (e << 7));
+      ab = a & b;
+      maj = ab ^ (a & c) ^ bc;
+      ch = (e & f) ^ (~e & g);
+      t1 = h + s1 + ch + K[j] + blocks[j];
+      t2 = s0 + maj;
+      h = (d + t1) << 0;
+      d = (t1 + t2) << 0;
+    }
+    s0 =
+      ((d >>> 2) | (d << 30)) ^
+      ((d >>> 13) | (d << 19)) ^
+      ((d >>> 22) | (d << 10));
+    s1 =
+      ((h >>> 6) | (h << 26)) ^
+      ((h >>> 11) | (h << 21)) ^
+      ((h >>> 25) | (h << 7));
+    da = d & a;
+    maj = da ^ (d & b) ^ ab;
+    ch = (g & h) ^ (~g & e);
+    t1 = f + s1 + ch + K[j + 1] + blocks[j + 1];
+    t2 = s0 + maj;
+    g = (c + t1) << 0;
+    c = (t1 + t2) << 0;
+    s0 =
+      ((c >>> 2) | (c << 30)) ^
+      ((c >>> 13) | (c << 19)) ^
+      ((c >>> 22) | (c << 10));
+    s1 =
+      ((g >>> 6) | (g << 26)) ^
+      ((g >>> 11) | (g << 21)) ^
+      ((g >>> 25) | (g << 7));
+    cd = c & d;
+    maj = cd ^ (c & a) ^ da;
+    ch = (f & g) ^ (~f & h);
+    t1 = e + s1 + ch + K[j + 2] + blocks[j + 2];
+    t2 = s0 + maj;
+    f = (b + t1) << 0;
+    b = (t1 + t2) << 0;
+    s0 =
+      ((b >>> 2) | (b << 30)) ^
+      ((b >>> 13) | (b << 19)) ^
+      ((b >>> 22) | (b << 10));
+    s1 =
+      ((f >>> 6) | (f << 26)) ^
+      ((f >>> 11) | (f << 21)) ^
+      ((f >>> 25) | (f << 7));
+    bc = b & c;
+    maj = bc ^ (b & d) ^ cd;
+    ch = (f & g) ^ (~f & h);
+    t1 = e + s1 + ch + K[j + 3] + blocks[j + 3];
+    t2 = s0 + maj;
+    e = (a + t1) << 0;
+    a = (t1 + t2) << 0;
+    this.chromeBugWorkAround = true;
+  }
+
+  this.h0 = (this.h0 + a) << 0;
+  this.h1 = (this.h1 + b) << 0;
+  this.h2 = (this.h2 + c) << 0;
+  this.h3 = (this.h3 + d) << 0;
+  this.h4 = (this.h4 + e) << 0;
+  this.h5 = (this.h5 + f) << 0;
+  this.h6 = (this.h6 + g) << 0;
+  this.h7 = (this.h7 + h) << 0;
+};
+
+Sha256.prototype.hex = function () {
+  this.finalize();
+
+  var h0 = this.h0,
+    h1 = this.h1,
+    h2 = this.h2,
+    h3 = this.h3,
+    h4 = this.h4,
+    h5 = this.h5,
+    h6 = this.h6,
+    h7 = this.h7;
+
+  var hex =
+    HEX_CHARS[(h0 >>> 28) & 0x0f] +
+    HEX_CHARS[(h0 >>> 24) & 0x0f] +
+    HEX_CHARS[(h0 >>> 20) & 0x0f] +
+    HEX_CHARS[(h0 >>> 16) & 0x0f] +
+    HEX_CHARS[(h0 >>> 12) & 0x0f] +
+    HEX_CHARS[(h0 >>> 8) & 0x0f] +
+    HEX_CHARS[(h0 >>> 4) & 0x0f] +
+    HEX_CHARS[h0 & 0x0f] +
+    HEX_CHARS[(h1 >>> 28) & 0x0f] +
+    HEX_CHARS[(h1 >>> 24) & 0x0f] +
+    HEX_CHARS[(h1 >>> 20) & 0x0f] +
+    HEX_CHARS[(h1 >>> 16) & 0x0f] +
+    HEX_CHARS[(h1 >>> 12) & 0x0f] +
+    HEX_CHARS[(h1 >>> 8) & 0x0f] +
+    HEX_CHARS[(h1 >>> 4) & 0x0f] +
+    HEX_CHARS[h1 & 0x0f] +
+    HEX_CHARS[(h2 >>> 28) & 0x0f] +
+    HEX_CHARS[(h2 >>> 24) & 0x0f] +
+    HEX_CHARS[(h2 >>> 20) & 0x0f] +
+    HEX_CHARS[(h2 >>> 16) & 0x0f] +
+    HEX_CHARS[(h2 >>> 12) & 0x0f] +
+    HEX_CHARS[(h2 >>> 8) & 0x0f] +
+    HEX_CHARS[(h2 >>> 4) & 0x0f] +
+    HEX_CHARS[h2 & 0x0f] +
+    HEX_CHARS[(h3 >>> 28) & 0x0f] +
+    HEX_CHARS[(h3 >>> 24) & 0x0f] +
+    HEX_CHARS[(h3 >>> 20) & 0x0f] +
+    HEX_CHARS[(h3 >>> 16) & 0x0f] +
+    HEX_CHARS[(h3 >>> 12) & 0x0f] +
+    HEX_CHARS[(h3 >>> 8) & 0x0f] +
+    HEX_CHARS[(h3 >>> 4) & 0x0f] +
+    HEX_CHARS[h3 & 0x0f] +
+    HEX_CHARS[(h4 >>> 28) & 0x0f] +
+    HEX_CHARS[(h4 >>> 24) & 0x0f] +
+    HEX_CHARS[(h4 >>> 20) & 0x0f] +
+    HEX_CHARS[(h4 >>> 16) & 0x0f] +
+    HEX_CHARS[(h4 >>> 12) & 0x0f] +
+    HEX_CHARS[(h4 >>> 8) & 0x0f] +
+    HEX_CHARS[(h4 >>> 4) & 0x0f] +
+    HEX_CHARS[h4 & 0x0f] +
+    HEX_CHARS[(h5 >>> 28) & 0x0f] +
+    HEX_CHARS[(h5 >>> 24) & 0x0f] +
+    HEX_CHARS[(h5 >>> 20) & 0x0f] +
+    HEX_CHARS[(h5 >>> 16) & 0x0f] +
+    HEX_CHARS[(h5 >>> 12) & 0x0f] +
+    HEX_CHARS[(h5 >>> 8) & 0x0f] +
+    HEX_CHARS[(h5 >>> 4) & 0x0f] +
+    HEX_CHARS[h5 & 0x0f] +
+    HEX_CHARS[(h6 >>> 28) & 0x0f] +
+    HEX_CHARS[(h6 >>> 24) & 0x0f] +
+    HEX_CHARS[(h6 >>> 20) & 0x0f] +
+    HEX_CHARS[(h6 >>> 16) & 0x0f] +
+    HEX_CHARS[(h6 >>> 12) & 0x0f] +
+    HEX_CHARS[(h6 >>> 8) & 0x0f] +
+    HEX_CHARS[(h6 >>> 4) & 0x0f] +
+    HEX_CHARS[h6 & 0x0f];
+  if (!this.is224) {
+    hex +=
+      HEX_CHARS[(h7 >>> 28) & 0x0f] +
+      HEX_CHARS[(h7 >>> 24) & 0x0f] +
+      HEX_CHARS[(h7 >>> 20) & 0x0f] +
+      HEX_CHARS[(h7 >>> 16) & 0x0f] +
+      HEX_CHARS[(h7 >>> 12) & 0x0f] +
+      HEX_CHARS[(h7 >>> 8) & 0x0f] +
+      HEX_CHARS[(h7 >>> 4) & 0x0f] +
+      HEX_CHARS[h7 & 0x0f];
+  }
+  return hex;
+};
+
+Sha256.prototype.toString = Sha256.prototype.hex;
+
+Sha256.prototype.digest = function () {
+  this.finalize();
+
+  var h0 = this.h0,
+    h1 = this.h1,
+    h2 = this.h2,
+    h3 = this.h3,
+    h4 = this.h4,
+    h5 = this.h5,
+    h6 = this.h6,
+    h7 = this.h7;
+
+  var arr = [
+    (h0 >>> 24) & 0xff,
+    (h0 >>> 16) & 0xff,
+    (h0 >>> 8) & 0xff,
+    h0 & 0xff,
+    (h1 >>> 24) & 0xff,
+    (h1 >>> 16) & 0xff,
+    (h1 >>> 8) & 0xff,
+    h1 & 0xff,
+    (h2 >>> 24) & 0xff,
+    (h2 >>> 16) & 0xff,
+    (h2 >>> 8) & 0xff,
+    h2 & 0xff,
+    (h3 >>> 24) & 0xff,
+    (h3 >>> 16) & 0xff,
+    (h3 >>> 8) & 0xff,
+    h3 & 0xff,
+    (h4 >>> 24) & 0xff,
+    (h4 >>> 16) & 0xff,
+    (h4 >>> 8) & 0xff,
+    h4 & 0xff,
+    (h5 >>> 24) & 0xff,
+    (h5 >>> 16) & 0xff,
+    (h5 >>> 8) & 0xff,
+    h5 & 0xff,
+    (h6 >>> 24) & 0xff,
+    (h6 >>> 16) & 0xff,
+    (h6 >>> 8) & 0xff,
+    h6 & 0xff,
+  ];
+  if (!this.is224) {
+    arr.push(
+      (h7 >>> 24) & 0xff,
+      (h7 >>> 16) & 0xff,
+      (h7 >>> 8) & 0xff,
+      h7 & 0xff
+    );
+  }
+  return arr;
+};
+
+Sha256.prototype.array = Sha256.prototype.digest;
+
+Sha256.prototype.arrayBuffer = function () {
+  this.finalize();
+
+  var buffer = new ArrayBuffer(this.is224 ? 28 : 32);
+  var dataView = new DataView(buffer);
+  dataView.setUint32(0, this.h0);
+  dataView.setUint32(4, this.h1);
+  dataView.setUint32(8, this.h2);
+  dataView.setUint32(12, this.h3);
+  dataView.setUint32(16, this.h4);
+  dataView.setUint32(20, this.h5);
+  dataView.setUint32(24, this.h6);
+  if (!this.is224) {
+    dataView.setUint32(28, this.h7);
+  }
+  return buffer;
+};
+
+export const sha256: HashKeyEncoder = (...strings: string[]) => {
+  return new Sha256(false, true).update(strings.join("")).hex();
+};

--- a/langchain-core/src/utils/js-sha256/hash.ts
+++ b/langchain-core/src/utils/js-sha256/hash.ts
@@ -13,8 +13,6 @@
 /*jslint bitwise: true */
 "use strict";
 
-import { type HashKeyEncoder } from "../hash.js";
-
 var HEX_CHARS = "0123456789abcdef".split("");
 var EXTRA = [-2147483648, 8388608, 32768, 128];
 var SHIFT = [24, 16, 8, 0];
@@ -501,6 +499,6 @@ Sha256.prototype.arrayBuffer = function () {
   return buffer;
 };
 
-export const sha256: HashKeyEncoder = (...strings: string[]) => {
+export const sha256 = (...strings: string[]) => {
   return new Sha256(false, true).update(strings.join("")).hex();
 };

--- a/langchain-core/src/utils/tests/hash.test.ts
+++ b/langchain-core/src/utils/tests/hash.test.ts
@@ -43,15 +43,6 @@ describe("insecureHash", () => {
 });
 
 describe("sha256", () => {
-  it("should return the correct SHA-256 hash for a given string", async () => {
-    const { sha256 } = await import("../js-sha256/hash.js");
-    // Test vector from NIST: "abc"
-    const hash = sha256("abc");
-    expect(hash).toBe(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-    );
-  });
-
   it("should return different hashes for different inputs", async () => {
     const { sha256 } = await import("../js-sha256/hash.js");
     const hash1 = sha256("foo");

--- a/langchain-core/src/utils/tests/hash.test.ts
+++ b/langchain-core/src/utils/tests/hash.test.ts
@@ -1,0 +1,75 @@
+import {
+  it,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+describe("insecureHash", () => {
+  let originalConsoleWarn: typeof console.warn;
+
+  beforeEach(() => {
+    // Save and mock console.warn
+    originalConsoleWarn = console.warn;
+    console.warn = jest.fn(console.log);
+    // Reset the hasLoggedWarning flag by re-importing the module
+    // This is a workaround since hasLoggedWarning is module-scoped.
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore console.warn
+    console.warn = originalConsoleWarn;
+  });
+
+  it("should emit a console.warn once on first use", async () => {
+    const { insecureHash } = await import("../js-sha1/hash.js");
+    insecureHash("foo");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    insecureHash("bar");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    insecureHash("baz");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return a hash string", async () => {
+    const { insecureHash } = await import("../js-sha1/hash.js");
+    const hash = insecureHash("foo");
+    expect(typeof hash).toBe("string");
+    expect(hash.length).toBeGreaterThan(0);
+  });
+});
+
+describe("sha256", () => {
+  it("should return the correct SHA-256 hash for a given string", async () => {
+    const { sha256 } = await import("../js-sha256/hash.js");
+    // Test vector from NIST: "abc"
+    const hash = sha256("abc");
+    expect(hash).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+  });
+
+  it("should return different hashes for different inputs", async () => {
+    const { sha256 } = await import("../js-sha256/hash.js");
+    const hash1 = sha256("foo");
+    const hash2 = sha256("bar");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("should return the same hash for the same input", async () => {
+    const { sha256 } = await import("../js-sha256/hash.js");
+    const hash1 = sha256("repeat");
+    const hash2 = sha256("repeat");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("should hash multiple arguments as a concatenated string", async () => {
+    const { sha256 } = await import("../js-sha256/hash.js");
+    const hash1 = sha256("foo", "bar");
+    const hash2 = sha256("foobar");
+    expect(hash1).toBe(hash2);
+  });
+});


### PR DESCRIPTION
This PR deprecates the `insecureHash` and introduces a support for Custom Key Encoders for Caching and Indexing.

Note: The `insecureHash` function is currently based on SHA-1 algorithm, which may lead to security issues as discussed with @sinedied and @jacoblee93


