### PR TITLE
Support passing of Bedrock guardrails parameter

### DIFF
--- a/libs/langchain-aws/src/chat_models.ts
+++ b/libs/langchain-aws/src/chat_models.ts
@@ -802,7 +802,9 @@ export class ChatBedrockConverse
       additionalModelRequestFields:
         this.additionalModelRequestFields ??
         options?.additionalModelRequestFields,
-      guardrailConfig: options?.guardrailConfig,
+      guardrailConfig: 
+        this.guardrailConfig ??
+        options?.guardrailConfig,
       performanceConfig: options?.performanceConfig,
     };
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
Makes sure that Bedrock guardrailCondig object can be passed and not be overriden when setting invocation parameters.