### PR TITLE
fix(docs) Update README.md to fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This framework consists of several parts.
 - **Open-source libraries**: Build your applications using LangChain's open-source [building blocks](https://js.langchain.com/docs/concepts/lcel), [components](https://js.langchain.com/docs/concepts), and [third-party integrations](https://js.langchain.com/docs/integrations/platforms/).
   Use [LangGraph.js](https://js.langchain.com/docs/concepts/#langgraphjs) to build stateful agents with first-class streaming and human-in-the-loop support.
 - **Productionization**: Use [LangSmith](https://docs.smith.langchain.com/) to inspect, monitor and evaluate your chains, so that you can continuously optimize and deploy with confidence.
-- **Deployment**: Turn your LangGraph applications into production-ready APIs and Assistants with [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/).
+- **Deployment**: Turn your LangGraph applications into production-ready APIs and Assistants with [LangGraph Cloud](https://docs.langchain.com/langgraph-platform/deployment-quickstart).
 
 The LangChain libraries themselves are made up of several different packages.
 


### PR DESCRIPTION
### 🛠 Fix broken link in documentation
While reviewing the documentation, I noticed that the link to LangGraph Cloud was returning a 404 error. To resolve this, I replaced the outdated URL:

https://langchain-ai.github.io/langgraph/cloud/
with what appears to be the correct and currently working link:

https://docs.langchain.com/langgraph-platform/deployment-quickstart
This new link points to the LangGraph Platform Deployment Quickstart, which seems to match the intended destination based on context.

Although I'm not 100% certain this is the exact intended page, it looks like the most relevant replacement. Happy to adjust if there's a better target.