### PR TITLE
fix(weaviate): Make flattenObjectForWeaviate more resilient

### DIFF
--- a/libs/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -5,10 +5,15 @@ test("flattenObjectForWeaviate", () => {
   expect(
     flattenObjectForWeaviate({
       array2: [{}, "a"],
+      "some:colon": "key only should:be:replaced with some_colon",
+      "some;crazy;keys": "test",
+      "more*crazy*keys": "test",
       deep: {
         string: "deep string",
         array: ["1", 2],
         array3: [1, 3],
+        "duda:colon:test": "test",
+        "caret^test": "test",
         deepdeep: {
           string: "even a deeper string",
         },
@@ -21,9 +26,14 @@ test("flattenObjectForWeaviate", () => {
         1,
         3,
       ],
+      "deep_caret_test": "test",
       "deep_deepdeep_string": "even a deeper string",
+      "deep_duda_colon_test": "test",
       "deep_string": "deep string",
       "emptyArray": [],
+      "more_crazy_keys": "test",
+      "some_colon": "key only should:be:replaced with some_colon",
+      "some_crazy_keys": "test",
     }
   `);
 });

--- a/libs/langchain-weaviate/src/vectorstores.ts
+++ b/libs/langchain-weaviate/src/vectorstores.ts
@@ -26,38 +26,41 @@ import { maximalMarginalRelevance } from "@langchain/core/utils/math";
 // https://weaviate.io/developers/weaviate/config-refs/datatypes#introduction
 export const flattenObjectForWeaviate = (obj: Record<string, unknown>) => {
   const flattenedObject: Record<string, unknown> = {};
-
   for (const key in obj) {
     if (!Object.hasOwn(obj, key)) {
       continue;
     }
+
+    // Replace any character that is not a letter, a number, or an underscore with '_'
+    const newKey = key.replace(/[^a-zA-Z0-9_]/g, "_");
+
     const value = obj[key];
     if (typeof value === "object" && !Array.isArray(value)) {
       const recursiveResult = flattenObjectForWeaviate(
         value as Record<string, unknown>
       );
-
       for (const deepKey in recursiveResult) {
-        if (Object.hasOwn(obj, key)) {
-          flattenedObject[`${key}_${deepKey}`] = recursiveResult[deepKey];
+        if (Object.hasOwn(recursiveResult, deepKey)) {
+          // Replace any character in the deepKey that is not a letter, a number, or an underscore with '_'
+          const newDeepKey = deepKey.replace(/[^a-zA-Z0-9_]/g, "_");
+          flattenedObject[`${newKey}_${newDeepKey}`] = recursiveResult[deepKey];
         }
       }
     } else if (Array.isArray(value)) {
       if (value.length === 0) {
-        flattenedObject[key] = value;
+        flattenedObject[newKey] = value;
       } else if (
         typeof value[0] !== "object" &&
         value.every((el: unknown) => typeof el === typeof value[0])
       ) {
         // Weaviate only supports arrays of primitive types,
         // where all elements are of the same type
-        flattenedObject[key] = value;
+        flattenedObject[newKey] = value;
       }
     } else {
-      flattenedObject[key] = value;
+      flattenedObject[newKey] = value;
     }
   }
-
   return flattenedObject;
 };
 


### PR DESCRIPTION
This will avoid errors when property has special characters, eg pdf metadata having, for example author:something

Before this patch, it will fail for some documents, as it will produce a property name as [`author:something` which is not allowed](https://docs.weaviate.io/weaviate/config-refs/collections#name).

Added tests