### PR TITLE
fix(core): extract variables from inside Mustache sections

### DIFF
--- a/langchain-core/src/prompts/template.ts
+++ b/langchain-core/src/prompts/template.ts
@@ -87,19 +87,30 @@ export const parseFString = (template: string): ParsedTemplateNode[] => {
  */
 const mustacheTemplateToNodes = (
   template: mustache.TemplateSpans
-): ParsedTemplateNode[] =>
-  template.map((temp) => {
+): ParsedTemplateNode[] => {
+  const nodes: ParsedTemplateNode[] = [];
+
+  for (const temp of template) {
     if (temp[0] === "name") {
       const name = temp[1].includes(".") ? temp[1].split(".")[0] : temp[1];
-      return { type: "variable", name };
+      nodes.push({ type: "variable", name });
     } else if (["#", "&", "^", ">"].includes(temp[0])) {
       // # represents a section, "&" represents an unescaped variable.
       // These should both be considered variables.
-      return { type: "variable", name: temp[1] };
+      nodes.push({ type: "variable", name: temp[1] });
+
+      // If this is a section with nested content, recursively process it
+      if (temp[0] === "#" && temp.length > 4 && Array.isArray(temp[4])) {
+        const nestedNodes = mustacheTemplateToNodes(temp[4]);
+        nodes.push(...nestedNodes);
+      }
     } else {
-      return { type: "literal", text: temp[1] };
+      nodes.push({ type: "literal", text: temp[1] });
     }
-  });
+  }
+
+  return nodes;
+};
 
 export const parseMustache = (template: string) => {
   configureMustache();

--- a/langchain-core/src/prompts/tests/chat.mustache.test.ts
+++ b/langchain-core/src/prompts/tests/chat.mustache.test.ts
@@ -180,3 +180,22 @@ test("Mustache image template with nested props", async () => {
 
   expect(template.inputVariables.sort()).toEqual(["agent", "messages"]);
 });
+
+test("with ChatPromptTemplate", async () => {
+  const samplePrompt = "Hey {{name}}, {{#isTrue}}how are {{myvar}}?{{/isTrue}}";
+
+  const sampleVariables = {
+    name: "John",
+    isTrue: true,
+    myvar: "you", // <-- this is not included in the inputVariables
+  };
+
+  const expectedResult = "Hey John, how are you?";
+  const prompt = ChatPromptTemplate.fromMessages([["system", samplePrompt]], {
+    templateFormat: "mustache",
+  });
+  expect(prompt.inputVariables).toEqual(["name", "isTrue", "myvar"]);
+  expect(await prompt.format(sampleVariables)).toBe(
+    `System: ${expectedResult}`
+  );
+});

--- a/langchain-core/src/prompts/tests/prompt.mustache.test.ts
+++ b/langchain-core/src/prompts/tests/prompt.mustache.test.ts
@@ -72,7 +72,7 @@ test("section/context variables", async () => {
   expect(formattedPrompt).toEqual(`This
 yo
 is a test.`);
-  expect(prompt.inputVariables).toEqual(["foo"]);
+  expect(prompt.inputVariables).toEqual(["foo", "bar"]);
 });
 
 test("section/context variables with repeats", async () => {
@@ -90,7 +90,7 @@ yo
 
 hello
 is a test.`);
-  expect(promptWithRepeats.inputVariables).toEqual(["foo"]);
+  expect(promptWithRepeats.inputVariables).toEqual(["foo", "bar"]);
 });
 
 test("Escaped variables", async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md
-->
This PR fixes a bug in Mustache template parsing where variables inside conditional sections were not being extracted as input variables.

**Problem**: 
When using Mustache templates with conditional sections like `"Hey {{name}}, {{#isTrue}}{{myvar}}{{/isTrue}}"`, the variable `myvar` inside the conditional block was not being recognized as an input variable. The `inputVariables` array would only contain `["name", "isTrue"]` instead of the expected `["name", "isTrue", "myvar"]`.

**Root Cause**: 
The `mustacheTemplateToNodes` function in `langchain-core/src/prompts/template.ts` was not recursively processing nested content inside Mustache sections. It only extracted the section variable (`isTrue`) but ignored variables inside the section (`myvar`).

**Solution**: 
- Modified `mustacheTemplateToNodes` to recursively process nested content inside sections
- Ensures all variables are properly extracted regardless of whether they appear inside conditional blocks
- Updated test expectations to reflect the new comprehensive variable extraction behavior
- Fixed test template spacing to match actual Mustache output

**Impact**: 
This fix ensures that variables inside Mustache conditional sections are properly extracted as input variables when they are provided as top-level input values, improving the robustness of Mustache template parsing.

**Files Changed**:
- `langchain-core/src/prompts/template.ts` - Core fix for recursive variable extraction
- `langchain-core/src/prompts/tests/chat.mustache.test.ts` - Updated test expectations
- `langchain-core/src/prompts/tests/prompt.mustache.test.ts` - Updated test expectations

Fixes #8456