### PR TITLE
fix(mcp-adapters): use DynamicStructuredTool instead of interface type

### DIFF
--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -12,7 +12,7 @@ import {
   type StreamableHTTPReconnectionOptions,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import type { StructuredToolInterface } from "@langchain/core/tools";
+import type { DynamicStructuredTool } from "@langchain/core/tools";
 import debug from "debug";
 import { z } from "zod";
 import { loadMcpTools } from "./tools.js";
@@ -115,7 +115,7 @@ function isResolvedStreamableHTTPConnection(
 export class MultiServerMCPClient {
   private _clients: Record<string, Client> = {};
 
-  private _serverNameToTools: Record<string, StructuredToolInterface[]> = {};
+  private _serverNameToTools: Record<string, DynamicStructuredTool[]> = {};
 
   private _connections?: Record<string, ResolvedConnection>;
 
@@ -194,7 +194,7 @@ export class MultiServerMCPClient {
    * @throws {MCPClientError} If initialization fails
    */
   async initializeConnections(): Promise<
-    Record<string, StructuredToolInterface[]>
+    Record<string, DynamicStructuredTool[]>
   > {
     if (!this._connections || Object.keys(this._connections).length === 0) {
       throw new MCPClientError("No connections to initialize");
@@ -241,7 +241,7 @@ export class MultiServerMCPClient {
    *                 If not provided, returns tools from all servers.
    * @returns A flattened array of tools from the specified servers (or all servers)
    */
-  async getTools(...servers: string[]): Promise<StructuredToolInterface[]> {
+  async getTools(...servers: string[]): Promise<DynamicStructuredTool[]> {
     await this.initializeConnections();
     if (servers.length === 0) {
       return this._getAllToolsAsFlatArray();
@@ -890,8 +890,8 @@ export class MultiServerMCPClient {
    *
    * @returns A flattened array of all tools
    */
-  private _getAllToolsAsFlatArray(): StructuredToolInterface[] {
-    const allTools: StructuredToolInterface[] = [];
+  private _getAllToolsAsFlatArray(): DynamicStructuredTool[] {
+    const allTools: DynamicStructuredTool[] = [];
     for (const tools of Object.values(this._serverNameToTools)) {
       allTools.push(...tools);
     }
@@ -904,10 +904,8 @@ export class MultiServerMCPClient {
    * @param serverNames - Names of servers to get tools from
    * @returns A flattened array of tools from the specified servers
    */
-  private _getToolsFromServers(
-    serverNames: string[]
-  ): StructuredToolInterface[] {
-    const allTools: StructuredToolInterface[] = [];
+  private _getToolsFromServers(serverNames: string[]): DynamicStructuredTool[] {
+    const allTools: DynamicStructuredTool[] = [];
     for (const serverName of serverNames) {
       const tools = this._serverNameToTools[serverName];
       if (tools) {

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -6,10 +6,7 @@ import type {
   ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import {
-  DynamicStructuredTool,
-  type StructuredToolInterface,
-} from "@langchain/core/tools";
+import { DynamicStructuredTool } from "@langchain/core/tools";
 import {
   Base64ContentBlock,
   DataContentBlock,
@@ -489,7 +486,7 @@ export async function loadMcpTools(
   serverName: string,
   client: Client,
   options?: LoadMcpToolsOptions
-): Promise<StructuredToolInterface[]> {
+): Promise<DynamicStructuredTool[]> {
   const {
     throwOnLoadError,
     prefixToolNameWithServerName,
@@ -540,6 +537,7 @@ export async function loadMcpTools(
               description: tool.description || "",
               schema: tool.inputSchema,
               responseFormat: "content_and_artifact",
+              metadata: { annotations: tool.annotations },
               func: async (
                 args: Record<string, unknown>,
                 _runManager?: CallbackManagerForToolRun,
@@ -567,5 +565,5 @@ export async function loadMcpTools(
           }
         })
     )
-  ).filter(Boolean) as StructuredToolInterface[];
+  ).filter(Boolean) as DynamicStructuredTool[];
 }


### PR DESCRIPTION
The current class signatures return a `StructuredToolInterface` type which doesn't have the `withConfig` function, meaning the note on setting tool timeouts in the README is inaccurate currently.

See https://github.com/langchain-ai/langchainjs/issues/8279#issuecomment-2938421697