### PR TITLE
feat(agents): support AbortSignal in createReactAgent

### DIFF
--- a/internal/build/index.ts
+++ b/internal/build/index.ts
@@ -46,10 +46,12 @@ async function buildProject(
   const sourcemap = !opts.skipSourcemap;
 
   /**
-   * don't clean if user passes `--skipClean` or if `--noEmit` is enabled
-   * as we don't want to clean previous builds if we're not emitting anything
+   * don't clean if we:
+   * - user passes `--skipClean` or
+   * - have watch mode enabled (it would confuse the IDE due to missing type for a short moment)
+   * - if `--noEmit` is enabled (we don't want to clean previous builds if we're not emitting anything)
    */
-  const clean = !opts.skipClean && !opts.noEmit;
+  const clean = !opts.skipClean && !watch && !opts.noEmit;
 
   /**
    * generate type declarations if not disabled

--- a/libs/langchain-agents/src/ToolNode.ts
+++ b/libs/langchain-agents/src/ToolNode.ts
@@ -19,10 +19,19 @@ import {
 import { RunnableCallable } from "./RunnableCallable.js";
 import { isSend } from "./utils.js";
 
+/**
+ * TypeScript currently doesn't support types for `AbortSignal.any`
+ * @see https://github.com/microsoft/TypeScript/issues/60695
+ */
+declare const AbortSignal: {
+  any?(signals: AbortSignal[]): AbortSignal;
+};
+
 export type ToolNodeOptions = {
   name?: string;
   tags?: string[];
   handleToolErrors?: boolean;
+  signal?: AbortSignal;
 };
 
 const isBaseMessageArray = (input: unknown): input is BaseMessage[] =>
@@ -164,6 +173,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
   trace = false;
 
+  signal?: AbortSignal;
+
   constructor(
     tools: (StructuredToolInterface | DynamicTool | RunnableToolLike)[],
     options?: ToolNodeOptions
@@ -176,6 +187,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     });
     this.tools = tools;
     this.handleToolErrors = handleToolErrors ?? this.handleToolErrors;
+    this.signal = options?.signal;
   }
 
   protected async runTool(
@@ -187,7 +199,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (tool === undefined) {
         throw new Error(`Tool "${call.name}" not found.`);
       }
-      const output = await tool.invoke({ ...call, type: "tool_call" }, config);
+
+      /**
+       * `config` always contains a signal from LangGraphs Pregel class.
+       * To ensure we acknowledge the abort signal from the user, we merge it
+       * with the signal from the ToolNode.
+       */
+      const signal = this.signal
+        ? this.signal && AbortSignal.any
+          ? AbortSignal.any([this.signal, config.signal!])
+          : config.signal
+        : config.signal;
+
+      const output = await tool.invoke(
+        { ...call, type: "tool_call" },
+        { ...config, signal }
+      );
 
       if (
         (isBaseMessage(output) && output.getType() === "tool") ||

--- a/libs/langchain-agents/src/index.ts
+++ b/libs/langchain-agents/src/index.ts
@@ -484,6 +484,7 @@ export function createReactAgent<
     postModelHook,
     name,
     includeAgentName,
+    abortSignal,
   } = params;
 
   let toolClasses: (ClientTool | ServerTool)[];
@@ -494,7 +495,9 @@ export function createReactAgent<
     toolNode = tools;
   } else {
     toolClasses = tools;
-    toolNode = new ToolNode(toolClasses.filter(isClientTool));
+    toolNode = new ToolNode(toolClasses.filter(isClientTool), {
+      signal: abortSignal,
+    });
   }
 
   let cachedStaticModel: Runnable | null = null;
@@ -590,7 +593,10 @@ export function createReactAgent<
       modelWithStructuredOutput = model.withStructuredOutput(responseFormat);
     }
 
-    const response = await modelWithStructuredOutput.invoke(messages, config);
+    const response = await modelWithStructuredOutput.invoke(messages, {
+      ...config,
+      signal: abortSignal,
+    });
     return { structuredResponse: response };
   };
 
@@ -606,10 +612,10 @@ export function createReactAgent<
         : await _getStaticModel(llm);
 
     // TODO: Auto-promote streaming.
-    const response = (await modelRunnable.invoke(
-      getModelInputState(state),
-      config
-    )) as BaseMessage;
+    const response = (await modelRunnable.invoke(getModelInputState(state), {
+      ...config,
+      signal: abortSignal,
+    })) as BaseMessage;
     // add agent name to the AIMessage
     // TODO: figure out if we can avoid mutating the message directly
     response.name = name;

--- a/libs/langchain-agents/src/tests/reactAgent.test.ts
+++ b/libs/langchain-agents/src/tests/reactAgent.test.ts
@@ -372,7 +372,7 @@ describe("createReactAgent", () => {
         const agent = createReactAgent({
           llm: model.bindTools([tool1, tool2]),
           tools,
-          // version, // TODO: Add version support when available
+          asStateGraph: true,
         });
 
         const result = await agent.nodes.tools.invoke({
@@ -1857,5 +1857,165 @@ describe("createReactAgent", () => {
       // The dynamic model function should receive the original state, not the processed model input
       expect(dynamicModel).toHaveBeenCalledWith(inputState, expect.any(Object));
     });
+  });
+
+  it("should handle abort signal", async () => {
+    const model = new FakeToolCallingChatModel({
+      responses: [new AIMessage("ai response")],
+    });
+
+    const abortController = new AbortController();
+    const agent = createReactAgent({
+      llm: model,
+      tools: [],
+      abortSignal: abortController.signal,
+    });
+
+    abortController.abort(new Error("custom abortion"));
+
+    await expect(agent.invoke({ messages: "hello" })).rejects.toThrow(
+      "custom abortion"
+    );
+  });
+
+  it("should handle abort signal in tools", async () => {
+    const abortController = new AbortController();
+
+    const abortableTool = tool(
+      async () => {
+        // Simulate some long running async work
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        return "Tool completed successfully";
+      },
+      {
+        name: "abortable_tool",
+        description: "A tool that can be aborted",
+        schema: z.object({
+          input: z.string(),
+        }),
+      }
+    );
+
+    const llm = new FakeToolCallingChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "test-call-1",
+              name: "abortable_tool",
+              args: { input: "test" },
+              type: "tool_call",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const agent = createReactAgent({
+      llm,
+      tools: [abortableTool],
+      abortSignal: abortController.signal,
+    });
+
+    // Start the agent execution
+    const executionPromise = agent.invoke({
+      messages: [
+        {
+          role: "user",
+          content: "Please run the abortable tool with input 'test'",
+        },
+      ],
+    });
+
+    // Abort after a short delay
+    setTimeout(() => {
+      abortController.abort("custom abort");
+    }, 1000);
+
+    // Verify that the execution throws an abort error
+    await expect(executionPromise).rejects.toThrow("custom abort");
+  });
+
+  it("should merge abort signals from agent and config", async () => {
+    const agentAbortController = new AbortController();
+    const configAbortController = new AbortController();
+
+    const signalCheckTool = tool(
+      async () => {
+        // some long running async work
+        return new Promise((resolve) =>
+          setTimeout(() => resolve("Not aborted"), 500)
+        );
+      },
+      {
+        name: "signal_check_tool",
+        description: "Checks abort signal",
+        schema: z.object({
+          input: z.string(),
+        }),
+      }
+    );
+
+    const llm = new FakeToolCallingChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "test-call-2",
+              name: "signal_check_tool",
+              args: { input: "test" },
+              type: "tool_call",
+            },
+          ],
+        }),
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              id: "test-call-3",
+              name: "signal_check_tool",
+              args: { input: "test" },
+              type: "tool_call",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const agent = createReactAgent({
+      llm,
+      tools: [signalCheckTool],
+      abortSignal: agentAbortController.signal,
+    });
+
+    // Test aborting via config signal
+    const configExecution = agent.invoke(
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Run signal_check_tool with input 'test'",
+          },
+        ],
+      },
+      { signal: configAbortController.signal }
+    );
+
+    setTimeout(() => {
+      console.log("ABORTING CONFIG");
+      configAbortController.abort(new Error("Config abort"));
+    }, 1000);
+    setTimeout(() => {
+      agentAbortController.abort(new Error("Agent abort"));
+    }, 2000);
+
+    /**
+     * Abort reason is currently not being propagated in LangGraphJS
+     * @see https://github.com/langchain-ai/langgraphjs/pull/1521
+     */
+    // await expect(configExecution).rejects.toThrow(/Config abort/);
+    await expect(configExecution).rejects.toThrow();
   });
 });

--- a/libs/langchain-agents/src/types.ts
+++ b/libs/langchain-agents/src/types.ts
@@ -202,4 +202,9 @@ export type CreateReactAgentParams<
    * @default false
    */
   asStateGraph?: AsStateGraph;
+
+  /**
+   * An optional AbortSignal to abort the agent.
+   */
+  abortSignal?: AbortSignal;
 };

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -1958,7 +1958,7 @@ export class RunnableSequence<
       }
       // TypeScript can't detect that the last output of the sequence returns RunOutput, so call it out of the loop here
       if (options?.signal?.aborted) {
-        throw new Error("Aborted");
+        throw new Error(options.signal.reason ?? "Aborted");
       }
       finalOutput = await this.last.invoke(
         nextStepInput,

--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -680,6 +680,10 @@ export function tool<
     schema,
     func: async (input, runManager, config) => {
       return new Promise<ToolOutputT>((resolve, reject) => {
+        config?.signal?.addEventListener("abort", () => {
+          return reject(config?.signal?.reason ?? new Error("Aborted"));
+        });
+
         const childConfig = patchConfig(config, {
           callbacks: runManager?.getChild(),
         });
@@ -687,7 +691,13 @@ export function tool<
           pickRunnableConfigKeys(childConfig),
           async () => {
             try {
-              resolve(func(input, childConfig));
+              const result = await func(input, childConfig);
+
+              if (config?.signal?.aborted) {
+                return;
+              }
+
+              resolve(result);
             } catch (e) {
               reject(e);
             }

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -1,6 +1,8 @@
 import pRetry from "p-retry";
 import PQueueMod from "p-queue";
 
+import { getAbortSignalError } from "./signal";
+
 const STATUS_NO_RETRY = [
   400, // Bad Request
   401, // Unauthorized
@@ -142,7 +144,7 @@ export class AsyncCaller {
         this.call<A, T>(callable, ...args),
         new Promise<never>((_, reject) => {
           options.signal?.addEventListener("abort", () => {
-            reject(new Error("AbortError"));
+            reject(getAbortSignalError(options.signal));
           });
         }),
       ]);

--- a/libs/langchain-core/src/utils/signal.ts
+++ b/libs/langchain-core/src/utils/signal.ts
@@ -16,13 +16,22 @@ export async function raceWithSignal<T>(
     }),
     new Promise<never>((_, reject) => {
       listener = () => {
-        reject(new Error("Aborted"));
+        reject(getAbortSignalError(signal));
       };
       signal.addEventListener("abort", listener);
       // Must be here inside the promise to avoid a race condition
       if (signal.aborted) {
-        reject(new Error("Aborted"));
+        reject(getAbortSignalError(signal));
       }
     }),
   ]).finally(() => signal.removeEventListener("abort", listener));
+}
+
+export function getAbortSignalError(signal?: AbortSignal) {
+  console.log("COME HERE", signal?.reason);
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : typeof signal?.reason === "string"
+    ? new Error(signal.reason)
+    : new Error("Aborted");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -604,31 +604,31 @@ importers:
         version: 0.25.8
       '@rolldown/binding-darwin-arm64':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-darwin-x64':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-linux-arm64-gnu':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-linux-arm64-musl':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-linux-x64-gnu':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-linux-x64-musl':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-win32-arm64-msvc':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-win32-ia32-msvc':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@rolldown/binding-win32-x64-msvc':
         specifier: '*'
-        version: 1.0.0-beta.31
+        version: 1.0.0-beta.32
       '@swc/core-win32-x64-msvc':
         specifier: '*'
         version: 1.13.3
@@ -8523,8 +8523,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
-    resolution: {integrity: sha512-BHfHJ8Nb5G7ZKJl6pimJacupONT4F7w6gmQHw41rouAnJF51ORDwGefWeb6OMLzGmJwzxlIVPERfnJf1EsMM7A==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.32':
+    resolution: {integrity: sha512-W8oMqzGcI7wKPXUtS3WJNXzbghHfNiuM1UBAGpVb+XlUCgYRQJd2PRGP7D3WGql3rR3QEhUvSyAuCBAftPQw6Q==}
     cpu: [arm64]
     os: [darwin]
 
@@ -8533,8 +8533,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
-    resolution: {integrity: sha512-4MiuRtExC08jHbSU/diIL+IuQP+3Ck1FbWAplK+ysQJ7fxT3DMxy5FmnIGfmhaqow8oTjb2GEwZJKgTRjZL1Vw==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.32':
+    resolution: {integrity: sha512-pM4c4sKUk37noJrnnDkJknLhCsfZu7aWyfe67bD0GQHfzAPjV16wPeD9CmQg4/0vv+5IfHYaa4VE536xbA+W0Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -8553,8 +8553,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
-    resolution: {integrity: sha512-oTDZVfqIAjLB2I1yTiLyyhfPPO6dky33sTblxTCpe+ZT55WizN3KDoBKJ4yXG8shI6I4bRShVu29Xg0yAjyQYw==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.32':
+    resolution: {integrity: sha512-hRZygRlaGCjcNTNY9GV7dDI18sG1dK3cc7ujHq72LoDad23zFDUGMQjiSxHWK+/r92iMV+j2MiHbvzayxqynsg==}
     cpu: [arm64]
     os: [linux]
 
@@ -8563,8 +8563,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
-    resolution: {integrity: sha512-duJ3IkEBj9Xe9NYW1n8Y3483VXHGi8zQ0ZsLbK8464EJUXLF7CXM8Ry+jkkUw+ZvA+Zu1E/+C6p2Y6T9el0C9g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.32':
+    resolution: {integrity: sha512-HzgT6h+CXLs+GKAU0Wvkt3rvcv0CmDBsDjlPhh4GHysOKbG9NjpKYX2zvjx671E9pGbTvcPpwy7gGsy7xpu+8g==}
     cpu: [arm64]
     os: [linux]
 
@@ -8578,8 +8578,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
-    resolution: {integrity: sha512-H7+r34TSV8udB2gAsebFM/YuEeNCkPGEAGJ1JE7SgI9XML6FflqcdKfrRSneQFsPaom/gCEc1g0WW5MZ0O3blw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.32':
+    resolution: {integrity: sha512-Ab/wbf6gdzphDbsg51UaxsC93foQ7wxhtg0SVCXd25BrV4MAJ1HoDtKN/f4h0maFmJobkqYub2DlmoasUzkvBg==}
     cpu: [x64]
     os: [linux]
 
@@ -8588,8 +8588,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
-    resolution: {integrity: sha512-zRm2YmzFVqbsmUsyyZnHfJrOlQUcWS/FJ5ZWL8Q1kZh5PnLBrTVZNpakIWwAxpN5gNEi9MmFd5YHocVJp8ps1Q==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.32':
+    resolution: {integrity: sha512-VoxqGEfh5A1Yx+zBp/FR5QwAbtzbuvky2SVc+ii4g1gLD4zww6mt/hPi5zG+b88zYPFBKHpxMtsz9cWqXU5V5Q==}
     cpu: [x64]
     os: [linux]
 
@@ -8603,8 +8603,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
-    resolution: {integrity: sha512-4nftR9V2KHH3zjBwf6leuZZJQZ7v0d70ogjHIqB3SDsbDLvVEZiGSsSn2X6blSZRZeJSFzK0pp4kZ67zdZXwSw==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.32':
+    resolution: {integrity: sha512-k3MvDf8SiA7uP2ikP0unNouJ2YCrnwi7xcVW+RDgMp5YXVr3Xu6svmT3HGn0tkCKUuPmf+uy8I5uiHt5qWQbew==}
     cpu: [arm64]
     os: [win32]
 
@@ -8613,8 +8613,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
-    resolution: {integrity: sha512-0TQcKu9xZVHYALit+WJsSuADGlTFfOXhnZoIHWWQhTk3OgbwwbYcSoZUXjRdFmR6Wswn4csHtJGN1oYKeQ6/2g==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.32':
+    resolution: {integrity: sha512-wAi/FxGh7arDOUG45UmnXE1sZUa0hY4cXAO2qWAjFa3f7bTgz/BqwJ7XN5SUezvAJPNkME4fEpInfnBvM25a0w==}
     cpu: [ia32]
     os: [win32]
 
@@ -8623,8 +8623,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
-    resolution: {integrity: sha512-3zMICWwpZh1jrkkKDYIUCx/2wY3PXLICAS0AnbeLlhzfWPhCcpNK9eKhiTlLAZyTp+3kyipoi/ZSVIh+WDnBpQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.32':
+    resolution: {integrity: sha512-Ej0i4PZk8ltblZtzVK8ouaGUacUtxRmTm5S9794mdyU/tYxXjAJNseOfxrnHpMWKjMDrOKbqkPqJ52T9NR4LQQ==}
     cpu: [x64]
     os: [win32]
 
@@ -26204,13 +26204,13 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.30':
@@ -26222,13 +26222,13 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.30':
@@ -26237,13 +26237,13 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.30':
@@ -26254,19 +26254,19 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.32':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.32':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.30': {}


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

## Description

This PR adds support for `AbortSignal` in the `createReactAgent` function, allowing users to cancel agent execution and tool invocations. This is particularly useful for long-running agent operations where users may want to cancel execution based on external events or user interaction.

### Key Changes:

1. **Added `abortSignal` parameter** to `CreateReactAgentParams` - Users can now pass an `AbortSignal` when creating an agent
2. **Signal propagation to tools** - The abort signal is passed to the `ToolNode` and properly merged with any existing signals from LangGraph's Pregel class
3. **Signal merging with `AbortSignal.any()`** - When both agent-level and config-level signals are present, they are merged using `AbortSignal.any()` (with appropriate TypeScript declarations for this newer API)
4. **Improved error propagation** - Abort signal reasons are now properly propagated throughout the execution chain
5. **Comprehensive test coverage** - Added tests to verify abort functionality works correctly at both the agent and tool levels

### Usage Example:

```typescript
const abortController = new AbortController();

const agent = createReactAgent({
  llm: model,
  tools: [myTool],
  abortSignal: abortController.signal,
});

// Start agent execution
const executionPromise = agent.invoke({
  messages: [{ role: "user", content: "Do something long running" }],
});

// Cancel after some condition
setTimeout(() => {
  abortController.abort("User cancelled operation");
}, 5000);
```

### Additional Improvements:

- Fixed build script to not clean in watch mode (prevents IDE issues with missing types)
- Updated signal utilities in langchain-core to properly extract and propagate abort reasons
- Added TypeScript declarations for `AbortSignal.any()` which is not yet in TypeScript's lib

<!-- Remove if not applicable -->

Fixes #(issue)
