### PR TITLE
fix(google-cloud-sql-pg/v1): properly handle explicit metadata columns in PostgresVectorStore

### DIFF
--- a/.changeset/tame-impalas-battle.md
+++ b/.changeset/tame-impalas-battle.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-cloud-sql-pg": patch
+---
+
+properly handle explicit metadata columns in PostgresVectorStore (#8334)

--- a/libs/providers/langchain-google-cloud-sql-pg/src/tests/vectorstore.int.test.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/tests/vectorstore.int.test.ts
@@ -108,6 +108,22 @@ describe("VectorStore creation", () => {
     );
   });
 
+  // https://github.com/langchain-ai/langchainjs/issues/8334
+  test("should set metadataColumns if ignoreMetadataColumns is not defined", async () => {
+    const pvectorArgs: PostgresVectorStoreArgs = {
+      metadataColumns: ["page", "source"],
+    };
+
+    vectorStoreInstance = await PostgresVectorStore.initialize(
+      PEInstance,
+      embeddingService,
+      CUSTOM_TABLE,
+      pvectorArgs
+    );
+
+    expect(vectorStoreInstance.metadataColumns).toEqual(["page", "source"]);
+  });
+
   test("should throw an error if idColumn does not exist", async () => {
     const pvectorArgs: PostgresVectorStoreArgs = {
       idColumn: "my_id_column",

--- a/libs/providers/langchain-google-cloud-sql-pg/src/vectorstore.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/vectorstore.ts
@@ -365,6 +365,12 @@ export class PostgresVectorStore extends VectorStore {
       delete allColumns[contentColumn];
       delete allColumns[embeddingColumn];
       allMetadataColumns = Object.keys(allColumns);
+    } else {
+      for (const column of metadataColumns) {
+        if (Object.prototype.hasOwnProperty.call(allColumns, column)) {
+          allMetadataColumns.push(column);
+        }
+      }
     }
     return new PostgresVectorStore(embeddings, {
       engine,


### PR DESCRIPTION
mirror of #8909