### PR TITLE
chore: bump core versions for aws + ollama

### DIFF
--- a/libs/providers/langchain-aws/package.json
+++ b/libs/providers/langchain-aws/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/credential-provider-node": "^3.750.0"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.58 <0.4.0"
+    "@langchain/core": "^1.0.0-alpha.1"
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.734.0",

--- a/libs/providers/langchain-ollama/package.json
+++ b/libs/providers/langchain-ollama/package.json
@@ -34,7 +34,7 @@
     "uuid": "^10.0.0"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.58 <0.4.0"
+    "@langchain/core": "^1.0.0-alpha.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",


### PR DESCRIPTION
pre-requisite for v1 alphas of these packages
