### PR TITLE
chore(openai): minor cleanup in withStructuredOutput

### DIFF
--- a/libs/providers/langchain-openai/src/tests/structuredOutput.test.ts
+++ b/libs/providers/langchain-openai/src/tests/structuredOutput.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "@jest/globals";
+import { getStructuredOutputMethod } from "../utils/structuredOutput.js";
+
+describe("getStructuredOutputMethod", () => {
+  it("should return the default method if no method is provided", () => {
+    expect(getStructuredOutputMethod("gpt-4o-mini", undefined)).toBe(
+      "jsonSchema"
+    );
+  });
+
+  it("should default to functionCalling if the model does not support jsonSchema", () => {
+    expect(getStructuredOutputMethod("gpt-3.5-turbo", undefined)).toBe(
+      "functionCalling"
+    );
+  });
+
+  it("should acknowledge the method if provided", () => {
+    expect(getStructuredOutputMethod("gpt-4o-mini", "jsonSchema")).toBe(
+      "jsonSchema"
+    );
+    expect(getStructuredOutputMethod("gpt-4o-mini", "functionCalling")).toBe(
+      "functionCalling"
+    );
+    expect(getStructuredOutputMethod("gpt-4o-mini", "jsonMode")).toBe(
+      "jsonMode"
+    );
+  });
+
+  it("should throw an error if the method is invalid", () => {
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", "invalid")).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", null)).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", 1)).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", true)).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", false)).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", {})).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", [])).toThrow();
+    expect(() => getStructuredOutputMethod("gpt-4o-mini", () => {})).toThrow();
+  });
+});

--- a/libs/providers/langchain-openai/src/utils/structuredOutput.ts
+++ b/libs/providers/langchain-openai/src/utils/structuredOutput.ts
@@ -1,0 +1,57 @@
+const SUPPORTED_METHODS = [
+  "jsonSchema",
+  "functionCalling",
+  "jsonMode",
+] as const;
+type SupportedMethod = (typeof SUPPORTED_METHODS)[number];
+
+/**
+ * Get the structured output method for a given model. By default, it uses
+ * `jsonSchema` if the model supports it, otherwise it uses `functionCalling`.
+ *
+ * @throws if the method is invalid, e.g. is not a string or invalid method is provided.
+ * @param model - The model name.
+ * @param config - The structured output method options.
+ * @returns The structured output method.
+ */
+export function getStructuredOutputMethod(
+  model: string,
+  method: unknown
+): SupportedMethod {
+  /**
+   * If a method is provided, validate it.
+   */
+  if (
+    typeof method !== "undefined" &&
+    !SUPPORTED_METHODS.includes(method as SupportedMethod)
+  ) {
+    throw new Error(
+      `Invalid method: ${method}. Supported methods are: ${SUPPORTED_METHODS.join(
+        ", "
+      )}`
+    );
+  }
+
+  const hasSupportForJsonSchema =
+    !model.startsWith("gpt-3") &&
+    !model.startsWith("gpt-4-") &&
+    model !== "gpt-4";
+
+  /**
+   * If the model supports JSON Schema, use it by default.
+   */
+  if (hasSupportForJsonSchema && !method) {
+    return "jsonSchema";
+  }
+
+  if (!hasSupportForJsonSchema && method === "jsonSchema") {
+    throw new Error(
+      `JSON Schema is not supported for model "${model}". Please use a different method, e.g. "functionCalling" or "jsonMode".`
+    );
+  }
+
+  /**
+   * If the model does not support JSON Schema, use function calling by default.
+   */
+  return (method as SupportedMethod) ?? "functionCalling";
+}


### PR DESCRIPTION
This patch aims to improve the `withStructuredOutput` logic in two ways:

- cleans up the need to check for "schema" in the response format object, this has been [deprecated](https://github.com/langchain-ai/langchainjs/blob/37bfcd7bf89f3b420f595651ba377f3dbd7de77a/libs/langchain-core/src/language_models/base.ts#L299-L301)
- move `_getStructuredOutputMethod` into a utility function to not expose it to the user
- add tests to verify default choice of structured output method in OpenAI