### PR TITLE
feat(google): Updates to embeddings

### DIFF
--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -19,7 +19,7 @@ import type {
   VertexModelFamily,
   GoogleAIAPIConfig,
   AnthropicAPIConfig,
-  GeminiAPIConfig,
+  GeminiAPIConfig, GoogleModelParams,
 } from "./types.js";
 import {
   GoogleAbstractedClient,
@@ -405,7 +405,7 @@ export abstract class GoogleAIConnection<
 
   abstract formatData(
     input: InputType,
-    parameters: GoogleAIModelRequestParams
+    parameters: GoogleModelParams
   ): Promise<unknown>;
 
   async request(

--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -19,7 +19,8 @@ import type {
   VertexModelFamily,
   GoogleAIAPIConfig,
   AnthropicAPIConfig,
-  GeminiAPIConfig, GoogleModelParams,
+  GeminiAPIConfig,
+  GoogleModelParams,
 } from "./types.js";
 import {
   GoogleAbstractedClient,

--- a/libs/langchain-google-common/src/embeddings.ts
+++ b/libs/langchain-google-common/src/embeddings.ts
@@ -18,7 +18,10 @@ import {
   GoogleEmbeddingsRequest,
   VertexEmbeddingsResponse,
   AIStudioEmbeddingsResponse,
-  VertexEmbeddingsResponsePrediction, AIStudioEmbeddingsRequest, GeminiPartText, VertexEmbeddingsRequest,
+  VertexEmbeddingsResponsePrediction,
+  AIStudioEmbeddingsRequest,
+  GeminiPartText,
+  VertexEmbeddingsRequest,
 } from "./types.js";
 
 class EmbeddingsConnection<
@@ -56,7 +59,9 @@ class EmbeddingsConnection<
       case "gai":
         return this.buildUrlMethodAiStudio();
       default:
-        throw new Error(`Unknown platform when building method: ${this.platform}`);
+        throw new Error(
+          `Unknown platform when building method: ${this.platform}`
+        );
     }
   }
 
@@ -67,20 +72,22 @@ class EmbeddingsConnection<
 
   formatDataAiStudio(
     input: VertexEmbeddingsInstance[],
-    parameters: VertexEmbeddingsParameters,
+    parameters: VertexEmbeddingsParameters
   ): AIStudioEmbeddingsRequest {
-    const parts: GeminiPartText[] = input.map((instance: VertexEmbeddingsInstance) => ({
-      text: instance.content,
-    }))
+    const parts: GeminiPartText[] = input.map(
+      (instance: VertexEmbeddingsInstance) => ({
+        text: instance.content,
+      })
+    );
     const content = {
-      parts
-    }
+      parts,
+    };
     const outputDimensionality = parameters?.outputDimensionality;
 
     const ret: AIStudioEmbeddingsRequest = {
       content,
       outputDimensionality,
-    }
+    };
 
     // Remove undefined attributes
     let key: keyof AIStudioEmbeddingsRequest;
@@ -95,7 +102,7 @@ class EmbeddingsConnection<
 
   formatDataVertex(
     input: VertexEmbeddingsInstance[],
-    parameters: VertexEmbeddingsParameters,
+    parameters: VertexEmbeddingsParameters
   ): VertexEmbeddingsRequest {
     return {
       instances: input,
@@ -105,7 +112,7 @@ class EmbeddingsConnection<
 
   async formatData(
     input: VertexEmbeddingsInstance[],
-    parameters: VertexEmbeddingsParameters,
+    parameters: VertexEmbeddingsParameters
   ): Promise<GoogleEmbeddingsRequest> {
     switch (this.platform) {
       case "gcp":
@@ -113,7 +120,9 @@ class EmbeddingsConnection<
       case "gai":
         return this.formatDataAiStudio(input, parameters);
       default:
-        throw new Error(`Unknown platform to format embeddings ${this.platform}`);
+        throw new Error(
+          `Unknown platform to format embeddings ${this.platform}`
+        );
     }
   }
 }
@@ -191,8 +200,12 @@ export abstract class BaseGoogleEmbeddings<AuthOptions>
   }
 
   vertexResponseToValues(response: VertexEmbeddingsResponse): number[][] {
-    const predictions: VertexEmbeddingsResponsePrediction[] = response?.data?.predictions ?? [];
-    return predictions.map( (prediction: VertexEmbeddingsResponsePrediction): number[] => prediction.embeddings.values);
+    const predictions: VertexEmbeddingsResponsePrediction[] =
+      response?.data?.predictions ?? [];
+    return predictions.map(
+      (prediction: VertexEmbeddingsResponsePrediction): number[] =>
+        prediction.embeddings.values
+    );
   }
 
   aiStudioResponseToValues(response: AIStudioEmbeddingsResponse): number[][] {
@@ -203,11 +216,17 @@ export abstract class BaseGoogleEmbeddings<AuthOptions>
   responseToValues(response: GoogleEmbeddingsResponse): number[][] {
     switch (this.connection.platform) {
       case "gcp":
-        return this.vertexResponseToValues(response as VertexEmbeddingsResponse);
+        return this.vertexResponseToValues(
+          response as VertexEmbeddingsResponse
+        );
       case "gai":
-        return this.aiStudioResponseToValues(response as AIStudioEmbeddingsResponse);
+        return this.aiStudioResponseToValues(
+          response as AIStudioEmbeddingsResponse
+        );
       default:
-        throw new Error(`Unknown response platform: ${this.connection.platform}`)
+        throw new Error(
+          `Unknown response platform: ${this.connection.platform}`
+        );
     }
   }
 
@@ -239,12 +258,8 @@ export abstract class BaseGoogleEmbeddings<AuthOptions>
       )
     );
     const result: number[][] =
-      responses
-        ?.map(
-          (response) =>
-            this.responseToValues(response)
-        )
-        .flat() ?? [];
+      responses?.map((response) => this.responseToValues(response)).flat() ??
+      [];
     return result;
   }
 

--- a/libs/langchain-google-common/src/embeddings.ts
+++ b/libs/langchain-google-common/src/embeddings.ts
@@ -159,12 +159,16 @@ export abstract class BaseGoogleEmbeddings<AuthOptions>
    * @returns A promise that resolves to a 2D array of embeddings for each document.
    */
   async embedDocuments(documents: string[]): Promise<number[][]> {
+    // Vertex "text-" models could do up 5 documents at once,
+    // but the "gemini-embedding-001" can only do 1.
+    // TODO: Make this configurable
+    const chunkSize = 1;
     const instanceChunks: GoogleEmbeddingsInstance[][] = chunkArray(
       documents.map((document) => ({
         content: document,
       })),
-      5
-    ); // Vertex AI accepts max 5 instances per prediction
+      chunkSize
+    );
     const parameters = {};
     const options = {};
     const responses = await Promise.all(

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -908,9 +908,9 @@ export type GoogleEmbeddingsTaskType =
  * Represents an instance for generating embeddings using the Google
  * Vertex AI API. It contains the content to be embedded.
  */
-export interface GoogleEmbeddingsInstance {
+export interface VertexEmbeddingsInstance {
   content: string;
-  task_type?: GoogleEmbeddingsTaskType;
+  taskType?: GoogleEmbeddingsTaskType;
   title?: string;
 }
 
@@ -920,8 +920,30 @@ export interface VertexEmbeddingsParameters extends GoogleModelParams {
 }
 
 export interface VertexEmbeddingsRequest {
-  instances: GoogleEmbeddingsInstance[],
+  instances: VertexEmbeddingsInstance[],
   parameters?: VertexEmbeddingsParameters,
+}
+
+export interface AIStudioEmbeddingsRequest {
+  content: {
+    parts: GeminiPartText[],
+  },
+  model?: string, // Documentation says required, but tests say otherwise
+  taskType?: GoogleEmbeddingsTaskType,
+  title?: string,
+  outputDimensionality?: number,
+}
+
+export type GoogleEmbeddingsRequest = VertexEmbeddingsRequest | AIStudioEmbeddingsRequest;
+
+export interface VertexEmbeddingsResponsePrediction {
+  embeddings: {
+    statistics: {
+      token_count: number;
+      truncated: boolean;
+    };
+    values: number[];
+  };
 }
 
 /**
@@ -929,16 +951,18 @@ export interface VertexEmbeddingsRequest {
  * Vertex AI API. It extends GoogleBasePrediction and contains the
  * embeddings and their statistics.
  */
-export interface GoogleEmbeddingsResponse extends GoogleResponse {
+export interface VertexEmbeddingsResponse extends GoogleResponse {
   data: {
-    predictions: {
-      embeddings: {
-        statistics: {
-          token_count: number;
-          truncated: boolean;
-        };
-        values: number[];
-      };
-    }[];
+    predictions: VertexEmbeddingsResponsePrediction[];
   };
 }
+
+export interface AIStudioEmbeddingsResponse extends GoogleResponse {
+  data: {
+    embedding: {
+      values: number[];
+    }
+  }
+}
+
+export type GoogleEmbeddingsResponse = VertexEmbeddingsResponse | AIStudioEmbeddingsResponse;

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -9,8 +9,8 @@ import {
   MessageContent,
 } from "@langchain/core/messages";
 import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
-import {EmbeddingsParams} from "@langchain/core/embeddings";
-import {AsyncCallerCallOptions} from "@langchain/core/utils/async_caller";
+import { EmbeddingsParams } from "@langchain/core/embeddings";
+import { AsyncCallerCallOptions } from "@langchain/core/utils/async_caller";
 import type { JsonStream } from "./utils/stream.js";
 import { MediaManager } from "./experimental/utils/media_core.js";
 import {
@@ -223,7 +223,6 @@ export interface GoogleModelParams {
 }
 
 export interface GoogleAIModelParams extends GoogleModelParams {
-
   /** Sampling temperature to use */
   temperature?: number;
 
@@ -884,7 +883,6 @@ export interface BaseGoogleEmbeddingsParams<AuthOptions>
    * An alias for "dimensions"
    */
   outputDimensionality?: number;
-
 }
 
 /**
@@ -920,21 +918,23 @@ export interface VertexEmbeddingsParameters extends GoogleModelParams {
 }
 
 export interface VertexEmbeddingsRequest {
-  instances: VertexEmbeddingsInstance[],
-  parameters?: VertexEmbeddingsParameters,
+  instances: VertexEmbeddingsInstance[];
+  parameters?: VertexEmbeddingsParameters;
 }
 
 export interface AIStudioEmbeddingsRequest {
   content: {
-    parts: GeminiPartText[],
-  },
-  model?: string, // Documentation says required, but tests say otherwise
-  taskType?: GoogleEmbeddingsTaskType,
-  title?: string,
-  outputDimensionality?: number,
+    parts: GeminiPartText[];
+  };
+  model?: string; // Documentation says required, but tests say otherwise
+  taskType?: GoogleEmbeddingsTaskType;
+  title?: string;
+  outputDimensionality?: number;
 }
 
-export type GoogleEmbeddingsRequest = VertexEmbeddingsRequest | AIStudioEmbeddingsRequest;
+export type GoogleEmbeddingsRequest =
+  | VertexEmbeddingsRequest
+  | AIStudioEmbeddingsRequest;
 
 export interface VertexEmbeddingsResponsePrediction {
   embeddings: {
@@ -961,8 +961,10 @@ export interface AIStudioEmbeddingsResponse extends GoogleResponse {
   data: {
     embedding: {
       values: number[];
-    }
-  }
+    };
+  };
 }
 
-export type GoogleEmbeddingsResponse = VertexEmbeddingsResponse | AIStudioEmbeddingsResponse;
+export type GoogleEmbeddingsResponse =
+  | VertexEmbeddingsResponse
+  | AIStudioEmbeddingsResponse;

--- a/libs/langchain-google-common/src/types.ts
+++ b/libs/langchain-google-common/src/types.ts
@@ -9,6 +9,8 @@ import {
   MessageContent,
 } from "@langchain/core/messages";
 import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
+import {EmbeddingsParams} from "@langchain/core/embeddings";
+import {AsyncCallerCallOptions} from "@langchain/core/utils/async_caller";
 import type { JsonStream } from "./utils/stream.js";
 import { MediaManager } from "./experimental/utils/media_core.js";
 import {
@@ -209,14 +211,18 @@ export type GoogleSpeechConfigSimplified =
   | GoogleSpeechVoice
   | GoogleSpeechSimplifiedLanguage;
 
-export interface GoogleAIModelParams {
+export interface GoogleModelParams {
   /** Model to use */
   model?: string;
+
   /**
    * Model to use
    * Alias for `model`
    */
   modelName?: string;
+}
+
+export interface GoogleAIModelParams extends GoogleModelParams {
 
   /** Sampling temperature to use */
   temperature?: number;
@@ -854,4 +860,85 @@ export type GoogleAIAPIConfig = GeminiAPIConfig | AnthropicAPIConfig;
 export interface GoogleAIAPIParams {
   apiName?: string;
   apiConfig?: GoogleAIAPIConfig;
+}
+
+// Embeddings
+
+/**
+ * Defines the parameters required to initialize a
+ * GoogleEmbeddings instance. It extends EmbeddingsParams and
+ * GoogleConnectionParams.
+ */
+export interface BaseGoogleEmbeddingsParams<AuthOptions>
+  extends EmbeddingsParams,
+    GoogleConnectionParams<AuthOptions> {
+  model: string;
+
+  /**
+   * Used to specify output embedding size.
+   * If set, output embeddings will be truncated to the size specified.
+   */
+  dimensions?: number;
+
+  /**
+   * An alias for "dimensions"
+   */
+  outputDimensionality?: number;
+
+}
+
+/**
+ * Defines additional options specific to the
+ * GoogleEmbeddingsInstance. It extends AsyncCallerCallOptions.
+ */
+export interface BaseGoogleEmbeddingsOptions extends AsyncCallerCallOptions {}
+
+export type GoogleEmbeddingsTaskType =
+  | "RETRIEVAL_QUERY"
+  | "RETRIEVAL_DOCUMENT"
+  | "SEMANTIC_SIMILARITY"
+  | "CLASSIFICATION"
+  | "CLUSTERING"
+  | "QUESTION_ANSWERING"
+  | "FACT_VERIFICATION"
+  | "CODE_RETRIEVAL_QUERY"
+  | string;
+
+/**
+ * Represents an instance for generating embeddings using the Google
+ * Vertex AI API. It contains the content to be embedded.
+ */
+export interface GoogleEmbeddingsInstance {
+  content: string;
+  task_type?: GoogleEmbeddingsTaskType;
+  title?: string;
+}
+
+export interface VertexEmbeddingsParameters extends GoogleModelParams {
+  autoTruncate?: boolean;
+  outputDimensionality?: number;
+}
+
+export interface VertexEmbeddingsRequest {
+  instances: GoogleEmbeddingsInstance[],
+  parameters?: VertexEmbeddingsParameters,
+}
+
+/**
+ * Defines the structure of the embeddings results returned by the Google
+ * Vertex AI API. It extends GoogleBasePrediction and contains the
+ * embeddings and their statistics.
+ */
+export interface GoogleEmbeddingsResponse extends GoogleResponse {
+  data: {
+    predictions: {
+      embeddings: {
+        statistics: {
+          token_count: number;
+          truncated: boolean;
+        };
+        values: number[];
+      };
+    }[];
+  };
 }

--- a/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
@@ -54,7 +54,6 @@ describe.each(testModels)(
         model: modelName,
         location,
         onFailedAttempt,
-
       });
 
       const res = await embeddings.embedDocuments([
@@ -74,5 +73,17 @@ describe.each(testModels)(
 
     });
 
+    test("dimensions", async () => {
+      const testDimensions: number = 512;
+      const embeddings = new VertexAIEmbeddings({
+        model: modelName,
+        location,
+        onFailedAttempt,
+        dimensions: testDimensions,
+      });
+      const res = await embeddings.embedQuery("Hello world");
+      expect(typeof res[0]).toBe("number");
+      expect(res.length).toEqual(testDimensions);
+    })
   }
 );

--- a/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
@@ -37,8 +37,7 @@ const testModels = [
 
 describe.each(testModels)(
   `Vertex Embeddings ($modelName) ($location)`,
-  ({modelName, location, defaultOutputDimensions}) => {
-
+  ({ modelName, location, defaultOutputDimensions }) => {
     test("embedQuery", async () => {
       const embeddings = new VertexAIEmbeddings({
         model: modelName,
@@ -70,7 +69,6 @@ describe.each(testModels)(
         expect(typeof r[0]).toBe("number");
         expect(r.length).toEqual(defaultOutputDimensions);
       });
-
     });
 
     test("dimensions", async () => {
@@ -84,6 +82,6 @@ describe.each(testModels)(
       const res = await embeddings.embedQuery("Hello world");
       expect(typeof res[0]).toBe("number");
       expect(res.length).toEqual(testDimensions);
-    })
+    });
   }
 );

--- a/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-vertexai/src/tests/embeddings.int.test.ts
@@ -1,40 +1,78 @@
 import { test, expect } from "@jest/globals";
 import { VertexAIEmbeddings } from "../embeddings.js";
 
-test("Test VertexAIEmbeddings.embedQuery", async () => {
-  const embeddings = new VertexAIEmbeddings({
-    model: "textembedding-gecko",
-  });
-  const res = await embeddings.embedQuery("Hello world");
-  expect(typeof res[0]).toBe("number");
-});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function onFailedAttempt(err: any): any {
+  console.error(err);
+  throw err;
+}
 
-const testModelsLocations = [
-  ["text-embedding-005", "us-central1"],
-  ["text-multilingual-embedding-002", "us-central1"],
-  ["text-embedding-005", "europe-west9"],
-  ["text-multilingual-embedding-002", "europe-west9"],
+const testModels = [
+  {
+    modelName: "text-embedding-005",
+    location: "us-central1",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-embedding-005",
+    location: "europe-west9",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-multilingual-embedding-002",
+    location: "us-central1",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-multilingual-embedding-002",
+    location: "europe-west9",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "gemini-embedding-001",
+    location: "us-central1",
+    defaultOutputDimensions: 3072,
+  },
 ];
 
-test.each(testModelsLocations)(
-  "VertexAIEmbeddings.embedDocuments %s %s",
-  async (model, location) => {
-    const embeddings = new VertexAIEmbeddings({
-      model,
-      location,
+describe.each(testModels)(
+  `Vertex Embeddings ($modelName) ($location)`,
+  ({modelName, location, defaultOutputDimensions}) => {
+
+    test("embedQuery", async () => {
+      const embeddings = new VertexAIEmbeddings({
+        model: modelName,
+        location,
+      });
+      const res = await embeddings.embedQuery("Hello world");
+      expect(typeof res[0]).toBe("number");
+      expect(res.length).toEqual(defaultOutputDimensions);
     });
-    const res = await embeddings.embedDocuments([
-      "Hello world",
-      "Bye bye",
-      "we need",
-      "at least",
-      "six documents",
-      "to test pagination",
-    ]);
-    // console.log(res);
-    expect(res).toHaveLength(6);
-    res.forEach((r) => {
-      expect(typeof r[0]).toBe("number");
+
+    test("embedDocuments", async () => {
+      const embeddings = new VertexAIEmbeddings({
+        model: modelName,
+        location,
+        onFailedAttempt,
+
+      });
+
+      const res = await embeddings.embedDocuments([
+        "Hello world",
+        "Bye bye",
+        "we need",
+        "at least",
+        "six documents",
+        "to test pagination",
+      ]);
+      // console.log(res);
+      expect(res).toHaveLength(6);
+      res.forEach((r) => {
+        expect(typeof r[0]).toBe("number");
+        expect(r.length).toEqual(defaultOutputDimensions);
+      });
+
     });
+
   }
 );

--- a/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@jest/globals";
-import {GoogleEmbeddings} from "../embeddings.js";
+import {GooglePlatformType} from "@langchain/google-common";
+import {getEnvironmentVariable} from "@langchain/core/utils/env";
+import {GoogleEmbeddings, GoogleEmbeddingsInput} from "../embeddings.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function onFailedAttempt(err: any): any {
@@ -10,51 +12,70 @@ function onFailedAttempt(err: any): any {
 const testModels = [
   {
     modelName: "text-embedding-005",
+    platformType: "gcp",
     location: "us-central1",
     defaultOutputDimensions: 768,
   },
   {
     modelName: "text-embedding-005",
+    platformType: "gcp",
     location: "europe-west9",
     defaultOutputDimensions: 768,
   },
   {
     modelName: "text-multilingual-embedding-002",
+    platformType: "gcp",
     location: "us-central1",
     defaultOutputDimensions: 768,
   },
   {
     modelName: "text-multilingual-embedding-002",
+    platformType: "gcp",
     location: "europe-west9",
     defaultOutputDimensions: 768,
   },
   {
     modelName: "gemini-embedding-001",
+    platformType: "gcp",
     location: "us-central1",
+    defaultOutputDimensions: 3072,
+  },
+  {
+    modelName: "gemini-embedding-001",
+    platformType: "gai",
     defaultOutputDimensions: 3072,
   },
 ];
 
 describe.each(testModels)(
   `Webauth Embeddings ($modelName) ($location)`,
-  ({modelName, location, defaultOutputDimensions}) => {
+  ({modelName, platformType, location, defaultOutputDimensions}) => {
+
+    function newModel(fields?: Omit<GoogleEmbeddingsInput, "model">): GoogleEmbeddings {
+      const apiKey =
+        platformType === "gai"
+          ? getEnvironmentVariable("TEST_API_KEY")
+          : undefined;
+
+      return new GoogleEmbeddings({
+        model: modelName,
+        platformType: platformType as GooglePlatformType,
+        apiKey,
+        location,
+        onFailedAttempt,
+        ...(fields ?? {}),
+      })
+    }
 
     test("embedQuery", async () => {
-      const embeddings = new GoogleEmbeddings({
-        model: modelName,
-        location,
-      });
+      const embeddings = newModel();
       const res = await embeddings.embedQuery("Hello world");
       expect(typeof res[0]).toBe("number");
       expect(res.length).toEqual(defaultOutputDimensions);
     });
 
     test("embedDocuments", async () => {
-      const embeddings = new GoogleEmbeddings({
-        model: modelName,
-        location,
-        onFailedAttempt,
-      });
+      const embeddings = newModel();
 
       const res = await embeddings.embedDocuments([
         "Hello world",
@@ -75,10 +96,7 @@ describe.each(testModels)(
 
     test("dimensions", async () => {
       const testDimensions: number = 512;
-      const embeddings = new GoogleEmbeddings({
-        model: modelName,
-        location,
-        onFailedAttempt,
+      const embeddings = newModel({
         dimensions: testDimensions,
       });
       const res = await embeddings.embedQuery("Hello world");

--- a/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@jest/globals";
+import {GoogleEmbeddings} from "../embeddings.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function onFailedAttempt(err: any): any {
+  console.error(err);
+  throw err;
+}
+
+const testModels = [
+  {
+    modelName: "text-embedding-005",
+    location: "us-central1",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-embedding-005",
+    location: "europe-west9",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-multilingual-embedding-002",
+    location: "us-central1",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "text-multilingual-embedding-002",
+    location: "europe-west9",
+    defaultOutputDimensions: 768,
+  },
+  {
+    modelName: "gemini-embedding-001",
+    location: "us-central1",
+    defaultOutputDimensions: 3072,
+  },
+];
+
+describe.each(testModels)(
+  `Webauth Embeddings ($modelName) ($location)`,
+  ({modelName, location, defaultOutputDimensions}) => {
+
+    test("embedQuery", async () => {
+      const embeddings = new GoogleEmbeddings({
+        model: modelName,
+        location,
+      });
+      const res = await embeddings.embedQuery("Hello world");
+      expect(typeof res[0]).toBe("number");
+      expect(res.length).toEqual(defaultOutputDimensions);
+    });
+
+    test("embedDocuments", async () => {
+      const embeddings = new GoogleEmbeddings({
+        model: modelName,
+        location,
+        onFailedAttempt,
+      });
+
+      const res = await embeddings.embedDocuments([
+        "Hello world",
+        "Bye bye",
+        "we need",
+        "at least",
+        "six documents",
+        "to test pagination",
+      ]);
+      // console.log(res);
+      expect(res).toHaveLength(6);
+      res.forEach((r: number[]) => {
+        expect(typeof r[0]).toBe("number");
+        expect(r.length).toEqual(defaultOutputDimensions);
+      });
+
+    });
+
+    test("dimensions", async () => {
+      const testDimensions: number = 512;
+      const embeddings = new GoogleEmbeddings({
+        model: modelName,
+        location,
+        onFailedAttempt,
+        dimensions: testDimensions,
+      });
+      const res = await embeddings.embedQuery("Hello world");
+      expect(typeof res[0]).toBe("number");
+      expect(res.length).toEqual(testDimensions);
+    })
+  }
+);

--- a/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/embeddings.int.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@jest/globals";
-import {GooglePlatformType} from "@langchain/google-common";
-import {getEnvironmentVariable} from "@langchain/core/utils/env";
-import {GoogleEmbeddings, GoogleEmbeddingsInput} from "../embeddings.js";
+import { GooglePlatformType } from "@langchain/google-common";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { GoogleEmbeddings, GoogleEmbeddingsInput } from "../embeddings.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function onFailedAttempt(err: any): any {
@@ -49,9 +49,10 @@ const testModels = [
 
 describe.each(testModels)(
   `Webauth Embeddings ($modelName) ($location)`,
-  ({modelName, platformType, location, defaultOutputDimensions}) => {
-
-    function newModel(fields?: Omit<GoogleEmbeddingsInput, "model">): GoogleEmbeddings {
+  ({ modelName, platformType, location, defaultOutputDimensions }) => {
+    function newModel(
+      fields?: Omit<GoogleEmbeddingsInput, "model">
+    ): GoogleEmbeddings {
       const apiKey =
         platformType === "gai"
           ? getEnvironmentVariable("TEST_API_KEY")
@@ -64,7 +65,7 @@ describe.each(testModels)(
         location,
         onFailedAttempt,
         ...(fields ?? {}),
-      })
+      });
     }
 
     test("embedQuery", async () => {
@@ -91,7 +92,6 @@ describe.each(testModels)(
         expect(typeof r[0]).toBe("number");
         expect(r.length).toEqual(defaultOutputDimensions);
       });
-
     });
 
     test("dimensions", async () => {
@@ -102,6 +102,6 @@ describe.each(testModels)(
       const res = await embeddings.embedQuery("Hello world");
       expect(typeof res[0]).toBe("number");
       expect(res.length).toEqual(testDimensions);
-    })
+    });
   }
 );


### PR DESCRIPTION
Updates support for embeddings on Google platforms, including:
* Adds support for the AI Studio API in addition to previously supported Vertex AI API
* Adds "dimensions" parameter to optionally set a reduced dimension size for the returned vector.
  * This term was chosen for maximum cross-platform compatibility. Google's term, "outputDimensionality" is also accepted as an alias.
* The AI Studio API and "gemini-embedding-001" in Vertex AI don't accept batches. Forced batch size to 1 for all models
* Updates tests
  * Tested using the webauth package as well as vertexai package
  * Obsoleted "textembedding-gecko" is no longer tested
  * Added "gemini-embedding-001" model to test

Fixes #8490 
