### PR TITLE
fix: add support for anyOf, allOf, oneOf in openapi conversion

### DIFF
--- a/.changeset/petite-lights-doubt.md
+++ b/.changeset/petite-lights-doubt.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+add support for anyOf, allOf, oneOf in openapi conversion


### PR DESCRIPTION
Hello!

This PR adds support for the composition types [`anyOf`, `allOf` and `oneOf`](https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/) in the OpenAPI to JSON schema conversion. I also included the tests for all of these.

Before this PR composition types would just be converted to the fallback type `string`.

PS: The test is becoming a bit unwieldy. If you want me to restructure the test into smaller ones, let me know. It will just take a bit, since I am on vacation the next two weeks :)