### PR TITLE
fix(core): make mustache prompt with nested object working correctly

### DIFF
--- a/.changeset/strong-worms-sneeze.md
+++ b/.changeset/strong-worms-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+make mustache prompt with nested object working correctly

--- a/langchain-core/src/prompts/chat.ts
+++ b/langchain-core/src/prompts/chat.ts
@@ -1064,25 +1064,33 @@ export class ChatPromptTemplate<
           await this._parseImagePrompts(promptMessage, allValues)
         );
       } else {
-        const inputValues = promptMessage.inputVariables.reduce(
-          (acc, inputVariable) => {
-            if (
-              !(inputVariable in allValues) &&
-              !(isMessagesPlaceholder(promptMessage) && promptMessage.optional)
-            ) {
-              const error = addLangChainErrorFields(
-                new Error(
-                  `Missing value for input variable \`${inputVariable.toString()}\``
-                ),
-                "INVALID_PROMPT_INPUT"
-              );
-              throw error;
-            }
-            acc[inputVariable] = allValues[inputVariable];
-            return acc;
-          },
-          {} as InputValues
-        );
+        let inputValues: InputValues;
+
+        if (this.templateFormat === "mustache") {
+          inputValues = { ...allValues };
+        } else {
+          inputValues = promptMessage.inputVariables.reduce(
+            (acc, inputVariable) => {
+              if (
+                !(inputVariable in allValues) &&
+                !(
+                  isMessagesPlaceholder(promptMessage) && promptMessage.optional
+                )
+              ) {
+                const error = addLangChainErrorFields(
+                  new Error(
+                    `Missing value for input variable \`${inputVariable.toString()}\``
+                  ),
+                  "INVALID_PROMPT_INPUT"
+                );
+                throw error;
+              }
+              acc[inputVariable] = allValues[inputVariable];
+              return acc;
+            },
+            {} as InputValues
+          );
+        }
         const message = await promptMessage.formatMessages(inputValues);
         resultMessages = resultMessages.concat(message);
       }

--- a/langchain-core/src/prompts/template.ts
+++ b/langchain-core/src/prompts/template.ts
@@ -83,10 +83,12 @@ export const parseFString = (template: string): ParsedTemplateNode[] => {
  * to make it compatible with other LangChain string parsing template formats.
  *
  * @param {mustache.TemplateSpans} template The result of parsing a mustache template with the mustache.js library.
+ * @param {string[]} context Array of section variable names for nested context
  * @returns {ParsedTemplateNode[]}
  */
 const mustacheTemplateToNodes = (
-  template: mustache.TemplateSpans
+  template: mustache.TemplateSpans,
+  context: string[] = []
 ): ParsedTemplateNode[] => {
   const nodes: ParsedTemplateNode[] = [];
 
@@ -101,7 +103,8 @@ const mustacheTemplateToNodes = (
 
       // If this is a section with nested content, recursively process it
       if (temp[0] === "#" && temp.length > 4 && Array.isArray(temp[4])) {
-        const nestedNodes = mustacheTemplateToNodes(temp[4]);
+        const newContext = [...context, temp[1]];
+        const nestedNodes = mustacheTemplateToNodes(temp[4], newContext);
         nodes.push(...nestedNodes);
       }
     } else {

--- a/langchain-core/src/prompts/tests/chat.mustache.test.ts
+++ b/langchain-core/src/prompts/tests/chat.mustache.test.ts
@@ -201,6 +201,34 @@ test("with ChatPromptTemplate", async () => {
   );
 });
 
+test.only("nested object", async () => {
+  const samplePrompt =
+    "Here are the locations:\n\n{{#locations}}\n- {{name}}\n{{/locations}}";
+
+  const sampleVariables = {
+    locations: [
+      {
+        name: "Tokyo",
+      },
+      {
+        name: "Los Angeles",
+      },
+      {
+        name: "Palo Alto",
+      },
+    ],
+  };
+
+  const expectedResult =
+    "Here are the locations:\n\n- Tokyo\n- Los Angeles\n- Palo Alto\n";
+  const prompt = ChatPromptTemplate.fromMessages([["system", samplePrompt]], {
+    templateFormat: "mustache",
+  });
+  expect(await prompt.format(sampleVariables)).toBe(
+    `System: ${expectedResult}`
+  );
+});
+
 test("Rendering a prompt with conditionals doesn't result in empty text blocks", async () => {
   const manifest = {
     lc: 1,

--- a/langchain-core/src/prompts/tests/chat.mustache.test.ts
+++ b/langchain-core/src/prompts/tests/chat.mustache.test.ts
@@ -201,9 +201,9 @@ test("with ChatPromptTemplate", async () => {
   );
 });
 
-test.only("nested object", async () => {
+test("nested object", async () => {
   const samplePrompt =
-    "Here are the locations:\n\n{{#locations}}\n- {{name}}\n{{/locations}}";
+    "Here are the {{name}}:\n\n{{#locations}}\n- {{name}}\n{{/locations}}\n{{name}} end";
 
   const sampleVariables = {
     locations: [
@@ -217,10 +217,11 @@ test.only("nested object", async () => {
         name: "Palo Alto",
       },
     ],
+    name: "locations",
   };
 
   const expectedResult =
-    "Here are the locations:\n\n- Tokyo\n- Los Angeles\n- Palo Alto\n";
+    "Here are the locations:\n\n- Tokyo\n- Los Angeles\n- Palo Alto\nlocations end";
   const prompt = ChatPromptTemplate.fromMessages([["system", samplePrompt]], {
     templateFormat: "mustache",
   });


### PR DESCRIPTION
~This PR adds a test case that reveals a circumstance in which Mustache nested objects do not work correctly.~
~Since I don't have a detailed enough understanding to make code changes, I'll start by adding test cases.~
~This test case passes on @langchain/core@0.3.64 which I'm using for now.~

~This issue may be caused by the following PR: https://github.com/langchain-ai/langchainjs/pull/8580.~

This PR fixes an mustache template issue that nested objects won't work correctly.