### PR TITLE
feat(bedrock): add clientOptions to BedrockEmbeddings and ChatBedrock…

### DIFF
--- a/libs/langchain-aws/src/chat_models.ts
+++ b/libs/langchain-aws/src/chat_models.ts
@@ -19,6 +19,7 @@ import type {
 } from "@aws-sdk/client-bedrock-runtime";
 import {
   BedrockRuntimeClient,
+  BedrockRuntimeClientConfig,
   ConverseCommand,
   ConverseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
@@ -70,6 +71,13 @@ export interface ChatBedrockConverseInput
    * in case it is not provided here.
    */
   client?: BedrockRuntimeClient;
+
+  /**
+   * Overrideable configuration options for the BedrockRuntimeClient.
+   * Allows customization of client configuration such as requestHandler, etc.
+   * Will be ignored if 'client' is provided.
+   */
+  clientOptions?: BedrockRuntimeClientConfig;
 
   /**
    * Whether or not to stream responses
@@ -244,6 +252,10 @@ export interface ChatBedrockConverseCallOptions
  *     secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
  *     accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
  *   },
+ *   // Configure client options (e.g., custom request handler)
+ *   // clientOptions: {
+ *   //   requestHandler: myCustomRequestHandler,
+ *   // },
  *   // other params...
  * });
  * ```
@@ -666,6 +678,8 @@ export class ChatBedrockConverse
 
   client: BedrockRuntimeClient;
 
+  clientOptions?: BedrockRuntimeClientConfig;
+
   /**
    * Which types of `tool_choice` values the model supports.
    *
@@ -713,6 +727,7 @@ export class ChatBedrockConverse
     this.client =
       fields?.client ??
       new BedrockRuntimeClient({
+        ...fields?.clientOptions,
         region,
         credentials,
         endpoint: rest.endpointHost
@@ -731,6 +746,7 @@ export class ChatBedrockConverse
     this.streamUsage = rest?.streamUsage ?? this.streamUsage;
     this.guardrailConfig = rest?.guardrailConfig;
     this.performanceConfig = rest?.performanceConfig;
+    this.clientOptions = rest?.clientOptions;
 
     if (rest?.supportsToolChoiceValues === undefined) {
       this.supportsToolChoiceValues = supportedToolChoiceValuesForModel(

--- a/libs/langchain-aws/src/embeddings.ts
+++ b/libs/langchain-aws/src/embeddings.ts
@@ -1,5 +1,6 @@
 import {
   BedrockRuntimeClient,
+  BedrockRuntimeClientConfig,
   InvokeModelCommand,
 } from "@aws-sdk/client-bedrock-runtime";
 import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
@@ -22,6 +23,13 @@ export interface BedrockEmbeddingsParams extends EmbeddingsParams {
    */
   client?: BedrockRuntimeClient;
 
+  /**
+   * Overrideable configuration options for the BedrockRuntimeClient.
+   * Allows customization of client configuration such as requestHandler, etc.
+   * Will be ignored if 'client' is provided.
+   */
+  clientOptions?: BedrockRuntimeClientConfig;
+
   region?: string;
 
   credentials?: CredentialType;
@@ -39,6 +47,10 @@ export interface BedrockEmbeddingsParams extends EmbeddingsParams {
  *     secretAccessKey: "your-secret-access-key",
  *   },
  *   model: "amazon.titan-embed-text-v1",
+ *   // Configure client options (e.g., custom request handler)
+ *   // clientOptions: {
+ *   //   requestHandler: myCustomRequestHandler,
+ *   // },
  * });
  *
  * // Embed a query and log the result
@@ -56,16 +68,20 @@ export class BedrockEmbeddings
 
   client: BedrockRuntimeClient;
 
+  clientOptions?: BedrockRuntimeClientConfig;
+
   batchSize = 512;
 
   constructor(fields?: BedrockEmbeddingsParams) {
     super(fields ?? {});
 
     this.model = fields?.model ?? "amazon.titan-embed-text-v1";
+    this.clientOptions = fields?.clientOptions;
 
     this.client =
       fields?.client ??
       new BedrockRuntimeClient({
+        ...fields?.clientOptions,
         region: fields?.region,
         credentials: fields?.credentials,
       });


### PR DESCRIPTION
This PR adds support for customizable BedrockRuntimeClientConfig options in both ChatBedrockConverse and BedrockEmbeddings classes, enabling users to configure client-specific settings such as custom request handlers without instanciating a BedrockRuntimeClient.