### PR TITLE
fix(community): postgres indexes getTime returning NaN due to missing alias

### DIFF
--- a/.changeset/hot-bugs-clap.md
+++ b/.changeset/hot-bugs-clap.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": patch
+---
+
+postgres indexes getTime returning NaN due to missing alias

--- a/libs/langchain-community/src/indexes/postgres.ts
+++ b/libs/langchain-community/src/indexes/postgres.ts
@@ -69,7 +69,7 @@ export class PostgresRecordManager implements RecordManagerInterface {
 
   async getTime(): Promise<number> {
     const res = await this.pool.query(
-      "SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)"
+      "SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) AS extract"
     );
     return Number.parseFloat(res.rows[0].extract);
   }


### PR DESCRIPTION
Hello,

When running the SQL query included in the `getTime()` function on PostgreSQL 13.18, I got the following result:

```csv
date_part
1755534822.917985
```

This causes the function to return `NaN` since the `extract` property does not exist.

When the `getTime` function returns `NaN`, both the `incremental` and `full` cleanup operations remove all added documents, rendering the indexing feature unusable:

```js
{ numAdded: 1, numDeleted: 1, numUpdated: 0, numSkipped: 0 }
```

This PR fixes the issue by always adding an alias using the `AS` SQL keyword.