### PR TITLE
chore: Add tool annotations to metadata

### DIFF
--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -540,6 +540,7 @@ export async function loadMcpTools(
               description: tool.description || "",
               schema: tool.inputSchema,
               responseFormat: "content_and_artifact",
+              metadata: { annotations: tool.annotations },
               func: async (
                 args: Record<string, unknown>,
                 _runManager?: CallbackManagerForToolRun,


### PR DESCRIPTION
Tools annotations from the MCP Server are not set in the `DynamicStructuredTool` and are completely ignored. 
This change will set the tools annotations within the `metadata` property.
