### PR TITLE
chore(langchain): remove constraint on lower core alpha

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -48,7 +48,7 @@ jobs:
   langchain-latest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain/') || contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-textsplitters/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/langchain/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-textsplitters/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -67,7 +67,7 @@ jobs:
   langchain-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/langchain/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -87,7 +87,7 @@ jobs:
   # community-latest-deps:
   #   runs-on: ubuntu-latest
   #   needs: get-changed-files
-  #   if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
+  #   if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/community/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/'))
   #   steps:
   #     - uses: actions/checkout@v4
   #     - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -105,7 +105,7 @@ jobs:
   # community-lowest-deps:
   #   runs-on: ubuntu-latest
   #   needs: get-changed-files
-  #   if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/')
+  #   if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/community/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-community/'))
   #   steps:
   #     - uses: actions/checkout@v4
   #     - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -142,7 +142,7 @@ jobs:
   openai-latest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -162,7 +162,7 @@ jobs:
   openai-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/openai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-openai/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -183,7 +183,7 @@ jobs:
   anthropic-latest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-anthropic/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/anthropic/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-anthropic/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -203,7 +203,7 @@ jobs:
   anthropic-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-anthropic/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/anthropic/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-anthropic/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -224,7 +224,7 @@ jobs:
   google-vertexai-latest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-vertexai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-gauth/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-common/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/google-vertexai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-vertexai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-gauth/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-common/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -244,7 +244,7 @@ jobs:
   google-vertexai-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-vertexai/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/google-vertexai/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-google-vertexai/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -265,7 +265,7 @@ jobs:
   cohere-latest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-cohere/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/cohere/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/langchain-core/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-cohere/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -285,7 +285,7 @@ jobs:
   cohere-lowest-deps:
     runs-on: ubuntu-latest
     needs: get-changed-files
-    if: contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-cohere/')
+    if: (contains(needs.get-changed-files.outputs.changed_files, 'dependency_range_tests/scripts/with_standard_tests/cohere/') || contains(needs.get-changed-files.outputs.changed_files, 'libs/providers/langchain-cohere/'))
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm

--- a/dependency_range_tests/scripts/langchain/node/update_resolutions_latest.js
+++ b/dependency_range_tests/scripts/langchain/node/update_resolutions_latest.js
@@ -12,7 +12,6 @@ if (
 ) {
   currentPackageJson.peerDependencies = {
     ...currentPackageJson.peerDependencies,
-    "@langchain/core": "1.0.0-alpha.1",
   };
 }
 


### PR DESCRIPTION
`langchain` depends on `-alpha.3` which we're overriding to `-alpha.1` in dep tests