### PR TITLE
docs: fix a minor grammatical error

### DIFF
--- a/docs/core_docs/docs/how_to/installation.mdx
+++ b/docs/core_docs/docs/how_to/installation.mdx
@@ -41,7 +41,7 @@ for some special considerations when installing LangChain packages.
 ## Ecosystem packages
 
 With the exception of the `langsmith` SDK, all packages in the LangChain ecosystem depend on `@langchain/core`, which contains base
-classes and abstractions that other packages use. The dependency graph below shows how the difference packages are related.
+classes and abstractions that other packages use. The dependency graph below shows how the different packages are related.
 A directed arrow indicates that the source package depends on the target package:
 
 ![](/img/ecosystem_packages.png)


### PR DESCRIPTION
 Fix to a minor grammatical mistake in the [docs](https://js.langchain.com/docs/how_to/installation/). 
 
Fixes # (issue)
