### PR TITLE
fix(core): omit tool call chunks without tool call id

### DIFF
--- a/.changeset/honest-hats-brush.md
+++ b/.changeset/honest-hats-brush.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+omit tool call chunks without tool call id

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -271,21 +271,36 @@ export class AIMessageChunk extends BaseMessageChunk {
             : undefined,
       };
     } else {
-      const groupedToolCallChunk = fields.tool_call_chunks.reduce(
+      const groupedToolCallChunks = fields.tool_call_chunks.reduce(
         (acc, chunk) => {
-          // Assign a fallback ID if the chunk doesn't have one
-          // This can happen with tools that have empty schemas
-          const groupId = chunk.id || `fallback-${chunk.index || 0}`;
-          acc[groupId] = acc[groupId] ?? [];
-          acc[groupId].push(chunk);
+          const matchedChunkIndex = acc.findIndex(([match]) => {
+            // If chunk has an id and index, match if both are present
+            if ("id" in chunk && "index" in chunk) {
+              return chunk.id === match.id && chunk.index === match.index;
+            }
+            // If chunk has an id, we match on id
+            if ("id" in chunk) {
+              return chunk.id === match.id;
+            }
+            // If chunk has an index, we match on index
+            if ("index" in chunk) {
+              return chunk.index === match.index;
+            }
+            return false;
+          });
+          if (matchedChunkIndex !== -1) {
+            acc[matchedChunkIndex].push(chunk);
+          } else {
+            acc.push([chunk]);
+          }
           return acc;
         },
-        {} as Record<string, ToolCallChunk[]>
+        [] as ToolCallChunk[][]
       );
 
       const toolCalls: ToolCall[] = [];
       const invalidToolCalls: InvalidToolCall[] = [];
-      for (const chunks of Object.values(groupedToolCallChunk)) {
+      for (const chunks of groupedToolCallChunks) {
         let parsedArgs = {};
         const name = chunks[0]?.name ?? "";
         const joinedArgs = chunks.map((c) => c.args || "").join("");

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -275,15 +275,20 @@ export class AIMessageChunk extends BaseMessageChunk {
         (acc, chunk) => {
           const matchedChunkIndex = acc.findIndex(([match]) => {
             // If chunk has an id and index, match if both are present
-            if ("id" in chunk && "index" in chunk) {
+            if (
+              "id" in chunk &&
+              chunk.id &&
+              "index" in chunk &&
+              chunk.index !== undefined
+            ) {
               return chunk.id === match.id && chunk.index === match.index;
             }
             // If chunk has an id, we match on id
-            if ("id" in chunk) {
+            if ("id" in chunk && chunk.id) {
               return chunk.id === match.id;
             }
             // If chunk has an index, we match on index
-            if ("index" in chunk) {
+            if ("index" in chunk && chunk.index !== undefined) {
               return chunk.index === match.index;
             }
             return false;

--- a/langchain-core/src/messages/ai.ts
+++ b/langchain-core/src/messages/ai.ts
@@ -275,9 +275,9 @@ export class AIMessageChunk extends BaseMessageChunk {
         (acc, chunk) => {
           // Assign a fallback ID if the chunk doesn't have one
           // This can happen with tools that have empty schemas
-          const chunkId = chunk.id || `fallback-${chunk.index || 0}`;
-          acc[chunkId] = acc[chunkId] ?? [];
-          acc[chunkId].push(chunk);
+          const groupId = chunk.id || `fallback-${chunk.index || 0}`;
+          acc[groupId] = acc[groupId] ?? [];
+          acc[groupId].push(chunk);
           return acc;
         },
         {} as Record<string, ToolCallChunk[]>
@@ -285,16 +285,16 @@ export class AIMessageChunk extends BaseMessageChunk {
 
       const toolCalls: ToolCall[] = [];
       const invalidToolCalls: InvalidToolCall[] = [];
-      for (const [id, chunks] of Object.entries(groupedToolCallChunk)) {
+      for (const chunks of Object.values(groupedToolCallChunk)) {
         let parsedArgs = {};
         const name = chunks[0]?.name ?? "";
         const joinedArgs = chunks.map((c) => c.args || "").join("");
         const argsStr = joinedArgs.length ? joinedArgs : "{}";
-        // Use the original ID from the first chunk if it exists, otherwise use the grouped ID
-        const originalId = chunks[0]?.id || id;
+        const id = chunks[0]?.id;
         try {
           parsedArgs = parsePartialJson(argsStr);
           if (
+            !id ||
             parsedArgs === null ||
             typeof parsedArgs !== "object" ||
             Array.isArray(parsedArgs)
@@ -304,14 +304,14 @@ export class AIMessageChunk extends BaseMessageChunk {
           toolCalls.push({
             name,
             args: parsedArgs,
-            id: originalId,
+            id,
             type: "tool_call",
           });
         } catch (e) {
           invalidToolCalls.push({
             name,
             args: argsStr,
-            id: originalId,
+            id,
             error: "Malformed args.",
             type: "invalid_tool_call",
           });

--- a/langchain-core/src/messages/base.ts
+++ b/langchain-core/src/messages/base.ts
@@ -418,7 +418,9 @@ export function _mergeDicts(
       if (key === "type") {
         // Do not merge 'type' fields
         continue;
-      } else if (["id", "output_version", "model_provider"].includes(key)) {
+      } else if (
+        ["id", "name", "output_version", "model_provider"].includes(key)
+      ) {
         // Keep the incoming value for these fields
         merged[key] = value;
       } else {

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -466,7 +466,7 @@ describe("Complex AIMessageChunk concat", () => {
     ]);
   });
 
-  it("concatenates tool call chunks without IDs", () => {
+  it("omits tool call chunks without IDs", () => {
     const chunks: ToolCallChunk[] = [
       {
         name: "get_current_time",
@@ -481,14 +481,13 @@ describe("Complex AIMessageChunk concat", () => {
       tool_call_chunks: chunks,
     });
 
-    expect(result.tool_calls?.length).toBe(1);
-    expect(result.invalid_tool_calls?.length).toBe(0);
-    expect(result.tool_calls).toEqual([
+    expect(result.tool_calls?.length).toBe(0);
+    expect(result.invalid_tool_calls?.length).toBe(1);
+    expect(result.invalid_tool_calls).toEqual([
       {
-        id: "fallback-0", // Should get fallback ID
         name: "get_current_time",
-        args: {},
         type: "tool_call",
+        args: {},
       },
     ]);
   });
@@ -507,11 +506,10 @@ describe("Complex AIMessageChunk concat", () => {
       tool_call_chunks: chunks,
     });
 
-    expect(result.tool_calls?.length).toBe(1);
-    expect(result.invalid_tool_calls?.length).toBe(0);
-    expect(result.tool_calls).toEqual([
+    expect(result.tool_calls?.length).toBe(0);
+    expect(result.invalid_tool_calls?.length).toBe(1);
+    expect(result.invalid_tool_calls).toEqual([
       {
-        id: "fallback-0", // Should get fallback ID with index 0
         name: "get_current_time",
         args: {},
         type: "tool_call",

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -485,9 +485,11 @@ describe("Complex AIMessageChunk concat", () => {
     expect(result.invalid_tool_calls?.length).toBe(1);
     expect(result.invalid_tool_calls).toEqual([
       {
+        type: "invalid_tool_call",
+        id: undefined,
         name: "get_current_time",
-        type: "tool_call",
-        args: {},
+        args: "{}",
+        error: "Malformed args.",
       },
     ]);
   });
@@ -510,9 +512,11 @@ describe("Complex AIMessageChunk concat", () => {
     expect(result.invalid_tool_calls?.length).toBe(1);
     expect(result.invalid_tool_calls).toEqual([
       {
+        type: "invalid_tool_call",
+        id: undefined,
         name: "get_current_time",
-        args: {},
-        type: "tool_call",
+        args: "{}",
+        error: "Malformed args.",
       },
     ]);
   });

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -552,11 +552,14 @@ describe("Complex AIMessageChunk concat", () => {
     for (const chunk of chunks) {
       finalChunk = finalChunk.concat(chunk);
     }
+    expect(finalChunk.tool_calls).toHaveLength(1);
     expect(finalChunk.tool_calls).toEqual([
       {
         type: "tool_call",
         name: "get_weather",
-        args: "San Francisco",
+        args: {
+          location: "San Francisco",
+        },
         id: "call_q6ZzjkLjKNYb4DizyMOaqpfW",
       },
     ]);

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -466,59 +466,159 @@ describe("Complex AIMessageChunk concat", () => {
     ]);
   });
 
-  it("omits tool call chunks without IDs", () => {
-    const chunks: ToolCallChunk[] = [
-      {
-        name: "get_current_time",
-        type: "tool_call_chunk",
-        index: 0,
-        // no `id` provided
-      },
+  it("concatenates tool call chunks without IDs", () => {
+    const chunks = [
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            name: "get_weather",
+            args: "",
+            id: "call_q6ZzjkLjKNYb4DizyMOaqpfW",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: '{"',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: "location",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: '":"',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: "San",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: " Francisco",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
+      new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            args: '"}',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      }),
     ];
-
-    const result = new AIMessageChunk({
-      content: "",
-      tool_call_chunks: chunks,
-    });
-
-    expect(result.tool_calls?.length).toBe(0);
-    expect(result.invalid_tool_calls?.length).toBe(1);
-    expect(result.invalid_tool_calls).toEqual([
+    let finalChunk = new AIMessageChunk("");
+    for (const chunk of chunks) {
+      finalChunk = finalChunk.concat(chunk);
+    }
+    expect(finalChunk.tool_calls).toEqual([
       {
-        type: "invalid_tool_call",
-        id: undefined,
-        name: "get_current_time",
-        args: "{}",
-        error: "Malformed args.",
+        type: "tool_call",
+        name: "get_weather",
+        args: "San Francisco",
+        id: "call_q6ZzjkLjKNYb4DizyMOaqpfW",
       },
     ]);
   });
+});
 
-  it("concatenates tool call chunks without IDs and no index", () => {
-    const chunks: ToolCallChunk[] = [
-      {
-        name: "get_current_time",
-        type: "tool_call_chunk",
-        // no `id` or `index` provided
-      },
-    ];
+describe("AIMessageChunk", () => {
+  describe("constructor", () => {
+    it("omits tool call chunks without IDs", () => {
+      const chunks: ToolCallChunk[] = [
+        {
+          name: "get_current_time",
+          type: "tool_call_chunk",
+          index: 0,
+          // no `id` provided
+        },
+      ];
 
-    const result = new AIMessageChunk({
-      content: "",
-      tool_call_chunks: chunks,
+      const result = new AIMessageChunk({
+        content: "",
+        tool_call_chunks: chunks,
+      });
+
+      expect(result.tool_calls?.length).toBe(0);
+      expect(result.invalid_tool_calls?.length).toBe(1);
+      expect(result.invalid_tool_calls).toEqual([
+        {
+          type: "invalid_tool_call",
+          id: undefined,
+          name: "get_current_time",
+          args: "{}",
+          error: "Malformed args.",
+        },
+      ]);
     });
 
-    expect(result.tool_calls?.length).toBe(0);
-    expect(result.invalid_tool_calls?.length).toBe(1);
-    expect(result.invalid_tool_calls).toEqual([
-      {
-        type: "invalid_tool_call",
-        id: undefined,
-        name: "get_current_time",
-        args: "{}",
-        error: "Malformed args.",
-      },
-    ]);
+    it("omits tool call chunks without IDs and no index", () => {
+      const chunks: ToolCallChunk[] = [
+        {
+          name: "get_current_time",
+          type: "tool_call_chunk",
+          // no `id` or `index` provided
+        },
+      ];
+
+      const result = new AIMessageChunk({
+        content: "",
+        tool_call_chunks: chunks,
+      });
+
+      expect(result.tool_calls?.length).toBe(0);
+      expect(result.invalid_tool_calls?.length).toBe(1);
+      expect(result.invalid_tool_calls).toEqual([
+        {
+          type: "invalid_tool_call",
+          id: undefined,
+          name: "get_current_time",
+          args: "{}",
+          error: "Malformed args.",
+        },
+      ]);
+    });
   });
 });
 

--- a/langchain-core/src/messages/tests/base_message.test.ts
+++ b/langchain-core/src/messages/tests/base_message.test.ts
@@ -622,6 +622,63 @@ describe("AIMessageChunk", () => {
         },
       ]);
     });
+
+    it("can concatenate tool call chunks without IDs", () => {
+      const chunk = new AIMessageChunk({
+        id: "chatcmpl-x",
+        content: "",
+        tool_call_chunks: [
+          {
+            name: "get_weather",
+            args: "",
+            id: "call_q6ZzjkLjKNYb4DizyMOaqpfW",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: '{"',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: "location",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: '":"',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: "San",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: " Francisco",
+            index: 0,
+            type: "tool_call_chunk",
+          },
+          {
+            args: '"}',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      });
+      expect(chunk.tool_calls).toHaveLength(1);
+      expect(chunk.tool_calls).toEqual([
+        {
+          type: "tool_call",
+          name: "get_weather",
+          args: {
+            location: "San Francisco",
+          },
+          id: "call_q6ZzjkLjKNYb4DizyMOaqpfW",
+        },
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
Fixes an issue where tool call chunks that were missing an ID were showing up as separate tool calls

Fixes #8990