### PR TITLE
openai/chat_models: remove console.log line

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -2639,7 +2639,6 @@ export class ChatOpenAICompletions<
             clientOptions
           );
         } else {
-          console.log("request", request);
           return await this.client.chat.completions.create(
             request,
             clientOptions


### PR DESCRIPTION
I'm pretty sure this console.log is a left over from development. This PR removes that line.