### PR TITLE
fix(build): update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8590,53 +8590,77 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb-darwin-arm64@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb-darwin-arm64@npm:0.13.0"
+"@lancedb/lancedb-darwin-arm64@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-darwin-arm64@npm:0.19.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb-darwin-x64@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb-darwin-x64@npm:0.13.0"
+"@lancedb/lancedb-darwin-x64@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-darwin-x64@npm:0.19.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb-linux-arm64-gnu@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb-linux-arm64-gnu@npm:0.13.0"
+"@lancedb/lancedb-linux-arm64-gnu@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-linux-arm64-gnu@npm:0.19.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb-linux-x64-gnu@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb-linux-x64-gnu@npm:0.13.0"
+"@lancedb/lancedb-linux-arm64-musl@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-linux-arm64-musl@npm:0.19.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@lancedb/lancedb-linux-x64-gnu@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-linux-x64-gnu@npm:0.19.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb-win32-x64-msvc@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb-win32-x64-msvc@npm:0.13.0"
+"@lancedb/lancedb-linux-x64-musl@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-linux-x64-musl@npm:0.19.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@lancedb/lancedb-win32-arm64-msvc@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-win32-arm64-msvc@npm:0.19.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@lancedb/lancedb-win32-x64-msvc@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb-win32-x64-msvc@npm:0.19.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@lancedb/lancedb@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@lancedb/lancedb@npm:0.13.0"
+"@lancedb/lancedb@npm:^0.19.1":
+  version: 0.19.1
+  resolution: "@lancedb/lancedb@npm:0.19.1"
   dependencies:
-    "@lancedb/lancedb-darwin-arm64": 0.13.0
-    "@lancedb/lancedb-darwin-x64": 0.13.0
-    "@lancedb/lancedb-linux-arm64-gnu": 0.13.0
-    "@lancedb/lancedb-linux-x64-gnu": 0.13.0
-    "@lancedb/lancedb-win32-x64-msvc": 0.13.0
+    "@lancedb/lancedb-darwin-arm64": 0.19.1
+    "@lancedb/lancedb-darwin-x64": 0.19.1
+    "@lancedb/lancedb-linux-arm64-gnu": 0.19.1
+    "@lancedb/lancedb-linux-arm64-musl": 0.19.1
+    "@lancedb/lancedb-linux-x64-gnu": 0.19.1
+    "@lancedb/lancedb-linux-x64-musl": 0.19.1
+    "@lancedb/lancedb-win32-arm64-msvc": 0.19.1
+    "@lancedb/lancedb-win32-x64-msvc": 0.19.1
     reflect-metadata: ^0.2.2
   peerDependencies:
-    apache-arrow: ">=13.0.0 <=17.0.0"
+    apache-arrow: ">=15.0.0 <=18.1.0"
   dependenciesMeta:
     "@lancedb/lancedb-darwin-arm64":
       optional: true
@@ -8644,7 +8668,13 @@ __metadata:
       optional: true
     "@lancedb/lancedb-linux-arm64-gnu":
       optional: true
+    "@lancedb/lancedb-linux-arm64-musl":
+      optional: true
     "@lancedb/lancedb-linux-x64-gnu":
+      optional: true
+    "@lancedb/lancedb-linux-x64-musl":
+      optional: true
+    "@lancedb/lancedb-win32-arm64-msvc":
       optional: true
     "@lancedb/lancedb-win32-x64-msvc":
       optional: true
@@ -9018,7 +9048,7 @@ __metadata:
     "@huggingface/transformers": ^3.5.2
     "@ibm-cloud/watsonx-ai": ^1.6.10
     "@jest/globals": ^29.5.0
-    "@lancedb/lancedb": ^0.13.0
+    "@lancedb/lancedb": ^0.19.1
     "@langchain/core": "workspace:*"
     "@langchain/openai": ">=0.2.0 <0.7.0"
     "@langchain/scripts": ">=0.1.0 <0.2.0"
@@ -9201,7 +9231,7 @@ __metadata:
     "@huggingface/inference": ^4.0.5
     "@huggingface/transformers": ^3.5.2
     "@ibm-cloud/watsonx-ai": "*"
-    "@lancedb/lancedb": ^0.12.0
+    "@lancedb/lancedb": ^0.19.1
     "@langchain/core": ">=0.3.58 <0.4.0"
     "@layerup/layerup-security": ^1.5.12
     "@libsql/client": ^0.14.0
@@ -24644,7 +24674,7 @@ __metadata:
     "@getmetal/metal-sdk": ^4.0.0
     "@gomomento/sdk": ^1.51.1
     "@google/generative-ai": ^0.7.0
-    "@lancedb/lancedb": ^0.13.0
+    "@lancedb/lancedb": ^0.19.1
     "@langchain/anthropic": "workspace:*"
     "@langchain/aws": "workspace:*"
     "@langchain/azure-cosmosdb": "workspace:*"


### PR DESCRIPTION
Some PRs came with dep changes and it was not possible to get `yarn.lock` updated without requesting users to take action. This PR will fix the issue with that.