### PR TITLE
fix(azure-cosmosdb/v1): missing init while retrieving context

### DIFF
--- a/.changeset/curly-spoons-build.md
+++ b/.changeset/curly-spoons-build.md
@@ -1,0 +1,5 @@
+---
+"@langchain/azure-cosmosdb": patch
+---
+
+Fix missing init while retrieving context in AzureCosmsosDBNoSQLChatMessageHistory

--- a/libs/providers/langchain-azure-cosmosdb/src/chat_histories/nosql.ts
+++ b/libs/providers/langchain-azure-cosmosdb/src/chat_histories/nosql.ts
@@ -231,6 +231,7 @@ export class AzureCosmsosDBNoSQLChatMessageHistory extends BaseListChatMessageHi
   }
 
   async getContext(): Promise<Record<string, unknown>> {
+    await this.initializeContainer();
     const document = await this.container
       .item(this.sessionId, this.userId)
       .read();


### PR DESCRIPTION
fixes #8965