### PR TITLE
fix(build): change script name to avoid double compilation

### DIFF
--- a/internal/build/package.json
+++ b/internal/build/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" tsx cli.ts"
+    "compile": "NODE_OPTIONS=\"--max-old-space-size=8192\" tsx cli.ts"
   },
   "dependencies": {
     "@arethetypeswrong/core": "^0.18.2",

--- a/libs/create-langchain-integration/template/package.json
+++ b/libs/create-langchain-integration/template/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/INTEGRATION_NAME/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/INTEGRATION_NAME",
+    "build": "pnpm --filter @langchain/build compile @langchain/INTEGRATION_NAME",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-community/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/community",
+    "build": "pnpm --filter @langchain/build compile @langchain/community",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/langchain-core/package.json
+++ b/libs/langchain-core/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/langchain-core/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/core",
+    "build": "pnpm --filter @langchain/build compile @langchain/core",
     "clean": "rm -rf .turbo dist/",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",

--- a/libs/langchain-standard-tests/package.json
+++ b/libs/langchain-standard-tests/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-standard-tests/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/standard-tests",
+    "build": "pnpm --filter @langchain/build compile @langchain/standard-tests",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-textsplitters/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/textsplitters",
+    "build": "pnpm --filter @langchain/build compile @langchain/textsplitters",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/langchain/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build langchain",
+    "build": "pnpm --filter @langchain/build compile langchain",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-anthropic/package.json
+++ b/libs/providers/langchain-anthropic/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-anthropic/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/anthropic",
+    "build": "pnpm --filter @langchain/build compile @langchain/anthropic",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-aws/package.json
+++ b/libs/providers/langchain-aws/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-aws/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/aws",
+    "build": "pnpm --filter @langchain/build compile @langchain/aws",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-azure-cosmosdb/package.json
+++ b/libs/providers/langchain-azure-cosmosdb/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-azure-cosmosdb/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/azure-cosmosdb",
+    "build": "pnpm --filter @langchain/build compile @langchain/azure-cosmosdb",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-azure-dynamic-sessions/package.json
+++ b/libs/providers/langchain-azure-dynamic-sessions/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-INTEGRATION_NAME/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/azure-dynamic-sessions",
+    "build": "pnpm --filter @langchain/build compile @langchain/azure-dynamic-sessions",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-azure-openai/package.json
+++ b/libs/providers/langchain-azure-openai/package.json
@@ -13,7 +13,7 @@
     "url": "git@github.com:langchain-ai/langchainjs.git"
   },
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/azure-openai",
+    "build": "pnpm --filter @langchain/build compile @langchain/azure-openai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-baidu-qianfan/package.json
+++ b/libs/providers/langchain-baidu-qianfan/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-baidu-qianfan/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/baidu-qianfan",
+    "build": "pnpm --filter @langchain/build compile @langchain/baidu-qianfan",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-cerebras/package.json
+++ b/libs/providers/langchain-cerebras/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-cerebras/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/cerebras",
+    "build": "pnpm --filter @langchain/build compile @langchain/cerebras",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-cloudflare/package.json
+++ b/libs/providers/langchain-cloudflare/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-cloudflare/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/cloudflare",
+    "build": "pnpm --filter @langchain/build compile @langchain/cloudflare",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-cohere/package.json
+++ b/libs/providers/langchain-cohere/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-cohere/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/cohere",
+    "build": "pnpm --filter @langchain/build compile @langchain/cohere",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-deepseek/package.json
+++ b/libs/providers/langchain-deepseek/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-deepseek",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/deepseek",
+    "build": "pnpm --filter @langchain/build compile @langchain/deepseek",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-exa/package.json
+++ b/libs/providers/langchain-exa/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-exa/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/exa",
+    "build": "pnpm --filter @langchain/build compile @langchain/exa",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-cloud-sql-pg/package.json
+++ b/libs/providers/langchain-google-cloud-sql-pg/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-cloud-sql-pg/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-cloud-sql-pg",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-cloud-sql-pg",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-common/package.json
+++ b/libs/providers/langchain-google-common/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-common/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-common",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-common",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-gauth/package.json
+++ b/libs/providers/langchain-google-gauth/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-gauth/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-gauth",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-gauth",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-genai/package.json
+++ b/libs/providers/langchain-google-genai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-genai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-genai",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-genai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-vertexai-web/package.json
+++ b/libs/providers/langchain-google-vertexai-web/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-vertexai-web/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-vertexai-web",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-vertexai-web",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-vertexai/package.json
+++ b/libs/providers/langchain-google-vertexai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-vertexai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-vertexai",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-vertexai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-google-webauth/package.json
+++ b/libs/providers/langchain-google-webauth/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-google-webauth/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/google-webauth",
+    "build": "pnpm --filter @langchain/build compile @langchain/google-webauth",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-groq/package.json
+++ b/libs/providers/langchain-groq/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-groq/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/groq",
+    "build": "pnpm --filter @langchain/build compile @langchain/groq",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-mcp-adapters/package.json
+++ b/libs/providers/langchain-mcp-adapters/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "run-s \"build:main\" \"build:examples\"",
-    "build:main": "pnpm --filter @langchain/build build @langchain/mcp-adapters",
+    "build:main": "pnpm --filter @langchain/build compile @langchain/mcp-adapters",
     "build:examples": "tsc -p tsconfig.examples.json",
     "clean": "rm -rf dist/ dist-cjs/ .turbo/",
     "format": "prettier --config .prettierrc --write \"src/**/*.ts\" \"examples/**/*.ts\"",

--- a/libs/providers/langchain-mistralai/package.json
+++ b/libs/providers/langchain-mistralai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mistralai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/mistralai",
+    "build": "pnpm --filter @langchain/build compile @langchain/mistralai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-mixedbread-ai/package.json
+++ b/libs/providers/langchain-mixedbread-ai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mixedbread-ai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/mixedbread-ai",
+    "build": "pnpm --filter @langchain/build compile @langchain/mixedbread-ai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-mongodb/package.json
+++ b/libs/providers/langchain-mongodb/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mongodb/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/mongodb",
+    "build": "pnpm --filter @langchain/build compile @langchain/mongodb",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-nomic/package.json
+++ b/libs/providers/langchain-nomic/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-nomic/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/nomic",
+    "build": "pnpm --filter @langchain/build compile @langchain/nomic",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-ollama/package.json
+++ b/libs/providers/langchain-ollama/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-ollama/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/ollama",
+    "build": "pnpm --filter @langchain/build compile @langchain/ollama",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/providers/langchain-openai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/openai",
+    "build": "pnpm --filter @langchain/build compile @langchain/openai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-pinecone/package.json
+++ b/libs/providers/langchain-pinecone/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-pinecone/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/pinecone",
+    "build": "pnpm --filter @langchain/build compile @langchain/pinecone",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-qdrant/package.json
+++ b/libs/providers/langchain-qdrant/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-qdrant",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/qdrant",
+    "build": "pnpm --filter @langchain/build compile @langchain/qdrant",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-redis/package.json
+++ b/libs/providers/langchain-redis/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-redis/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/redis",
+    "build": "pnpm --filter @langchain/build compile @langchain/redis",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-tavily/package.json
+++ b/libs/providers/langchain-tavily/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-tavily/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/tavily",
+    "build": "pnpm --filter @langchain/build compile @langchain/tavily",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-weaviate/package.json
+++ b/libs/providers/langchain-weaviate/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-weaviate/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/weaviate",
+    "build": "pnpm --filter @langchain/build compile @langchain/weaviate",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-xai/package.json
+++ b/libs/providers/langchain-xai/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-xai/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/xai",
+    "build": "pnpm --filter @langchain/build compile @langchain/xai",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",

--- a/libs/providers/langchain-yandex/package.json
+++ b/libs/providers/langchain-yandex/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-yandex/",
   "scripts": {
-    "build": "pnpm --filter @langchain/build build @langchain/yandex",
+    "build": "pnpm --filter @langchain/build compile @langchain/yandex",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js src/",
     "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "pnpm lint:eslint && pnpm lint:dpdm",


### PR DESCRIPTION
This patch fixes a small issue with have with the build system: since the script to make `@langchain/build` compile the entire project is called `build`, Turborepo calls that command first before it calls the individual build commands of all packages. This has caused the `pnpm build` command to compile the project twice.

I renamed the script to `compile` to fix the problem.