### PR TITLE
feat(tavily-search): adding startDate and endDate params to TavilySearch tool

### DIFF
--- a/libs/langchain-tavily/src/tavily-search.ts
+++ b/libs/langchain-tavily/src/tavily-search.ts
@@ -106,6 +106,20 @@ export type TavilySearchAPIRetrieverFields = ToolParams & {
   includeFavicon?: boolean;
 
   /**
+   * Filters search results to include only content published on or after this date.
+   *
+   * @default undefined
+   */
+  startDate?: string;
+
+  /**
+   * Filters search results to include only content published on or before this date.
+   *
+   * @default undefined
+   */
+  endDate?: string;
+
+  /**
    * The name of the tool.
    *
    * @default "tavily_search"
@@ -348,6 +362,10 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
 
   includeFavicon?: boolean;
 
+  startDate?: string;
+
+  endDate?: string;
+
   handleToolError = true;
 
   apiWrapper: TavilySearchAPIWrapper;
@@ -398,6 +416,8 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
     this.country = params.country;
     this.autoParameters = params.autoParameters;
     this.includeFavicon = params.includeFavicon;
+    this.startDate = params.startDate;
+    this.endDate = params.endDate;
   }
 
   async _call(
@@ -439,6 +459,8 @@ export class TavilySearch extends StructuredTool<typeof inputSchema> {
         country: this.country,
         autoParameters: this.autoParameters,
         includeFavicon: this.includeFavicon,
+        startDate: this.startDate,
+        endDate: this.endDate,
       });
 
       if (


### PR DESCRIPTION
## Summary
Adds `startDate` and `endDate` params to `TavilySearch` tool

Notes
The Start Date and End Date parameters can be used to return search results within a specified time range.

`startDate`: Filters search results to include only content published on or after this date.

`endDate`: Filters search results to include only content published on or before this date.