### PR TITLE
fix(openai/v1): add streaming support for custom tools

### DIFF
--- a/libs/providers/langchain-openai/src/chat_models.ts
+++ b/libs/providers/langchain-openai/src/chat_models.ts
@@ -1531,7 +1531,10 @@ export class ChatOpenAIResponses<
       for (const [key, value] of Object.entries(chunk.response)) {
         if (key !== "id") response_metadata[key] = value;
       }
-    } else if (chunk.type === "response.function_call_arguments.delta") {
+    } else if (
+      chunk.type === "response.function_call_arguments.delta" ||
+      chunk.type === "response.custom_tool_call_input.delta"
+    ) {
       tool_call_chunks.push({
         type: "tool_call_chunk",
         args: chunk.delta,


### PR DESCRIPTION
## Description

This PR fixes an issue where custom tools weren't streaming their arguments when using the OpenAI Responses API. The problem was identified by a community member who provided a patch showing that the `response.custom_tool_call_input.delta` event type was not being handled in the streaming response processing.

### The Problem
When using ChatOpenAI with custom tools, the streaming functionality was broken because the `_convertResponsesDeltaToBaseMessageChunk` function only handled `response.function_call_arguments.delta` events but not `response.custom_tool_call_input.delta` events, which are used specifically for custom tools in the Responses API.

### The Solution
Updated the event handling to capture both event types:
```typescript
} else if (
  chunk.type === "response.function_call_arguments.delta" ||
  chunk.type === "response.custom_tool_call_input.delta"
) {
```

This ensures that custom tools stream their arguments in real-time just like regular function calls.

### Testing
Added unit tests to verify:
- Custom tool delta events are properly converted to tool call chunks
- Both function call and custom tool delta events produce identical output structures

Thanks to the community member who identified this issue and provided the initial patch!

Fixes #8854