### PR TITLE
fix(langchain): bump peer dep to core

### DIFF
--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -29,7 +29,7 @@
     "js-tiktoken": "^1.0.12"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.21 <0.4.0 || ^1.0.0-alpha"
+    "@langchain/core": "^1.0.0-alpha"
   },
   "devDependencies": {
     "@langchain/core": "workspace:*",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -29,7 +29,7 @@
     "js-tiktoken": "^1.0.12"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.21 <0.4.0"
+    "@langchain/core": ">=1.x"
   },
   "devDependencies": {
     "@langchain/core": "workspace:*",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -29,7 +29,7 @@
     "js-tiktoken": "^1.0.12"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.x"
+    "@langchain/core": ">=0.2.21 <0.4.0 || ^1.0.0-alpha"
   },
   "devDependencies": {
     "@langchain/core": "workspace:*",

--- a/libs/langchain-textsplitters/package.json
+++ b/libs/langchain-textsplitters/package.json
@@ -29,7 +29,7 @@
     "js-tiktoken": "^1.0.12"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0-alpha"
+    "@langchain/core": "^1.0.0-alpha.1 <2.0.0"
   },
   "devDependencies": {
     "@langchain/core": "workspace:*",

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -65,7 +65,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0-alpha",
+    "@langchain/core": "^1.0.0-alpha.1 <2.0.0",
     "cheerio": "*",
     "peggy": "^3.0.2",
     "typeorm": "*"

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -65,7 +65,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.58 <0.4.0",
+    "@langchain/core": ">=1.x",
     "cheerio": "*",
     "peggy": "^3.0.2",
     "typeorm": "*"

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -66,7 +66,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.58 <0.4.0 || ^1.0.0-alpha",
+    "@langchain/core": "^1.0.0-alpha",
     "cheerio": "*",
     "peggy": "^3.0.2",
     "typeorm": "*"
@@ -86,6 +86,7 @@
     "@langchain/openai": "workspace:*",
     "@langchain/textsplitters": "workspace:*",
     "@langchain/langgraph": "^1.0.0-alpha",
+    "@langchain/langgraph-checkpoint": "^0.1.1",
     "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",
     "openapi-types": "^12.1.3",
@@ -95,7 +96,6 @@
     "zod": "^3.25.32"
   },
   "optionalDependencies": {
-    "@langchain/langgraph-checkpoint": "^0.1.0",
     "langsmith": "^0.3.64"
   },
   "publishConfig": {

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -35,6 +35,7 @@
     "@langchain/anthropic": "workspace:*",
     "@langchain/cohere": "workspace:*",
     "@langchain/core": "workspace:*",
+    "@langchain/langgraph-checkpoint": "^0.1.0",
     "@tsconfig/recommended": "^1.0.2",
     "@types/js-yaml": "^4",
     "@types/jsdom": "^21.1.1",
@@ -85,7 +86,6 @@
     "@langchain/openai": "workspace:*",
     "@langchain/textsplitters": "workspace:*",
     "@langchain/langgraph": "^1.0.0-alpha",
-    "@langchain/langgraph-checkpoint": "^0.1.0",
     "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",
     "openapi-types": "^12.1.3",
@@ -95,6 +95,7 @@
     "zod": "^3.25.32"
   },
   "optionalDependencies": {
+    "@langchain/langgraph-checkpoint": "^0.1.0",
     "langsmith": "^0.3.64"
   },
   "publishConfig": {

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -35,7 +35,6 @@
     "@langchain/anthropic": "workspace:*",
     "@langchain/cohere": "workspace:*",
     "@langchain/core": "workspace:*",
-    "@langchain/langgraph-checkpoint": "^0.1.0",
     "@tsconfig/recommended": "^1.0.2",
     "@types/js-yaml": "^4",
     "@types/jsdom": "^21.1.1",

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -65,7 +65,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.x",
+    "@langchain/core": ">=0.3.58 <0.4.0 || ^1.0.0-alpha",
     "cheerio": "*",
     "peggy": "^3.0.2",
     "typeorm": "*"
@@ -84,7 +84,7 @@
   "dependencies": {
     "@langchain/openai": "workspace:*",
     "@langchain/textsplitters": "workspace:*",
-    "@langchain/langgraph": "^0.4.3",
+    "@langchain/langgraph": "^1.0.0-alpha",
     "@langchain/langgraph-checkpoint": "^0.1.0",
     "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",

--- a/libs/langchain/src/agents/tests/types.test-d.ts
+++ b/libs/langchain/src/agents/tests/types.test-d.ts
@@ -2,7 +2,7 @@
 import { describe, it, expectTypeOf } from "vitest";
 import { z } from "zod";
 import { SystemMessage, BaseMessage } from "@langchain/core/messages";
-import { BaseStore } from "@langchain/langgraph-checkpoint";
+import { type BaseStore } from "@langchain/langgraph-checkpoint";
 
 import { createReactAgent } from "../index.js";
 import { FakeToolCallingModel } from "./utils.js";

--- a/libs/langchain/src/hub/base.ts
+++ b/libs/langchain/src/hub/base.ts
@@ -1,6 +1,7 @@
 import type { BaseLanguageModel } from "@langchain/core/language_models/base";
 import type { Runnable } from "@langchain/core/runnables";
 import type { Client, ClientConfig } from "langsmith";
+import type { PromptCommit } from "langsmith/schemas";
 
 /**
  * Push a prompt to the hub.
@@ -43,7 +44,7 @@ export async function basePush(
 export async function basePull(
   ownerRepoCommit: string,
   options?: { apiKey?: string; apiUrl?: string; includeModel?: boolean }
-) {
+): Promise<PromptCommit> {
   const Client = await loadLangSmith();
   const client = new Client(options);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,9 +785,6 @@ importers:
       '@langchain/langgraph':
         specifier: ^1.0.0-alpha
         version: 1.0.0-alpha.0(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint':
-        specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@libs+langchain-core)
       '@langchain/openai':
         specifier: workspace:*
         version: link:../providers/langchain-openai
@@ -907,6 +904,9 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
     optionalDependencies:
+      '@langchain/langgraph-checkpoint':
+        specifier: ^0.1.0
+        version: 0.1.0(@langchain/core@libs+langchain-core)
       langsmith:
         specifier: ^0.3.64
         version: 0.3.64(@opentelemetry/api@1.9.0)(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,8 +783,8 @@ importers:
   libs/langchain:
     dependencies:
       '@langchain/langgraph':
-        specifier: ^0.4.3
-        version: 0.4.5(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))
+        specifier: ^1.0.0-alpha
+        version: 1.0.0-alpha.0(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
       '@langchain/langgraph-checkpoint':
         specifier: ^0.1.0
         version: 0.1.0(@langchain/core@libs+langchain-core)
@@ -6989,8 +6989,8 @@ packages:
       react-dom:
         optional: true
 
-  '@langchain/langgraph-sdk@0.0.107':
-    resolution: {integrity: sha512-2qzboDgYH8KJNz7q2Yzvj6H9i4iZUYfZnB7xY+Dkye6yvI+2m1fFIdpP/Ppu+eFvoIUAsbDHDF+wvR4F11kS3Q==}
+  '@langchain/langgraph-sdk@0.0.112':
+    resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
     peerDependencies:
       '@langchain/core': workspace:*
       react: ^18 || ^19
@@ -7013,11 +7013,12 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@langchain/langgraph@0.4.5':
-    resolution: {integrity: sha512-LpKDe/SROC9/qIPkuGiyBkIeuPJ4FxWljaJPd8P2cp6IjYI8UqWk7w6IHiq+JIB1oPPcKGprc3D4OZjq59WHzQ==}
+  '@langchain/langgraph@1.0.0-alpha.0':
+    resolution: {integrity: sha512-cCYqWW3/aoU4V6oURiL5sd/uij1r0u/nJT/Po4L8C8HhFM07JlI0Eg92yfkP+Cy9T5gMwta5UX2GtOS3LuurGA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': workspace:*
+      zod: ^3.25.32
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
       zod-to-json-schema:
@@ -24515,7 +24516,7 @@ snapshots:
       react: 19.0.0
       react-dom: 18.3.1(react@19.0.0)
 
-  '@langchain/langgraph-sdk@0.0.107(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)':
+  '@langchain/langgraph-sdk@0.0.112(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
@@ -24539,11 +24540,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@0.4.5(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))':
+  '@langchain/langgraph@1.0.0-alpha.0(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@langchain/core': link:libs/langchain-core
       '@langchain/langgraph-checkpoint': 0.1.0(@langchain/core@libs+langchain-core)
-      '@langchain/langgraph-sdk': 0.0.107(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
+      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
       uuid: 10.0.0
       zod: 3.25.76
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,9 @@ importers:
       '@langchain/langgraph':
         specifier: ^1.0.0-alpha
         version: 1.0.0-alpha.0(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint':
+        specifier: ^0.1.1
+        version: 0.1.1(@langchain/core@libs+langchain-core)
       '@langchain/openai':
         specifier: workspace:*
         version: link:../providers/langchain-openai
@@ -904,9 +907,6 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
     optionalDependencies:
-      '@langchain/langgraph-checkpoint':
-        specifier: ^0.1.0
-        version: 0.1.0(@langchain/core@libs+langchain-core)
       langsmith:
         specifier: ^0.3.64
         version: 0.3.64(@opentelemetry/api@1.9.0)(openai@5.11.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))
@@ -6969,8 +6969,8 @@ packages:
     peerDependencies:
       '@langchain/core': workspace:*
 
-  '@langchain/langgraph-checkpoint@0.1.0':
-    resolution: {integrity: sha512-7oY5b0VQSxcV3DgoHdXiCgBhEzml/ZjZfKNeuq6oZ3ggcdUICa/fzrIBbFju6gxPU8ly93s0OsjF4yURnHw70Q==}
+  '@langchain/langgraph-checkpoint@0.1.1':
+    resolution: {integrity: sha512-h2bP0RUikQZu0Um1ZUPErQLXyhzroJqKRbRcxYRTAh49oNlsfeq4A3K4YEDRbGGuyPZI/Jiqwhks1wZwY73AZw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': workspace:*
@@ -24500,7 +24500,7 @@ snapshots:
       '@langchain/core': link:libs/langchain-core
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@0.1.0(@langchain/core@libs+langchain-core)':
+  '@langchain/langgraph-checkpoint@0.1.1(@langchain/core@libs+langchain-core)':
     dependencies:
       '@langchain/core': link:libs/langchain-core
       uuid: 10.0.0
@@ -24543,7 +24543,7 @@ snapshots:
   '@langchain/langgraph@1.0.0-alpha.0(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@langchain/core': link:libs/langchain-core
-      '@langchain/langgraph-checkpoint': 0.1.0(@langchain/core@libs+langchain-core)
+      '@langchain/langgraph-checkpoint': 0.1.1(@langchain/core@libs+langchain-core)
       '@langchain/langgraph-sdk': 0.0.112(@langchain/core@libs+langchain-core)(react-dom@18.3.1(react@19.0.0))(react@19.0.0)
       uuid: 10.0.0
       zod: 3.25.76


### PR DESCRIPTION
Bumping peer dependencies to `@langchain/core` and `@langchain/textsplitters`