### PR TITLE
fix(google-genai): compute per-chunk token deltas while streaming

### DIFF
--- a/libs/langchain-google-genai/src/chat_models.ts
+++ b/libs/langchain-google-genai/src/chat_models.ts
@@ -913,6 +913,9 @@ export class ChatGoogleGenerativeAI
     );
 
     let usageMetadata: UsageMetadata | undefined;
+    // Keep prior cumulative counts for calculating token deltas while streaming
+    let prevPromptTokenCount = 0;
+    let prevCandidatesTokenCount = 0;
     let index = 0;
     for await (const response of stream) {
       if (
@@ -921,28 +924,23 @@ export class ChatGoogleGenerativeAI
         options.streamUsage !== false
       ) {
         const genAIUsageMetadata = response.usageMetadata as {
-          promptTokenCount: number | undefined;
-          candidatesTokenCount: number | undefined;
+          promptTokenCount: number | undefined; // Number of tokens in the request
+          candidatesTokenCount: number | undefined; // Nummber of tokens in the response(s)
           totalTokenCount: number | undefined;
         };
-        if (!usageMetadata) {
-          usageMetadata = {
-            input_tokens: genAIUsageMetadata.promptTokenCount ?? 0,
-            output_tokens: genAIUsageMetadata.candidatesTokenCount ?? 0,
-            total_tokens: genAIUsageMetadata.totalTokenCount ?? 0,
-          };
-        } else {
-          // Under the hood, LangChain combines the prompt tokens. Google returns the updated
-          // total each time, so we need to find the difference between the tokens.
-          const outputTokenDiff =
-            (genAIUsageMetadata.candidatesTokenCount ?? 0) -
-            usageMetadata.output_tokens;
-          usageMetadata = {
-            input_tokens: 0,
-            output_tokens: outputTokenDiff,
-            total_tokens: outputTokenDiff,
-          };
-        }
+        // Under the hood, LangChain combines the prompt tokens. Google returns the updated
+        // total each time, so we need to find the difference between the tokens.
+        const newPromptTokenCount = genAIUsageMetadata.promptTokenCount ?? 0;
+        const newCandidatesTokenCount = genAIUsageMetadata.candidatesTokenCount ?? 0;
+        const inputDelta = Math.max(0, newPromptTokenCount - prevPromptTokenCount);
+        const outputDelta = Math.max(0, newCandidatesTokenCount   - prevCandidatesTokenCount);
+        prevPromptTokenCount = newPromptTokenCount;
+        prevCandidatesTokenCount = newCandidatesTokenCount;
+        usageMetadata = {
+          input_tokens: inputDelta,
+          output_tokens: outputDelta,
+          total_tokens: inputDelta + outputDelta,
+        };
       }
 
       const chunk = convertResponseContentToChatGenerationChunk(response, {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->
### Summary

Fix inflated token usage in `ChatGoogleGenerativeAI` streaming by computing per-chunk deltas from Google’s cumulative `usageMetadata`.

### Details

Previously, per-chunk usage was calculated from the prior delta, not the prior cumulative total. This produced no abnormal behavior when using Gemini 1.5 Flash as it only reports the total `candidatesTokenCount` in the final streaming chunk, but causes an inflated token count for models like Gemini 2.5 Pro that report cumulative output tokens each chunk.

The fix stores the last cumulative prompt and candidate counts, then diffs against them to produce correct per-chunk `usageMetadata`. Works correctly for both cumulative-per-chunk and final-chunk-only models.

### Impact

* Accurate token counts in LangSmith traces and downstream metrics
* No change to non-streaming path

