### PR TITLE
fix(google-genai): Update multimodal model check to include gemma-3

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -628,8 +628,9 @@ export class ChatGoogleGenerativeAI
     return (
       this.model.includes("vision") ||
       this.model.startsWith("gemini-1.5") ||
-      this.model.startsWith("gemini-2") || 
-      this.model.startsWith("gemma-3-") && !this.model.startsWith("gemma-3-1b") // gemma-3 models are multimodal(but gemma-3n-* and gemma-3-1b are not)
+      this.model.startsWith("gemini-2") ||
+      (this.model.startsWith("gemma-3-") &&
+        !this.model.startsWith("gemma-3-1b")) // gemma-3 models are multimodal(but gemma-3n-* and gemma-3-1b are not)
     );
   }
 


### PR DESCRIPTION
This PR extends multimodal support to include the Gemma 3(but not 3n and 1b version) family of models.