### PR TITLE
fix(langchain): remove MemorySaver re-export

### DIFF
--- a/examples/src/createAgent/accessLongTermMemory.ts
+++ b/examples/src/createAgent/accessLongTermMemory.ts
@@ -24,7 +24,8 @@
  */
 
 import fs from "node:fs/promises";
-import { createAgent, tool, InMemoryStore } from "langchain";
+import { createAgent, tool } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 

--- a/examples/src/createAgent/accessLongTermMemoryInTools.ts
+++ b/examples/src/createAgent/accessLongTermMemoryInTools.ts
@@ -19,7 +19,8 @@
  */
 
 import fs from "node:fs/promises";
-import { createAgent, tool, InMemoryStore } from "langchain";
+import { createAgent, tool } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 

--- a/examples/src/createAgent/middleware/hitl.ts
+++ b/examples/src/createAgent/middleware/hitl.ts
@@ -1,6 +1,6 @@
-import { createAgent, HumanMessage, tool, MemorySaver } from "langchain";
+import { createAgent, HumanMessage, tool } from "langchain";
 import { humanInTheLoopMiddleware } from "langchain/middleware";
-import { Command } from "@langchain/langgraph";
+import { Command, MemorySaver } from "@langchain/langgraph";
 import { z } from "zod";
 
 const checkpointSaver = new MemorySaver();

--- a/examples/src/createAgent/middleware/simpleHitl.ts
+++ b/examples/src/createAgent/middleware/simpleHitl.ts
@@ -1,10 +1,5 @@
-import {
-  createMiddleware,
-  createAgent,
-  HumanMessage,
-  MemorySaver,
-} from "langchain";
-import { Command, interrupt } from "@langchain/langgraph";
+import { createMiddleware, createAgent, HumanMessage } from "langchain";
+import { Command, interrupt, MemorySaver } from "@langchain/langgraph";
 
 const checkpointer = new MemorySaver();
 

--- a/examples/src/createAgent/postModelHook.ts
+++ b/examples/src/createAgent/postModelHook.ts
@@ -18,7 +18,8 @@
  */
 
 import fs from "node:fs/promises";
-import { createAgent, tool, AIMessage, MemorySaver } from "langchain";
+import { createAgent, tool, AIMessage } from "langchain";
+import { MemorySaver } from "@langchain/langgraph";
 import { interrupt } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";

--- a/examples/src/createAgent/postModelHook.ts
+++ b/examples/src/createAgent/postModelHook.ts
@@ -146,7 +146,6 @@ const agent = createAgent({
   llm: new ChatOpenAI({ model: "gpt-4o", temperature: 0.7 }),
   tools: [productInfoTool],
   checkpointer: new MemorySaver(),
-  // eslint-disable-next-line object-shorthand
   postModelHook: function postModelHook(state) {
     stats.total += 1;
 

--- a/examples/src/createAgent/tools.ts
+++ b/examples/src/createAgent/tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { createAgent, InMemoryStore, tool } from "langchain";
+import { createAgent, tool } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 
 const store = new InMemoryStore();

--- a/examples/src/createAgent/updateLongTermMemoryInTools.ts
+++ b/examples/src/createAgent/updateLongTermMemoryInTools.ts
@@ -16,7 +16,8 @@
  */
 
 import fs from "node:fs/promises";
-import { createAgent, tool, InMemoryStore } from "langchain";
+import { createAgent, tool } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 

--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -45,10 +45,9 @@ export {
 } from "./agents/index.js";
 
 /**
- * LangChain Memory
- * Check in what we want to export here
+ * LangChain Stores
  */
-export { MemorySaver, InMemoryStore } from "@langchain/langgraph";
+export { InMemoryStore } from "@langchain/core/stores";
 
 /**
  * LangChain Context


### PR DESCRIPTION
We should not re-export LangGraph primitives from `langchain` canonical.