### PR TITLE
fix: add missing APAC region prefix in Bedrock models

### DIFF
--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -59,6 +59,7 @@ const AWS_REGIONS = [
   "us",
   "sa",
   "me",
+  "mx",
   "il",
   "eu",
   "cn",

--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -63,6 +63,7 @@ const AWS_REGIONS = [
   "ap",
   "af",
   "us-gov",
+  "apac",
 ];
 
 const ALLOWED_MODEL_PROVIDERS = [

--- a/libs/langchain-community/src/chat_models/bedrock/web.ts
+++ b/libs/langchain-community/src/chat_models/bedrock/web.ts
@@ -52,6 +52,9 @@ type AnthropicTool = Record<string, unknown>;
 
 type BedrockChatToolType = BindToolsInput | AnthropicTool;
 
+/**
+ * @see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html#Concepts.RegionsAndAvailabilityZones.Regions
+ */
 const AWS_REGIONS = [
   "us",
   "sa",

--- a/libs/langchain-community/src/chat_models/tests/chatbedrock.test.ts
+++ b/libs/langchain-community/src/chat_models/tests/chatbedrock.test.ts
@@ -57,3 +57,84 @@ test("Test Bedrock serialization from environment variables", async () => {
     `{"lc":1,"type":"constructor","id":["langchain","chat_models","bedrock","BedrockChat"],"kwargs":{"region_name":"us-west-2","model_id":"anthropic.claude-3-sonnet-20240229-v1:0","aws_access_key_id":{"lc":1,"type":"secret","id":["AWS_ACCESS_KEY_ID"]},"aws_secret_access_key":{"lc":1,"type":"secret","id":["AWS_SECRET_ACCESS_KEY"]},"credentials":{"accessKeyId":{"lc":1,"type":"secret","id":["AWS_ACCESS_KEY_ID"]},"secretAccessKey":{"lc":1,"type":"secret","id":["AWS_SECRET_ACCESS_KEY"]}}}}`
   );
 });
+
+describe("Test model provider detection", () => {
+  const testCases = [
+    {
+      modelId: "eu.anthropic.claude-3-haiku-20240307-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "eu-west-1",
+    },
+    {
+      modelId: "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "ap-northeast-1",
+    },
+    {
+      modelId: "us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "us-gov-west-1",
+    },
+    {
+      modelId: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "us-west-2",
+    },
+    {
+      modelId: "meta.llama3-1-405b-instruct-v1:0",
+      expectedProvider: "meta",
+      shouldThrow: false,
+      region: "us-west-2",
+    },
+    {
+      modelId:
+        "arn:aws:bedrock:us-east-1::custom-model/cohere.command-r-v1:0/MyCustomModel2",
+      expectedProvider: "arn:aws:bedrock:us-east-1::custom-model/cohere",
+      shouldThrow: true, // This is not in ALLOWED_MODEL_PROVIDERS, so it should throw
+      region: "us-east-1",
+    },
+    {
+      modelId: "anthropic.claude-3-sonnet-20240229-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "us-east-1",
+    },
+  ];
+
+  test.each(testCases)(
+    "should handle model $modelId with provider $provider",
+    ({ modelId, expectedProvider, shouldThrow, region }) => {
+      if (shouldThrow) {
+        expect(() => {
+          // eslint-disable-next-line no-new
+          new BedrockChat({
+            model: modelId,
+            region,
+            credentials: {
+              accessKeyId: "unused",
+              secretAccessKey: "unused",
+              sessionToken: "unused",
+            },
+          });
+        }).toThrow();
+        return;
+      }
+
+      const bedrock = new BedrockChat({
+        model: modelId,
+        region,
+        credentials: {
+          accessKeyId: "unused",
+          secretAccessKey: "unused",
+          sessionToken: "unused",
+        },
+      });
+      expect(bedrock.modelProvider).toBe(expectedProvider);
+      expect(bedrock.region).toBe(region);
+    }
+  );
+});

--- a/libs/langchain-community/src/chat_models/tests/chatbedrock.test.ts
+++ b/libs/langchain-community/src/chat_models/tests/chatbedrock.test.ts
@@ -67,6 +67,12 @@ describe("Test model provider detection", () => {
       region: "eu-west-1",
     },
     {
+      modelId: "mx.anthropic.claude-3-5-sonnet-20240620-v1:0",
+      expectedProvider: "anthropic",
+      shouldThrow: false,
+      region: "us-west-2",
+    },
+    {
       modelId: "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
       expectedProvider: "anthropic",
       shouldThrow: false,

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -28,6 +28,7 @@ const AWS_REGIONS = [
   "ap",
   "af",
   "us-gov",
+  "apac",
 ];
 
 const ALLOWED_MODEL_PROVIDERS = [

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -17,6 +17,9 @@ import {
 } from "../../utils/bedrock/index.js";
 import type { SerializedFields } from "../../load/map_keys.js";
 
+/**
+ * @see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html#Concepts.RegionsAndAvailabilityZones.Regions
+ */
 const AWS_REGIONS = [
   "us",
   "sa",

--- a/libs/langchain-community/src/llms/bedrock/web.ts
+++ b/libs/langchain-community/src/llms/bedrock/web.ts
@@ -24,6 +24,7 @@ const AWS_REGIONS = [
   "us",
   "sa",
   "me",
+  "mx",
   "il",
   "eu",
   "cn",


### PR DESCRIPTION
## Add support for APAC region prefix in Bedrock models

- Add "apac" to AWS_REGIONS list in both chat models and LLMs
- Add comprehensive test suite for model provider detection
- Test various regional model prefixes (eu, apac, us-gov, us)
- Ensure proper handling of different model ID formats and providers
- Add validation for unsupported custom model ARNs

This enables support for APAC-specific Bedrock model IDs like: `apac.anthropic.claude-3-5-sonnet-20240620-v1:0`

This change resolves the issue where users in APAC regions couldn't use region-specific Bedrock model identifiers. Previously, attempting to use models with the `apac.` prefix would result in an "Unknown model provider" error because the APAC region prefix wasn't recognized in the AWS_REGIONS configuration.

The fix includes:
- Adding "apac" to the supported AWS regions in both `BedrockChat` and `Bedrock` LLM classes
- Comprehensive test coverage for all regional model prefixes including edge cases
- Validation that ensures proper error handling for unsupported custom model ARNs

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Fixes [#8408](https://github.com/langchain-ai/langchainjs/issues/8408)