### PR TITLE
patch[gemini]: Gemini 2 5 Flash-Lite

### DIFF
--- a/libs/langchain-google-common/src/connection.ts
+++ b/libs/langchain-google-common/src/connection.ts
@@ -350,11 +350,7 @@ export abstract class GoogleAIConnection<
   get computedLocation(): string {
     switch (this.apiName) {
       case "google":
-        if (this.modelName.startsWith("gemini-2.5-flash-lite")) {
-          return "global";
-        } else {
-          return super.computedLocation;
-        }
+        return super.computedLocation;
       case "anthropic":
         return "us-east5";
       default:

--- a/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
+++ b/libs/langchain-google-webauth/src/tests/chat_models.int.test.ts
@@ -536,12 +536,12 @@ const testGeminiModelNames = [
     apiVersion: "v1",
   },
   {
-    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    modelName: "gemini-2.5-flash-lite",
     platformType: "gai",
     apiVersion: "v1beta",
   },
   {
-    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    modelName: "gemini-2.5-flash-lite",
     platformType: "gcp",
     apiVersion: "v1",
   },
@@ -1725,12 +1725,12 @@ describe.each(testTtsModelNames)(
 
 const testReasoningModelNames = [
   {
-    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    modelName: "gemini-2.5-flash-lite",
     platformType: "gai",
     apiVersion: "v1beta",
   },
   {
-    modelName: "gemini-2.5-flash-lite-preview-06-17",
+    modelName: "gemini-2.5-flash-lite",
     platformType: "gcp",
     apiVersion: "v1",
   },


### PR DESCRIPTION
* Since Gemini 2.5 Flash Lite on Vertex now works in more regions, use the same default region as other models (us-central1). (The previous default region is still valid.)
* Update tests to use release name gemini-2.5-flash-lite

