### PR TITLE
fix: ValidationException for blank text blocks in ChatBedrockConverse

### DIFF
--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -54,13 +54,13 @@ import {
 function isDefaultCachePoint(block: unknown): boolean {
   return Boolean(
     typeof block === "object" &&
-      block !== null &&
-      "cachePoint" in block &&
-      block.cachePoint &&
-      typeof block.cachePoint === "object" &&
-      block.cachePoint !== null &&
-      "type" in block.cachePoint &&
-      block.cachePoint.type === "default"
+    block !== null &&
+    "cachePoint" in block &&
+    block.cachePoint &&
+    typeof block.cachePoint === "object" &&
+    block.cachePoint !== null &&
+    "type" in block.cachePoint &&
+    block.cachePoint.type === "default"
   );
 }
 
@@ -377,23 +377,33 @@ function convertAIMessageToConverseMessage(msg: AIMessage): BedrockMessage {
     });
   } else if (Array.isArray(msg.content)) {
     const concatenatedBlocks = concatenateLangchainReasoningBlocks(msg.content);
-    const contentBlocks: ContentBlock[] = concatenatedBlocks.map((block) => {
+    const contentBlocks: ContentBlock[] = []
+    concatenatedBlocks.forEach((block) => {
       if (block.type === "text" && block.text !== "") {
-        return {
-          text: block.text,
-        };
+        // Merge whitespace/newlines with previous text blocks to avoid validation errors.
+        const cleanedText = block.text?.replace(/\n/g, "").trim();
+        if (cleanedText === "") {
+          if (contentBlocks.length > 0) {
+            const mergedTextContent = `${contentBlocks[contentBlocks.length - 1].text}${block.text}`;
+            contentBlocks[contentBlocks.length - 1].text = mergedTextContent;
+          }
+        } else {
+          contentBlocks.push({
+            text: block.text,
+          });
+        }
       } else if (block.type === "reasoning_content") {
-        return {
+        contentBlocks.push({
           reasoningContent: langchainReasoningBlockToBedrockReasoningBlock(
             block as MessageContentReasoningBlock
           ),
-        };
+        });
       } else if (isDefaultCachePoint(block)) {
-        return {
+        contentBlocks.push({
           cachePoint: {
             type: "default",
           },
-        };
+        });
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")
@@ -440,17 +450,17 @@ function convertHumanMessageToConverseMessage(
 
   const content: ContentBlock[] = Array.isArray(msg.content)
     ? msg.content.map((c) =>
-        convertLangChainContentBlockToConverseContentBlock({
-          block: c,
-          onUnknown: "throw",
-        })
-      )
+      convertLangChainContentBlockToConverseContentBlock({
+        block: c,
+        onUnknown: "throw",
+      })
+    )
     : [
-        convertLangChainContentBlockToConverseContentBlock({
-          block: msg.content,
-          onUnknown: "throw",
-        }),
-      ];
+      convertLangChainContentBlockToConverseContentBlock({
+        block: msg.content,
+        onUnknown: "throw",
+      }),
+    ];
 
   return {
     role: "user" as const,
@@ -659,8 +669,8 @@ export function convertToBedrockToolChoice(
 
     throw new Error(
       `${supportedTxt} Please see` +
-        "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html" +
-        "for the latest documentation on models that support tool choice."
+      "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html" +
+      "for the latest documentation on models that support tool choice."
     );
   }
 

--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -54,13 +54,13 @@ import {
 function isDefaultCachePoint(block: unknown): boolean {
   return Boolean(
     typeof block === "object" &&
-    block !== null &&
-    "cachePoint" in block &&
-    block.cachePoint &&
-    typeof block.cachePoint === "object" &&
-    block.cachePoint !== null &&
-    "type" in block.cachePoint &&
-    block.cachePoint.type === "default"
+      block !== null &&
+      "cachePoint" in block &&
+      block.cachePoint &&
+      typeof block.cachePoint === "object" &&
+      block.cachePoint !== null &&
+      "type" in block.cachePoint &&
+      block.cachePoint.type === "default"
   );
 }
 
@@ -377,14 +377,16 @@ function convertAIMessageToConverseMessage(msg: AIMessage): BedrockMessage {
     });
   } else if (Array.isArray(msg.content)) {
     const concatenatedBlocks = concatenateLangchainReasoningBlocks(msg.content);
-    const contentBlocks: ContentBlock[] = []
+    const contentBlocks: ContentBlock[] = [];
     concatenatedBlocks.forEach((block) => {
       if (block.type === "text" && block.text !== "") {
         // Merge whitespace/newlines with previous text blocks to avoid validation errors.
         const cleanedText = block.text?.replace(/\n/g, "").trim();
         if (cleanedText === "") {
           if (contentBlocks.length > 0) {
-            const mergedTextContent = `${contentBlocks[contentBlocks.length - 1].text}${block.text}`;
+            const mergedTextContent = `${
+              contentBlocks[contentBlocks.length - 1].text
+            }${block.text}`;
             contentBlocks[contentBlocks.length - 1].text = mergedTextContent;
           }
         } else {
@@ -450,17 +452,17 @@ function convertHumanMessageToConverseMessage(
 
   const content: ContentBlock[] = Array.isArray(msg.content)
     ? msg.content.map((c) =>
-      convertLangChainContentBlockToConverseContentBlock({
-        block: c,
-        onUnknown: "throw",
-      })
-    )
+        convertLangChainContentBlockToConverseContentBlock({
+          block: c,
+          onUnknown: "throw",
+        })
+      )
     : [
-      convertLangChainContentBlockToConverseContentBlock({
-        block: msg.content,
-        onUnknown: "throw",
-      }),
-    ];
+        convertLangChainContentBlockToConverseContentBlock({
+          block: msg.content,
+          onUnknown: "throw",
+        }),
+      ];
 
   return {
     role: "user" as const,
@@ -669,8 +671,8 @@ export function convertToBedrockToolChoice(
 
     throw new Error(
       `${supportedTxt} Please see` +
-      "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html" +
-      "for the latest documentation on models that support tool choice."
+        "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html" +
+        "for the latest documentation on models that support tool choice."
     );
   }
 

--- a/libs/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/langchain-aws/src/tests/chat_models.test.ts
@@ -416,13 +416,19 @@ test("Streaming supports empty string chunks", async () => {
     {
       contentBlockIndex: 0,
       delta: {
-        text: "Hello ",
+        text: "Hello",
       },
     },
     {
       contentBlockIndex: 0,
       delta: {
         text: "",
+      },
+    },
+    {
+      contentBlockIndex: 0,
+      delta: {
+        text: " ",
       },
     },
     {


### PR DESCRIPTION
Fixes a `ValidationException` that occurred when using `ChatBedrockConverse` with AWS Bedrock models:
It's related to the issue #5960.

### Problem
The error occurred when message chunks contained only whitespace or newlines (e.g., `'  '`, `'\n '`, `' '`). In these cases, the AWS Bedrock's Converse API was throwing the following exception:
`ValidationException: The text field in the ContentBlock object at messages.X.content.Y is blank. Add text to the text field, and try again.`

### Solution
Modified the text block processing logic in `convertAIMessageToConverseMessage` to:
- Detect whitespace-only content by trimming and checking for empty strings
- Merge whitespace-only blocks with the previous text block to preserve content

### Testing
- Update test case `"Streaming supports empty string chunks"` to verify proper handling of whitespace text
- Confirmed the fix resolves the validation error while maintaining message integrity.