### PR TITLE
fix: URL encode paths in GitHub document loader

### DIFF
--- a/libs/langchain-community/src/document_loaders/tests/github.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/github.test.ts
@@ -61,3 +61,53 @@ describe("GithubRepoLoader recursion", () => {
     ).toThrow();
   });
 });
+
+describe("GithubRepoLoader URL encoding", () => {
+  test("Should properly encode special characters in directory paths", async () => {
+    // Mock fetch to capture the URLs being called
+    const mockFetch = jest.fn().mockImplementation((url) => {
+      // Check that special characters are properly encoded in the URL
+      expect(url).toContain("src%2Fapp%2F%255Fmeta"); // The full encoded path
+      
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{
+          name: "%5Fmeta",
+          path: "src/app/%5Fmeta",
+          type: "dir",
+          size: 0,
+          url: "https://api.github.com/repos/test/test/contents/src/app/%5Fmeta",
+          html_url: "",
+          sha: "abc123",
+          git_url: "",
+          download_url: "",
+          _links: {
+            self: "",
+            git: "",
+            html: "",
+          },
+        }]),
+      });
+    });
+
+    global.fetch = mockFetch as any;
+
+    const loader = new GithubRepoLoader(
+      "https://github.com/test/test/tree/main/src/app/%5Fmeta",
+      {
+        branch: "main",
+        recursive: false,
+        unknown: "warn",
+      }
+    );
+
+    // This should call fetchRepoFiles with "src/app/%5Fmeta" path
+    await loader.load();
+    
+    // Verify that fetch was called with properly encoded URL
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("contents/src%2Fapp%2F%255Fmeta"),
+      expect.any(Object)
+    );
+  });
+});

--- a/libs/langchain-community/src/document_loaders/tests/github.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/github.test.ts
@@ -68,25 +68,28 @@ describe("GithubRepoLoader URL encoding", () => {
     const mockFetch = jest.fn().mockImplementation((url) => {
       // Check that special characters are properly encoded in the URL
       expect(url).toContain("src%2Fapp%2F%255Fmeta"); // The full encoded path
-      
+
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([{
-          name: "%5Fmeta",
-          path: "src/app/%5Fmeta",
-          type: "dir",
-          size: 0,
-          url: "https://api.github.com/repos/test/test/contents/src/app/%5Fmeta",
-          html_url: "",
-          sha: "abc123",
-          git_url: "",
-          download_url: "",
-          _links: {
-            self: "",
-            git: "",
-            html: "",
-          },
-        }]),
+        json: () =>
+          Promise.resolve([
+            {
+              name: "%5Fmeta",
+              path: "src/app/%5Fmeta",
+              type: "dir",
+              size: 0,
+              url: "https://api.github.com/repos/test/test/contents/src/app/%5Fmeta",
+              html_url: "",
+              sha: "abc123",
+              git_url: "",
+              download_url: "",
+              _links: {
+                self: "",
+                git: "",
+                html: "",
+              },
+            },
+          ]),
       });
     });
 
@@ -103,7 +106,7 @@ describe("GithubRepoLoader URL encoding", () => {
 
     // This should call fetchRepoFiles with "src/app/%5Fmeta" path
     await loader.load();
-    
+
     // Verify that fetch was called with properly encoded URL
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("contents/src%2Fapp%2F%255Fmeta"),

--- a/libs/langchain-community/src/document_loaders/web/github.ts
+++ b/libs/langchain-community/src/document_loaders/web/github.ts
@@ -647,7 +647,9 @@ export class GithubRepoLoader
    * @returns A promise that resolves to an array of GithubFile instances.
    */
   private async fetchRepoFiles(path: string): Promise<GithubFile[]> {
-    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
+    const url = `${this.apiUrl}/repos/${this.owner}/${
+      this.repo
+    }/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
     return this.caller.call(async () => {
       this.log(`Fetching ${url}`);
       const response = await fetch(url, { headers: this.headers });

--- a/libs/langchain-community/src/document_loaders/web/github.ts
+++ b/libs/langchain-community/src/document_loaders/web/github.ts
@@ -647,7 +647,7 @@ export class GithubRepoLoader
    * @returns A promise that resolves to an array of GithubFile instances.
    */
   private async fetchRepoFiles(path: string): Promise<GithubFile[]> {
-    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`;
+    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
     return this.caller.call(async () => {
       this.log(`Fetching ${url}`);
       const response = await fetch(url, { headers: this.headers });


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
Fix issue where directories with special characters (like '%5Fmeta') would cause 404 errors because paths were not properly URL encoded when constructing GitHub API requests.

- Apply encodeURIComponent() to path parameter in fetchRepoFiles method
- Add unit test to verify proper encoding of paths with special characters