### PR TITLE
fix(langchain): add more message exports

### DIFF
--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -3,10 +3,18 @@
  */
 export {
   BaseMessage,
+  BaseMessageChunk,
   AIMessage,
+  AIMessageChunk,
   SystemMessage,
+  SystemMessageChunk,
   HumanMessage,
+  HumanMessageChunk,
   ToolMessage,
+  ToolMessageChunk,
+  type ContentBlock,
+  filterMessages,
+  trimMessages,
 } from "@langchain/core/messages";
 
 /**


### PR DESCRIPTION
Found these being used quite extensively in the docs, so we should export them from the root.