### PR TITLE
feat(chroma): Default to Null Embedding Function for Chroma Collection

### DIFF
--- a/libs/langchain-community/src/vectorstores/chroma.ts
+++ b/libs/langchain-community/src/vectorstores/chroma.ts
@@ -245,6 +245,7 @@ export class Chroma extends VectorStore {
       try {
         this.collection = await this.index.getOrCreateCollection({
           name: this.collectionName,
+          embeddingFunction: null,
           ...(this.collectionMetadata && { metadata: this.collectionMetadata }),
         });
       } catch (err) {


### PR DESCRIPTION
The new Chroma JS client required a separate installation of an EF provider package. This is not suitable for Langchain as embeddings are provided directly to the collection. 

fixes #8710 