### PR TITLE
fix(langchain): add LangGraph re-exports for better compatibility

### DIFF
--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -45,10 +45,15 @@ export {
 } from "./agents/index.js";
 
 /**
- * LangChain Memory
- * Check in what we want to export here
+ * Re-export essential LangGraph primitives for state persistence, storage,
+ * and execution control to ensure version compatibility across the ecosystem
  */
-export { MemorySaver, InMemoryStore } from "@langchain/langgraph";
+export {
+  MemorySaver,
+  InMemoryStore,
+  Command,
+  interrupt,
+} from "@langchain/langgraph";
 
 /**
  * LangChain Context


### PR DESCRIPTION
We've discovered that some primitives in LangGraph v0.x aren't compatible with Langchain v1 as it depends on LangGraph v1. To avoid friction let's allow users to import these primitives from `langchain` directly.