### PR TITLE
feat(community): warn if chat model name is missing

### DIFF
--- a/libs/langchain-community/src/chat_models/alibaba_tongyi.ts
+++ b/libs/langchain-community/src/chat_models/alibaba_tongyi.ts
@@ -280,6 +280,12 @@ export class ChatAlibabaTongyi
     this.maxTokens = fields.maxTokens;
     this.repetitionPenalty = fields.repetitionPenalty;
     this.enableSearch = fields.enableSearch;
+
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        `Alibaba Tongyi model name not specified. Defaulting to "qwen-turbo".`
+      );
+    }
     this.modelName = fields?.model ?? fields.modelName ?? "qwen-turbo";
     this.model = this.modelName;
   }

--- a/libs/langchain-community/src/chat_models/baiduwenxin.ts
+++ b/libs/langchain-community/src/chat_models/baiduwenxin.ts
@@ -279,6 +279,11 @@ export class ChatBaiduWenxin
     this.topP = fields?.topP ?? this.topP;
     this.penaltyScore = fields?.penaltyScore ?? this.penaltyScore;
 
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        `Baidu Wenxin model name not specified. Defaulting to "${this.model}".`
+      );
+    }
     this.modelName = fields?.model ?? fields?.modelName ?? this.model;
     this.model = this.modelName;
 

--- a/libs/langchain-community/src/chat_models/cloudflare_workersai.ts
+++ b/libs/langchain-community/src/chat_models/cloudflare_workersai.ts
@@ -69,6 +69,11 @@ export class ChatCloudflareWorkersAI
   constructor(fields?: CloudflareWorkersAIInput & BaseChatModelParams) {
     super(fields ?? {});
 
+    if (!fields?.model) {
+      console.warn(
+        `Cloudflare Workers AI model name not specified. Defaulting to "${this.model}".`
+      );
+    }
     this.model = fields?.model ?? this.model;
     this.streaming = fields?.streaming ?? this.streaming;
     this.cloudflareAccountId =

--- a/libs/langchain-community/src/chat_models/deepinfra.ts
+++ b/libs/langchain-community/src/chat_models/deepinfra.ts
@@ -214,6 +214,12 @@ export class ChatDeepInfra
     }
 
     this.apiUrl = API_BASE_URL;
+
+    if (!fields.model) {
+      console.warn(
+        `DeepInfra model name not specified. Defaulting to "${DEFAULT_MODEL}".`
+      );
+    }
     this.model = fields.model ?? DEFAULT_MODEL;
     this.temperature = fields.temperature ?? 0;
     this.maxTokens = fields.maxTokens;

--- a/libs/langchain-community/src/chat_models/fireworks.ts
+++ b/libs/langchain-community/src/chat_models/fireworks.ts
@@ -495,6 +495,11 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
       );
     }
 
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        'Fireworks model name not specified. Defaulting to "accounts/fireworks/models/llama-v3p1-8b-instruct".'
+      );
+    }
     super({
       ...fields,
       model:

--- a/libs/langchain-community/src/chat_models/minimax.ts
+++ b/libs/langchain-community/src/chat_models/minimax.ts
@@ -438,6 +438,11 @@ export class ChatMinimax
     this.replyConstraints = fields?.replyConstraints ?? this.replyConstraints;
     this.defaultBotName = fields?.defaultBotName ?? this.defaultBotName;
 
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        `Minimax model name not specified. Defaulting to "${this.model}".`
+      );
+    }
     this.modelName = fields?.model ?? fields?.modelName ?? this.model;
     this.model = this.modelName;
     this.basePath = fields?.configuration?.basePath ?? this.basePath;

--- a/libs/langchain-community/src/chat_models/moonshot.ts
+++ b/libs/langchain-community/src/chat_models/moonshot.ts
@@ -237,6 +237,12 @@ export class ChatMoonshot extends BaseChatModel implements ChatMoonshotParams {
     this.topP = fields.topP ?? 1;
     this.stop = fields.stop;
     this.maxTokens = fields.maxTokens;
+
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        'Moonshot model name not specified. Defaulting to "moonshot-v1-8k".'
+      );
+    }
     this.modelName = fields?.model ?? fields.modelName ?? "moonshot-v1-8k";
     this.model = this.modelName;
     this.presencePenalty = fields.presencePenalty ?? 0;

--- a/libs/langchain-community/src/chat_models/novita.ts
+++ b/libs/langchain-community/src/chat_models/novita.ts
@@ -83,6 +83,11 @@ export class ChatNovitaAI extends ChatOpenAICompletions<ChatNovitaCallOptions> {
       );
     }
 
+    if (!fields?.model) {
+      console.warn(
+        'Novita model name not specified. Defaulting to "gryphe/mythomax-l2-13b"'
+      );
+    }
     super({
       ...fields,
       model: fields?.model || "gryphe/mythomax-l2-13b",

--- a/libs/langchain-community/src/chat_models/ollama.ts
+++ b/libs/langchain-community/src/chat_models/ollama.ts
@@ -145,6 +145,12 @@ export class ChatOllama
 
   constructor(fields: OllamaInput & BaseChatModelParams) {
     super(fields);
+
+    if (!fields.model) {
+      console.warn(
+        `Ollama model name not specified. Defaulting to "${this.model}".`
+      );
+    }
     this.model = fields.model ?? this.model;
     this.baseUrl = fields.baseUrl?.endsWith("/")
       ? fields.baseUrl.slice(0, -1)

--- a/libs/langchain-community/src/chat_models/togetherai.ts
+++ b/libs/langchain-community/src/chat_models/togetherai.ts
@@ -454,9 +454,16 @@ export class ChatTogetherAI extends ChatOpenAICompletions<ChatTogetherAICallOpti
       );
     }
 
+    const model = fields?.model;
+    if (!model) {
+      console.warn(
+        `TogetherAI model name not specified. Defaulting to "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free".`
+      );
+    }
+
     super({
       ...fields,
-      model: fields?.model || "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      model: fields?.model || "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
       apiKey: togetherAIApiKey,
       configuration: {
         baseURL: "https://api.together.xyz/v1/",

--- a/libs/langchain-community/src/chat_models/yandex.ts
+++ b/libs/langchain-community/src/chat_models/yandex.ts
@@ -80,6 +80,11 @@ export class ChatYandexGPT extends BaseChatModel {
     this.iamToken = iamToken;
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;
     this.temperature = fields?.temperature ?? this.temperature;
+    if (!fields?.model) {
+      console.warn(
+        `YandexGPT model name not specified. Defaulting to "${this.model}".`
+      );
+    }
     this.model = fields?.model ?? this.model;
   }
 

--- a/libs/langchain-community/src/chat_models/zhipuai.ts
+++ b/libs/langchain-community/src/chat_models/zhipuai.ts
@@ -246,6 +246,12 @@ export class ChatZhipuAI extends BaseChatModel implements ChatZhipuAIParams {
     this.topP = fields.topP ?? 0.7;
     this.stop = fields.stop;
     this.maxTokens = fields.maxTokens;
+
+    if (!fields?.model && !fields?.modelName) {
+      console.warn(
+        'ZhipuAI model name not specified. Defaulting to "glm-3-turbo".'
+      );
+    }
     this.modelName = fields?.model ?? fields.modelName ?? "glm-3-turbo";
     this.model = this.modelName;
     this.doSample = fields.doSample;


### PR DESCRIPTION
Added a console warning for all chat model provider integrations that
silently fall back to a default model when no model name is provided.
This makes the behavior explicit and consistent across providers.

Silent fallbacks can catch developers off guard. For example, a simple
typo in the parameter name previously wouldn't be caught until the
developer dug deep to identify the cause of unexpected model behavior
or a billing issue from the provider.

For `ChatTogetherAI()`, the default (fallback) model has also been
changed from `mistralai/Mixtral-8x7B-Instruct-v0` to
`meta-llama/Llama-3.3-70B-Instruct-Turbo-Free`, which TogetherAI
graciously hosts for free with more restrictive rate limits.


Fixes https://github.com/langchain-ai/langchainjs/issues/8094
Replaces: https://github.com/langchain-ai/langchainjs/pull/8263



x: YasharF3
linkedin.com/in/yasharf
