### PR TITLE
chore(core): centralise import for v1 primitives

### DIFF
--- a/langchain-core/src/_standard/content/index.ts
+++ b/langchain-core/src/_standard/content/index.ts
@@ -109,3 +109,5 @@ export declare namespace ContentBlock {
     | Tools.ContentBlock
     | Multimodal.ContentBlock;
 }
+
+export { isMultimodalContentBlock } from "./multimodal.js";

--- a/langchain-core/src/_standard/content/multimodal.ts
+++ b/langchain-core/src/_standard/content/multimodal.ts
@@ -103,3 +103,23 @@ export declare namespace Multimodal {
 
   export type ContentBlock = Image | Video | Audio | PlainText | File;
 }
+
+export function isMultimodalContentBlock(
+  content_block: unknown
+): content_block is Multimodal.ContentBlock {
+  if (typeof content_block !== "object" || content_block === null) {
+    return false;
+  }
+
+  if (!("type" in content_block) || typeof content_block.type !== "string") {
+    return false;
+  }
+
+  return (
+    content_block.type === "image" ||
+    content_block.type === "video" ||
+    content_block.type === "audio" ||
+    content_block.type === "text-plain" ||
+    content_block.type === "file"
+  );
+}

--- a/langchain-core/src/_standard/content/tools.ts
+++ b/langchain-core/src/_standard/content/tools.ts
@@ -39,6 +39,7 @@ export declare namespace Tools {
     callId: string;
     /**
      * The result of the tool call
+     * ToDo: maybe this should be content?
      */
     result: unknown;
   }
@@ -152,6 +153,7 @@ export declare namespace Tools {
 
   export type ContentBlock =
     | ToolCall
+    | ToolResult
     | SearchCall
     | SearchResult
     | CodeInterpreterCall

--- a/langchain-core/src/_standard/content/tools.ts
+++ b/langchain-core/src/_standard/content/tools.ts
@@ -28,6 +28,21 @@ export declare namespace Tools {
     callId: string;
   }
 
+  export interface ToolResult extends BaseContentBlock {
+    /**
+     * Type of the content block
+     */
+    readonly type: "tool_result";
+    /**
+     * The result of the tool call
+     */
+    callId: string;
+    /**
+     * The result of the tool call
+     */
+    result: unknown;
+  }
+
   /** Content block for a built-in web search tool call. */
   export interface SearchCall extends BaseContentBlock {
     /**

--- a/langchain-core/src/_standard/index.ts
+++ b/langchain-core/src/_standard/index.ts
@@ -1,0 +1,2 @@
+export * from "./message.js";
+export * from "./utils.js";

--- a/langchain-core/src/_standard/index.ts
+++ b/langchain-core/src/_standard/index.ts
@@ -1,2 +1,3 @@
 export * from "./message.js";
 export * from "./utils.js";
+export * from "./content/index.js";

--- a/langchain-core/src/_standard/message.ts
+++ b/langchain-core/src/_standard/message.ts
@@ -104,3 +104,21 @@ export type SystemMessage<
 export type ToolMessage<
   TComplex extends $MessageComplex = $StandardMessageComplex
 > = BaseMessage<TComplex, "tool">;
+
+export function isAIMessage(message: BaseMessage): message is AIMessage {
+  return message.type === "ai";
+}
+
+export function isHumanMessage(message: BaseMessage): message is HumanMessage {
+  return message.type === "user";
+}
+
+export function isSystemMessage(
+  message: BaseMessage
+): message is SystemMessage {
+  return message.type === "system";
+}
+
+export function isToolMessage(message: BaseMessage): message is ToolMessage {
+  return message.type === "tool";
+}

--- a/langchain-core/src/_standard/utils.ts
+++ b/langchain-core/src/_standard/utils.ts
@@ -1,0 +1,135 @@
+import { ProviderFormatTypes } from "../messages/content_blocks.js";
+import { ContentBlock } from "./content/index.js";
+
+/**
+ * Utility interface for converting between standard and provider-specific data content blocks, to be
+ * used when implementing chat model providers.
+ *
+ * Meant to be used with {@link convertToProviderContentBlock} and
+ * {@link convertToStandardContentBlock} rather than being consumed directly.
+ */
+export interface StandardContentBlockConverter<
+  Formats extends Partial<ProviderFormatTypes>
+> {
+  /**
+   * The name of the provider type that corresponds to the provider-specific content block types
+   * that this converter supports.
+   */
+  providerName: string;
+
+  /**
+   * Convert from a standard image block to a provider's proprietary image block format.
+   * @param block - The standard image block to convert.
+   * @returns The provider image block.
+   */
+  fromStandardImageBlock?(
+    block: ContentBlock.Multimodal.Image
+  ): Formats["image"];
+
+  /**
+   * Convert from a standard audio block to a provider's proprietary audio block format.
+   * @param block - The standard audio block to convert.
+   * @returns The provider audio block.
+   */
+  fromStandardAudioBlock?(
+    block: ContentBlock.Multimodal.Audio
+  ): Formats["audio"];
+
+  /**
+   * Convert from a standard video block to a provider's proprietary video block format.
+   * @param block - The standard video block to convert.
+   * @returns The provider video block.
+   */
+  fromStandardVideoBlock?(
+    block: ContentBlock.Multimodal.Video
+  ): Formats["video"];
+
+  /**
+   * Convert from a standard file block to a provider's proprietary file block format.
+   * @param block - The standard file block to convert.
+   * @returns The provider file block.
+   */
+  fromStandardFileBlock?(block: ContentBlock.Multimodal.File): Formats["file"];
+
+  /**
+   * Convert from a standard text block to a provider's proprietary text block format.
+   * @param block - The standard text block to convert.
+   * @returns The provider text block.
+   */
+  fromStandardTextBlock?(
+    block: ContentBlock.Multimodal.PlainText
+  ): Formats["text"];
+}
+
+/**
+ * Convert from a standard data content block to a provider's proprietary data content block format.
+ *
+ * Don't override this method. Instead, override the more specific conversion methods and use this
+ * method unmodified.
+ *
+ * @param block - The standard data content block to convert.
+ * @returns The provider data content block.
+ * @throws An error if the standard data content block type is not supported.
+ */
+export function convertToProviderContentBlock<
+  Formats extends Partial<ProviderFormatTypes>
+>(
+  block: ContentBlock.Multimodal.ContentBlock,
+  converter: StandardContentBlockConverter<Formats>
+): Formats[keyof Formats] {
+  if (block.type === "text-plain") {
+    if (!converter.fromStandardTextBlock) {
+      throw new Error(
+        `Converter for ${converter.providerName} does not implement \`fromStandardTextBlock\` method.`
+      );
+    }
+    return converter.fromStandardTextBlock(
+      block as ContentBlock.Multimodal.PlainText
+    );
+  }
+  if (block.type === "image") {
+    if (!converter.fromStandardImageBlock) {
+      throw new Error(
+        `Converter for ${converter.providerName} does not implement \`fromStandardImageBlock\` method.`
+      );
+    }
+    return converter.fromStandardImageBlock(
+      block as ContentBlock.Multimodal.Image
+    );
+  }
+  if (block.type === "audio") {
+    if (!converter.fromStandardAudioBlock) {
+      throw new Error(
+        `Converter for ${converter.providerName} does not implement \`fromStandardAudioBlock\` method.`
+      );
+    }
+    return converter.fromStandardAudioBlock(
+      block as ContentBlock.Multimodal.Audio
+    );
+  }
+  if (block.type === "video") {
+    if (!converter.fromStandardVideoBlock) {
+      throw new Error(
+        `Converter for ${converter.providerName} does not implement \`fromStandardVideoBlock\` method.`
+      );
+    }
+    return converter.fromStandardVideoBlock(
+      block as ContentBlock.Multimodal.Video
+    );
+  }
+  if (block.type === "file") {
+    if (!converter.fromStandardFileBlock) {
+      throw new Error(
+        `Converter for ${converter.providerName} does not implement \`fromStandardFileBlock\` method.`
+      );
+    }
+    return converter.fromStandardFileBlock(
+      block as ContentBlock.Multimodal.File
+    );
+  }
+  throw new Error(
+    `Unable to convert content block type '${
+      (block as { type?: string }).type || "unknown"
+    }' to provider-specific format: not recognized.`
+  );
+}

--- a/langchain-core/src/messages/content_blocks.ts
+++ b/langchain-core/src/messages/content_blocks.ts
@@ -279,12 +279,14 @@ export type ProviderFormatTypes<
   TextFormat = unknown,
   ImageFormat = unknown,
   AudioFormat = unknown,
-  FileFormat = unknown
+  FileFormat = unknown,
+  VideoFormat = unknown
 > = {
   text: TextFormat;
   image: ImageFormat;
   audio: AudioFormat;
   file: FileFormat;
+  video: VideoFormat;
 };
 
 /**

--- a/langchain-core/src/messages/index.ts
+++ b/langchain-core/src/messages/index.ts
@@ -19,5 +19,4 @@ export {
   isToolMessageChunk,
 } from "./tool.js";
 
-export * from "../_standard/content/index.js";
 export * as v1 from "../_standard/index.js";

--- a/langchain-core/src/messages/index.ts
+++ b/langchain-core/src/messages/index.ts
@@ -20,5 +20,4 @@ export {
 } from "./tool.js";
 
 export * from "../_standard/content/index.js";
-export * as v1 from "../_standard/message.js";
-export * as v1Utils from "../_standard/utils.js";
+export * as v1 from "../_standard/index.js";

--- a/langchain-core/src/messages/index.ts
+++ b/langchain-core/src/messages/index.ts
@@ -18,3 +18,7 @@ export {
   isToolMessage,
   isToolMessageChunk,
 } from "./tool.js";
+
+export * from "../_standard/content/index.js";
+export * as v1 from "../_standard/message.js";
+export * as v1Utils from "../_standard/utils.js";


### PR DESCRIPTION
This patch includes:

- centralize export for new v1 primitives
- add helper functions for detecting message and content block types
- port `StandardContentBlockConverter` to new message format