### PR TITLE
fix(langchain): add support for toolMessageContent

### DIFF
--- a/libs/langchain/src/agents/responses.ts
+++ b/libs/langchain/src/agents/responses.ts
@@ -323,6 +323,11 @@ export type ToolStrategyError =
   | MultipleStructuredOutputsError;
 export interface ToolStrategyOptions {
   /**
+   * Allows you to customize the message that appears in the conversation history when structured
+   * output is generated.
+   */
+  toolMessageContent?: string;
+  /**
    * Handle errors from the structured output tool call. Using tools to generate structured output
    * can cause errors, e.g. if:
    * - you provide multiple structured output schemas and the model calls multiple structured output tools

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -263,6 +263,14 @@ describe("structured output handling", () => {
         });
 
         expect(res.structuredResponse).toEqual({ foo: "bar" });
+
+        /**
+         * We expect 3 messages:
+         * 1. The user message
+         * 2. The tool message
+         * 3. The structured response message
+         */
+        expect(res.messages.length).toBe(3);
         expect(res.messages.at(-1)?.content).toContain("foobar");
       });
 

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -238,10 +238,38 @@ describe("structured output handling", () => {
         expect(res.structuredResponse).toEqual({ foo: "bar" });
       });
 
+      it("should return a structured response if it matches the schema and toolMessageContent is provided", async () => {
+        const model = new FakeToolCallingModel({
+          toolCalls: [
+            [{ name: "extract-13", args: { foo: "bar" }, id: "call_1" }],
+          ],
+        });
+
+        const agent = createReactAgent({
+          llm: model,
+          tools: [],
+          responseFormat: toolStrategy(
+            z.object({
+              foo: z.string(),
+            }),
+            {
+              toolMessageContent: "foobar",
+            }
+          ),
+        });
+
+        const res = await agent.invoke({
+          messages: [{ role: "user", content: "hi" }],
+        });
+
+        expect(res.structuredResponse).toEqual({ foo: "bar" });
+        expect(res.messages.at(-1)?.content).toContain("foobar");
+      });
+
       it("should return structured response if it matches one of the schemas", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-14", args: { bar: "foo" }, id: "call_1" }],
+            [{ name: "extract-15", args: { bar: "foo" }, id: "call_1" }],
           ],
         });
         const agent = createReactAgent({


### PR DESCRIPTION
This is something I've missed from the Python implementation of structured output.