### PR TITLE
fix(google): Gemini 2 5

### DIFF
--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -349,7 +349,11 @@ export abstract class GoogleAIConnection<
   get computedLocation(): string {
     switch (this.apiName) {
       case "google":
-        return super.computedLocation;
+        if (this.modelName.startsWith("gemini-2.5-flash-lite")) {
+          return "global";
+        } else {
+          return super.computedLocation;
+        }
       case "anthropic":
         return "us-east5";
       default:

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -555,7 +555,6 @@ const testGeminiModelNames = [
     platformType: "gcp",
     apiVersion: "v1",
   },
-
 ];
 
 /*

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -41,6 +41,9 @@ import { BlobStoreAIStudioFile } from "../media.js";
 import MockedFunction = jest.MockedFunction;
 
 function propSum(o: Record<string, number>): number {
+  if (typeof o !== "object") {
+    return 0;
+  }
   return Object.keys(o)
     .map((key) => o[key])
     .reduce((acc, val) => acc + val);
@@ -69,8 +72,9 @@ const apiKeyModelNames = [
   ["gemini-1.5-flash-002"],
   ["gemini-2.0-flash-001"],
   ["gemini-2.0-flash-lite-001"],
-  ["gemini-2.5-flash-preview-05-20"],
-  ["gemini-2.5-pro-preview-05-06"],
+  ["gemini-2.5-flash"], // GA
+  ["gemini-2.5-pro"], // GA
+  ["gemini-2.5-flash-lite-preview-06-17"],
   ["gemma-3-27b-it"],
   ["gemma-3n-e4b-it"],
 ];
@@ -522,29 +526,36 @@ const testGeminiModelNames = [
     apiVersion: "v1",
   },
   {
-    modelName: "gemini-2.5-flash-preview-05-20",
+    modelName: "gemini-2.5-flash-lite-preview-06-17",
     platformType: "gai",
     apiVersion: "v1beta",
   },
   {
-    modelName: "gemini-2.5-flash-preview-05-20",
+    modelName: "gemini-2.5-flash-lite-preview-06-17",
     platformType: "gcp",
     apiVersion: "v1",
   },
   {
-    modelName: "gemini-2.5-pro-preview-05-06",
+    modelName: "gemini-2.5-flash",
     platformType: "gai",
     apiVersion: "v1beta",
   },
   {
-    modelName: "gemini-2.5-pro-preview-05-06",
+    modelName: "gemini-2.5-flash",
+    platformType: "gcp",
+    apiVersion: "v1",
+  },
+  {
+    modelName: "gemini-2.5-pro",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  {
+    modelName: "gemini-2.5-pro",
     platformType: "gcp",
     apiVersion: "v1",
   },
 
-  // Flash Thinking doesn't have functions or other features
-  // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gai"},
-  // {modelName: "gemini-2.0-flash-thinking-exp", platformType: "gcp"},
 ];
 
 /*
@@ -1685,19 +1696,29 @@ describe.each(testTtsModelNames)(
 
 const testReasoningModelNames = [
   {
-    modelName: "gemini-2.5-flash-preview-05-20",
+    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    platformType: "gai",
+    apiVersion: "v1beta",
+  },
+  {
+    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    platformType: "gcp",
+    apiVersion: "v1",
+  },
+  {
+    modelName: "gemini-2.5-flash",
     platformType: "gai",
   },
   {
-    modelName: "gemini-2.5-flash-preview-05-20",
+    modelName: "gemini-2.5-flash",
     platformType: "gcp",
   },
   {
-    modelName: "gemini-2.5-pro-preview-05-06",
+    modelName: "gemini-2.5-pro",
     platformType: "gai",
   },
   {
-    modelName: "gemini-2.5-pro-preview-05-06",
+    modelName: "gemini-2.5-pro",
     platformType: "gcp",
   },
 ];
@@ -1746,6 +1767,7 @@ describe.each(testReasoningModelNames)(
 
     test("default", async () => {
       // By default, it should not return reasoning tokens, tho it should report some
+      // 2.5-flash-lite, apparently, defaults to thinking off.
       const model = newChatGoogle();
       const prompt =
         "You roll two dice. What’s the probability they add up to 7? Give me just the answer - do not explain.";
@@ -1788,6 +1810,7 @@ describe.each(testReasoningModelNames)(
 
     test("off", async () => {
       // By default, it should not return reasoning tokens, and should not report any
+      // 2.5 pro cannot turn reasoning off.
       const model = newChatGoogle({
         maxReasoningTokens: 0,
       });


### PR DESCRIPTION
Tests for Gemini 2.5 models
* Gemini 2.5 Pro is now GA
* Gemini 2.5 Flash is now GA
* Gemini 2.5 Flash Lite is in preview

Fix:
* Gemini 2.5 Flash Lite for Vertex is only available in the "global" region. Changed default region for it.

Notes:
* Gemini 2.5 Pro cannot have reasoning turned off
* Gemini 2.5 Flash Lite defaults to reasoning off, but can be turned on
* There is a discrepancy between the AI Studio and Vertex AI reporting for output tokens. AI Studio does not report the modality of output tokens, while Vertex AI does. Issue opened with Google.

Otherwise - integration tests performed as expected.
