### PR TITLE
docs(retrievers): Correct the grammatical errors in the retriever doc…

### DIFF
--- a/docs/core_docs/docs/concepts/retrievers.mdx
+++ b/docs/core_docs/docs/concepts/retrievers.mdx
@@ -57,7 +57,7 @@ Despite the flexibility of the retriever interface, a few common types of retrie
 ### Search apis
 
 It's important to note that retrievers don't need to actually _store_ documents.
-For example, we can be built retrievers on top of search APIs that simply return search results!
+For example, we can build retrievers on top of search APIs that simply return search results!
 
 ### Relational or graph database
 


### PR DESCRIPTION
Fix the grammar error. Change the statement to: 
“For example, we can build retrievers on top of search APIs that simply return search results! ”

Fixes #8784

