### PR TITLE
Fixes incorrect runtime behavior of isAIMessage and isAIMessageChunk.

### DIFF
--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -220,11 +220,11 @@ export class AIMessage extends BaseMessage {
 }
 
 export function isAIMessage(x: BaseMessage): x is AIMessage {
-  return x._getType() === "ai";
+  return x instanceof AIMessage;
 }
 
 export function isAIMessageChunk(x: BaseMessageChunk): x is AIMessageChunk {
-  return x._getType() === "ai";
+  return x instanceof AIMessageChunk;
 }
 
 export type AIMessageChunkFields = AIMessageFields & {


### PR DESCRIPTION
Previously, both guards only checked `_getType() === "ai"`, which caused them to return true for both `AIMessage` and `AIMessageChunk`. This made it impossible to distinguish between full messages and streaming chunks at runtime, leading to issues in streaming workflows.

This PR updates the guards to use `instanceof` checks, ensuring proper runtime discrimination between `AIMessage` and `AIMessageChunk`. This improves reliability when handling streaming output and prevents duplicate or incorrect processing of messages.

[Related Discussion](https://github.com/langchain-ai/langchainjs/discussions/8318)

