### PR TITLE
docs(langchain-redis): add delete documents by IDs documentation

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/redis.ipynb
+++ b/docs/core_docs/docs/integrations/vectorstores/redis.ipynb
@@ -179,7 +179,7 @@
       "id": "dcf1b905",
       "metadata": {},
       "source": [
-        "Top-level document ids and deletion are currently not supported."
+        "Top-level document ids are currently not supported, but you can delete documents by providing their IDs directly to the vector store."
       ]
     },
     {
@@ -304,9 +304,19 @@
       "id": "069f1b5f",
       "metadata": {},
       "source": [
-        "## Deleting an index\n",
+        "## Deleting documents\n",
         "\n",
-        "You can delete an entire index with the following command:"
+        "You can delete documents from the vector store in two ways:\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dde32a56",
+      "metadata": {},
+      "source": [
+        "### Delete all documents\n",
+        "\n",
+        "You can delete an entire index and all its documents with the following command:"
       ]
     },
     {
@@ -321,6 +331,27 @@
     },
     {
       "cell_type": "markdown",
+      "id": "b77fa077",
+      "metadata": {},
+      "source": [
+        "### Delete specific documents by ID\n",
+        "\n",
+        "You can also delete specific documents by providing their IDs. Note that the configured key prefix will be automatically added to the IDs you provide:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "cb7a85ee",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "// The key prefix will be automatically added to each ID\n",
+        "await vectorStore.delete({ ids: [\"doc1\", \"doc2\", \"doc3\"] });\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "id": "bf2357b3",
       "metadata": {},
       "source": [
@@ -331,7 +362,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 12,
       "id": "48a98cba",
       "metadata": {},
       "outputs": [],


### PR DESCRIPTION
## Summary

This PR updates the Redis vectorstore documentation to include the new delete by IDs feature that was introduced in [PR #8738](https://github.com/langchain-ai/langchainjs/pull/8738) (commit: [e4c183d](https://github.com/langchain-ai/langchainjs/commit/e4c183ddca1443a1647cccce3bcef40731ff8b31)).

## Changes Made

- **Added documentation for delete by IDs feature**: Document the new `delete({ ids: string[] })` method alongside the existing `delete({ deleteAll: boolean })` method
- **Updated section structure**: Changed "Deleting an index" to "Deleting documents" with clear subsections for both deletion methods
- **Added key prefix clarification**: Document that the configured key prefix is automatically added to the provided IDs
- **Updated limitation note**: Removed outdated statement about deletion not being supported
- **Added code examples**: Provided practical examples for both deletion approaches

## Documentation Structure

The deletion section now clearly presents both options:
1. **Delete all documents**: `await vectorStore.delete({ deleteAll: true })`
2. **Delete specific documents by ID**: `await vectorStore.delete({ ids: ["doc1", "doc2", "doc3"] })`

## Benefits

- Users can now easily find and understand how to delete specific documents
- Clear guidance on key prefix handling prevents confusion
- Better organization makes the documentation more user-friendly
- Reflects the current capabilities of the RedisVectorStore

## Preview
 URL - [Click here](https://langchainjs-docs-pvx2fkxzu-langchain.vercel.app/docs/integrations/vectorstores/redis/#deleting-documents)
 
<img width="334" height="200" alt="Screenshot 2025-09-14 at 5 26 37 PM" src="https://github.com/user-attachments/assets/67ee69be-45a4-4df0-b187-ba5e54c53671" />


## Related

- Feature implementation: [PR #8738](https://github.com/langchain-ai/langchainjs/pull/8738)
- Commit: [e4c183d](https://github.com/langchain-ai/langchainjs/commit/e4c183ddca1443a1647cccce3bcef40731ff8b31)