### PR TITLE
fix: Fix BaseDocumentLoader import errors in fs document loaders

### DIFF
--- a/langchain/src/document_loaders/fs/buffer.ts
+++ b/langchain/src/document_loaders/fs/buffer.ts
@@ -1,7 +1,7 @@
 import type { readFile as ReadFileT } from "node:fs/promises";
 import { Document } from "@langchain/core/documents";
 import { getEnv } from "@langchain/core/utils/env";
-import { BaseDocumentLoader } from "../base.js";
+import { BaseDocumentLoader } from "@langchain/core/document_loaders/base";
 
 /**
  * Abstract class that extends the `BaseDocumentLoader` class. It

--- a/langchain/src/document_loaders/fs/text.ts
+++ b/langchain/src/document_loaders/fs/text.ts
@@ -1,7 +1,7 @@
 import type { readFile as ReadFileT } from "node:fs/promises";
 import { Document } from "@langchain/core/documents";
 import { getEnv } from "@langchain/core/utils/env";
-import { BaseDocumentLoader } from "../base.js";
+import { BaseDocumentLoader } from "@langchain/core/document_loaders/base";
 
 /**
  * A class that extends the `BaseDocumentLoader` class. It represents a


### PR DESCRIPTION
- Update buffer.ts and text.ts to import BaseDocumentLoader directly from @langchain/core
- Resolves runtime import errors where BaseDocumentLoader was not exported from ../base.js
- Fixes issues with PDF and CSV loaders that depend on these base classes

Fixes import errors:
- "BaseDocumentLoader is not exported from '../base.js'" in buffer.js
- "BaseDocumentLoader is not exported from '../base.js'" in text.js

Fixes #8441 
