### PR TITLE
feat(community): Add GPT-5(Openai) support for forwarding verbosity parameter

### DIFF
--- a/libs/langchain-openai/src/tests/chat_models_responses.standard.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models_responses.standard.test.ts
@@ -37,3 +37,16 @@ test("ChatOpenAIResponsesStandardUnitTests", () => {
   const testResults = testClass.runTests();
   expect(testResults).toBe(true);
 });
+
+test("Responses API includes text.verbosity and reasoning", () => {
+  process.env.OPENAI_API_KEY = "test";
+  const m = new ChatOpenAI({
+    useResponsesApi: true,
+    model: "gpt-5",
+    verbosity: "low",
+    reasoning: { effort: "minimal" },
+  });
+  const params: any = m.invocationParams({});
+  expect(params.text.verbosity).toBe("low");
+  expect(params.reasoning).toEqual({ effort: "minimal" });
+});


### PR DESCRIPTION
- Adds a model-level verbosity option to ChatOpenAI and includes it as text.verbosity when using the OpenAI Responses API.
- Preserves any user-provided options.text; only augments it with verbosity if not already present.
- Continues forwarding reasoning to the Responses API;