### PR TITLE
Fix toolbar formatting for TypeDoc's CSS pages

### DIFF
--- a/docs/api_refs/scripts/update-typedoc-css.js
+++ b/docs/api_refs/scripts/update-typedoc-css.js
@@ -8,6 +8,38 @@ const CSS = `\n.tsd-navigation {
   display: none;
 }
 
+.tsd-toolbar-icon.menu {
+  display: flex;
+  justify-content: center;
+  margin-left: 1rem;
+}
+
+@media (max-width: 769px) {
+.col-content {
+    margin-top: 1.5rem;
+  }
+#tsd-toolbar-links {
+        display: block
+    }
+    a.title {
+  margin-left: 1.8rem;
+}
+}
+
+@media (min-width: 770px) {
+#tsd-search {
+  display: flex;
+  align-items: center;
+}
+a.title {
+  margin-left: auto;
+  margin-right: auto;
+}
+a.tsd-widget.tsd-toolbar-icon.menu.no-caption {
+    display: none;
+  }
+}
+
 .deprecation-warning {
   background-color: #ef4444;
   border-radius: 0.375rem;


### PR DESCRIPTION
## Summary

This PR adjusts the generated TypeDoc CSS for the JS API docs to address four UX issues:

1. Hamburger icon (mobile) and toolbar title were touching the left page margin
2. Breadcrumb and toolbar lacked vertical breathing room on mobile
3. Version selector dropdown was hidden on mobile without a functional reason
4. Hamburger icon showed up on desktop in local builds, but should be mobile-only

Changes are CSS-only, scoped to TypeDoc output from one file `update-typedoc-css.js`.

**What I changed**
- Add left margin spacing so the hamburger and mobile toolbar title don't directly lean on the left viewport edge
- Add margin spacing between breadcrumb and toolbar on mobile
- Unhide the version selector on mobile
- Center the toolbar title on desktop
- Hide the hamburger at desktop breakpoint

### Screenshots

Here are before and after images of the same pages on the live site and a preview local build for mobile and desktop to demonstrate the CSS formatting changes. *Note: I used a more streamlined build process so the content has some differences but the formatting and layout still use the same CSS files. The toolbar title content is NOT changed by my CSS code applied here.*

**Mobile Before:**
![mobile-before](https://github.com/user-attachments/assets/d20f0ee6-a7cd-4048-bc04-69cdb1b9b494)


**Mobile After:**
![mobile-after](https://github.com/user-attachments/assets/bccee66a-0d16-4917-931c-b2def4683786)

Here for desktop the only applied CSS change is the positioning of the title moved from left to center toolbar.

**Desktop Before:**
![desktop-before](https://github.com/user-attachments/assets/90044e72-df4b-44dc-8db6-e9059e1263a9)


**Desktop After:**
![desktop-after](https://github.com/user-attachments/assets/e12a6f7b-f541-43a6-b2e2-0d3c2f8c62c6)

### Implementation

Since none of the original CSS contained any comments, my added code doesn't contain any either, but because the added code is relatively brief, I will add the full code below with comments to display the verbatim changes and their effects applied.

```
/* center the hamburger icon in wrapper and shift right so it isn't touching left page margin */
.tsd-toolbar-icon.menu {
  display: flex;
  justify-content: center;
  margin-left: 1rem;
}

@media (max-width: 769px) {
/* breathing room for mobile breadcrumb and header*/
.col-content {
    margin-top: 1.5rem;
  }
/* Show the versioning dropdown in the toolbar on mobile */
#tsd-toolbar-links {
        display: block
    }
    /* Give title breathing room from left page margin; perpendicular to hamburger icon */
    a.title {
  margin-left: 1.8rem;
}
}

/* straighten title out in toolbar on wider screens */
@media (min-width: 770px) {
#tsd-search {
  display: flex;
  align-items: center;
}
a.title {
  margin-left: auto;
  margin-right: auto;
}
/* hide hamburger menu icon when menu becomes static sidebar */
a.tsd-widget.tsd-toolbar-icon.menu.no-caption {
    display: none;
  }
}
```

@rito_rhymes
