### PR TITLE
fix(langchain): port and export AgentRuntime

### DIFF
--- a/libs/langchain-core/src/tools/types.ts
+++ b/libs/langchain-core/src/tools/types.ts
@@ -87,7 +87,7 @@ export type ToolRunnableConfig<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigurableFieldType extends Record<string, any> = Record<string, any>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ContextSchema extends Record<string, any> = Record<string, any>
+  ContextSchema = any
 > = RunnableConfig<ConfigurableFieldType> & {
   toolCall?: ToolCall;
   context?: ContextSchema;

--- a/libs/langchain/src/agents/tests/types.test-d.ts
+++ b/libs/langchain/src/agents/tests/types.test-d.ts
@@ -2,9 +2,10 @@
 import { describe, it, expectTypeOf } from "vitest";
 import { z } from "zod";
 import { SystemMessage, BaseMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
 import { type BaseStore } from "@langchain/langgraph-checkpoint";
 
-import { createReactAgent } from "../index.js";
+import { createReactAgent, AgentRuntime } from "../index.js";
 import { FakeToolCallingModel } from "./utils.js";
 
 describe("types", () => {
@@ -70,5 +71,29 @@ describe("types", () => {
       contextSchema,
       tools: [],
     });
+  });
+
+  it("should provide runtime type", () => {
+    const contextSchema = z.object({
+      userId: z.string(),
+    });
+
+    tool(
+      async (_, runtime: AgentRuntime<z.infer<typeof contextSchema>>) => {
+        expectTypeOf(runtime.context).toEqualTypeOf<
+          z.infer<typeof contextSchema> | undefined
+        >();
+        expectTypeOf(runtime.store).toEqualTypeOf<BaseStore | undefined>();
+        expectTypeOf(runtime.writer).toEqualTypeOf<
+          ((chunk: unknown) => void) | undefined
+        >();
+        expectTypeOf(runtime.signal).toEqualTypeOf<AbortSignal | undefined>();
+      },
+      {
+        name: "test",
+        description: "test",
+        schema: z.object({}),
+      }
+    );
   });
 });

--- a/libs/langchain/src/agents/types.ts
+++ b/libs/langchain/src/agents/types.ts
@@ -5,7 +5,6 @@ import type {
 import type {
   LangGraphRunnableConfig,
   START,
-  Runtime,
   StateGraph,
 } from "@langchain/langgraph";
 
@@ -153,11 +152,27 @@ export type AgentState<
     | InteropZodObject = AnyAnnotationRoot
 > = ToAnnotationRoot<AnnotationRoot>["State"] & PreHookAnnotation["State"];
 
-export type AgentRuntime<
-  AnnotationRoot extends
-    | AnyAnnotationRoot
-    | InteropZodObject = AnyAnnotationRoot
-> = Runtime<ToAnnotationRoot<AnnotationRoot>["State"]>;
+export interface AgentRuntime<ContextType = Record<string, unknown>> {
+  /**
+   * The context of the agent.
+   */
+  context?: ContextType;
+
+  /**
+   * The store passed to the agent.
+   */
+  store?: BaseStore;
+
+  /**
+   * The writer of the agent to write to the output stream.
+   */
+  writer?: (chunk: unknown) => void;
+
+  /**
+   * An optional abort signal that indicates that the overall operation should be aborted.
+   */
+  signal?: AbortSignal;
+}
 
 export type CreateReactAgentParams<
   StateSchema extends AnyAnnotationRoot | InteropZodObject = AnyAnnotationRoot,
@@ -463,5 +478,5 @@ type DynamicLLMFunction<
   ContextSchema extends AnyAnnotationRoot | InteropZodObject = AnyAnnotationRoot
 > = (
   state: ToAnnotationRoot<StateSchema>["State"] & PreHookAnnotation["State"],
-  runtime: Runtime<ToAnnotationRoot<ContextSchema>["State"]>
+  runtime: AgentRuntime<ToAnnotationRoot<ContextSchema>["State"]>
 ) => Promise<LanguageModelLike> | LanguageModelLike;

--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -36,6 +36,7 @@ export {
   providerStrategy,
   ToolNode,
   type AgentState,
+  type AgentRuntime,
   type HumanInterrupt,
   type HumanInterruptConfig,
   type ActionRequest,


### PR DESCRIPTION
Let's have user import an `AgentRuntime` type that is similar to Langgraphs version but now can be imported with type comments directly from `langchain`.