### PR TITLE
fix(cloudflare): similaritySearchVectorWithScore not returning id

### DIFF
--- a/libs/langchain-cloudflare/src/vectorstores.ts
+++ b/libs/langchain-cloudflare/src/vectorstores.ts
@@ -160,7 +160,7 @@ export class CloudflareVectorizeStore extends VectorStore {
       for (const res of results.matches) {
         const { [this.textKey]: pageContent, ...metadata } = res.metadata ?? {};
         result.push([
-          new Document({ metadata, pageContent: pageContent as string }),
+          new Document({ id: res.id, metadata, pageContent: pageContent as string }),
           res.score,
         ]);
       }

--- a/libs/langchain-cloudflare/src/vectorstores.ts
+++ b/libs/langchain-cloudflare/src/vectorstores.ts
@@ -96,7 +96,7 @@ export class CloudflareVectorizeStore extends VectorStore {
     options?: { ids?: string[] } | string[]
   ) {
     const ids = Array.isArray(options) ? options : options?.ids;
-    const documentIds = ids == null ? documents.map(() => uuid.v4()) : ids;
+    const documentIds = ids == null ? documents.map((document) => document.id ?? uuid.v4()) : ids;
     const vectorizeVectors = vectors.map((values, idx) => {
       const metadata: Record<string, VectorizeVectorMetadata> = {
         ...documents[idx].metadata,

--- a/libs/langchain-cloudflare/src/vectorstores.ts
+++ b/libs/langchain-cloudflare/src/vectorstores.ts
@@ -96,7 +96,8 @@ export class CloudflareVectorizeStore extends VectorStore {
     options?: { ids?: string[] } | string[]
   ) {
     const ids = Array.isArray(options) ? options : options?.ids;
-    const documentIds = ids == null ? documents.map((document) => document.id ?? uuid.v4()) : ids;
+    const documentIds =
+      ids == null ? documents.map((document) => document.id ?? uuid.v4()) : ids;
     const vectorizeVectors = vectors.map((values, idx) => {
       const metadata: Record<string, VectorizeVectorMetadata> = {
         ...documents[idx].metadata,
@@ -160,7 +161,11 @@ export class CloudflareVectorizeStore extends VectorStore {
       for (const res of results.matches) {
         const { [this.textKey]: pageContent, ...metadata } = res.metadata ?? {};
         result.push([
-          new Document({ id: res.id, metadata, pageContent: pageContent as string }),
+          new Document({
+            id: res.id,
+            metadata,
+            pageContent: pageContent as string,
+          }),
           res.score,
         ]);
       }


### PR DESCRIPTION
Fixes # 
- similaritySearchVectorWithScore not returning id
-  use existing document.id if available when generating documentIds

