### PR TITLE
fix(langchain/agents): remove llm prop from middleware agent

### DIFF
--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -310,8 +310,6 @@ export class ReactAgent<
      */
     this.#graph = allNodeWorkflows.compile({
       checkpointer: this.options.checkpointer ?? this.options.checkpointSaver,
-      interruptBefore: this.options.interruptBefore,
-      interruptAfter: this.options.interruptAfter,
       store: this.options.store,
       name: this.options.name,
       description: this.options.description,

--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -15,7 +15,7 @@ import { ToolMessage, AIMessage } from "@langchain/core/messages";
 import { IterableReadableStream } from "@langchain/core/utils/stream";
 
 import { createAgentAnnotationConditional } from "./annotation.js";
-import { isClientTool, validateLLMHasNoBoundTools } from "../utils.js";
+import { isClientTool } from "../utils.js";
 
 import { AgentNode } from "./nodes/AgentNode.js";
 import { ToolNode } from "../nodes/ToolNode.js";
@@ -96,30 +96,6 @@ export class ReactAgent<
     public options: CreateAgentParams<StructuredResponseFormat, ContextSchema>
   ) {
     this.#toolBehaviorVersion = options.version ?? this.#toolBehaviorVersion;
-
-    /**
-     * Check if the LLM already has bound tools and throw if it does.
-     */
-    if (options.llm && typeof options.llm !== "function") {
-      validateLLMHasNoBoundTools(options.llm);
-    }
-
-    /**
-     * validate that model and llm options are not provided together
-     */
-    if (options.llm && options.model) {
-      throw new Error("Cannot provide both `model` and `llm` options.");
-    }
-
-    /**
-     * validate that either model or llm option is provided
-     */
-    if (!options.llm && !options.model) {
-      throw new Error(
-        "Either `model` or `llm` option must be provided to create an agent."
-      );
-    }
-
     const toolClasses =
       (Array.isArray(options.tools) ? options.tools : options.tools?.tools) ??
       [];
@@ -214,7 +190,6 @@ export class ReactAgent<
     allNodeWorkflows.addNode(
       "model_request",
       new AgentNode({
-        llm: this.options.llm,
         model: this.options.model,
         prompt: this.options.prompt,
         includeAgentName: this.options.includeAgentName,

--- a/libs/langchain/src/agents/middlewareAgent/middleware/tests/dynamicSystemPrompt.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/tests/dynamicSystemPrompt.test.ts
@@ -6,6 +6,7 @@ import {
   AIMessage,
   SystemMessage,
 } from "@langchain/core/messages";
+import { LanguageModelLike } from "@langchain/core/language_models/base";
 import { dynamicSystemPromptMiddleware } from "../dynamicSystemPrompt.js";
 import { createAgent } from "../../index.js";
 
@@ -27,7 +28,7 @@ function createMockModel() {
 
 describe("dynamicSystemPrompt", () => {
   it("should set system message from dynamic prompt before model call", async () => {
-    const mockModel = createMockModel();
+    const model = createMockModel() as unknown as LanguageModelLike;
     const contextSchema = z.object({ region: z.string().optional() });
 
     const middleware = dynamicSystemPromptMiddleware<
@@ -38,7 +39,7 @@ describe("dynamicSystemPrompt", () => {
     });
 
     const agent = createAgent({
-      llm: mockModel as any,
+      model,
       middleware: [middleware] as const,
       contextSchema,
     });
@@ -54,8 +55,8 @@ describe("dynamicSystemPrompt", () => {
       }
     );
 
-    expect(mockModel.invoke).toHaveBeenCalled();
-    const callArgs = (mockModel.invoke as any).mock.calls[0];
+    expect(model.invoke).toHaveBeenCalled();
+    const callArgs = (model.invoke as any).mock.calls[0];
     const [firstMessage] = callArgs[0];
     expect(firstMessage.type).toBe("system");
     expect(firstMessage.content).toBe(
@@ -64,7 +65,7 @@ describe("dynamicSystemPrompt", () => {
   });
 
   it("should throw if the function does not return a string", async () => {
-    const mockModel = createMockModel();
+    const model = createMockModel() as unknown as LanguageModelLike;
     const contextSchema = z.object({ region: z.string().optional() });
 
     const middleware = dynamicSystemPromptMiddleware<
@@ -78,7 +79,7 @@ describe("dynamicSystemPrompt", () => {
     });
 
     const agent = createAgent({
-      llm: mockModel as any,
+      model,
       middleware: [middleware] as const,
       contextSchema,
     });

--- a/libs/langchain/src/agents/middlewareAgent/middleware/tests/hitl.int.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/tests/hitl.int.test.ts
@@ -43,7 +43,7 @@ const nameGenerator = tool(
   }
 );
 
-const llm = new ChatOpenAI({ model: "gpt-4o" });
+const model = new ChatOpenAI({ model: "gpt-4o" });
 const thread = {
   configurable: {
     thread_id: "test-123",
@@ -55,7 +55,7 @@ describe("humanInTheLoopMiddleware", () => {
     it("should accept tool calls", async () => {
       const checkpointer = new MemorySaver();
       const agent = createAgent({
-        llm,
+        model,
         middleware: [
           humanInTheLoopMiddleware({
             toolConfigs: {
@@ -147,7 +147,7 @@ describe("humanInTheLoopMiddleware", () => {
         }
       );
       const agent = createAgent({
-        llm,
+        model,
         middleware: [
           humanInTheLoopMiddleware({
             toolConfigs: {
@@ -219,7 +219,7 @@ describe("humanInTheLoopMiddleware", () => {
     it("should respond to tool calls", async () => {
       const checkpointer = new MemorySaver();
       const agent = createAgent({
-        llm,
+        model,
         middleware: [
           humanInTheLoopMiddleware({
             toolConfigs: {
@@ -262,7 +262,7 @@ describe("humanInTheLoopMiddleware", () => {
     it("should respond with structured response for approved tool calls and custom response", async () => {
       const checkpointer = new MemorySaver();
       const agent = createAgent({
-        llm,
+        model,
         middleware: [
           humanInTheLoopMiddleware({
             toolConfigs: {

--- a/libs/langchain/src/agents/middlewareAgent/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/tests/hitl.test.ts
@@ -76,7 +76,7 @@ describe("humanInTheLoopMiddleware", () => {
     });
 
     // Create agent with mocked LLM
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         // First call: calculator tool (auto-approved)
         [
@@ -99,7 +99,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       prompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
@@ -142,7 +142,7 @@ describe("humanInTheLoopMiddleware", () => {
     expect(mathMessages[2].content).toBe("42 * 17 = 714");
 
     // Test 2: Write file tool (requires approval)
-    llm.index = 1;
+    model.index = 1;
     await agent.invoke(
       {
         messages: [new HumanMessage("Write 'Hello World' to greeting.txt")],
@@ -185,7 +185,7 @@ describe("humanInTheLoopMiddleware", () => {
     `);
 
     // Resume with approval
-    llm.index = 1;
+    model.index = 1;
     const resumedResult = await agent.invoke(
       new Command({
         resume: [{ type: "accept" }],
@@ -217,7 +217,7 @@ describe("humanInTheLoopMiddleware", () => {
       },
     });
 
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         [
           {
@@ -231,7 +231,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       tools: [writeFileTool],
       middleware: [hitlMiddleware] as const,
@@ -287,7 +287,7 @@ describe("humanInTheLoopMiddleware", () => {
       },
     });
 
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         [
           {
@@ -301,7 +301,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       tools: [writeFileTool],
       middleware: [hitlMiddleware] as const,
@@ -356,7 +356,7 @@ describe("humanInTheLoopMiddleware", () => {
       },
     });
 
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         [
           {
@@ -370,7 +370,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       tools: [writeFileTool],
       middleware: [hitlMiddleware] as const,
@@ -423,7 +423,7 @@ describe("humanInTheLoopMiddleware", () => {
     });
 
     // Create agent with mocked LLM
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         // First call: calculator tool (auto-approved)
         [
@@ -443,7 +443,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       prompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
@@ -526,7 +526,7 @@ describe("humanInTheLoopMiddleware", () => {
     });
 
     // Create agent with mocked LLM
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         // First call: calculator tool (auto-approved)
         [
@@ -546,7 +546,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       prompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
@@ -592,7 +592,7 @@ describe("humanInTheLoopMiddleware", () => {
     });
 
     // Create agent with mocked LLM
-    const llm = new FakeToolCallingModel({
+    const model = new FakeToolCallingModel({
       toolCalls: [
         // First call: calculator tool (auto-approved)
         [
@@ -612,7 +612,7 @@ describe("humanInTheLoopMiddleware", () => {
 
     const checkpointer = new MemorySaver();
     const agent = createAgent({
-      llm,
+      model,
       checkpointer,
       prompt:
         "You are a helpful assistant. Use the tools provided to help the user.",

--- a/libs/langchain/src/agents/middlewareAgent/middleware/tests/promptCaching.int.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/tests/promptCaching.int.test.ts
@@ -92,7 +92,7 @@ const messages = [
 
 describe("anthropicPromptCachingMiddleware", () => {
   it("should allow middleware to update model, messages and systemMessage", async () => {
-    const anthropicModel = new ChatAnthropic({
+    const model = new ChatAnthropic({
       model: "claude-opus-4-20250514",
       temperature: 0.7,
       maxTokens: 500,
@@ -101,7 +101,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     // Create agent with OpenAI model string and the middleware
     const agent = createAgent({
-      llm: anthropicModel,
+      model,
       tools: [simpleTool],
       prompt: "You are a geography expert.",
       middleware: [
@@ -117,8 +117,7 @@ describe("anthropicPromptCachingMiddleware", () => {
       messages,
     });
 
-    const { anthropicFetchMock, anthropicResponse } = (anthropicModel as any)
-      .mocks;
+    const { anthropicFetchMock, anthropicResponse } = (model as any).mocks;
 
     // Verify that Anthropic was called (not OpenAI)
     expect(anthropicFetchMock).toHaveBeenCalled();

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
@@ -21,7 +21,7 @@ describe("middleware", () => {
       middlewareCBeforeModelState: "CBefore",
       middlewareCAfterModelState: "CAfter",
     };
-    const llm = new FakeToolCallingChatModel({
+    const model = new FakeToolCallingChatModel({
       responses: [new AIMessage("The weather in Tokyo is 25°C")],
     });
     const middlewareA = createMiddleware({
@@ -86,7 +86,7 @@ describe("middleware", () => {
       },
     });
     const agent = createAgent({
-      llm,
+      model,
       tools: [],
       middleware: [middlewareA, middlewareB, middlewareC] as const,
     });
@@ -116,7 +116,7 @@ describe("middleware", () => {
   });
 
   it("should propagate context schema to middleware hooks", async () => {
-    const llm = new FakeToolCallingChatModel({
+    const model = new FakeToolCallingChatModel({
       responses: [new AIMessage("The weather in Tokyo is 25°C")],
     });
     const middleware = createMiddleware({
@@ -141,7 +141,7 @@ describe("middleware", () => {
     });
 
     const agent = createAgent({
-      llm,
+      model,
       tools: [],
       contextSchema: z.object({
         customContext: z.string(),
@@ -165,7 +165,7 @@ describe("middleware", () => {
 
   describe("control actions", () => {
     it("should terminate the agent in beforeModel hook", async () => {
-      const llm = new FakeToolCallingChatModel({
+      const model = new FakeToolCallingChatModel({
         responses: [new AIMessage("The weather in Tokyo is 25°C")],
       });
       const middleware = createMiddleware({
@@ -176,7 +176,7 @@ describe("middleware", () => {
       });
       const toolFn = vi.fn();
       const agent = createAgent({
-        llm,
+        model,
         tools: [
           tool(toolFn, {
             name: "tool",
@@ -197,7 +197,7 @@ describe("middleware", () => {
     });
 
     it("should terminate the agent in afterModel hook", async () => {
-      const llm = new FakeToolCallingModel({
+      const model = new FakeToolCallingModel({
         toolCalls: [[{ id: "call_1", name: "tool", args: { name: "test" } }]],
       });
       const beforeModel = vi.fn();
@@ -212,7 +212,7 @@ describe("middleware", () => {
       });
       const toolFn = vi.fn();
       const agent = createAgent({
-        llm,
+        model,
         tools: [
           tool(toolFn, {
             name: "tool",

--- a/libs/langchain/src/agents/middlewareAgent/tests/reactAgent.int.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/reactAgent.int.test.ts
@@ -182,7 +182,7 @@ Please provide a clear, direct, and authoritative answer, as this information wi
     };
 
     // Create OpenAI model initially without any tools
-    const openAIModel = new ChatOpenAI({
+    const model = new ChatOpenAI({
       model: "gpt-4",
       temperature: 0,
       configuration: {
@@ -242,7 +242,7 @@ Please provide a clear, direct, and authoritative answer, as this information wi
 
     // Create agent with the middleware
     const agent = createAgent({
-      llm: openAIModel,
+      model,
       // No tools provided initially
       tools: [],
       middleware: [toolsMiddleware],

--- a/libs/langchain/src/agents/middlewareAgent/tests/state.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/state.test.ts
@@ -8,7 +8,7 @@ import { FakeToolCallingModel } from "../../tests/utils.js";
 describe("middleware state management", () => {
   it("should allow to define private state props with _ that doesn't leak out", async () => {
     expect.assertions(10);
-    const llm = new FakeToolCallingModel({});
+    const model = new FakeToolCallingModel({});
 
     /**
      * Middleware A defines
@@ -108,7 +108,7 @@ describe("middleware state management", () => {
     });
 
     const agent = createAgent({
-      llm,
+      model,
       middleware: [middlewareA, middlewareB, middlewareC] as const,
     });
 

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -13,9 +13,8 @@ import type {
 } from "@langchain/langgraph";
 
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
-import type { SystemMessage, BaseMessage } from "@langchain/core/messages";
+import type { BaseMessage } from "@langchain/core/messages";
 import type {
-  All,
   BaseCheckpointSaver,
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
@@ -436,7 +435,8 @@ export type CreateAgentParams<
     | ResponseFormatUndefined
 > = {
   /**
-   * Initializes a ChatModel based on the provided model name and provider.
+   * Defines a model to use for the agent. You can either pass in an instance of a LangChain chat model
+   * or a string. If a string is provided the agent initializes a ChatModel based on the provided model name and provider.
    * It supports various model providers and allows for runtime configuration of model parameters.
    *
    * @uses {@link initChatModel}
@@ -447,10 +447,39 @@ export type CreateAgentParams<
    *   // ...
    * });
    * ```
+   *
+   * @example
+   * ```ts
+   * import { ChatOpenAI } from "@langchain/openai";
+   * const agent = createAgent({
+   *   model: new ChatOpenAI({ model: "gpt-4o" }),
+   *   // ...
+   * });
+   * ```
    */
   model?: string | LanguageModelLike;
 
-  /** A list of tools or a ToolNode. */
+  /**
+   * A list of tools or a ToolNode.
+   *
+   * @example
+   * ```ts
+   * import { tool } from "langchain";
+   *
+   * const weatherTool = tool(() => "Sunny!", {
+   *   name: "get_weather",
+   *   description: "Get the weather for a location",
+   *   schema: z.object({
+   *     location: z.string().describe("The location to get weather for"),
+   *   }),
+   * });
+   *
+   * const agent = createAgent({
+   *   tools: [weatherTool],
+   *   // ...
+   * });
+   * ```
+   */
   tools?: ToolNode | (ServerTool | ClientTool)[];
 
   /**
@@ -469,7 +498,7 @@ export type CreateAgentParams<
    *
    * Cannot be used together with `modifyModelRequest`.
    */
-  prompt?: SystemMessage | string;
+  prompt?: string;
 
   /**
    * An optional schema for the context. It allows to pass in a typed context object into the agent
@@ -509,10 +538,10 @@ export type CreateAgentParams<
   checkpointSaver?: BaseCheckpointSaver | boolean;
   /** An optional checkpoint saver to persist the agent's state. Alias of "checkpointSaver". */
   checkpointer?: BaseCheckpointSaver | boolean;
-  /** An optional list of node names to interrupt before running. */
-  interruptBefore?: N[] | All;
-  /** An optional list of node names to interrupt after running. */
-  interruptAfter?: N[] | All;
+  /**
+   * An optional store to persist the agent's state.
+   * @see {@link https://docs.langchain.com/oss/javascript/langgraph/memory#memory-storage | Long-term memory}
+   */
   store?: BaseStore;
   /**
    * An optional schema for the final agent output.

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -20,11 +20,7 @@ import type {
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
 
-import type {
-  PreHookAnnotation,
-  AnyAnnotationRoot,
-  ToAnnotationRoot,
-} from "../annotation.js";
+import type { AnyAnnotationRoot, ToAnnotationRoot } from "../annotation.js";
 
 import type {
   ResponseFormat,
@@ -36,7 +32,7 @@ import type {
 } from "../responses.js";
 import type { Interrupt } from "../interrupt.js";
 import type { ToolNode } from "../nodes/ToolNode.js";
-import type { ClientTool, ServerTool, AgentRuntime } from "../types.js";
+import type { ClientTool, ServerTool } from "../types.js";
 
 export type N = typeof START | "model_request" | "tools";
 
@@ -423,13 +419,6 @@ export interface LLMCall {
   response?: BaseMessage;
 }
 
-export type DynamicLLMFunction<
-  ContextSchema extends AnyAnnotationRoot | InteropZodObject = AnyAnnotationRoot
-> = (
-  state: AgentBuiltInState & PreHookAnnotation["State"],
-  runtime: AgentRuntime<ToAnnotationRoot<ContextSchema>["State"]>
-) => Promise<LanguageModelLike> | LanguageModelLike;
-
 export type CreateAgentParams<
   StructuredResponseType extends Record<string, any> = Record<string, any>,
   ContextSchema extends
@@ -446,9 +435,6 @@ export type CreateAgentParams<
     | ProviderStrategy<StructuredResponseType>
     | ResponseFormatUndefined
 > = {
-  /** The chat model that can utilize OpenAI-style tool calling. */
-  llm?: LanguageModelLike | DynamicLLMFunction<ContextSchema>;
-
   /**
    * Initializes a ChatModel based on the provided model name and provider.
    * It supports various model providers and allows for runtime configuration of model parameters.
@@ -462,7 +448,7 @@ export type CreateAgentParams<
    * });
    * ```
    */
-  model?: string;
+  model?: string | LanguageModelLike;
 
   /** A list of tools or a ToolNode. */
   tools?: ToolNode | (ServerTool | ClientTool)[];


### PR DESCRIPTION
With introducing middleware we got rid of allowing users to provide an `llm` property. Instead they pass in a chat instance or a string to the `model` property. There are still some inconsistencies with Python which I will clear up in a separate PR.