### PR TITLE
fix(community/v1): remove deprecated 'namespace' param

### DIFF
--- a/.changeset/fruity-llamas-chew.md
+++ b/.changeset/fruity-llamas-chew.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": patch
+---
+
+fix(astra): replace deprecated 'namespace' param name

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -62,7 +62,7 @@
     "@clickhouse/client": "^0.2.5",
     "@cloudflare/ai": "1.0.12",
     "@cloudflare/workers-types": "^4.20230922.0",
-    "@datastax/astra-db-ts": "^1.0.1",
+    "@datastax/astra-db-ts": "^1.5.0",
     "@elastic/elasticsearch": "^8.4.0",
     "@faker-js/faker": "8.4.1",
     "@getmetal/metal-sdk": "^4.0.0",

--- a/libs/langchain-community/src/vectorstores/astradb.ts
+++ b/libs/langchain-community/src/vectorstores/astradb.ts
@@ -27,7 +27,7 @@ export interface AstraLibArgs extends AsyncCallerParams {
   token: string;
   endpoint: string;
   collection: string;
-  namespace?: string;
+  keyspace?: string;
   idKey?: string;
   contentKey?: string;
   skipCollectionProvisioning?: boolean;
@@ -70,14 +70,14 @@ export class AstraDBVectorStore extends VectorStore {
       endpoint,
       collection,
       collectionOptions,
-      namespace,
+      keyspace,
       idKey,
       contentKey,
       skipCollectionProvisioning,
       ...callerArgs
     } = args;
     const dataAPIClient = new DataAPIClient(token, { caller: ["langchainjs"] });
-    this.astraDBClient = dataAPIClient.db(endpoint, { namespace });
+    this.astraDBClient = dataAPIClient.db(endpoint, { keyspace });
     this.skipCollectionProvisioning = skipCollectionProvisioning ?? false;
     if (this.skipCollectionProvisioning && collectionOptions) {
       throw new Error(

--- a/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
+++ b/libs/langchain-community/src/vectorstores/tests/astradb.int.test.ts
@@ -14,7 +14,7 @@ describe.skip("AstraDBVectorStore", () => {
     const clientConfig = {
       token: process.env.ASTRA_DB_APPLICATION_TOKEN ?? "dummy",
       endpoint: process.env.ASTRA_DB_ENDPOINT ?? "dummy",
-      namespace: process.env.ASTRA_DB_NAMESPACE ?? "default_keyspace",
+      keyspace: process.env.ASTRA_DB_KEYSPACE ?? "default_keyspace",
     };
 
     const dataAPIClient = new DataAPIClient(clientConfig.token);


### PR DESCRIPTION
mirror of #8830