### PR TITLE
added config for (https://js.langchain.com/docs/introduction/) to respect user theme

### DIFF
--- a/docs/core_docs/docusaurus.config.js
+++ b/docs/core_docs/docusaurus.config.js
@@ -328,7 +328,6 @@ const config = {
 
         contextualSearch: false,
       },
-
     }),
 
   scripts: [baseUrl + "js/job_link.js"],

--- a/docs/core_docs/docusaurus.config.js
+++ b/docs/core_docs/docusaurus.config.js
@@ -141,6 +141,10 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       announcementBar: {
         content:
           '<strong>Our <a href="https://academy.langchain.com/courses/ambient-agents/?utm_medium=internal&utm_source=docs&utm_campaign=q2-2025_ambient-agents_co" target="_blank">Building Ambient Agents with LangGraph</a> course is now available on LangChain Academy!</strong>',
@@ -324,6 +328,7 @@ const config = {
 
         contextualSearch: false,
       },
+
     }),
 
   scripts: [baseUrl + "js/job_link.js"],


### PR DESCRIPTION
This fixes the JS langchain's doc website, which does not respect the user-defined system theme.
I added a docusaurus config based on what is described in their documentation: [here](https://docusaurus.io/docs/api/themes/configuration#defaultMode) 

Fixes #8390 

