### PR TITLE
feat(community): add jira issue title to metadata for documents

### DIFF
--- a/libs/langchain-community/src/document_loaders/tests/jira.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/jira.test.ts
@@ -35,7 +35,7 @@ describe("JiraDocumentConverter Unit Tests", () => {
       id: issue.id,
       host: converter.host,
       projectKey: converter.projectKey,
-      title: "Caveo aurum adipisci tonsor.",
+      title: expect.any(String),
     });
   });
 

--- a/libs/langchain-community/src/document_loaders/tests/jira.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/jira.test.ts
@@ -35,6 +35,7 @@ describe("JiraDocumentConverter Unit Tests", () => {
       id: issue.id,
       host: converter.host,
       projectKey: converter.projectKey,
+      title: "Caveo aurum adipisci tonsor.",
     });
   });
 

--- a/libs/langchain-community/src/document_loaders/web/jira.ts
+++ b/libs/langchain-community/src/document_loaders/web/jira.ts
@@ -185,6 +185,7 @@ export class JiraDocumentConverter {
       }),
       metadata: {
         id: issue.id,
+        title: issue.fields.summary,
         host: this.host,
         projectKey: this.projectKey,
       },


### PR DESCRIPTION
### Description

This PR adds the `title` field to the metadata of jira documents.
The value is taken from the Jira issue’s `summary` field.  

Docs:
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-post
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post