### PR TITLE
fix: Relax constraint on empty message content in convertMessageContentToParts

### DIFF
--- a/libs/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/langchain-google-genai/src/tests/chat_models.test.ts
@@ -233,6 +233,20 @@ test("convertMessageContentToParts: correctly handles standard text content bloc
   expect(parts).toEqual([{ text: "This is a test message" }]);
 });
 
+test("convertMessageContentToParts: correctly handles empty text content block", () => {
+  const isMultimodalModel = true;
+  const content: [StandardTextBlock] = [
+    {
+      text: "",
+      type: "text",
+      source_type: "text",
+    },
+  ];
+  const message = new HumanMessage({ content });
+  const parts = convertMessageContentToParts(message, isMultimodalModel, []);
+  expect(parts).toEqual([{ text: "" }]);
+});
+
 test("convertMessageContentToParts: correctly handles http url standard image block", () => {
   const isMultimodalModel = true;
   const content: [StandardImageBlock] = [

--- a/libs/langchain-google-genai/src/utils/common.ts
+++ b/libs/langchain-google-genai/src/utils/common.ts
@@ -379,7 +379,7 @@ export function convertMessageContentToParts(
   let functionCalls: FunctionCallPart[] = [];
   const messageParts: Part[] = [];
 
-  if (typeof message.content === "string" && message.content) {
+  if (typeof message.content === "string") {
     messageParts.push({ text: message.content });
   }
 


### PR DESCRIPTION
This change removes the constraint when building the Gemini API parts message that the string content must be non-empty. This is to ensure that even if empty content is passed along it will be populated as a fully fledged text component when calling the Gemini API.
