### PR TITLE
minor[mcp]: disable disambiguation by default

### DIFF
--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -50,10 +50,10 @@ const client = new MultiServerMCPClient({
   // Global tool configuration options
   // Whether to throw on errors if a tool fails to load (optional, default: true)
   throwOnLoadError: true,
-  // Whether to prefix tool names with the server name (optional, default: true)
-  prefixToolNameWithServerName: true,
-  // Optional additional prefix for tool names (optional, default: "mcp")
-  additionalToolNamePrefix: "mcp",
+  // Whether to prefix tool names with the server name (optional, default: false)
+  prefixToolNameWithServerName: false,
+  // Optional additional prefix for tool names (optional, default: "")
+  additionalToolNamePrefix: "",
 
   // Use standardized content block format in tool outputs
   useStandardContentBlocks: true,
@@ -195,10 +195,10 @@ try {
     throwOnLoadError: true,
     // Whether to prefix tool names with the server name (optional, default: false)
     prefixToolNameWithServerName: false,
-    // Optional additional prefix for tool names (optional, default: "mcp")
-    additionalToolNamePrefix: "mcp",
-    // Use standardized content block format in tool outputs
-    useStandardContentBlocks: true,
+    // Optional additional prefix for tool names (optional, default: "")
+    additionalToolNamePrefix: "",
+    // Use standardized content block format in tool outputs (default: false)
+    useStandardContentBlocks: false,
   });
 
   // Create and run the agent
@@ -227,10 +227,11 @@ When loading MCP tools either directly through `loadMcpTools` or via `MultiServe
 | Option                         | Type                                   | Default                                               | Description                                                                          |
 | ------------------------------ | -------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `throwOnLoadError`             | `boolean`                              | `true`                                                | Whether to throw an error if a tool fails to load                                    |
-| `prefixToolNameWithServerName` | `boolean`                              | `true`                                                | If true, prefixes all tool names with the server name (e.g., `serverName__toolName`) |
-| `additionalToolNamePrefix`     | `string`                               | `"mcp"`                                               | Additional prefix to add to tool names (e.g., `prefix__serverName__toolName`)        |
+| `prefixToolNameWithServerName` | `boolean`                              | `false`                                               | If true, prefixes all tool names with the server name (e.g., `serverName__toolName`) |
+| `additionalToolNamePrefix`     | `string`                               | `""`                                                  | Additional prefix to add to tool names (e.g., `prefix__serverName__toolName`)        |
 | `useStandardContentBlocks`     | `boolean`                              | `false`                                               | See [Tool Output Mapping](#tool-output-mapping); set true for new applications       |
 | `outputHandling`               | `"content"`, `"artifact"`, or `object` | `resource` -> `"artifact"`, all others -> `"content"` | See [Tool Output Mapping](#tool-output-mapping)                                      |
+| `defaultToolTimeout`           | `number`                               | `0`                                                   | Default timeout for all tools (overridable on a per-tool basis)                      |
 
 ## Tool Output Mapping
 

--- a/libs/langchain-mcp-adapters/__tests__/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/__tests__/client.basic.test.ts
@@ -324,6 +324,75 @@ describe("MultiServerMCPClient", () => {
     test("should handle empty tool lists correctly", async () => {
       // Mock implementation similar to above
     });
+
+    describe("should apply tool name prefixes correctly", () => {
+      test("when prefixToolNameWithServerName is true", async () => {
+        const client = new MultiServerMCPClient({
+          mcpServers: {
+            "test-server": {
+              transport: "stdio",
+              command: "python",
+              args: ["./script.py"],
+            },
+          },
+          prefixToolNameWithServerName: true,
+        });
+        const tools = await client.getTools();
+
+        expect(tools.length).toBe(2);
+        expect(tools[0].name).toBe("test-server__tool1");
+        expect(tools[1].name).toBe("test-server__tool2");
+      });
+      test("when additionalToolNamePrefix is set", async () => {
+        const client = new MultiServerMCPClient({
+          mcpServers: {
+            "test-server": {
+              transport: "stdio",
+              command: "python",
+              args: ["./script.py"],
+            },
+          },
+          additionalToolNamePrefix: "mcp",
+        });
+        const tools = await client.getTools();
+
+        expect(tools.length).toBe(2);
+        expect(tools[0].name).toBe("mcp__tool1");
+        expect(tools[1].name).toBe("mcp__tool2");
+      });
+      test("with both server name and additional prefix when set", async () => {
+        const client = new MultiServerMCPClient({
+          mcpServers: {
+            "test-server": {
+              transport: "stdio",
+              command: "python",
+              args: ["./script.py"],
+            },
+          },
+          prefixToolNameWithServerName: true,
+          additionalToolNamePrefix: "mcp",
+        });
+        const tools = await client.getTools();
+
+        expect(tools.length).toBe(2);
+        expect(tools[0].name).toBe("mcp__test-server__tool1");
+        expect(tools[1].name).toBe("mcp__test-server__tool2");
+      });
+      test("shouldn't apply prefixes by default", async () => {
+        const client = new MultiServerMCPClient({
+          "test-server": {
+            transport: "stdio",
+            command: "python",
+            args: ["./script.py"],
+          },
+        });
+        const tools = await client.getTools();
+
+        expect(tools.length).toBe(2);
+        expect(tools[0].name).toBe("tool1");
+        expect(tools[1].name).toBe("tool2");
+      });
+    });
   });
 
   // Cleanup Handling tests

--- a/libs/langchain-mcp-adapters/__tests__/client.comprehensive.test.ts
+++ b/libs/langchain-mcp-adapters/__tests__/client.comprehensive.test.ts
@@ -1,8 +1,6 @@
 import { vi, describe, test, expect, beforeEach, type Mock } from "vitest";
 import { ZodError } from "zod";
-import type {
-  Connection,
-} from "../src/types.js";
+import type { Connection } from "../src/types.js";
 
 import "./mocks.js";
 
@@ -346,16 +344,16 @@ describe("MultiServerMCPClient", () => {
       });
 
       const conf = client.config;
-      expect(conf.additionalToolNamePrefix).toBe("mcp");
-      expect(conf.prefixToolNameWithServerName).toBe(true);
+      expect(conf.additionalToolNamePrefix).toBe("");
+      expect(conf.prefixToolNameWithServerName).toBe(false);
 
       await client.initializeConnections();
       const tools = await client.getTools();
 
       // Should have 2 tools
       expect(tools.length).toBe(2);
-      expect(tools[0].name).toBe("mcp__server1__tool1");
-      expect(tools[1].name).toBe("mcp__server1__tool2");
+      expect(tools[0].name).toBe("tool1");
+      expect(tools[1].name).toBe("tool2");
     });
 
     test("should get tools from a specific server", async () => {

--- a/libs/langchain-mcp-adapters/__tests__/client.int.test.ts
+++ b/libs/langchain-mcp-adapters/__tests__/client.int.test.ts
@@ -460,17 +460,20 @@ describe("MultiServerMCPClient Integration Tests", () => {
       );
 
       const client = new MultiServerMCPClient({
-        "stdio-server": {
-          command,
-          args,
+        mcpServers: {
+          "stdio-server": {
+            command,
+            args,
+          },
+          "http-server": {
+            url: `${streamableHttpBaseUrl}/mcp`,
+          },
+          "sse-server": {
+            url: `${sseBaseUrl}/sse`,
+            transport: "sse",
+          },
         },
-        "http-server": {
-          url: `${streamableHttpBaseUrl}/mcp`,
-        },
-        "sse-server": {
-          url: `${sseBaseUrl}/sse`,
-          transport: "sse",
-        },
+        prefixToolNameWithServerName: true,
       });
 
       try {
@@ -505,13 +508,16 @@ describe("MultiServerMCPClient Integration Tests", () => {
         await testServers.createHTTPServer("filter-http");
 
       const client = new MultiServerMCPClient({
-        "stdio-server": {
-          command,
-          args,
+        mcpServers: {
+          "stdio-server": {
+            command,
+            args,
+          },
+          "http-server": {
+            url: `${streamableHttpBaseUrl}/mcp`,
+          },
         },
-        "http-server": {
-          url: `${streamableHttpBaseUrl}/mcp`,
-        },
+        prefixToolNameWithServerName: true,
       });
 
       try {

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -448,7 +448,7 @@ export const clientConfigSchema = z
       .boolean()
       .describe("Whether to prefix tool names with the server name")
       .optional()
-      .default(true),
+      .default(false),
     /**
      * An additional prefix to add to the tool name Prefixes are separated by double underscores
      * (example: `mcp__add`).
@@ -459,7 +459,7 @@ export const clientConfigSchema = z
       .string()
       .describe("An additional prefix to add to the tool name")
       .optional()
-      .default("mcp"),
+      .default(""),
     /**
      * If true, the tool will use LangChain's standard multimodal content blocks for tools that output
      * image or audio content, and embedded resources will be converted to `StandardFileBlock` objects.


### PR DESCRIPTION
The current default for mcp-adapters is to prefix the server name to each returned tool by default. We generally think that it's not very intuitive to set prefixes on tool names this way, which is motivation for the change.

MCP spec also makes mention that this is something that sdk clients ***can*** do to avoid tool name conflicts, but isn't be the default behavior.

This is being released as a minor version as to not automatically change tool context when package managers upgrade to the latest patch.