### PR TITLE
docs(langchain): Update configurableFields object key reference description

### DIFF
--- a/langchain/src/chat_models/universal.ts
+++ b/langchain/src/chat_models/universal.ts
@@ -797,7 +797,7 @@ export async function initChatModel<
  * This function initializes a ChatModel based on the provided model name and provider.
  * It supports various model providers and allows for runtime configuration of model parameters.
  *
- * Security Note: Setting `configurableFields` to "any" means fields like api_key, base_url, etc.
+ * Security Note: Setting `configurableFields` to "any" means fields like apiKey, baseUrl, etc.
  * can be altered at runtime, potentially redirecting model requests to a different service/user.
  * Make sure that if you're accepting untrusted configurations, you enumerate the
  * `configurableFields` explicitly.


### PR DESCRIPTION
The referenced api_key and base_url aren't the right name of the key that will be used when executing initChatModel but apiKey and baseUrl. This change will give more clarity of key name to use when want to configure this fields.

Fixes # 
changed configurableFields name reference to what it will use in the langchainjs package
