### PR TITLE
feat(mongodb): auto append client metadata for mongodb

### DIFF
--- a/.changeset/mighty-moments-know.md
+++ b/.changeset/mighty-moments-know.md
@@ -2,4 +2,4 @@
 "@langchain/mongodb": minor
 ---
 
-Updates the mongodb vector search package to append client metadata
+Updates the mongodb vector search, memory, and chat history modules to append client metadata

--- a/.changeset/mighty-moments-know.md
+++ b/.changeset/mighty-moments-know.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mongodb": minor
+---
+
+Updates the mongodb vector search package to append client metadata

--- a/examples/src/memory/mongodb.ts
+++ b/examples/src/memory/mongodb.ts
@@ -4,9 +4,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { ConversationChain } from "langchain/chains";
 import { MongoDBChatMessageHistory } from "@langchain/mongodb";
 
-const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "", {
-  driverInfo: { name: "langchainjs" },
-});
+const client = new MongoClient(process.env.MONGODB_ATLAS_URI || "");
 await client.connect();
 const collection = client.db("langchain").collection("memory");
 

--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -32,7 +32,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "mongodb": "^6.17.0"
+    "mongodb": "baileympearson/node-mongodb-native#NODE-7138"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.2.21 <0.4.0"

--- a/libs/langchain-mongodb/package.json
+++ b/libs/langchain-mongodb/package.json
@@ -32,7 +32,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "mongodb": "baileympearson/node-mongodb-native#NODE-7138"
+    "mongodb": "^6.20.0"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.2.21 <0.4.0"

--- a/libs/langchain-mongodb/src/chat_history.ts
+++ b/libs/langchain-mongodb/src/chat_history.ts
@@ -10,6 +10,7 @@ import {
   mapChatMessagesToStoredMessages,
   mapStoredMessagesToChatMessages,
 } from "@langchain/core/messages";
+import { VERSION } from "./version.js";
 
 export interface MongoDBChatMessageHistoryInput {
   collection: Collection<MongoDBDocument>;
@@ -40,6 +41,10 @@ export class MongoDBChatMessageHistory extends BaseListChatMessageHistory {
     super();
     this.collection = collection;
     this.sessionId = sessionId;
+    this.collection.db.client.appendMetadata({
+      name: 'langchainjs_chat_history',
+      version: VERSION
+    });
   }
 
   async getMessages(): Promise<BaseMessage[]> {

--- a/libs/langchain-mongodb/src/chat_history.ts
+++ b/libs/langchain-mongodb/src/chat_history.ts
@@ -10,7 +10,6 @@ import {
   mapChatMessagesToStoredMessages,
   mapStoredMessagesToChatMessages,
 } from "@langchain/core/messages";
-import { VERSION } from "./version.js";
 
 export interface MongoDBChatMessageHistoryInput {
   collection: Collection<MongoDBDocument>;
@@ -42,8 +41,7 @@ export class MongoDBChatMessageHistory extends BaseListChatMessageHistory {
     this.collection = collection;
     this.sessionId = sessionId;
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_chat_history',
-      version: VERSION
+      name: 'langchainjs_chat_history'
     });
   }
 

--- a/libs/langchain-mongodb/src/chat_history.ts
+++ b/libs/langchain-mongodb/src/chat_history.ts
@@ -41,7 +41,7 @@ export class MongoDBChatMessageHistory extends BaseListChatMessageHistory {
     this.collection = collection;
     this.sessionId = sessionId;
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_chat_history'
+      name: "langchainjs_chat_history",
     });
   }
 

--- a/libs/langchain-mongodb/src/storage.ts
+++ b/libs/langchain-mongodb/src/storage.ts
@@ -1,5 +1,6 @@
 import { BaseStore } from "@langchain/core/stores";
 import { Collection, Document as MongoDocument } from "mongodb";
+import { VERSION } from "./version.js";
 
 /**
  * Type definition for the input parameters required to initialize an
@@ -65,6 +66,10 @@ export class MongoDBStore extends BaseStore<string, Uint8Array> {
     this.yieldKeysScanBatchSize =
       fields.yieldKeysScanBatchSize ?? this.yieldKeysScanBatchSize;
     this.namespace = fields.namespace;
+    this.collection.db.client.appendMetadata({
+      name: 'langchainjs_storage',
+      version: VERSION
+    });
   }
 
   _getPrefixedKey(key: string) {

--- a/libs/langchain-mongodb/src/storage.ts
+++ b/libs/langchain-mongodb/src/storage.ts
@@ -66,7 +66,7 @@ export class MongoDBStore extends BaseStore<string, Uint8Array> {
       fields.yieldKeysScanBatchSize ?? this.yieldKeysScanBatchSize;
     this.namespace = fields.namespace;
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_storage'
+      name: "langchainjs_storage",
     });
   }
 

--- a/libs/langchain-mongodb/src/storage.ts
+++ b/libs/langchain-mongodb/src/storage.ts
@@ -1,6 +1,5 @@
 import { BaseStore } from "@langchain/core/stores";
 import { Collection, Document as MongoDocument } from "mongodb";
-import { VERSION } from "./version.js";
 
 /**
  * Type definition for the input parameters required to initialize an
@@ -67,8 +66,7 @@ export class MongoDBStore extends BaseStore<string, Uint8Array> {
       fields.yieldKeysScanBatchSize ?? this.yieldKeysScanBatchSize;
     this.namespace = fields.namespace;
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_storage',
-      version: VERSION
+      name: 'langchainjs_storage'
     });
   }
 

--- a/libs/langchain-mongodb/src/tests/chat_history.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/chat_history.int.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-process-env */
-
+import { beforeAll, expect, test } from "@jest/globals";
 import { Collection, MongoClient, ObjectId } from "mongodb";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { MongoDBChatMessageHistory } from "../chat_history.js";

--- a/libs/langchain-mongodb/src/tests/storage.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/storage.int.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-process-env */
+import { beforeAll, expect, test } from "@jest/globals";
 import { v4 as uuidv4 } from "uuid";
 import { Collection, MongoClient, ServerApiVersion } from "mongodb";
 import { MongoDBStore } from "../storage.js";

--- a/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -12,7 +12,6 @@ import { Document as BSONDocument } from "bson";
 import { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 import { isUsingLocalAtlas, uri, waitForIndexToBeQueryable } from "./utils.js";
-import { VERSION } from "../version.js";
 
 /**
  * The following json can be used to create an index in atlas for Cohere embeddings.
@@ -122,7 +121,7 @@ test("MongoDBStore sets client metadata", () => {
       collection,
     }
   );
-  expect(spy).toHaveBeenCalledWith({ name: "langchainjs_vector", version: VERSION });
+  expect(spy).toHaveBeenCalledWith({ name: "langchainjs_vector" });
   jest.clearAllMocks();
 });
 

--- a/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -116,11 +116,9 @@ function getEmbeddings() {
 test("MongoDBStore sets client metadata", () => {
   const spy = jest.spyOn(client, "appendMetadata");
   // eslint-disable-next-line no-new
-  new PatchedVectorStore(
-    getEmbeddings(), {
-      collection,
-    }
-  );
+  new PatchedVectorStore(getEmbeddings(), {
+    collection,
+  });
   expect(spy).toHaveBeenCalledWith({ name: "langchainjs_vector" });
   jest.clearAllMocks();
 });

--- a/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -12,6 +12,7 @@ import { Document as BSONDocument } from "bson";
 import { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 import { isUsingLocalAtlas, uri, waitForIndexToBeQueryable } from "./utils.js";
+import { VERSION } from "../version.js";
 
 /**
  * The following json can be used to create an index in atlas for Cohere embeddings.
@@ -112,6 +113,18 @@ function getEmbeddings() {
   }
   return new OpenAIEmbeddings();
 }
+
+test("MongoDBStore sets client metadata", () => {
+  const spy = jest.spyOn(client, "appendMetadata");
+  // eslint-disable-next-line no-new
+  new PatchedVectorStore(
+    getEmbeddings(), {
+      collection,
+    }
+  );
+  expect(spy).toHaveBeenCalledWith({ name: "langchainjs_vector", version: VERSION });
+  jest.clearAllMocks();
+});
 
 test("MongoDBAtlasVectorSearch with external ids", async () => {
   const vectorStore = new PatchedVectorStore(getEmbeddings(), {

--- a/libs/langchain-mongodb/src/vectorstores.ts
+++ b/libs/langchain-mongodb/src/vectorstores.ts
@@ -11,7 +11,6 @@ import {
   AsyncCaller,
   AsyncCallerParams,
 } from "@langchain/core/utils/async_caller";
-import { VERSION } from "./version.js";
 
 /**
  * Type that defines the arguments required to initialize the
@@ -81,8 +80,7 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     this.primaryKey = args.primaryKey ?? "_id";
     this.caller = new AsyncCaller(args);
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_vector',
-      version: VERSION
+      name: 'langchainjs_vector'
     });
   }
 

--- a/libs/langchain-mongodb/src/vectorstores.ts
+++ b/libs/langchain-mongodb/src/vectorstores.ts
@@ -11,6 +11,7 @@ import {
   AsyncCaller,
   AsyncCallerParams,
 } from "@langchain/core/utils/async_caller";
+import { VERSION } from "./version.js";
 
 /**
  * Type that defines the arguments required to initialize the
@@ -79,6 +80,10 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     this.embeddingKey = args.embeddingKey ?? "embedding";
     this.primaryKey = args.primaryKey ?? "_id";
     this.caller = new AsyncCaller(args);
+    this.collection.db.client.appendMetadata({
+      name: 'langchainjs_vector',
+      version: VERSION
+    });
   }
 
   /**

--- a/libs/langchain-mongodb/src/vectorstores.ts
+++ b/libs/langchain-mongodb/src/vectorstores.ts
@@ -80,7 +80,7 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     this.primaryKey = args.primaryKey ?? "_id";
     this.caller = new AsyncCaller(args);
     this.collection.db.client.appendMetadata({
-      name: 'langchainjs_vector'
+      name: "langchainjs_vector",
     });
   }
 

--- a/libs/langchain-mongodb/src/version.ts
+++ b/libs/langchain-mongodb/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = '0.1.0';

--- a/libs/langchain-mongodb/src/version.ts
+++ b/libs/langchain-mongodb/src/version.ts
@@ -1,3 +1,0 @@
-import pkg from '../package.json';
-
-export const VERSION = pkg.version;

--- a/libs/langchain-mongodb/src/version.ts
+++ b/libs/langchain-mongodb/src/version.ts
@@ -1,1 +1,3 @@
-export const VERSION = '0.1.0';
+import pkg from '../package.json';
+
+export const VERSION = pkg.version;

--- a/libs/langchain-mongodb/tsconfig.json
+++ b/libs/langchain-mongodb/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedParameters": true,
     "useDefineForClassFields": true,
     "strictPropertyInitialization": false,
+    "resolveJsonModule": true,
     "allowJs": true,
     "strict": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10165,7 +10165,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
-    mongodb: ^6.17.0
+    mongodb: "baileympearson/node-mongodb-native#NODE-7138"
     prettier: ^2.8.3
     release-it: ^18.1.2
     rollup: ^4.5.2
@@ -10993,6 +10993,15 @@ __metadata:
   dependencies:
     sparse-bitfield: ^3.0.3
   checksum: 6f13983e41c9fbd5273eeae9135e47e5b7a19125a63287bea69e33a618f8e034cfcf2258c77d0f5d6dcf386dfe2bb520bc01613afd1528c52f82c71172629242
+  languageName: node
+  linkType: hard
+
+"@mongodb-js/saslprep@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@mongodb-js/saslprep@npm:1.3.0"
+  dependencies:
+    sparse-bitfield: ^3.0.3
+  checksum: 0003ab0a943220df74f8ffcf076c4e4fc4105b20d6b1610d802231d2a6d3b74ad0fa9d26e3d828cb07daabe511ffb2760c347f7a4c0f985d8a7770f7d95190a3
   languageName: node
   linkType: hard
 
@@ -31998,6 +32007,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mongodb-connection-string-url@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mongodb-connection-string-url@npm:3.0.2"
+  dependencies:
+    "@types/whatwg-url": ^11.0.2
+    whatwg-url: ^14.1.0 || ^13.0.0
+  checksum: 382319aa41d381ff4be9370024e3cf765ded14aa581bca7c7a171fcaae618b8d92912329b6b13898334c3b6f3cab12ae8785defad2745ca20226ceeb253ef1ae
+  languageName: node
+  linkType: hard
+
+"mongodb@baileympearson/node-mongodb-native#NODE-7138":
+  version: 6.19.0
+  resolution: "mongodb@https://github.com/baileympearson/node-mongodb-native.git#commit=b1d2838be85f0f47ca9ea2761eb8ec4e50d4d7e3"
+  dependencies:
+    "@mongodb-js/saslprep": ^1.3.0
+    bson: ^6.10.4
+    mongodb-connection-string-url: ^3.0.2
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.1.0 || ^2.0.0
+    gcp-metadata: ^5.2.0
+    kerberos: ^2.0.1
+    mongodb-client-encryption: ">=6.0.0 <7"
+    snappy: ^7.3.2
+    socks: ^2.7.1
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    gcp-metadata:
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+    socks:
+      optional: true
+  checksum: 4667a78afb49b660169a93358dd6839deec788712d7c6dc63a7ece700303ebe4bd7f3ec3996212def3f51181405c02f63a2df77e7b2d50e284641e46c7a45ced
+  languageName: node
+  linkType: hard
+
 "mongodb@npm:^6.17.0":
   version: 6.17.0
   resolution: "mongodb@npm:6.17.0"
@@ -39698,6 +39751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: ^2.3.1
+  checksum: da7a04bd3f77e641abdabe948bb84f24e6ee73e81c8c96c36fe79796c889ba97daf3dbacae778f8581ff60307a4136ee14c9540a5f85ebe44f99c6cc39a97690
+  languageName: node
+  linkType: hard
+
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
@@ -42006,6 +42068,16 @@ __metadata:
     tr46: ^5.0.0
     webidl-conversions: ^7.0.0
   checksum: 4b5887e50f786583bead70916413e67a381d2126899b9eb5c67ce664bba1e7ec07cdff791404581ce73c6190d83c359c9ca1d50711631217905db3877dec075c
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^14.1.0 || ^13.0.0":
+  version: 14.2.0
+  resolution: "whatwg-url@npm:14.2.0"
+  dependencies:
+    tr46: ^5.1.0
+    webidl-conversions: ^7.0.0
+  checksum: c4f1ae1d353b9e56ab3c154cd73bf2b621cea1a2499fd2a9b2a17d448c2ed5e73a8922a0f395939de565fc3661461140111ae2aea26d4006a1ad0cfbf021c034
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10165,7 +10165,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
-    mongodb: "baileympearson/node-mongodb-native#NODE-7138"
+    mongodb: ^6.20.0
     prettier: ^2.8.3
     release-it: ^18.1.2
     rollup: ^4.5.2
@@ -32017,40 +32017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb@baileympearson/node-mongodb-native#NODE-7138":
-  version: 6.19.0
-  resolution: "mongodb@https://github.com/baileympearson/node-mongodb-native.git#commit=b1d2838be85f0f47ca9ea2761eb8ec4e50d4d7e3"
-  dependencies:
-    "@mongodb-js/saslprep": ^1.3.0
-    bson: ^6.10.4
-    mongodb-connection-string-url: ^3.0.2
-  peerDependencies:
-    "@aws-sdk/credential-providers": ^3.188.0
-    "@mongodb-js/zstd": ^1.1.0 || ^2.0.0
-    gcp-metadata: ^5.2.0
-    kerberos: ^2.0.1
-    mongodb-client-encryption: ">=6.0.0 <7"
-    snappy: ^7.3.2
-    socks: ^2.7.1
-  peerDependenciesMeta:
-    "@aws-sdk/credential-providers":
-      optional: true
-    "@mongodb-js/zstd":
-      optional: true
-    gcp-metadata:
-      optional: true
-    kerberos:
-      optional: true
-    mongodb-client-encryption:
-      optional: true
-    snappy:
-      optional: true
-    socks:
-      optional: true
-  checksum: 4667a78afb49b660169a93358dd6839deec788712d7c6dc63a7ece700303ebe4bd7f3ec3996212def3f51181405c02f63a2df77e7b2d50e284641e46c7a45ced
-  languageName: node
-  linkType: hard
-
 "mongodb@npm:^6.17.0":
   version: 6.17.0
   resolution: "mongodb@npm:6.17.0"
@@ -32082,6 +32048,40 @@ __metadata:
     socks:
       optional: true
   checksum: bae38d4758e6681b07d35849de18ec8a063d5306fb3dd7d76214b1945440a33a729a1497f4b4da5b0c4f35e0a31c2e6dda632ea9d437e385315d011f93598213
+  languageName: node
+  linkType: hard
+
+"mongodb@npm:^6.20.0":
+  version: 6.20.0
+  resolution: "mongodb@npm:6.20.0"
+  dependencies:
+    "@mongodb-js/saslprep": ^1.3.0
+    bson: ^6.10.4
+    mongodb-connection-string-url: ^3.0.2
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.1.0 || ^2.0.0
+    gcp-metadata: ^5.2.0
+    kerberos: ^2.0.1
+    mongodb-client-encryption: ">=6.0.0 <7"
+    snappy: ^7.3.2
+    socks: ^2.7.1
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    gcp-metadata:
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+    socks:
+      optional: true
+  checksum: 7f427ca631cf57ce2a0b835fe8ad61791e21abb4e5ebf8af83115ad782d0266dd574e3e540a741a1f27dd201d7e035f34681dd6dd6aa495af6e4b61457b38bec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Instead of using the docs show users how to set metadata, this PR adds the ability to add the name to the metadata post client construction in the MongoDB vcetor search, memory, and chat history modules.
