### PR TITLE
fix(google-common): fix 400 Bad Request error for external image URLs in Vertex AI

### DIFF
--- a/.changeset/serious-yaks-invite.md
+++ b/.changeset/serious-yaks-invite.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): fix 400 Bad Request error for external image URLs in Vertex AI

--- a/libs/providers/langchain-google-common/package.json
+++ b/libs/providers/langchain-google-common/package.json
@@ -37,6 +37,7 @@
     "@jest/globals": "^29.5.0",
     "@langchain/core": "workspace:*",
     "@langchain/eslint": "workspace:*",
+    "@types/uuid": "^10.0.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/libs/providers/langchain-google-common/src/tests/utils.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/utils.test.ts
@@ -4,7 +4,14 @@ import { InMemoryStore } from "@langchain/core/stores";
 import { SerializedConstructor } from "@langchain/core/load/serializable";
 import { load } from "@langchain/core/load";
 import { z } from "zod/v3";
+import { HumanMessage } from "@langchain/core/messages";
 import { schemaToGeminiParameters } from "../utils/zod_to_gemini_parameters.js";
+import { getGeminiAPI } from "../utils/gemini.js";
+import {
+  GeminiPartFileData,
+  GeminiPartInlineData,
+  GeminiRequest,
+} from "../types.js";
 import {
   BackedBlobStore,
   BlobStore,
@@ -531,5 +538,169 @@ describe("streaming", () => {
     expect(chunk).toBeNull();
 
     expect(stream.streamDone).toEqual(true);
+  });
+});
+
+describe("gemini image URL handling", () => {
+  test("handles image_url with external URL and infers MIME type", async () => {
+    const api = getGeminiAPI();
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "text",
+          text: "What is in the picture?",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: "https://example.com/image.jpg",
+          },
+        },
+      ],
+    });
+
+    const formatted = (await api.formatData([message], {})) as GeminiRequest;
+    const imagePart = formatted.contents?.[0]?.parts?.[1] as GeminiPartFileData;
+
+    expect(imagePart).toBeDefined();
+    expect(imagePart).toHaveProperty("fileData");
+    expect(imagePart?.fileData.mimeType).toBe("image/jpeg");
+    expect(imagePart?.fileData.fileUri).toBe("https://example.com/image.jpg");
+  });
+
+  test("handles image_url with png extension", async () => {
+    const api = getGeminiAPI();
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "text",
+          text: "What is in the picture?",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: "https://example.com/photo.png?size=large",
+          },
+        },
+      ],
+    });
+
+    const formatted = (await api.formatData([message], {})) as GeminiRequest;
+    const imagePart = formatted.contents?.[0]?.parts?.[1] as GeminiPartFileData;
+
+    expect(imagePart).toBeDefined();
+    expect(imagePart?.fileData.mimeType).toBe("image/png");
+    expect(imagePart?.fileData.fileUri).toBe(
+      "https://example.com/photo.png?size=large"
+    );
+  });
+
+  test("handles image_url with data URL", async () => {
+    const api = getGeminiAPI();
+    const dataUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "text",
+          text: "What is in the picture?",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: dataUrl,
+          },
+        },
+      ],
+    });
+
+    const formatted = (await api.formatData([message], {})) as GeminiRequest;
+    const imagePart = formatted.contents?.[0]
+      ?.parts?.[1] as GeminiPartInlineData;
+
+    expect(imagePart).toBeDefined();
+    expect(imagePart?.inlineData.mimeType).toBe("image/png");
+    expect(imagePart?.inlineData.data).toBeDefined();
+  });
+
+  test("handles image_url with unknown extension - uses default", async () => {
+    const api = getGeminiAPI();
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "text",
+          text: "What is in the picture?",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: "https://example.com/image",
+          },
+        },
+      ],
+    });
+
+    const formatted = (await api.formatData([message], {})) as GeminiRequest;
+    const imagePart = formatted.contents?.[0]?.parts?.[1] as GeminiPartFileData;
+
+    expect(imagePart).toBeDefined();
+    expect(imagePart?.fileData.mimeType).toBe("image/png"); // default fallback
+    expect(imagePart?.fileData.fileUri).toBe("https://example.com/image");
+  });
+
+  test("handles various image extensions correctly", async () => {
+    const api = getGeminiAPI();
+    const testCases = [
+      { ext: "jpeg", mime: "image/jpeg" },
+      { ext: "jpg", mime: "image/jpeg" },
+      { ext: "png", mime: "image/png" },
+      { ext: "gif", mime: "image/gif" },
+      { ext: "webp", mime: "image/webp" },
+      { ext: "bmp", mime: "image/bmp" },
+      { ext: "svg", mime: "image/svg+xml" },
+      { ext: "tiff", mime: "image/tiff" },
+      { ext: "tif", mime: "image/tiff" },
+    ];
+
+    for (const { ext, mime } of testCases) {
+      const message = new HumanMessage({
+        content: [
+          {
+            type: "image_url",
+            image_url: {
+              url: `https://example.com/image.${ext}`,
+            },
+          },
+        ],
+      });
+
+      const formatted = (await api.formatData([message], {})) as GeminiRequest;
+      const imagePart = formatted.contents?.[0]
+        ?.parts?.[0] as GeminiPartFileData;
+
+      expect(imagePart).toBeDefined();
+      expect(imagePart?.fileData.mimeType).toBe(mime);
+    }
+  });
+
+  test("handles malformed URLs gracefully", async () => {
+    const api = getGeminiAPI();
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "image_url",
+          image_url: {
+            url: "not-a-valid-url.jpg",
+          },
+        },
+      ],
+    });
+
+    const formatted = (await api.formatData([message], {})) as GeminiRequest;
+    const imagePart = formatted.contents?.[0]?.parts?.[0] as GeminiPartFileData;
+
+    expect(imagePart).toBeDefined();
+    expect(imagePart?.fileData.mimeType).toBe("image/jpeg");
+    expect(imagePart?.fileData.fileUri).toBe("not-a-valid-url.jpg");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2189,6 +2189,9 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.3
         version: 1.0.10
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1


### PR DESCRIPTION
This PR fixes a critical issue where `@langchain/google-vertexai` version 0.2.17+ was causing 400 Bad Request errors when using `image_url` content blocks with external URLs.

## Problem
When using `image_url` content blocks with external URLs (non-data URLs), the Google Vertex AI API was returning 400 Bad Request errors. This was a breaking change that affected all users trying to send images via URLs to Gemini models.

## Root Cause
The issue occurred during the conversion from OpenAI-style `image_url` blocks to Gemini's expected format. When the standard content block converter processed external image URLs, it was sending an empty string for the MIME type, which the Vertex AI API rejects.

## Solution
- Added `inferMimeTypeFromUrl()` function to detect MIME types from file extensions
- Updated `fromStandardImageBlock()` to infer MIME type when not provided
- Fixed `messageContentImageUrlData()` to use MIME type inference for external URLs
- Added appropriate fallback MIME types for different content types
- Added comprehensive test coverage for various image URL scenarios

## Testing
Added extensive unit tests.

Fixes #8939