### PR TITLE
BM25Retriever: escape regex metacharacters in getTermFrequency to prevent crashes

### DIFF
--- a/.changeset/major-lamps-walk.md
+++ b/.changeset/major-lamps-walk.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": patch
+---
+
+BM25Retriever: escape regex metacharacters in getTermFrequency to prevent crashes

--- a/libs/langchain-community/src/retrievers/tests/bm25.test.ts
+++ b/libs/langchain-community/src/retrievers/tests/bm25.test.ts
@@ -25,3 +25,24 @@ test("BM25Retriever", async () => {
     "The quick brown fox jumps over the lazy dog"
   );
 });
+
+test("getTermFrequency escapes regex metacharacters", async () => {
+  // Import directly from the inlined BM25 util to test the helper.
+  const { getTermFrequency } = await import(
+    "../../utils/@furkantoprak/bm25/BM25.js"
+  );
+
+  const corpus = "**Version 1:** What is the country of origin for the person in question?";
+  const term = "**Version 1:**";
+
+  // Should not throw and should find at least one match
+  const freq = getTermFrequency(term, corpus);
+  expect(freq).toBeGreaterThanOrEqual(1);
+
+  // Also test other metacharacters
+  const corpus2 = "Does this match (maybe)? [yes] *stars* +plus+";
+  expect(getTermFrequency("(maybe)?", corpus2)).toBeGreaterThanOrEqual(1);
+  expect(getTermFrequency("[yes]", corpus2)).toBeGreaterThanOrEqual(1);
+  expect(getTermFrequency("*stars*", corpus2)).toBeGreaterThanOrEqual(1);
+  expect(getTermFrequency("+plus+", corpus2)).toBeGreaterThanOrEqual(1);
+});

--- a/libs/langchain-community/src/retrievers/tests/bm25.test.ts
+++ b/libs/langchain-community/src/retrievers/tests/bm25.test.ts
@@ -28,7 +28,8 @@ test("BM25Retriever", async () => {
 });
 
 test("getTermFrequency escapes regex metacharacters", () => {
-  const corpus = "**Version 1:** What is the country of origin for the person in question?";
+  const corpus =
+    "**Version 1:** What is the country of origin for the person in question?";
   const term = "**Version 1:**";
 
   // Should not throw and should find at least one match

--- a/libs/langchain-community/src/retrievers/tests/bm25.test.ts
+++ b/libs/langchain-community/src/retrievers/tests/bm25.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { Document } from "@langchain/core/documents";
 import { BM25Retriever } from "../bm25.js";
+import { getTermFrequency } from "../../utils/@furkantoprak/bm25/BM25.js";
 
 test("BM25Retriever", async () => {
   const docs = [
@@ -26,12 +27,7 @@ test("BM25Retriever", async () => {
   );
 });
 
-test("getTermFrequency escapes regex metacharacters", async () => {
-  // Import directly from the inlined BM25 util to test the helper.
-  const { getTermFrequency } = await import(
-    "../../utils/@furkantoprak/bm25/BM25.js"
-  );
-
+test("getTermFrequency escapes regex metacharacters", () => {
   const corpus = "**Version 1:** What is the country of origin for the person in question?";
   const term = "**Version 1:**";
 

--- a/libs/langchain-community/src/utils/@furkantoprak/bm25/BM25.ts
+++ b/libs/langchain-community/src/utils/@furkantoprak/bm25/BM25.ts
@@ -12,7 +12,10 @@ export const getWordCount = (corpus: string) => {
 
 /** Number of occurences of a word in a string. */
 export const getTermFrequency = (term: string, corpus: string) => {
-  return ((corpus || "").match(new RegExp(term, "g")) || []).length;
+  // Escape any RegExp metacharacters in the term so constructing a RegExp
+  // from user-provided or model-generated queries does not throw an error
+  const escaped = (term || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return ((corpus || "").match(new RegExp(escaped, "g")) || []).length;
 };
 
 /** Inverse document frequency. */


### PR DESCRIPTION
Fixes #8746 

**Problem:** 
unescaped RegExp(term) throws on `**`, `[`, `?`, etc., crashing BM25 based retrieval functionality

**Fix:** 
escape metacharacters via `term.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")` before constructing `RegExp`