### PR TITLE
fix(langchain): handle tool errors when handleToolErrors is set to `true` (default)

### DIFF
--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -48,15 +48,14 @@ export interface ToolNodeOptions {
    * Whether to throw the error immediately if the tool fails or handle it by the `onToolError` function or via ToolMessage.
    *
    * If `true` (default):
-   *   - the error can be handled by the `onToolError` function if provided or
-   *   - a tool message with the error message will be returned to the LLM
+   *   - a tool message with the error will be returned to the LLM
    *
    * If `false`:
    *   - the error will be thrown immediately
    *
    * If a function is provided:
-   *   - you can catch the error and return a {@link ToolMessage} as result
-   *   - throw if the function returns undefined
+   *   - returns a custom {@link ToolMessage} as result
+   *   - throws an error otherwise
    *
    * @default true
    */
@@ -301,6 +300,12 @@ export class ToolNode<
         if (result && isToolMessage(result)) {
           return result;
         }
+      } else if (this.handleToolErrors) {
+        return new ToolMessage({
+          name: call.name,
+          content: `Error: ${e}\n Please fix your mistakes.`,
+          tool_call_id: call.id!,
+        });
       }
 
       /**

--- a/libs/langchain/src/agents/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/tests/ToolNode.test.ts
@@ -795,6 +795,32 @@ describe("ToolNode error handling", () => {
     ).rejects.toThrow(GraphInterrupt);
   });
 
+  it("should handle tool errors by default", async () => {
+    const toolWithError = tool(
+      async (_) => {
+        throw new Error("some error");
+      },
+      {
+        name: "tool_with_interrupt",
+        description: "A tool that returns an interrupt",
+        schema: z.object({}),
+      }
+    );
+    const toolNode = new ToolNode([toolWithError]);
+    await expect(
+      toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: "",
+            tool_calls: [
+              { name: "tool_with_interrupt", args: {}, id: "testid" },
+            ],
+          }),
+        ],
+      })
+    ).rejects.toThrow(/Please fix your mistakes./);
+  });
+
   it("should throw if handleToolErrors is false", async () => {
     const toolWithError = tool(
       async (_) => {

--- a/libs/langchain/src/agents/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/tests/ToolNode.test.ts
@@ -816,7 +816,7 @@ describe("ToolNode error handling", () => {
       ],
     });
     expect(result.messages[0].content).toBe(
-      "Error: some error\n Please fix your mistakes."
+      "Error: Error: some error\n Please fix your mistakes."
     );
   });
 

--- a/libs/langchain/src/agents/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/tests/ToolNode.test.ts
@@ -795,7 +795,7 @@ describe("ToolNode error handling", () => {
     ).rejects.toThrow(GraphInterrupt);
   });
 
-  it("should handle tool errors by default", async () => {
+  it.only("should handle tool errors by default", async () => {
     const toolWithError = tool(
       async (_) => {
         throw new Error("some error");
@@ -807,18 +807,17 @@ describe("ToolNode error handling", () => {
       }
     );
     const toolNode = new ToolNode([toolWithError]);
-    await expect(
-      toolNode.invoke({
-        messages: [
-          new AIMessage({
-            content: "",
-            tool_calls: [
-              { name: "tool_with_interrupt", args: {}, id: "testid" },
-            ],
-          }),
-        ],
-      })
-    ).rejects.toThrow(/Please fix your mistakes./);
+    const result = await toolNode.invoke({
+      messages: [
+        new AIMessage({
+          content: "",
+          tool_calls: [{ name: "tool_with_interrupt", args: {}, id: "testid" }],
+        }),
+      ],
+    });
+    expect(result.messages[0].content).toBe(
+      "Error: some error\n Please fix your mistakes."
+    );
   });
 
   it("should throw if handleToolErrors is false", async () => {

--- a/libs/langchain/src/agents/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/tests/ToolNode.test.ts
@@ -795,7 +795,7 @@ describe("ToolNode error handling", () => {
     ).rejects.toThrow(GraphInterrupt);
   });
 
-  it.only("should handle tool errors by default", async () => {
+  it("should handle tool errors by default", async () => {
     const toolWithError = tool(
       async (_) => {
         throw new Error("some error");


### PR DESCRIPTION
Minor oversight on my part. Discovered while updating docs.