### PR TITLE
feat(core): basic chunk impl

### DIFF
--- a/libs/langchain-core/src/_standard/chunk.ts
+++ b/libs/langchain-core/src/_standard/chunk.ts
@@ -1,0 +1,36 @@
+import {
+  $MessageStructure,
+  $StandardMessageStructure,
+  AIMessage,
+  Message,
+} from "./message.js";
+
+export interface MessageChunk extends Message {
+  concat(chunk: MessageChunk): MessageChunk;
+  toMessage(): Message;
+}
+
+export class AIMessageChunk<
+    TStructure extends $MessageStructure = $StandardMessageStructure
+  >
+  extends AIMessage<TStructure>
+  implements MessageChunk
+{
+  concat(other: AIMessageChunk): AIMessageChunk<TStructure> {
+    // TODO: Implement this
+    return new AIMessageChunk({
+      ...this,
+      content: [...this.content, ...other.content],
+    });
+  }
+
+  toMessage(): AIMessage<TStructure> {
+    return new AIMessage({
+      id: this.id,
+      name: this.name,
+      content: this.content,
+      responseMetadata: this.responseMetadata,
+      usageMetadata: this.usageMetadata,
+    });
+  }
+}

--- a/libs/langchain-core/src/_standard/message.ts
+++ b/libs/langchain-core/src/_standard/message.ts
@@ -650,7 +650,7 @@ export class AIMessage<
   readonly type = "ai" as const;
 
   /** Unique identifier for this message */
-  id: string;
+  id?: string;
 
   /** Optional name/identifier for the AI that generated this message */
   name?: string;
@@ -827,7 +827,7 @@ export class HumanMessage<
   readonly type = "human" as const;
 
   /** Unique identifier for the message */
-  id: string;
+  id?: string;
 
   /** Optional name identifier for the message sender */
   name?: string;
@@ -971,7 +971,7 @@ export class SystemMessage<
   readonly type = "system" as const;
 
   /** Unique identifier for this message */
-  id: string;
+  id?: string;
 
   /** Optional name/identifier for the system that generated this message */
   name?: string;
@@ -1114,7 +1114,7 @@ export class ToolMessage<
   readonly type = "tool" as const;
 
   /** Unique identifier for this message */
-  id: string;
+  id?: string;
 
   /** Optional name/identifier for the tool that generated this message */
   name?: string;


### PR DESCRIPTION
since message chunks are messages in v0 and v1, I don't expect them to change much for new message types. this is just a patch fix to unstick implementation until I get a chance to build this out more
