### PR TITLE
fix: add support for conversion of ref in array schema

### DIFF
--- a/.changeset/puny-poems-sink.md
+++ b/.changeset/puny-poems-sink.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+add support for conversion of ref in array schema

--- a/langchain/src/chains/openai_functions/openapi.ts
+++ b/langchain/src/chains/openai_functions/openapi.ts
@@ -193,9 +193,11 @@ export function convertOpenAPISchemaToJSONSchema(
     );
   }
   if (schema.type === "array") {
+    const openAPIItems = spec.getSchema(schema.items) ?? {};
+
     return {
       type: "array",
-      items: convertOpenAPISchemaToJSONSchema(schema.items ?? {}, spec),
+      items: convertOpenAPISchemaToJSONSchema(openAPIItems, spec),
       minItems: schema.minItems,
       maxItems: schema.maxItems,
     } as JsonSchema7ArrayType;

--- a/langchain/src/chains/openai_functions/tests/openapi.test.ts
+++ b/langchain/src/chains/openai_functions/tests/openapi.test.ts
@@ -70,6 +70,21 @@ test("Test convert OpenAPI params to JSON Schema", async () => {
               },
             },
             {
+              name: "refParam",
+              in: "query",
+              schema: {
+                $ref: "#/components/schemas/RefObject",
+              },
+            },
+            {
+              name: "refArrayParam",
+              in: "query",
+              schema: {
+                type: "array",
+                items: { $ref: "#/components/schemas/RefObject" },
+              },
+            },
+            {
               name: "nestedObjectInArrayParam",
               in: "query",
               schema: {
@@ -142,6 +157,21 @@ test("Test convert OpenAPI params to JSON Schema", async () => {
                   },
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        RefObject: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+            },
+            bar: {
+              type: "number",
             },
           },
         },
@@ -224,6 +254,26 @@ test("Test convert OpenAPI params to JSON Schema", async () => {
   );
   expect(typedStringArrayParamSchema.items).not.toBeUndefined();
   expectType("string", typedStringArrayParamSchema.items);
+
+  const refParamSchema = convertOpenAPISchemaToJSONSchema(
+    getParamSchema(createWidget, "refParam"),
+    spec
+  );
+  const typedRefParamSchema = expectType("object", refParamSchema);
+  expectType("string", typedRefParamSchema.properties.foo);
+  expectType("number", typedRefParamSchema.properties.bar);
+
+  const refArrayParamSchema = convertOpenAPISchemaToJSONSchema(
+    getParamSchema(createWidget, "refArrayParam"),
+    spec
+  );
+  const typedRefArrayParamSchema = expectType("array", refArrayParamSchema);
+  const typedRefArrayParamSchemaItems = expectType(
+    "object",
+    typedRefArrayParamSchema.items
+  );
+  expectType("string", typedRefArrayParamSchemaItems.properties.foo);
+  expectType("number", typedRefArrayParamSchemaItems.properties.bar);
 
   const nestedObjectInArrayParamSchema = convertOpenAPISchemaToJSONSchema(
     getParamSchema(createWidget, "nestedObjectInArrayParam"),


### PR DESCRIPTION
This PR fixes the conversion of $ref items in array schemas and adds this case to the existing test.

I also added a test for the conversion of refs that are not in an array schema.

Example:

```yaml
openapi: 3.1.0
info:
  title: A fake spec for testing
  version: 0.0.1
paths:
  /foo:
    post:
      operationId: createFoo
      description: Create multiple foo
      parameters:
        - name: fooArray
          in: query
          schema:
            type: array
            items:
              $ref: '#/components/schemas/Foo'
      responses:
        '201':
          description: Created
          content:
            application/json:
              schema:
                properties:
                  success:
                    type: boolean
components:
  schemas:
    Foo:
      type: object
      properties:
        bar:
          type: string
```

Converting the `fooArray` schema would result in

```json
{
  "type": "array",
  "items": {
    "type": "string"
  }
}
```

After the fix it gets converted into:

```json
{
  "type": "array",
  "items": {
    "type": "object",
    "properties": {
      "bar": {
        "type": "string"
      }
    },
    "required": [],
    "additionalProperties": {}
  }
}
```