### PR TITLE
fix(core): update chunk concat logic to match on missing ID fields

### DIFF
--- a/.changeset/afraid-paws-give.md
+++ b/.changeset/afraid-paws-give.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+update chunk concat logic to match on missing ID fields

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -456,17 +456,15 @@ export function _mergeLists<Content extends MessageContentComplex>(
         "index" in item &&
         typeof item.index === "number"
       ) {
-        const toMerge = merged.findIndex(
-          (leftItem) =>
-            leftItem !== null &&
-            typeof leftItem === "object" &&
-            "index" in leftItem &&
-            leftItem.index === item.index &&
-            // Only merge if IDs match or one has an ID that is undefined
-            ("id" in leftItem && "id" in item
-              ? leftItem.id === item.id
-              : !("id" in leftItem) || !("id" in item))
-        );
+        const toMerge = merged.findIndex((leftItem) => {
+          const isObject = typeof leftItem === "object";
+          const indiciesMatch =
+            "index" in leftItem && leftItem.index === item.index;
+          const idsMatch =
+            "id" in leftItem && "id" in item && leftItem?.id === item?.id;
+          const eitherItemMissingID = !("id" in leftItem) || !("id" in item);
+          return isObject && indiciesMatch && (idsMatch || eitherItemMissingID);
+        });
         if (
           toMerge !== -1 &&
           typeof merged[toMerge] === "object" &&

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -462,11 +462,12 @@ export function _mergeLists<Content extends MessageContentComplex>(
             typeof leftItem === "object" &&
             "index" in leftItem &&
             leftItem.index === item.index &&
-            // Only merge if IDs match (or both are undefined)
+            // Only merge if IDs match or one has an ID that is undefined
             ("id" in leftItem && "id" in item
               ? leftItem.id === item.id
-              : !("id" in leftItem) && !("id" in item))
+              : !("id" in leftItem) || !("id" in item))
         );
+        console.log(toMerge);
         if (
           toMerge !== -1 &&
           typeof merged[toMerge] === "object" &&

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -462,7 +462,11 @@ export function _mergeLists<Content extends MessageContentComplex>(
             "index" in leftItem && leftItem.index === item.index;
           const idsMatch =
             "id" in leftItem && "id" in item && leftItem?.id === item?.id;
-          const eitherItemMissingID = !("id" in leftItem) || !("id" in item);
+          const eitherItemMissingID =
+            !("id" in leftItem) ||
+            !leftItem?.id ||
+            !("id" in item) ||
+            !item?.id;
           return isObject && indiciesMatch && (idsMatch || eitherItemMissingID);
         });
         if (

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -467,7 +467,6 @@ export function _mergeLists<Content extends MessageContentComplex>(
               ? leftItem.id === item.id
               : !("id" in leftItem) || !("id" in item))
         );
-        console.log(toMerge);
         if (
           toMerge !== -1 &&
           typeof merged[toMerge] === "object" &&

--- a/langchain-core/src/messages/tests/ai.test.ts
+++ b/langchain-core/src/messages/tests/ai.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 import { AIMessageChunk } from "../ai.js";
 
 describe("AIMessageChunk", () => {
-  it("should properly merge tool call chunks", () => {
+  it("should properly merge tool call chunks that have matching indices and ids", () => {
     const chunk1 = new AIMessageChunk({
       content: "",
       tool_call_chunks: [
@@ -44,5 +44,39 @@ describe("AIMessageChunk", () => {
       '{"ideas":["read about Angular 19 updates"]}'
     );
     expect(secondCall?.id).toBe("5abf542e-87f3-4899-87c6-8f7d9cb6a28d");
+  });
+
+  it("should properly merge tool call chunks that have matching indices and at least one id is blank", () => {
+    const chunk1 = new AIMessageChunk({
+      content: "",
+      tool_call_chunks: [
+        {
+          name: "add_new_task",
+          type: "tool_call_chunk",
+          index: 0,
+          id: "9fb5c937-6944-4173-84be-ad1caee1cedd",
+        },
+      ],
+    });
+    const chunk2 = new AIMessageChunk({
+      content: "",
+      tool_call_chunks: [
+        {
+          args: '{"tasks":["buy tomatoes","help child with math"]}',
+          type: "tool_call_chunk",
+          index: 0,
+        },
+      ],
+    });
+
+    const merged = chunk1.concat(chunk2);
+    expect(merged.tool_call_chunks).toHaveLength(1);
+
+    const firstCall = merged.tool_call_chunks?.[0];
+    expect(firstCall?.name).toBe("add_new_task");
+    expect(firstCall?.args).toBe(
+      '{"tasks":["buy tomatoes","help child with math"]}'
+    );
+    expect(firstCall?.id).toBe("9fb5c937-6944-4173-84be-ad1caee1cedd");
   });
 });

--- a/langchain-core/src/messages/tests/ai.test.ts
+++ b/langchain-core/src/messages/tests/ai.test.ts
@@ -79,4 +79,37 @@ describe("AIMessageChunk", () => {
     );
     expect(firstCall?.id).toBe("9fb5c937-6944-4173-84be-ad1caee1cedd");
   });
+
+  it("should properly merge tool call chunks that have matching indices no IDs at all", () => {
+    const chunk1 = new AIMessageChunk({
+      content: "",
+      tool_call_chunks: [
+        {
+          name: "add_new_task",
+          type: "tool_call_chunk",
+          index: 0,
+        },
+      ],
+    });
+    const chunk2 = new AIMessageChunk({
+      content: "",
+      tool_call_chunks: [
+        {
+          args: '{"tasks":["buy tomatoes","help child with math"]}',
+          type: "tool_call_chunk",
+          index: 0,
+        },
+      ],
+    });
+
+    const merged = chunk1.concat(chunk2);
+    expect(merged.tool_call_chunks).toHaveLength(1);
+
+    const firstCall = merged.tool_call_chunks?.[0];
+    expect(firstCall?.name).toBe("add_new_task");
+    expect(firstCall?.args).toBe(
+      '{"tasks":["buy tomatoes","help child with math"]}'
+    );
+    expect(firstCall?.id).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR updates the logic so that if tool chunk indices match and one chunk does not have an ID, the tool chunks are then merged.

Fixes https://github.com/langchain-ai/langchainjs/issues/8985