### PR TITLE
fix(openai): re-enable custom tools

### DIFF
--- a/libs/providers/langchain-openai/src/chat_models.ts
+++ b/libs/providers/langchain-openai/src/chat_models.ts
@@ -1689,15 +1689,14 @@ export class ChatOpenAIResponses<
             };
           }
 
-          // FIXME(hntrl): resolve when core 1.0.0-alpha.2 is released
-          // // Handle custom tool output
-          // if (toolMessage.metadata?.customTool) {
-          //   return {
-          //     type: "custom_tool_call_output",
-          //     call_id: toolMessage.tool_call_id,
-          //     output: toolMessage.content as string,
-          //   };
-          // }
+          // Handle custom tool output
+          if (toolMessage.metadata?.customTool) {
+            return {
+              type: "custom_tool_call_output",
+              call_id: toolMessage.tool_call_id,
+              output: toolMessage.content as string,
+            };
+          }
 
           return {
             type: "function_call_output",

--- a/libs/providers/langchain-openai/src/tools/tests/custom.int.test.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/custom.int.test.ts
@@ -23,13 +23,12 @@ describe("customTool", () => {
     };
     const result = await tool.invoke(toolCall);
     expect(result).toBeInstanceOf(ToolMessage);
-    // FIXME(hntrl): resolve when core 1.0.0-alpha.2 is released
-    // expect(result.metadata).toEqual({
-    //   customTool: {
-    //     name: "text_tool",
-    //     description: "A tool that returns the input",
-    //   },
-    // });
+    expect(result.metadata).toEqual({
+      customTool: {
+        name: "text_tool",
+        description: "A tool that returns the input",
+      },
+    });
   });
 
   test("responding with a tool message from a custom tool will be used correctly", async () => {


### PR DESCRIPTION
core wasn't rebased for the first alpha release, so the core changes needed to make custom tools work weren't released