### PR TITLE
feat(core): infer tool name from function

### DIFF
--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -591,7 +591,7 @@ export function tool<SchemaT extends ZodStringV3, ToolOutputT = ToolOutputType>(
     ToolOutputT,
     ToolRunnableConfig
   >,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ): DynamicTool<ToolOutputT>;
 
 export function tool<SchemaT extends ZodStringV4, ToolOutputT = ToolOutputType>(
@@ -600,7 +600,7 @@ export function tool<SchemaT extends ZodStringV4, ToolOutputT = ToolOutputType>(
     ToolOutputT,
     ToolRunnableConfig
   >,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ): DynamicTool<ToolOutputT>;
 
 export function tool<
@@ -610,7 +610,7 @@ export function tool<
   ToolOutputT = ToolOutputType
 >(
   func: RunnableFunc<SchemaOutputT, ToolOutputT, ToolRunnableConfig>,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ): DynamicStructuredTool<SchemaT, SchemaOutputT, SchemaInputT, ToolOutputT>;
 
 export function tool<
@@ -620,7 +620,7 @@ export function tool<
   ToolOutputT = ToolOutputType
 >(
   func: RunnableFunc<SchemaOutputT, ToolOutputT, ToolRunnableConfig>,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ): DynamicStructuredTool<SchemaT, SchemaOutputT, SchemaInputT, ToolOutputT>;
 
 export function tool<
@@ -634,7 +634,7 @@ export function tool<
     ToolOutputT,
     ToolRunnableConfig
   >,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ): DynamicStructuredTool<SchemaT, SchemaOutputT, SchemaInputT, ToolOutputT>;
 
 export function tool<
@@ -647,13 +647,13 @@ export function tool<
   ToolOutputT = ToolOutputType
 >(
   func: RunnableFunc<SchemaOutputT, ToolOutputT, ToolRunnableConfig>,
-  fields: ToolWrapperParams<SchemaT>
+  fields?: ToolWrapperParams<SchemaT>
 ):
   | DynamicStructuredTool<SchemaT, SchemaOutputT, SchemaInputT, ToolOutputT>
   | DynamicTool<ToolOutputT> {
-  const isSimpleStringSchema = isSimpleStringZodSchema(fields.schema);
-  const isStringJSONSchema = validatesOnlyStrings(fields.schema);
-  const toolName = fields.name ?? func.name;
+  const isSimpleStringSchema = isSimpleStringZodSchema(fields?.schema);
+  const isStringJSONSchema = validatesOnlyStrings(fields?.schema);
+  const toolName = fields?.name ?? func.name;
 
   if (!toolName) {
     throw new Error(
@@ -662,13 +662,13 @@ export function tool<
   }
 
   // If the schema is not provided, or it's a simple string schema, create a DynamicTool
-  if (!fields.schema || isSimpleStringSchema || isStringJSONSchema) {
+  if (!fields?.schema || isSimpleStringSchema || isStringJSONSchema) {
     return new DynamicTool<ToolOutputT>({
       ...fields,
       name: toolName,
       description:
-        fields.description ??
-        (fields.schema as { description?: string } | undefined)?.description ??
+        fields?.description ??
+        (fields?.schema as { description?: string } | undefined)?.description ??
         `${toolName} tool`,
       func: async (input, runManager, config) => {
         return new Promise<ToolOutputT>((resolve, reject) => {
@@ -692,7 +692,7 @@ export function tool<
     });
   }
 
-  const schema = fields.schema as InteropZodObject | JSONSchema;
+  const schema = fields?.schema as InteropZodObject | JSONSchema;
 
   const description =
     fields.description ??

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -416,6 +416,43 @@ Details: [
 ]`);
 });
 
+describe("Tool name", () => {
+  test("is required", () => {
+    expect(() => {
+      tool(() => {
+        return "Sunny";
+      }, {});
+    }).toThrow("Tool name is required");
+  });
+
+  test("is inferred from the function name", () => {
+    const t = tool(function myTool() {
+      return "Sunny";
+    }, {});
+    expect(t.name).toBe("myTool");
+  });
+
+  it("is inferred from the option", () => {
+    const t = tool(
+      () => {
+        return "Sunny";
+      },
+      { name: "myTool" }
+    );
+    expect(t.name).toBe("myTool");
+  });
+
+  it("name option takes precedence over the function name", () => {
+    const t = tool(
+      function myTool() {
+        return "Sunny";
+      },
+      { name: "myTool2" }
+    );
+    expect(t.name).toBe("myTool2");
+  });
+});
+
 describe("isStructuredToolParams", () => {
   test("returns true for a tool with a zod schema", () => {
     const zodToolParams: StructuredToolParams = {

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -12,6 +12,13 @@ import {
 import { ToolMessage } from "../../messages/tool.js";
 import { RunnableConfig } from "../../runnables/types.js";
 
+test("should not require any fields", () => {
+  const t = tool(function myTool() {
+    return "Sunny";
+  });
+  expect(t.name).toBe("myTool");
+});
+
 test("Tool should error if responseFormat is content_and_artifact but the function doesn't return a tuple", async () => {
   const weatherSchema = z.object({
     location: z.string(),

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -13,6 +13,7 @@ import { ToolMessage } from "../../messages/tool.js";
 import { RunnableConfig } from "../../runnables/types.js";
 
 test("should not require any fields", () => {
+  // eslint-disable-next-line prefer-arrow-callback
   const t = tool(function myTool() {
     return "Sunny";
   });
@@ -433,6 +434,7 @@ describe("Tool name", () => {
   });
 
   test("is inferred from the function name", () => {
+    // eslint-disable-next-line prefer-arrow-callback
     const t = tool(function myTool() {
       return "Sunny";
     }, {});
@@ -451,6 +453,7 @@ describe("Tool name", () => {
 
   it("name option takes precedence over the function name", () => {
     const t = tool(
+      // eslint-disable-next-line prefer-arrow-callback
       function myTool() {
         return "Sunny";
       },


### PR DESCRIPTION
We can infer the tool name directly from the function allowing users to simplify a tool initiation to just:

```ts
const myTool = tool(function myTool() => {
  return "some result
})
```