### PR TITLE
feat: add personalAccessToken to jira loader (as in confluence loader)

### DIFF
--- a/libs/langchain-community/src/document_loaders/web/jira.ts
+++ b/libs/langchain-community/src/document_loaders/web/jira.ts
@@ -316,8 +316,9 @@ export class JiraDocumentConverter {
 export interface JiraProjectLoaderParams {
   host: string;
   projectKey: string;
-  username: string;
-  accessToken: string;
+  username?: string;
+  accessToken?: string;
+  personalAccessToken?: string;
   limitPerRequest?: number;
   createdAfter?: Date;
 }
@@ -330,19 +331,21 @@ const API_ENDPOINTS = {
  * Class representing a document loader for loading pages from Confluence.
  */
 export class JiraProjectLoader extends BaseDocumentLoader {
-  private readonly accessToken: string;
+  private readonly accessToken?: string;
 
   public readonly host: string;
 
   public readonly projectKey: string;
 
-  public readonly username: string;
+  public readonly username?: string;
 
   public readonly limitPerRequest: number;
 
   private readonly createdAfter?: Date;
 
   private readonly documentConverter: JiraDocumentConverter;
+
+  private readonly personalAccessToken?: string;
 
   constructor({
     host,
@@ -351,6 +354,7 @@ export class JiraProjectLoader extends BaseDocumentLoader {
     accessToken,
     limitPerRequest = 100,
     createdAfter,
+    personalAccessToken,
   }: JiraProjectLoaderParams) {
     super();
     this.host = host;
@@ -360,12 +364,18 @@ export class JiraProjectLoader extends BaseDocumentLoader {
     this.limitPerRequest = limitPerRequest;
     this.createdAfter = createdAfter;
     this.documentConverter = new JiraDocumentConverter({ host, projectKey });
+    this.personalAccessToken = personalAccessToken;
   }
 
   private buildAuthorizationHeader(): string {
-    return `Basic ${Buffer.from(
-      `${this.username}:${this.accessToken}`
-    ).toString("base64")}`;
+    if (this.personalAccessToken) {
+      return `Bearer ${this.personalAccessToken}`;
+    } else if (this.username && this.accessToken) {
+      return `Basic ${Buffer.from(
+        `${this.username}:${this.accessToken}`
+      ).toString("base64")}`;
+    }
+    throw new Error("No authentication method provided");
   }
 
   public async load(): Promise<Document[]> {


### PR DESCRIPTION
### Description

This is my first PR to LangChain.js 🙂  
It adds support for authenticating the `JiraProjectLoader` with a `personalAccessToken`.  
When provided, it will be used as a Bearer token in the `Authorization` header, similar to the Confluence loader.  
This change is backwards compatible with existing authentication methods.
