### PR TITLE
fix(internal): re-enable unused dependency check

### DIFF
--- a/environment_tests/test-exports-cf/package.json
+++ b/environment_tests/test-exports-cf/package.json
@@ -10,7 +10,6 @@
     "@langchain/openai": "workspace:*",
     "@tsconfig/recommended": "^1.0.2",
     "cheerio": "^1.1.2",
-    "handlebars": "^4.7.8",
     "langchain": "workspace:*",
     "wrangler": "^3.19.0",
     "vitest": "0.34.3",

--- a/environment_tests/test-exports-cjs/package.json
+++ b/environment_tests/test-exports-cjs/package.json
@@ -27,7 +27,6 @@
     "@tsconfig/recommended": "^1.0.10",
     "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.1.2",
-    "handlebars": "^4.7.8",
     "typeorm": "^0.3.25",
     "langchain": "workspace:*",
     "typescript": "^5.0.0"

--- a/environment_tests/test-exports-esbuild/package.json
+++ b/environment_tests/test-exports-esbuild/package.json
@@ -24,7 +24,6 @@
     "@types/node": "^18.15.11",
     "cheerio": "^1.1.2",
     "esbuild": "^0.17.18",
-    "handlebars": "^4.7.8",
     "langchain": "workspace:*",
     "typeorm": "^0.3.25",
     "typescript": "^5.0.0"

--- a/environment_tests/test-exports-esm/package.json
+++ b/environment_tests/test-exports-esm/package.json
@@ -26,7 +26,6 @@
     "@tsconfig/recommended": "^1.0.2",
     "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.1.2",
-    "handlebars": "^4.7.8",
     "langchain": "workspace:*",
     "typeorm": "^0.3.25",
     "reflect-metadata": "^0.1.13",

--- a/environment_tests/test-exports-vercel/package.json
+++ b/environment_tests/test-exports-vercel/package.json
@@ -19,7 +19,6 @@
     "cheerio": "^1.1.2",
     "eslint": "8.37.0",
     "eslint-config-next": "14.2.28",
-    "handlebars": "^4.7.8",
     "langchain": "workspace:*",
     "next": "^15.4.5",
     "peggy": "^5.0.5",

--- a/internal/build/index.ts
+++ b/internal/build/index.ts
@@ -79,7 +79,7 @@ async function buildProject(
    */
   const buildChecks = {
     unused:
-      !watch && !opts.skipUnused && false
+      !watch && !opts.skipUnused
         ? ({
             root: path,
             level: "error" as const,

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -69,7 +69,6 @@
     "@getmetal/metal-sdk": "^4.0.0",
     "@getzep/zep-cloud": "^1.0.6",
     "@getzep/zep-js": "^0.9.0",
-    "@gomomento/sdk": "^1.51.0",
     "@gomomento/sdk-core": "^1.51.1",
     "@google-ai/generativelanguage": "^2.5.0",
     "@google-cloud/storage": "^7.15.2",
@@ -243,7 +242,6 @@
     "@getmetal/metal-sdk": "*",
     "@getzep/zep-cloud": "^1.0.6",
     "@getzep/zep-js": "^0.9.0",
-    "@gomomento/sdk": "^1.51.0",
     "@gomomento/sdk-core": "^1.51.1",
     "@google-ai/generativelanguage": "*",
     "@google-cloud/storage": "^6.10.1 || ^7.7.0",
@@ -416,9 +414,6 @@
       "optional": true
     },
     "@getzep/zep-js": {
-      "optional": true
-    },
-    "@gomomento/sdk": {
       "optional": true
     },
     "@gomomento/sdk-core": {

--- a/libs/langchain-standard-tests/package.json
+++ b/libs/langchain-standard-tests/package.json
@@ -52,13 +52,9 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "jest": "^29.5.0",
     "vitest": "^3.2.4"
   },
   "peerDependenciesMeta": {
-    "jest": {
-      "optional": true
-    },
     "vitest": {
       "optional": true
     }

--- a/libs/langchain-standard-tests/package.json
+++ b/libs/langchain-standard-tests/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-no-instanceof": "^1.0.1",
     "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.7.0",
     "prettier": "^2.8.3",
     "release-it": "^18.1.2",
     "rollup": "^4.5.2",

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -41,7 +41,6 @@
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.2",
-    "@types/handlebars": "^4.1.0",
     "@types/html-to-text": "^9",
     "@types/js-yaml": "^4",
     "@types/jsdom": "^21.1.1",
@@ -59,7 +58,6 @@
     "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-no-instanceof": "^1.0.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "handlebars": "^4.7.8",
     "jest": "^29.5.0",
     "jest-environment-node": "^29.6.4",
     "langsmith": "^0.3.46",
@@ -78,15 +76,11 @@
   "peerDependencies": {
     "@langchain/core": ">=0.3.58 <0.4.0",
     "cheerio": "*",
-    "handlebars": "^4.7.8",
     "peggy": "^3.0.2",
     "typeorm": "*"
   },
   "peerDependenciesMeta": {
     "cheerio": {
-      "optional": true
-    },
-    "handlebars": {
       "optional": true
     },
     "peggy": {

--- a/libs/providers/langchain-anthropic/package.json
+++ b/libs/providers/langchain-anthropic/package.json
@@ -30,8 +30,7 @@
     "format:check": "prettier --config .prettierrc --check \"src\""
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.56.0",
-    "fast-xml-parser": "^4.4.1"
+    "@anthropic-ai/sdk": "^0.56.0"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.3.58 <0.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1735,6 +1735,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.1.0)(ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
       prettier:
         specifier: ^2.8.3
         version: 2.8.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -598,31 +598,31 @@ importers:
         version: 0.25.8
       '@rolldown/binding-darwin-arm64':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-darwin-x64':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-linux-arm64-gnu':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-linux-arm64-musl':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-linux-x64-gnu':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-linux-x64-musl':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-win32-arm64-msvc':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-win32-ia32-msvc':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@rolldown/binding-win32-x64-msvc':
         specifier: '*'
-        version: 1.0.0-beta.33
+        version: 1.0.0-beta.34
       '@swc/core-win32-x64-msvc':
         specifier: '*'
         version: 1.13.3
@@ -830,9 +830,6 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.2
         version: 1.0.10
-      '@types/handlebars':
-        specifier: ^4.1.0
-        version: 4.1.0
       '@types/html-to-text':
         specifier: ^9
         version: 9.0.4
@@ -884,9 +881,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.8
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.8.3))
@@ -1048,9 +1042,6 @@ importers:
       '@getzep/zep-js':
         specifier: ^0.9.0
         version: 0.9.0
-      '@gomomento/sdk':
-        specifier: ^1.51.0
-        version: 1.51.1(encoding@0.1.13)
       '@gomomento/sdk-core':
         specifier: ^1.51.1
         version: 1.111.0
@@ -1707,9 +1698,6 @@ importers:
       '@langchain/core':
         specifier: workspace:*
         version: link:../langchain-core
-      jest:
-        specifier: ^29.5.0
-        version: 29.7.0(@types/node@24.1.0)(ts-node@10.9.2(@swc/core@1.13.3(@swc/helpers@0.5.17))(@types/node@24.1.0)(typescript@5.8.3))
       zod:
         specifier: ^3.25.32
         version: 3.25.76
@@ -1829,9 +1817,6 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.56.0
         version: 0.56.0
-      fast-xml-parser:
-        specifier: ^4.4.1
-        version: 4.5.3
     devDependencies:
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.11.5
@@ -8073,8 +8058,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.33':
-    resolution: {integrity: sha512-7lhhY08v5ZtRq8JJQaJ49fnJombAPnqllKKCDLU/UvaqNAOEyTGC8J1WVOLC4EA4zbXO5U3CCRgVGyAFNH2VtQ==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.34':
+    resolution: {integrity: sha512-2F/TqH4QuJQ34tgWxqBjFL3XV1gMzeQgUO8YRtCPGBSP0GhxtoFzsp7KqmQEothsxztlv+KhhT9Dbg3HHwHViQ==}
     cpu: [arm64]
     os: [darwin]
 
@@ -8083,8 +8068,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.33':
-    resolution: {integrity: sha512-U2iGjcDV7NWyYyhap8YuY0nwrLX6TvX/9i7gBtdEMPm9z3wIUVGNMVdGlA43uqg7xDpRGpEqGnxbeDgiEwYdnA==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.34':
+    resolution: {integrity: sha512-E1QuFslgLWbHQ8Qli/AqUKdfg0pockQPwRxVbhNQ74SciZEZpzLaujkdmOLSccMlSXDfFCF8RPnMoRAzQ9JV8Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -8103,8 +8088,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.33':
-    resolution: {integrity: sha512-cHGp8yfHL4pes6uaLbO5L58ceFkUK4efd8iE86jClD1QPPDLKiqEXJCFYeuK3OfODuF5EBOmf0SlcUZNEYGdmw==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.34':
+    resolution: {integrity: sha512-a737FTqhFUoWfnebS2SnQ2BS50p0JdukdkUBwy2J06j4hZ6Eej0zEB8vTfAqoCjn8BQKkXBy+3Sx0IRkgwz1gA==}
     cpu: [arm64]
     os: [linux]
 
@@ -8113,8 +8098,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.33':
-    resolution: {integrity: sha512-wZ1t7JAvVeFgskH1L9y7c47ITitPytpL0s8FmAT8pVfXcaTmS58ZyoXT+y6cz8uCkQnETjrX3YezTGI18u3ecg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.34':
+    resolution: {integrity: sha512-NH+FeQWKyuw0k+PbXqpFWNfvD8RPvfJk766B/njdaWz4TmiEcSB0Nb6guNw1rBpM1FmltQYb3fFnTumtC6pRfA==}
     cpu: [arm64]
     os: [linux]
 
@@ -8128,8 +8113,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.33':
-    resolution: {integrity: sha512-cDndWo3VEYbm7yeujOV6Ie2XHz0K8YX/R/vbNmMo03m1QwtBKKvbYNSyJb3B9+8igltDjd8zNM9mpiNNrq/ekQ==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.34':
+    resolution: {integrity: sha512-Q3RSCivp8pNadYK8ke3hLnQk08BkpZX9BmMjgwae2FWzdxhxxUiUzd9By7kneUL0vRQ4uRnhD9VkFQ+Haeqdvw==}
     cpu: [x64]
     os: [linux]
 
@@ -8138,8 +8123,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.33':
-    resolution: {integrity: sha512-bl7uzi6es/l6LT++NZcBpiX43ldLyKXCPwEZGY1rZJ99HQ7m1g3KxWwYCcGxtKjlb2ExVvDZicF6k+96vxOJKg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.34':
+    resolution: {integrity: sha512-wDd/HrNcVoBhWWBUW3evJHoo7GJE/RofssBy3Dsiip05YUBmokQVrYAyrboOY4dzs/lJ7HYeBtWQ9hj8wlyF0A==}
     cpu: [x64]
     os: [linux]
 
@@ -8153,8 +8138,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.33':
-    resolution: {integrity: sha512-CpvOHyqDNOYx9riD4giyXQDIu72bWRU2Dwt1xFSPlBudk6NumK0OJl6Ch+LPnkp5podQHcQg0mMauAXPVKct7g==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.34':
+    resolution: {integrity: sha512-ga5hFhdTwpaNxEiuxZHWnD3ed0GBAzbgzS5tRHpe0ObptxM1a9Xrq6TVfNQirBLwb5Y7T/FJmJi3pmdLy95ljg==}
     cpu: [arm64]
     os: [win32]
 
@@ -8163,8 +8148,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.33':
-    resolution: {integrity: sha512-/tNTvZTWHz6HiVuwpR3zR0kGIyCNb+/tFhnJmti+Aw2fAXs3l7Aj0DcXd0646eFKMX8L2w5hOW9H08FXTUkN0g==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.34':
+    resolution: {integrity: sha512-4/MBp9T9eRnZskxWr8EXD/xHvLhdjWaeX/qY9LPRG1JdCGV3DphkLTy5AWwIQ5jhAy2ZNJR5z2fYRlpWU0sIyQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -8173,8 +8158,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.33':
-    resolution: {integrity: sha512-Bb2qK3z7g2mf4zaKRvkohHzweaP1lLbaoBmXZFkY6jJWMm0Z8Pfnh8cOoRlH1IVM1Ufbo8ZZ1WXp1LbOpRMtXw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.34':
+    resolution: {integrity: sha512-7O5iUBX6HSBKlQU4WykpUoEmb0wQmonb6ziKFr3dJTHud2kzDnWMqk344T0qm3uGv9Ddq6Re/94pInxo1G2d4w==}
     cpu: [x64]
     os: [win32]
 
@@ -9088,10 +9073,6 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
-
-  '@types/handlebars@4.1.0':
-    resolution: {integrity: sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==}
-    deprecated: This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -25742,13 +25723,13 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.33':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.33':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-beta.30':
@@ -25760,13 +25741,13 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.33':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.33':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.30':
@@ -25775,13 +25756,13 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.33':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.33':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.30':
@@ -25792,19 +25773,19 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.33':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.33':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.34':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.30':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.33':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.34':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.30': {}
@@ -26871,10 +26852,6 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.17.0
-
-  '@types/handlebars@4.1.0':
-    dependencies:
-      handlebars: 4.7.8
 
   '@types/hast@2.3.10':
     dependencies:
@@ -32585,6 +32562,7 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
+    optional: true
 
   has-bigints@1.1.0: {}
 


### PR DESCRIPTION
It seems like I've never enabled the "unused dependency check" in tsdown. This patch enables it again and removes unused dependencies found in the repository.