### PR TITLE
fix(tavily): pin zod to v3 to avoid "Type instantiation is excessively deep and possibly infinite" error

### DIFF
--- a/libs/langchain-tavily/package.json
+++ b/libs/langchain-tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/tavily",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Tavily integration for LangChain.js",
   "type": "module",
   "engines": {

--- a/libs/langchain-tavily/src/tavily-crawl.ts
+++ b/libs/langchain-tavily/src/tavily-crawl.ts
@@ -1,6 +1,6 @@
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { StructuredTool, ToolParams } from "@langchain/core/tools";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { InferInteropZodOutput } from "@langchain/core/dist/utils/types/zod.js";
 import {
   TavilyCrawlAPIWrapper,

--- a/libs/langchain-tavily/src/tavily-extract.ts
+++ b/libs/langchain-tavily/src/tavily-extract.ts
@@ -1,6 +1,6 @@
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { StructuredTool, ToolParams } from "@langchain/core/tools";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { InferInteropZodOutput } from "@langchain/core/dist/utils/types/zod.js";
 import {
   TavilyExtractAPIWrapper,

--- a/libs/langchain-tavily/src/tavily-map.ts
+++ b/libs/langchain-tavily/src/tavily-map.ts
@@ -1,6 +1,6 @@
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { StructuredTool, ToolParams } from "@langchain/core/tools";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { InferInteropZodOutput } from "@langchain/core/dist/utils/types/zod.js";
 import {
   TavilyMapAPIWrapper,

--- a/libs/langchain-tavily/src/tavily-search.ts
+++ b/libs/langchain-tavily/src/tavily-search.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { StructuredTool, ToolParams } from "@langchain/core/tools";
 import { InferInteropZodOutput } from "@langchain/core/utils/types";


### PR DESCRIPTION
With Zod 3.25.68+ we're observing elevated incidence count of "Type instantiation is excessively deep and possibly infinite," which is caused by packages importing from `"zod"` rather than `"zod/v3"`
