### PR TITLE
fix(openai): fix streaming in openai

### DIFF
--- a/.changeset/metal-camels-join.md
+++ b/.changeset/metal-camels-join.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): fix streaming in openai

--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -806,7 +806,7 @@ export abstract class BaseChatOpenAI<
     this.verbosity = fields?.verbosity ?? this.verbosity;
 
     // disable streaming in BaseChatModel if explicitly disabled
-    if (this.streaming === false) this.disableStreaming = true;
+    if (fields?.streaming === false) this.disableStreaming = true;
     if (this.disableStreaming === true) this.streaming = false;
 
     this.streamUsage = fields?.streamUsage ?? this.streamUsage;

--- a/libs/langchain-openai/src/tests/chat_models.test.ts
+++ b/libs/langchain-openai/src/tests/chat_models.test.ts
@@ -12,19 +12,19 @@ describe("ChatOpenAI", () => {
       let chat = new ChatOpenAI({
         model: "gpt-4o-mini",
       });
-      expect(chat.disableStreaming).toBe(true);
+      expect(chat.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       chat = new ChatOpenAI({
         model: "gpt-4o-mini",
         disableStreaming: undefined,
       } as any);
-      expect(chat.disableStreaming).toBe(true);
+      expect(chat.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       chat = new ChatOpenAI({
         model: "gpt-4o-mini",
         disableStreaming: false,
       });
-      expect(chat.disableStreaming).toBe(true);
+      expect(chat.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       chat = new ChatOpenAI({
         model: "gpt-4o-mini",
@@ -36,19 +36,19 @@ describe("ChatOpenAI", () => {
         model: "gpt-4o-mini",
         disableStreaming: null,
       } as any);
-      expect(chatWithNull.disableStreaming).toBe(true);
+      expect(chatWithNull.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       const chatWithZero = new ChatOpenAI({
         model: "gpt-4o-mini",
         disableStreaming: 0,
       } as any);
-      expect(chatWithZero.disableStreaming).toBe(true);
+      expect(chatWithZero.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       const chatWithEmptyString = new ChatOpenAI({
         model: "gpt-4o-mini",
         disableStreaming: "",
       } as any);
-      expect(chatWithEmptyString.disableStreaming).toBe(true);
+      expect(chatWithEmptyString.disableStreaming).toBe(false);
       expect(chat.streaming).toBe(false);
       chat = new ChatOpenAI({
         model: "gpt-4o-mini",


### PR DESCRIPTION
A previous change has caused streaming to break in OpenAI. This patch fixes that.