### PR TITLE
fix(v1): use `keyEncoder` instead of insecure cache key getter (#8978)

### DIFF
--- a/.changeset/angry-ads-retire.md
+++ b/.changeset/angry-ads-retire.md
@@ -1,0 +1,9 @@
+---
+"@langchain/azure-cosmosdb": patch
+"@langchain/cloudflare": patch
+"@langchain/community": patch
+"@langchain/redis": patch
+"langchain": patch
+---
+
+use `keyEncoder` instead of insecure cache key getter


### PR DESCRIPTION
mirror of #8978