### PR TITLE
fix(community): URL encode paths in GitHub document loader

### DIFF
--- a/libs/langchain-community/src/document_loaders/tests/github.test.ts
+++ b/libs/langchain-community/src/document_loaders/tests/github.test.ts
@@ -68,25 +68,28 @@ describe("GithubRepoLoader URL encoding", () => {
     const mockFetch = jest.fn().mockImplementation((url) => {
       // Check that special characters are properly encoded in the URL
       expect(url).toContain("src%2Fapp%2F%255Fmeta"); // The full encoded path
-      
+
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([{
-          name: "%5Fmeta",
-          path: "src/app/%5Fmeta",
-          type: "dir",
-          size: 0,
-          url: "https://api.github.com/repos/test/test/contents/src/app/%5Fmeta",
-          html_url: "",
-          sha: "abc123",
-          git_url: "",
-          download_url: "",
-          _links: {
-            self: "",
-            git: "",
-            html: "",
-          },
-        }]),
+        json: () =>
+          Promise.resolve([
+            {
+              name: "%5Fmeta",
+              path: "src/app/%5Fmeta",
+              type: "dir",
+              size: 0,
+              url: "https://api.github.com/repos/test/test/contents/src/app/%5Fmeta",
+              html_url: "",
+              sha: "abc123",
+              git_url: "",
+              download_url: "",
+              _links: {
+                self: "",
+                git: "",
+                html: "",
+              },
+            },
+          ]),
       });
     });
 
@@ -103,7 +106,7 @@ describe("GithubRepoLoader URL encoding", () => {
 
     // This should call fetchRepoFiles with "src/app/%5Fmeta" path
     await loader.load();
-    
+
     // Verify that fetch was called with properly encoded URL
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("contents/src%2Fapp%2F%255Fmeta"),

--- a/libs/langchain-community/src/document_loaders/web/github.ts
+++ b/libs/langchain-community/src/document_loaders/web/github.ts
@@ -647,7 +647,9 @@ export class GithubRepoLoader
    * @returns A promise that resolves to an array of GithubFile instances.
    */
   private async fetchRepoFiles(path: string): Promise<GithubFile[]> {
-    const url = `${this.apiUrl}/repos/${this.owner}/${this.repo}/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
+    const url = `${this.apiUrl}/repos/${this.owner}/${
+      this.repo
+    }/contents/${encodeURIComponent(path)}?ref=${this.branch}`;
     return this.caller.call(async () => {
       this.log(`Fetching ${url}`);
       const response = await fetch(url, { headers: this.headers });


### PR DESCRIPTION
continuation of #8847 