### PR TITLE
fix(tests): `chat_models` int tests updates and sync

### DIFF
--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -12,7 +12,7 @@ export interface StoredMessageData {
   tool_call_id: string | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   additional_kwargs?: Record<string, any>;
-  /** Response metadata. For example: response headers, logprobs, token counts. */
+  /** Response metadata. For example: response headers, logprobs, token counts, model name. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response_metadata?: Record<string, any>;
   id?: string;
@@ -95,7 +95,7 @@ export type BaseMessageFields = {
     tool_calls?: OpenAIToolCall[];
     [key: string]: unknown;
   };
-  /** Response metadata. For example: response headers, logprobs, token counts. */
+  /** Response metadata. For example: response headers, logprobs, token counts, model name. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response_metadata?: Record<string, any>;
   /**
@@ -254,7 +254,7 @@ export abstract class BaseMessage
   /** Additional keyword arguments */
   additional_kwargs: NonNullable<BaseMessageFields["additional_kwargs"]>;
 
-  /** Response metadata. For example: response headers, logprobs, token counts. */
+  /** Response metadata. For example: response headers, logprobs, token counts, model name. */
   response_metadata: NonNullable<BaseMessageFields["response_metadata"]>;
 
   /**

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -827,7 +827,6 @@ export abstract class ChatModelIntegrationTests<
 
     expect(result).toBeInstanceOf(this.invokeResponseType);
     expect(result.content).toBeDefined();
-    expect(result.content).not.toBe("");
 
     // Test 2: Passing 'stop' as an initialization parameter to the model's constructor.
     const customModel = new this.Cls({
@@ -837,7 +836,6 @@ export abstract class ChatModelIntegrationTests<
     const customResult = await customModel.invoke("hi", callOptions);
     expect(customResult).toBeInstanceOf(this.invokeResponseType);
     expect(customResult.content).toBeDefined();
-    expect(customResult.content).not.toBe("");
   }
 
   /**
@@ -850,7 +848,7 @@ export abstract class ChatModelIntegrationTests<
    * 2. Constructs a message history that includes a HumanMessage, an AIMessage with string content
    *    (simulating a tool call), and a ToolMessage with the tool's response.
    * 3. Invokes the model with this message history.
-   * 4. Verifies that the result is of the expected type (AIMessage or AIMessageChunk).
+   * 4. Verifies that the result is of the expected type (AIMessage or AIMessageChunk) and defined.
    *
    * This test ensures that the model can correctly process and respond to complex message
    * histories that include tool calls with string-based content structures.
@@ -878,13 +876,13 @@ export abstract class ChatModelIntegrationTests<
     const functionArgs = { a: 1, b: 2 };
 
     const { functionId } = this;
-    // Invoke the tool to get the result
+    // Invoke the tool (standalone) to get the result
     const functionResult = await adderTool.invoke(functionArgs);
 
     // Construct a message history with string-based content
     const messagesStringContent = [
       new HumanMessage("What is 1 + 2"),
-      // AIMessage with string content (simulating OpenAI's format)
+      // AIMessage with string content (simulating OpenAI's format) including the tool call
       new AIMessage({
         content: "",
         tool_calls: [
@@ -892,6 +890,7 @@ export abstract class ChatModelIntegrationTests<
             name: functionName,
             args: functionArgs,
             id: functionId,
+            type: "tool_call",
           },
         ],
       }),
@@ -905,8 +904,9 @@ export abstract class ChatModelIntegrationTests<
       callOptions
     );
 
-    // Verify that the result is of the expected type
+    // Verify that the result is of the expected type and defined
     expect(result).toBeInstanceOf(this.invokeResponseType);
+    expect(result.content).toBeDefined();
   }
 
   /**
@@ -965,6 +965,7 @@ export abstract class ChatModelIntegrationTests<
             name: functionName,
             args: functionArgs,
             id: functionId,
+            type: "tool_call",
           },
         ],
       }),
@@ -1034,6 +1035,7 @@ export abstract class ChatModelIntegrationTests<
             name: functionName,
             args: functionArgs,
             id: functionId,
+            type: "tool_call",
           },
         ],
       }),
@@ -1863,11 +1865,13 @@ Extraction path: {extractionPath}`,
             name: weatherTool.name,
             id: "get_current_weather_id",
             args: { location: "San Francisco" },
+            type: "tool_call",
           },
           {
             name: currentTimeTool.name,
             id: "get_current_time_id",
             args: { location: "San Francisco" },
+            type: "tool_call",
           },
         ],
       });

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -555,16 +555,15 @@ export abstract class ChatModelIntegrationTests<
     // Check that total_tokens is a number
     expect(typeof usageMetadata.total_tokens).toBe("number");
 
-    // This is required in Python: come back to this after checking
-    // // Ensure model_name is in response_metadata and is a non-empty string
-    // if (!("response_metadata" in result)) {
-    //   throw new Error("result is missing `response_metadata`");
-    // }
-    // const responseMetadata = result.response_metadata;
-    // expect(responseMetadata).toBeDefined();
-    // expect(responseMetadata.model_name).toBeDefined();
-    // expect(typeof responseMetadata.model_name).toBe("string");
-    // expect(responseMetadata.model_name).not.toBe("");
+    // Ensure model_name is in response_metadata and is a non-empty string
+    if (!("response_metadata" in result)) {
+      throw new Error("result is missing `response_metadata`");
+    }
+    const responseMetadata = result.response_metadata;
+    expect(responseMetadata).toBeDefined();
+    expect(responseMetadata.model_name).toBeDefined();
+    expect(typeof responseMetadata.model_name).toBe("string");
+    expect(responseMetadata.model_name).not.toBe("");
 
     // Test additional usage metadata details
     if (this.supportedUsageMetadataDetails.invoke.includes("audio_input")) {

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -40,8 +40,8 @@ const TEST_IMAGE_BASE64 =
 
 const TEST_IMAGE_DATA_URL = `data:image/png;base64,${TEST_IMAGE_BASE64}`;
 
-// TODO: need to find a short mp3 or wav file to use as a test
-// const TEST_AUDIO_URL = "https://www.w3schools.com/html/horse.ogg";
+const TEST_AUDIO_URL =
+  "https://upload.wikimedia.org/wikipedia/commons/e/ef/Phylloscopus_collybita_-_Common_Chiffchaff_XC170664.mp3";
 
 const TEST_AUDIO_BASE64 =
   "UklGRigAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA"; // Short silent WAV
@@ -2298,6 +2298,21 @@ Extraction path: {extractionPath}`,
       return;
     }
     const chatModel = new this.Cls(this.constructorArgs);
+    // URL
+    if (support.includes("url")) {
+      const msg = new HumanMessage({
+        content: [
+          {
+            type: "audio",
+            source_type: "url",
+            url: TEST_AUDIO_URL,
+          },
+        ],
+      });
+      const result = await chatModel.invoke([msg], callOptions);
+      expect(result).toBeDefined();
+      expect(result.text).not.toBe("");
+    }
     // base64
     if (support.includes("base64")) {
       const msg = new HumanMessage({

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -810,6 +810,37 @@ export abstract class ChatModelIntegrationTests<
   }
 
   /**
+   * Tests that the model does not fail when invoked with the `stop` parameter, which is a standard
+   * parameter for stopping generation at a certain token.
+   *
+   * This test verifies that the `stop` sequence can be supplied in two ways:
+   * 1. As a runtime option to the `invoke` method.
+   * 2. As a parameter during the model's initialization.
+   *
+   * @param {any | undefined} callOptions Optional call options to pass to the model.
+   * These options will be applied to the model at runtime.
+   */
+  async testStopSequence(callOptions?: any) {
+    // Test 1: Passing 'stop' as a runtime argument to the invoke call.
+    const model = new this.Cls(this.constructorArgs);
+    const result = await model.invoke("hi", { ...callOptions, stop: ["you"] });
+
+    expect(result).toBeInstanceOf(this.invokeResponseType);
+    expect(result.content).toBeDefined();
+    expect(result.content).not.toBe("");
+
+    // Test 2: Passing 'stop' as an initialization parameter to the model's constructor.
+    const customModel = new this.Cls({
+      ...this.constructorArgs,
+      stop: ["you"],
+    });
+    const customResult = await customModel.invoke("hi", callOptions);
+    expect(customResult).toBeInstanceOf(this.invokeResponseType);
+    expect(customResult.content).toBeDefined();
+    expect(customResult.content).not.toBe("");
+  }
+
+  /**
    * Tests the chat model's ability to handle message histories with string tool contents.
    * This test is specifically designed for models that support tool calling with string-based content,
    * such as OpenAI's GPT models.

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -7,6 +7,7 @@ import {
   AIMessageChunk,
   BaseMessageChunk,
   HumanMessage,
+  SystemMessage,
   ToolMessage,
   UsageMetadata,
   getBufferString,
@@ -360,7 +361,48 @@ export abstract class ChatModelIntegrationTests<
     // Check that the result is an instance of the expected response type
     expect(result).toBeInstanceOf(this.invokeResponseType);
 
-    // Verify that the response content is not empty
+    // Ensure the response content is a non-empty string
+    expect(typeof result.text).toBe("string");
+    expect(result.text).not.toBe("");
+  }
+
+  /**
+   * This test ensures that the model can process a sequence of numerous back-to-back messages
+   * from different roles (Human and AI) and generate an appropriate response.
+   *
+   * It verifies that:
+   * 1. The result is defined and is an instance of the correct response type.
+   * 2. The content of the response is a non-empty string.
+   *
+   * @param {any | undefined} callOptions Optional call options to pass to the model.
+   *  These options will be applied to the model at runtime.
+   */
+  async testDoubleMessageConversation(callOptions?: any) {
+    // Create a new instance of the chat model
+    const chatModel = new this.Cls(this.constructorArgs);
+
+    // Prepare a conversation history with alternating Human and AI messages
+    const messages = [
+      new SystemMessage("hello"),
+      new SystemMessage("hello"),
+      new HumanMessage("hello"),
+      new HumanMessage("hello"),
+      new AIMessage("hello"),
+      new AIMessage("hello"),
+      new HumanMessage("how are you"),
+    ];
+
+    // Invoke the model with the conversation history
+    const result = await chatModel.invoke(messages, callOptions);
+
+    // Verify that the result is defined
+    expect(result).toBeDefined();
+
+    // Check that the result is an instance of the expected response type
+    expect(result).toBeInstanceOf(this.invokeResponseType);
+
+    // Ensure the response content is a non-empty string
+    expect(typeof result.text).toBe("string");
     expect(result.text).not.toBe("");
   }
 

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -30,6 +30,7 @@ import {
   RecordStringAny,
 } from "../base.js";
 import { TestCallbackHandler } from "../utils.js";
+import { isMessageContentComplex } from "../utils/types.js";
 
 // Placeholder data for content block tests
 const TEST_IMAGE_URL =
@@ -111,86 +112,6 @@ interface ChatModelIntegrationTestsFields<
    * @default false
    */
   supportsParallelToolCalls?: boolean;
-}
-
-// --- Message Content Types ---
-// Per MessageContent and MessageContentComplex definitions
-export type MessageContentText = {
-  type: "text";
-  text: string;
-};
-
-export type MessageContentImageUrl = {
-  type: "image_url";
-  image_url:
-    | string
-    | {
-        url: string;
-        detail?: "auto" | "low" | "high";
-      };
-};
-
-// Generic fallback for other complex types
-export type MessageContentUnknown = Record<string, any> & {
-  type: string;
-};
-
-export type MessageContentComplex =
-  | MessageContentText
-  | MessageContentImageUrl
-  | MessageContentUnknown;
-
-export type MessageContent = string | MessageContentComplex[];
-
-// --- Type Guard Functions ---
-
-function isMessageContentText(obj: any): obj is MessageContentText {
-  return (
-    obj &&
-    typeof obj === "object" &&
-    obj.type === "text" &&
-    typeof obj.text === "string"
-  );
-}
-
-/**
- * Checks if an object is a valid MessageContentImageUrl which can be either a simple URL string
- * or an object with a `url` property. We assume that the `url` property is always a string
- */
-function isMessageContentImageUrl(obj: any): obj is MessageContentImageUrl {
-  if (obj?.type !== "image_url" || !("image_url" in obj)) {
-    return false;
-  }
-  const { image_url } = obj;
-  if (typeof image_url === "string") {
-    return true; // Simple URL string
-  }
-  if (
-    typeof image_url === "object" &&
-    image_url !== null &&
-    typeof image_url.url === "string"
-  ) {
-    return true; // Detailed object with a URL
-  }
-  return false;
-}
-
-/**
- * Checks if an object is a valid MessageContentComplex object.
- */
-function isMessageContentComplex(obj: any): obj is MessageContentComplex {
-  if (!obj || typeof obj !== "object" || typeof obj.type !== "string") {
-    return false;
-  }
-  // Check against the most specific types first
-  if (isMessageContentText(obj) || isMessageContentImageUrl(obj)) {
-    return true;
-  }
-  // Fallback for any other object that has any `type` property
-  if (obj.type) {
-    return true;
-  }
-  return false;
 }
 
 export abstract class ChatModelIntegrationTests<

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -884,70 +884,6 @@ export abstract class ChatModelIntegrationTests<
   }
 
   /**
-   * Tests the chat model's ability to bind and decide to use an OpenAI-formatted tool.
-   * This test ensures that the model can correctly process and use tools formatted in
-   * the OpenAI function calling style.
-   *
-   * It verifies that:
-   * 1. The model supports tool calling functionality.
-   * 2. The model can successfully bind an OpenAI-formatted tool.
-   * 3. The model invokes the bound tool correctly when prompted.
-   * 4. The result contains a tool call with the expected name.
-   *
-   * This test is crucial for ensuring compatibility with OpenAI's function
-   * calling format, which is a common standard in AI tool integration.
-   *
-   * @param {any | undefined} callOptions Optional call options to pass to the model.
-   *  These options will be applied to the model at runtime.
-   */
-  async testBindToolsWithOpenAIFormattedTools(callOptions?: any) {
-    // Skip the test if the model doesn't support tool calling
-    if (!this.chatModelHasToolCalling) {
-      console.log("Test requires tool calling. Skipping...");
-      return;
-    }
-
-    const model = new this.Cls(this.constructorArgs);
-    if (!model.bindTools) {
-      throw new Error(
-        "bindTools undefined. Cannot test OpenAI formatted tool calls."
-      );
-    }
-
-    // Bind an OpenAI-formatted tool to the model
-    const modelWithTools = model.bindTools([
-      {
-        type: "function",
-        function: {
-          name: "math_addition",
-          description: adderSchema.description,
-          parameters: toJsonSchema(adderSchema) as Record<string, any>, // Explicit cast
-        },
-      },
-    ]);
-
-    // Invoke the model with a prompt that should trigger the tool use
-    const result: AIMessage = await MATH_ADDITION_PROMPT.pipe(
-      modelWithTools
-    ).invoke(
-      {
-        toolName: "math_addition",
-      },
-      callOptions
-    );
-
-    // Verify that a tool call was made
-    expect(result.tool_calls?.[0]).toBeDefined();
-    if (!result.tool_calls?.[0]) {
-      throw new Error("result.tool_calls is undefined");
-    }
-    const { tool_calls } = result;
-
-    // Check that the correct tool was called
-    expect(tool_calls[0].name).toBe("math_addition");
-  }
-
-  /**
    * Tests the chat model's ability to bind and use Runnable-like tools.
    * This test ensures that the model can correctly process and use tools
    * that are created from Runnable objects using the `asTool` method.
@@ -1027,6 +963,70 @@ export abstract class ChatModelIntegrationTests<
 
     // Verify the tool call type is correct
     expect(toolCall.type).toBe("tool_call");
+  }
+
+  /**
+   * Tests the chat model's ability to bind and decide to use an OpenAI-formatted tool.
+   * This test ensures that the model can correctly process and use tools formatted in
+   * the OpenAI function calling style.
+   *
+   * It verifies that:
+   * 1. The model supports tool calling functionality.
+   * 2. The model can successfully bind an OpenAI-formatted tool.
+   * 3. The model invokes the bound tool correctly when prompted.
+   * 4. The result contains a tool call with the expected name.
+   *
+   * This test is crucial for ensuring compatibility with OpenAI's function
+   * calling format, which is a common standard in AI tool integration.
+   *
+   * @param {any | undefined} callOptions Optional call options to pass to the model.
+   *  These options will be applied to the model at runtime.
+   */
+  async testBindToolsWithOpenAIFormattedTools(callOptions?: any) {
+    // Skip the test if the model doesn't support tool calling
+    if (!this.chatModelHasToolCalling) {
+      console.log("Test requires tool calling. Skipping...");
+      return;
+    }
+
+    const model = new this.Cls(this.constructorArgs);
+    if (!model.bindTools) {
+      throw new Error(
+        "bindTools undefined. Cannot test OpenAI formatted tool calls."
+      );
+    }
+
+    // Bind an OpenAI-formatted tool to the model
+    const modelWithTools = model.bindTools([
+      {
+        type: "function",
+        function: {
+          name: "math_addition",
+          description: adderSchema.description,
+          parameters: toJsonSchema(adderSchema) as Record<string, any>, // Explicit cast
+        },
+      },
+    ]);
+
+    // Invoke the model with a prompt that should trigger the tool use
+    const result: AIMessage = await MATH_ADDITION_PROMPT.pipe(
+      modelWithTools
+    ).invoke(
+      {
+        toolName: "math_addition",
+      },
+      callOptions
+    );
+
+    // Verify that a tool call was made
+    expect(result.tool_calls?.[0]).toBeDefined();
+    if (!result.tool_calls?.[0]) {
+      throw new Error("result.tool_calls is undefined");
+    }
+    const { tool_calls } = result;
+
+    // Check that the correct tool was called
+    expect(tool_calls[0].name).toBe("math_addition");
   }
 
   /**

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -555,6 +555,17 @@ export abstract class ChatModelIntegrationTests<
     // Check that total_tokens is a number
     expect(typeof usageMetadata.total_tokens).toBe("number");
 
+    // This is required in Python: come back to this after checking
+    // // Ensure model_name is in response_metadata and is a non-empty string
+    // if (!("response_metadata" in result)) {
+    //   throw new Error("result is missing `response_metadata`");
+    // }
+    // const responseMetadata = result.response_metadata;
+    // expect(responseMetadata).toBeDefined();
+    // expect(responseMetadata.model_name).toBeDefined();
+    // expect(typeof responseMetadata.model_name).toBe("string");
+    // expect(responseMetadata.model_name).not.toBe("");
+
     // Test additional usage metadata details
     if (this.supportedUsageMetadataDetails.invoke.includes("audio_input")) {
       const msgWithAudioInput = await this.invokeWithAudioInput(false);

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -163,7 +163,7 @@ export abstract class ChatModelIntegrationTests<
    *
    * It verifies that:
    * 1. The result is defined and is an instance of the correct type.
-   * 2. The content of the response is a non-empty string.
+   * 2. The text content of the result is a non-empty string.
    *
    * @param {any | undefined} callOptions Optional call options to pass to the model.
    *  These options will be applied to the model at runtime.
@@ -181,7 +181,8 @@ export abstract class ChatModelIntegrationTests<
     // Check that the result is an instance of the expected response type
     expect(result).toBeInstanceOf(this.invokeResponseType);
 
-    // Verify that the response content is not empty
+    // Ensure the response content is a non-empty string
+    expect(typeof result.text).toBe("string");
     expect(result.text).not.toBe("");
   }
 
@@ -252,7 +253,8 @@ export abstract class ChatModelIntegrationTests<
       // Verify the result is of the expected type
       expect(result).toBeInstanceOf(this.invokeResponseType);
 
-      // Ensure the content is a non-empty string
+      // Ensure the response content is a non-empty string
+      expect(typeof result.text).toBe("string");
       expect(result.text).not.toBe("");
     }
   }

--- a/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
+++ b/libs/langchain-standard-tests/src/integration_tests/chat_models.ts
@@ -537,7 +537,7 @@ export abstract class ChatModelIntegrationTests<
 
     // Ensure that the result contains usage_metadata
     if (!("usage_metadata" in result)) {
-      throw new Error("result is not an instance of AIMessage");
+      throw new Error("result is missing `usage_metadata`");
     }
 
     // Extract the usage metadata from the result

--- a/libs/langchain-standard-tests/src/utils/types.ts
+++ b/libs/langchain-standard-tests/src/utils/types.ts
@@ -1,0 +1,74 @@
+import {
+  MessageContentImageUrl,
+  MessageContentText,
+} from "@langchain/core/messages";
+
+export type MessageContentUnknown = Record<string, unknown> & {
+  type: string;
+};
+
+export type MessageContentComplex =
+  | MessageContentText
+  | MessageContentImageUrl
+  | MessageContentUnknown;
+
+export type MessageContent = string | MessageContentComplex[];
+
+export function isMessageContentText(obj: unknown): obj is MessageContentText {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    obj.type === "text" &&
+    "text" in obj &&
+    typeof obj.text === "string"
+  );
+}
+
+/**
+ * Checks if an object is a valid MessageContentImageUrl which can be either a simple URL string
+ * or an object with a `url` property. We assume that the `url` property is always a string
+ */
+function isMessageContentImageUrl(obj: unknown): obj is MessageContentImageUrl {
+  if (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    obj.type === "image_url" &&
+    "image_url" in obj
+  ) {
+    if (typeof obj.image_url === "string") {
+      return true; // Simple URL string
+    }
+    if (
+      typeof obj.image_url === "object" &&
+      obj.image_url !== null &&
+      "url" in obj.image_url &&
+      typeof obj.image_url.url === "string"
+    ) {
+      return true; // Detailed object with a URL
+    }
+  }
+  return false;
+}
+
+/**
+ * Checks if an object is a valid MessageContentComplex object.
+ */
+export function isMessageContentComplex(
+  obj: unknown
+): obj is MessageContentComplex {
+  if (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    typeof obj.type === "string"
+  ) {
+    return true;
+  }
+  // Check against the most specific types first
+  if (isMessageContentText(obj) || isMessageContentImageUrl(obj)) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Working toward bringing some parity with the Python lib to the integration tests. Includes a fair bit of rewording to improve semantics.

- In `testStream`, we weren't checking that `content` was defined, and further, that it was composed of a valid string or MessageContentComplex[]. To do this, I added some helpers (`isMessageContentComplex`, `isMessageContentImageUrl`, `isMessageContentText`).
- Adds a missing test to check double-texting (`testDoubleMessageConversation`).
- Ensure that `model_name` is in the `response_metadata` (`testUsageMetadata`).
- Add missing `type=tool_call` to AIMessage `tool_calls[]`
- Rearrange some tests for better grouping & narrative flow
- Resolve TODO by finding TEST_AUDIO_URL and add corresponding conditional block to `testStandardAudioContentBlocks`