### PR TITLE
Added note on security considerations when using filters and Azure Cosmos DB for NoSQL

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
@@ -49,7 +49,37 @@ Using filters with user-provided input can be a security risk if the data is not
 
 Allowing raw user input to be concatenated into SQL-like clauses - such as `WHERE ${userFilter}` - introduces a critical risk of SQL injection attacks, potentially exposing unintended data or compromising your system's integrity. To mitigate this, always use Azure Cosmos DB's parameterized query mechanism, passing in `@param` placeholders, which cleanly separates the query logic from user-provided input.
 
-Please refer to the official documentation on [parameterized queries in Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/query/parameterized-queries) for usage examples and best practices.
+Here is an example of unsafe code:
+
+```typescript
+// Unsafe: user-controlled input injected into query string
+const status = req.query.status;  // e.g. "active' OR 1=1"
+const query = `SELECT * FROM c WHERE c.status = '${status}'`;
+const { resources } = await container.items.query(query).fetchAll();
+```
+
+if the attacker provides `active' OR 1=1`, then the query becomes:
+
+```typescript
+SELECT * FROM c WHERE c.status = 'active' OR 1=1
+```
+
+which forces the condition to always be true, causing it to bypasses the intended filter and return all user documents.
+
+To prevent injection risk, use a parameterized query by defining a placeholder like `@status` in the query string and binding user input separately as a parameter, ensuring it is treated strictly as data and not executable query logic.
+
+```typescript
+const status = req.query.status;
+const queryDef = {
+  query: "SELECT * FROM c WHERE c.status = @status",
+  parameters: [{ name: "@status", value: status }],
+};
+const { resources } = await container.items.query(queryDef).fetchAll();
+```
+
+Now, if the attacker enters `active' OR 1=1`, the input will be treated as a literal string value to match, and not as part of the query structure.
+
+Please refer to the official documentation on [parameterized queries in Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/query/parameterized-queries) for more usage examples and best practices.
 
 ## Usage example
 

--- a/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
@@ -52,32 +52,33 @@ Allowing raw user input to be concatenated into SQL-like clauses - such as `WHER
 Here is an example of unsafe code:
 
 ```typescript
-// Unsafe: user-controlled input injected into query string
-const status = req.query.status;  // e.g. "active' OR 1=1"
-const query = `SELECT * FROM c WHERE c.status = '${status}'`;
-const { resources } = await container.items.query(query).fetchAll();
-```
+import { AzureCosmosDBNoSQLVectorStore } from "@langchain/azure-cosmosdb";
 
-if the attacker provides `active' OR 1=1`, then the query becomes:
+const store = new AzureCosmosDBNoSQLVectorStore(embeddings, {});
 
-```typescript
-SELECT * FROM c WHERE c.status = 'active' OR 1=1
-```
-
-which forces the condition to always be true, causing it to bypasses the intended filter and return all user documents.
-
-To prevent injection risk, use a parameterized query by defining a placeholder like `@status` in the query string and binding user input separately as a parameter, ensuring it is treated strictly as data and not executable query logic.
-
-```typescript
-const status = req.query.status;
-const queryDef = {
-  query: "SELECT * FROM c WHERE c.status = @status",
-  parameters: [{ name: "@status", value: status }],
+// Unsafe: user-controlled input injected into the query
+const userId = req.query.userId;  // e.g. "123' OR 1=1"
+const unsafeQuerySpec = {
+  query: `SELECT * FROM c WHERE c.metadata.userId = '${userId}'`
 };
-const { resources } = await container.items.query(queryDef).fetchAll();
+
+await store.delete(unsafeQuerySpec);
 ```
 
-Now, if the attacker enters `active' OR 1=1`, the input will be treated as a literal string value to match, and not as part of the query structure.
+If the attacker provides `123 OR 1=1`, then the query becomes `SELECT * FROM c WHERE c.metadata.userId = '123' OR 1=1`, which forces the condition to always be true, causing it to bypass the intended filter and delete all documents.
+
+To prevent this injection risk, you define a placeholder like `@userId` and Cosmos DB binds the user input separately as a parameter, ensuring it is treated strictly as data and not executable query logic as shown below.
+
+```typescript
+const safeQuerySpec = {
+  query: "SELECT * FROM c WHERE c.metadata.userId = @userId",
+  parameters: [{ name: "@userId", value: userId }]
+};
+
+await store.delete(safeQuerySpec);
+```
+
+Now, if the attacker enters `123 OR 1=1`, the input will be treated as a literal string value to match, and not as part of the query structure.
 
 Please refer to the official documentation on [parameterized queries in Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/query/parameterized-queries) for more usage examples and best practices.
 

--- a/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
@@ -62,7 +62,7 @@ const unsafeQuerySpec = {
   query: `SELECT * FROM c WHERE c.metadata.userId = '${userId}'`
 };
 
-await store.delete(unsafeQuerySpec);
+await store.delete({ filter: unsafeQuerySpec });
 ```
 
 If the attacker provides `123 OR 1=1`, then the query becomes `SELECT * FROM c WHERE c.metadata.userId = '123' OR 1=1`, which forces the condition to always be true, causing it to bypass the intended filter and delete all documents.
@@ -70,12 +70,14 @@ If the attacker provides `123 OR 1=1`, then the query becomes `SELECT * FROM c W
 To prevent this injection risk, you define a placeholder like `@userId` and Cosmos DB binds the user input separately as a parameter, ensuring it is treated strictly as data and not executable query logic as shown below.
 
 ```typescript
-const safeQuerySpec = {
+import { SqlQuerySpec } from "@azure/cosmos";
+
+const safeQuerySpec: SqlQuerySpec = {
   query: "SELECT * FROM c WHERE c.metadata.userId = @userId",
   parameters: [{ name: "@userId", value: userId }]
 };
 
-await store.delete(safeQuerySpec);
+await store.delete({ filter: safeQuerySpec });
 ```
 
 Now, if the attacker enters `123 OR 1=1`, the input will be treated as a literal string value to match, and not as part of the query structure.

--- a/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
+++ b/docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx
@@ -39,6 +39,18 @@ When using Azure Managed Identity and role-based access control, you must ensure
 
 :::
 
+### Security considerations when using filters
+
+:::warning
+
+Using filters with user-provided input can be a security risk if the data is not sanitized properly. Follow the recommendation below to prevent potential security issues.
+
+:::
+
+Allowing raw user input to be concatenated into SQL-like clauses - such as `WHERE ${userFilter}` - introduces a critical risk of SQL injection attacks, potentially exposing unintended data or compromising your system's integrity. To mitigate this, always use Azure Cosmos DB's parameterized query mechanism, passing in `@param` placeholders, which cleanly separates the query logic from user-provided input.
+
+Please refer to the official documentation on [parameterized queries in Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/query/parameterized-queries) for usage examples and best practices.
+
 ## Usage example
 
 Below is an example that indexes documents from a file in Azure Cosmos DB for NoSQL, runs a vector search query, and finally uses a chain to answer a question in natural language


### PR DESCRIPTION
This pull request adds a new section to the Azure Cosmos DB integration documentation, focusing on security considerations when using filters. It highlights the risks of SQL injection and provides recommendations to mitigate them.

Documentation updates on security:

* [`docs/core_docs/docs/integrations/vectorstores/azure_cosmosdb_nosql.mdx`](diffhunk://#diff-4c4e9428e8cae1baabe6b682695879faed4b203f171cd664f0268059eab678e0R42-R53): Added a warning about the security risks of using filters with user-provided input. Included guidance on using Azure Cosmos DB's parameterized query mechanism to prevent SQL injection attacks.
