### PR TITLE
fix(community): improve TogetherAI error handling for chat models

### DIFF
--- a/.changeset/modern-melons-roll.md
+++ b/.changeset/modern-melons-roll.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": patch
+---
+
+fix(community): improve TogetherAI error handling for chat models

--- a/libs/langchain-community/src/llms/tests/togetherai.test.ts
+++ b/libs/langchain-community/src/llms/tests/togetherai.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, jest } from "@jest/globals";
+import { TogetherAI } from "../togetherai.js";
+
+test("TogetherAI should provide helpful error for chat models", async () => {
+  const model = new TogetherAI({
+    modelName: "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+    apiKey: "test-api-key",
+  });
+
+  jest.spyOn(model, "completionWithRetry").mockResolvedValue({
+    // Response without output or choices fields
+    error: "Invalid model",
+  });
+
+  await expect(model.invoke("Hello")).rejects.toThrow(
+    /may require the ChatTogetherAI class/
+  );
+});
+
+test("TogetherAI should warn when using chat models", () => {
+  const originalWarn = console.warn;
+  const mockWarn = jest.fn();
+  console.warn = mockWarn;
+
+  try {
+    void new TogetherAI({
+      modelName: "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+      apiKey: "test-api-key",
+    });
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("appears to be a chat/instruct model")
+    );
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Consider using ChatTogetherAI")
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Description

This PR fixes an issue where users attempting to use chat/instruct models with the `TogetherAI` class would encounter a cryptic error: `Cannot read properties of undefined (reading 'choices')`. This happened because the TogetherAI API returns different response formats for text completion models vs chat models, and users were unknowingly using the wrong class.

### Changes Made:

1. **Improved Error Handling**: Added proper error handling in the `_call` method to catch when the API response doesn't match the expected format and provide a helpful error message directing users to use `ChatTogetherAI` instead.

2. **Model Type Detection**: Implemented automatic detection of chat/instruct models (based on patterns like "instruct", "chat", "vision", or "turbo" in model names) and added a console warning when users instantiate `TogetherAI` with these models.

3. **Documentation Updates**: 
   - Added clear warnings and a model compatibility table to the TogetherAI documentation
   - Updated ChatTogetherAI documentation to clarify when to use each class
   - Included examples of which models work with which class

4. **Tests**: Added unit tests to verify the warning behavior and model type detection.

### Example of the fix in action:

**Before (confusing error):**
```typescript
const llm = new TogetherAI({
  model: 'meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo',
});
await llm.invoke('Hello'); 
// TypeError: Cannot read properties of undefined (reading 'choices')
```

**After (helpful guidance):**
```typescript
const llm = new TogetherAI({
  model: 'meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo',
});
// Console warning: "Warning: Model 'meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo' appears to be a chat/instruct model. Consider using ChatTogetherAI from @langchain/community/chat_models/togetherai instead."

await llm.invoke('Hello');
// Error: Unexpected response format from Together AI. The model 'meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo' may require the ChatTogetherAI class instead of TogetherAI class.
```

This slightly improves the developer experience by providing clear guidance on which class to use for different model types.

Fixes #6993