### PR TITLE
fix(net-mocks): dont put example tests on CI hot path

### DIFF
--- a/internal/net-mocks/example/__tests__/chat_models.test.ts
+++ b/internal/net-mocks/example/__tests__/chat_models.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { ChatAnthropic } from "../../../../libs/langchain-anthropic/src/chat_models";
-import { net } from "../../src";
 import { HumanMessage } from "@langchain/core/messages";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { net } from "../../src";
 
 const model = new ChatAnthropic({
   model: "claude-3-5-sonnet-20241022",

--- a/internal/net-mocks/package.json
+++ b/internal/net-mocks/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
-    "test": "vitest run --config=example/vitest.config.ts",
+    "test:int": "vitest run --config=example/vitest.config.ts",
     "lint": "eslint --cache --ext .ts,.js src/",
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write \"src\"",
@@ -29,6 +29,8 @@
     }
   },
   "devDependencies": {
+    "@langchain/anthropic": "workspace:*",
+    "@langchain/core": "workspace:*",
     "@types/deep-equal": "^1.0.4",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8619,6 +8619,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@langchain/net-mocks@workspace:internal/net-mocks"
   dependencies:
+    "@langchain/anthropic": "workspace:*"
+    "@langchain/core": "workspace:*"
     "@mswjs/interceptors": ^0.39.2
     "@types/deep-equal": ^1.0.4
     "@typescript-eslint/eslint-plugin": ^6.12.0


### PR DESCRIPTION
running `yarn test` from root locally would require ANTHROPIC_API_KEY without this