### PR TITLE
feat(openai/v1): add encodingFormat parameter support for embeddings

### DIFF
--- a/libs/providers/langchain-openai/src/embeddings.ts
+++ b/libs/providers/langchain-openai/src/embeddings.ts
@@ -50,6 +50,11 @@ export interface OpenAIEmbeddingsParams extends EmbeddingsParams {
    * See: https://github.com/openai/openai-python/issues/418#issuecomment-1525939500
    */
   stripNewLines?: boolean;
+
+  /**
+   * The format to return the embeddings in. Can be either 'float' or 'base64'.
+   */
+  encodingFormat?: "float" | "base64";
 }
 
 /**
@@ -87,6 +92,11 @@ export class OpenAIEmbeddings
    * Only supported in `text-embedding-3` and later models.
    */
   dimensions?: number;
+
+  /**
+   * The format to return the embeddings in. Can be either 'float' or 'base64'.
+   */
+  encodingFormat?: "float" | "base64";
 
   timeout?: number;
 
@@ -130,6 +140,7 @@ export class OpenAIEmbeddings
       fieldsWithDefaults?.stripNewLines ?? this.stripNewLines;
     this.timeout = fieldsWithDefaults?.timeout;
     this.dimensions = fieldsWithDefaults?.dimensions;
+    this.encodingFormat = fieldsWithDefaults?.encodingFormat;
 
     this.clientConfig = {
       apiKey,
@@ -160,6 +171,9 @@ export class OpenAIEmbeddings
       if (this.dimensions) {
         params.dimensions = this.dimensions;
       }
+      if (this.encodingFormat) {
+        params.encoding_format = this.encodingFormat;
+      }
       return this.embeddingWithRetry(params);
     });
     const batchResponses = await Promise.all(batchRequests);
@@ -188,6 +202,9 @@ export class OpenAIEmbeddings
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;
+    }
+    if (this.encodingFormat) {
+      params.encoding_format = this.encodingFormat;
     }
     const { data } = await this.embeddingWithRetry(params);
     return data[0].embedding;

--- a/libs/providers/langchain-openai/src/tests/embeddings.int.test.ts
+++ b/libs/providers/langchain-openai/src/tests/embeddings.int.test.ts
@@ -91,3 +91,37 @@ test("Test OpenAIEmbeddings.embedDocuments with v3 and dimensions", async () => 
   expect(res[0].length).toBe(127);
   expect(res[1].length).toBe(127);
 });
+
+test("Test OpenAIEmbeddings.embedQuery with encodingFormat", async () => {
+  const embeddings = new OpenAIEmbeddings({
+    modelName: "text-embedding-3-small",
+    encodingFormat: "float",
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  expect(typeof res[0]).toBe("number");
+  expect(res.length).toBe(1536); // Default dimension for text-embedding-3-small
+});
+
+test("Test OpenAIEmbeddings.embedDocuments with encodingFormat", async () => {
+  const embeddings = new OpenAIEmbeddings({
+    modelName: "text-embedding-3-small",
+    encodingFormat: "float",
+  });
+  const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
+  expect(res).toHaveLength(2);
+  expect(typeof res[0][0]).toBe("number");
+  expect(typeof res[1][0]).toBe("number");
+  expect(res[0].length).toBe(1536); // Default dimension for text-embedding-3-small
+  expect(res[1].length).toBe(1536);
+});
+
+test("Test OpenAIEmbeddings with encodingFormat and custom dimensions", async () => {
+  const embeddings = new OpenAIEmbeddings({
+    modelName: "text-embedding-3-small",
+    encodingFormat: "float",
+    dimensions: 256,
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  expect(typeof res[0]).toBe("number");
+  expect(res.length).toBe(256); // Should respect custom dimensions
+});


### PR DESCRIPTION
This PR adds support for the `encodingFormat` parameter in OpenAI embeddings, which allows users to specify the format of returned embeddings (`'float'` or `'base64'`).

The issue was that the `encoding_format` parameter wasn't being passed to the OpenAI API, causing incorrect vector lengths in certain scenarios. The fix ensures that:

- The parameter is exposed as `encodingFormat` (camelCase) in the public API for consistency
- It's correctly mapped to `encoding_format` (underscore) when calling the OpenAI API
- Both `embedQuery` and `embedDocuments` methods support this parameter

Integration tests have been added to verify the functionality works correctly with default dimensions and custom dimensions.

Fixes #8101