### PR TITLE
test(mongodb): use azure openid when available in tests

### DIFF
--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
+    "@langchain/azure-openai": "workspace:*",
     "@langchain/core": "workspace:*",
     "@langchain/openai": "workspace:*",
     "@langchain/scripts": ">=0.1.0 <0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9374,6 +9374,7 @@ __metadata:
   resolution: "@langchain/mongodb@workspace:libs/langchain-mongodb"
   dependencies:
     "@jest/globals": ^29.5.0
+    "@langchain/azure-openai": "workspace:*"
     "@langchain/core": "workspace:*"
     "@langchain/openai": "workspace:*"
     "@langchain/scripts": ">=0.1.0 <0.2.0"


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

This PR updates the MongoDB integration vector store tests to be able to use Azure OpenID, with a fallback to OpenID if the necessary environment variables are not there. This is due to us switching in our own integration test suite. (https://github.com/mongodb-labs/ai-ml-pipeline-testing)

The sister pull request to this is https://github.com/mongodb-labs/ai-ml-pipeline-testing/pull/89 in our other repo.
