### PR TITLE
feat(langchain-mcp-adapters): Interceptors for tool calls + per-call HTTP/SSE header and arg overrides

### DIFF
--- a/libs/providers/langchain-mcp-adapters/src/client.ts
+++ b/libs/providers/langchain-mcp-adapters/src/client.ts
@@ -28,6 +28,7 @@ import {
   type LoadMcpToolsOptions,
   _resolveAndApplyOverrideHandlingOverrides,
 } from "./types.js";
+import type { Interceptor } from "./interceptor.js";
 
 const debugLog = getDebugLog();
 
@@ -125,6 +126,8 @@ export class MultiServerMCPClient {
 
   private _config: ResolvedClientConfig;
 
+  #interceptor?: Interceptor;
+
   /**
    * Returns clone of server config for inspection purposes.
    *
@@ -182,6 +185,7 @@ export class MultiServerMCPClient {
 
     this._config = parsedServerConfig;
     this._connections = parsedServerConfig.mcpServers;
+    this.#interceptor = parsedServerConfig.interceptor;
   }
 
   /**
@@ -657,7 +661,8 @@ export class MultiServerMCPClient {
       const tools = await loadMcpTools(
         serverName,
         client,
-        this._loadToolsOptions[serverName]
+        this._loadToolsOptions[serverName],
+        this.#interceptor
       );
       this._serverNameToTools[serverName] = tools;
       debugLog(

--- a/libs/providers/langchain-mcp-adapters/src/connection.ts
+++ b/libs/providers/langchain-mcp-adapters/src/connection.ts
@@ -1,0 +1,366 @@
+import {
+  SSEClientTransport,
+  SSEClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/sse.js";
+
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  StreamableHTTPClientTransportOptions,
+  StreamableHTTPReconnectionOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+import { getDebugLog } from "./logging.js";
+import type {
+  ResolvedStreamableHTTPConnection,
+  ResolvedStdioConnection,
+} from "./types.js";
+
+const debugLog = getDebugLog("connection");
+
+export interface TransportOptions {
+  serverName: string;
+  headers?: Record<string, string>;
+  authProvider?: OAuthClientProvider;
+}
+
+type ClientKeyObject = Omit<TransportOptions, "headers"> & {
+  headers?: string;
+};
+
+interface Connection {
+  transport:
+    | StreamableHTTPClientTransport
+    | SSEClientTransport
+    | StdioClientTransport;
+  client: Client;
+  closeCallback: () => Promise<void>;
+}
+
+const transportTypes = ["streamable-http", "sse", "stdio"] as const;
+
+/**
+ * Manages a pool of MCP clients with different transport, server name and connection configurations.
+ * This ensures we don't create multiple connections for the same server with the same configuration.
+ */
+export class ConnectionManager {
+  #connections: Map<ClientKeyObject, Connection> = new Map();
+
+  async createClient(
+    type: "stdio",
+    serverName: string,
+    options: ResolvedStdioConnection
+  ): Promise<Client>;
+  async createClient(
+    type: "streamable-http",
+    serverName: string,
+    options: ResolvedStreamableHTTPConnection
+  ): Promise<Client>;
+  async createClient(
+    type: "sse",
+    serverName: string,
+    options: ResolvedStreamableHTTPConnection
+  ): Promise<Client>;
+  async createClient(
+    ...args:
+      | ["stdio", string, ResolvedStdioConnection]
+      | ["sse", string, ResolvedStreamableHTTPConnection]
+      | ["streamable-http", string, ResolvedStreamableHTTPConnection]
+  ): Promise<Client> {
+    const [type, serverName, options] = args;
+    if (!transportTypes.includes(type)) {
+      throw new Error(`Invalid transport type: ${type}`);
+    }
+
+    const transport =
+      type === "streamable-http"
+        ? await this.#createStreamableHTTPTransport(serverName, options)
+        : type === "sse"
+        ? await this.#createSSETransport(serverName, options)
+        : await this.#createStdioTransport(options);
+    const client = new Client({
+      name: "langchain-mcp-adapter",
+      version: "0.1.0",
+    });
+    await client.connect(transport);
+
+    const key: ClientKeyObject =
+      type === "stdio"
+        ? { serverName }
+        : {
+            serverName,
+            headers: serializeHeaders(options.headers),
+            authProvider: options.authProvider,
+          };
+
+    this.#connections.set(key, {
+      transport,
+      client,
+      closeCallback: async () => client.close(),
+    });
+    return client;
+  }
+
+  /**
+   * Get the transport based on server name and connection configuration.
+   * @param options - The options for the transport
+   * @returns The transport
+   */
+  get(serverName: string): Client | undefined;
+  get(options: TransportOptions): Client | undefined;
+  get(options: TransportOptions | string): Client | undefined {
+    if (typeof options === "string") {
+      return this.#queryConnection({ serverName: options })?.connection.client;
+    }
+
+    return this.#queryConnection(options)?.connection.client;
+  }
+
+  /**
+   * Find the connection based on the parameter provided. This approach makes sure
+   * that `this.get({ serverName })` and `this.get({ serverName, headers: undefined, authProvider: undefined })`
+   * will return the same connection.
+   *
+   * @param options - The options for the transport
+   * @returns The connection and the key
+   */
+  #queryConnection(
+    options: TransportOptions
+  ): { key: ClientKeyObject; connection: Connection } | undefined {
+    const headers = serializeHeaders(options.headers);
+    const [key, connection] =
+      [...this.#connections.entries()].find(([key]) => {
+        if (options.headers && options.authProvider) {
+          return (
+            key.serverName === options.serverName &&
+            key.headers === headers &&
+            key.authProvider === options.authProvider
+          );
+        }
+        if (options.headers && !options.authProvider) {
+          return (
+            key.serverName === options.serverName && key.headers === headers
+          );
+        }
+        if (options.authProvider && !options.headers) {
+          return (
+            key.serverName === options.serverName &&
+            key.authProvider === options.authProvider
+          );
+        }
+        return key.serverName === options.serverName;
+      }) ?? [];
+
+    if (key && connection) {
+      return { key, connection };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Check if a client exists based on server name and connection configuration.
+   * @param options - The options for the transport
+   * @returns True if the client exists, false otherwise
+   */
+  has(serverName: string): boolean;
+  has(options: TransportOptions): boolean;
+  has(options: TransportOptions | string): boolean {
+    return Boolean(
+      typeof options === "string" ? this.get(options) : this.get(options)
+    );
+  }
+
+  /**
+   * Delete the transport based on server name and connection configuration.
+   * @param options - The options for the transport, if not provided, all transports are deleted
+   */
+  async delete(options?: TransportOptions) {
+    if (!options) {
+      await Promise.all(
+        Array.from(this.#connections.values()).map((connection) =>
+          connection.closeCallback()
+        )
+      );
+      this.#connections.clear();
+      return;
+    }
+
+    const result = this.#queryConnection(options);
+    if (result) {
+      await result.connection.closeCallback();
+      this.#connections.delete(result.key);
+    }
+  }
+
+  getTransport(
+    options: TransportOptions
+  ):
+    | StreamableHTTPClientTransport
+    | SSEClientTransport
+    | StdioClientTransport
+    | undefined {
+    const result = this.#queryConnection(options);
+    if (result) {
+      return result.connection.transport;
+    }
+    return undefined;
+  }
+
+  async #createStreamableHTTPTransport(
+    serverName: string,
+    args: ResolvedStreamableHTTPConnection
+  ): Promise<StreamableHTTPClientTransport> {
+    const { url, headers, reconnect, authProvider } = args;
+
+    const options: StreamableHTTPClientTransportOptions = {
+      ...(authProvider ? { authProvider } : {}),
+      ...(headers ? { requestInit: { headers } } : {}),
+    };
+
+    if (reconnect != null) {
+      const reconnectionOptions: StreamableHTTPReconnectionOptions = {
+        initialReconnectionDelay: reconnect?.delayMs ?? 1000, // MCP default
+        maxReconnectionDelay: reconnect?.delayMs ?? 30000, // MCP default
+        maxRetries: reconnect?.maxAttempts ?? 2, // MCP default
+        reconnectionDelayGrowFactor: 1.5, // MCP default
+      };
+
+      if (reconnect.enabled === false) {
+        reconnectionOptions.maxRetries = 0;
+      }
+
+      options.reconnectionOptions = reconnectionOptions;
+    }
+
+    if (options.requestInit?.headers) {
+      debugLog(
+        `DEBUG: Using custom headers for SSE transport to server "${serverName}"`
+      );
+    }
+
+    if (options.authProvider) {
+      debugLog(
+        `DEBUG: Using OAuth authentication for Streamable HTTP transport to server "${serverName}"`
+      );
+    }
+
+    if (options.reconnectionOptions) {
+      if (options.reconnectionOptions.maxRetries === 0) {
+        debugLog(
+          `DEBUG: Disabling reconnection for Streamable HTTP transport to server "${serverName}"`
+        );
+      } else {
+        debugLog(
+          `DEBUG: Using custom reconnection options for Streamable HTTP transport to server "${serverName}"`
+        );
+      }
+    }
+
+    // Only pass options if there are any, otherwise use default constructor
+    return Object.keys(options).length > 0
+      ? new StreamableHTTPClientTransport(new URL(url), options)
+      : new StreamableHTTPClientTransport(new URL(url));
+  }
+
+  /**
+   * Create an SSE transport with appropriate EventSource implementation
+   *
+   * @param serverName - The name of the server
+   * @param url - The URL of the server
+   * @param headers - The headers to send with the request
+   * @param authProvider - The OAuth client provider to use for authentication
+   * @returns The SSE transport
+   */
+  async #createSSETransport(
+    serverName: string,
+    args: ResolvedStreamableHTTPConnection
+  ): Promise<SSEClientTransport> {
+    const { url, headers, authProvider } = args;
+    const options: SSEClientTransportOptions = {};
+
+    if (authProvider) {
+      options.authProvider = authProvider;
+      debugLog(
+        `DEBUG: Using OAuth authentication for SSE transport to server "${serverName}"`
+      );
+    }
+
+    if (headers) {
+      // For SSE, we need to pass headers via eventSourceInit.fetch for the initial connection
+      // and also via requestInit.headers for subsequent POST requests
+      options.eventSourceInit = {
+        fetch: async (url, init) => {
+          const requestHeaders = new Headers(init?.headers);
+
+          // Add OAuth token if authProvider is available
+          // This is necessary because setting eventSourceInit.fetch prevents automatic Authorization header
+          if (authProvider) {
+            const tokens = await authProvider.tokens();
+            if (tokens) {
+              requestHeaders.set(
+                "Authorization",
+                `Bearer ${tokens.access_token}`
+              );
+            }
+          }
+
+          // Add our custom headers
+          Object.entries(headers).forEach(([key, value]) => {
+            requestHeaders.set(key, value);
+          });
+          // Always include Accept header for SSE
+          requestHeaders.set("Accept", "text/event-stream");
+
+          return fetch(url, {
+            ...init,
+            headers: requestHeaders,
+          });
+        },
+      };
+
+      // Also include headers for POST requests
+      options.requestInit = { headers };
+
+      debugLog(
+        `DEBUG: Using custom headers for SSE transport to server "${serverName}"`
+      );
+    }
+
+    return new SSEClientTransport(new URL(url), options);
+  }
+
+  #createStdioTransport(
+    options: ResolvedStdioConnection
+  ): StdioClientTransport {
+    const { command, args, env, stderr } = options;
+    return new StdioClientTransport({
+      command,
+      args,
+      stderr,
+      // eslint-disable-next-line no-process-env
+      ...(env ? { env: { PATH: process.env.PATH!, ...env } } : {}),
+    });
+  }
+}
+
+/**
+ * A utility function that serializes the headers object to a string
+ * and orders the keys alphabetically so that the same headers object
+ * will always produce the same string.
+ * @param headers - The headers object to serialize
+ * @returns The serialized headers object
+ */
+function serializeHeaders(
+  headers?: Record<string, string>
+): string | undefined {
+  if (!headers) {
+    return;
+  }
+  return Object.entries(headers)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n");
+}

--- a/libs/providers/langchain-mcp-adapters/src/interceptor.ts
+++ b/libs/providers/langchain-mcp-adapters/src/interceptor.ts
@@ -1,0 +1,106 @@
+import { z } from "zod/v3";
+import type { ContentBlock } from "@langchain/core/messages";
+import {
+  LoggingMessageNotificationSchema,
+  ProgressSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const toolInfoSchema = z.object({
+  serverName: z.string(),
+  name: z.string(),
+  args: z.unknown(),
+});
+
+const toolInfoResultSchema = z.object({
+  ...toolInfoSchema.shape,
+  result: z.custom<ContentBlock>(),
+});
+
+const toolCallInterceptionSchema = z.object({
+  toolInfo: toolInfoSchema,
+  header: z.record(z.string()),
+});
+
+export const interceptorSchema = z.object({
+  /**
+   * Called before a tool call is made.
+   * Allows you to modify the tool call arguments or return a different tool call.
+   *
+   * @example
+   * ```ts
+   * const interceptor = {
+   *   beforeToolCall: (toolInfo) => {
+   *     return { toolInfo, header: { "X-Custom-Header": "Custom Value" } };
+   *   },
+   * };
+   * ```
+   */
+  beforeToolCall: z
+    .function()
+    .args(toolInfoSchema)
+    .returns(
+      z.union([
+        z.promise(toolCallInterceptionSchema),
+        toolCallInterceptionSchema,
+      ])
+    )
+    .optional(),
+
+  /**
+   * Called after a tool call is made.
+   * Allows you to modify the tool call result or return a different tool call result.
+   *
+   * @example
+   * ```ts
+   * const interceptor = {
+   *   afterToolCall: (toolInfoResult) => {
+   *     toolInfoResult.result = "Custom Value";
+   *     return { toolInfoResult };
+   *   },
+   * };
+   * ```
+   */
+  afterToolCall: z
+    .function()
+    .args(toolInfoResultSchema)
+    .returns(z.promise(z.unknown()))
+    .optional(),
+
+  /**
+   * Called when a log message is received.
+   *
+   * @example
+   * ```ts
+   * const interceptor = {
+   *   onLog: (logMessage) => {
+   *     console.log(logMessage);
+   *   },
+   * };
+   * ```
+   */
+  onLog: z
+    .function()
+    .args(LoggingMessageNotificationSchema)
+    .returns(z.union([z.void(), z.promise(z.void())]))
+    .optional(),
+
+  /**
+   * Called when a progress message is received.
+   *
+   * @example
+   * ```ts
+   * const interceptor = {
+   *   onProgress: (progress) => {
+   *     console.log(progress);
+   *   },
+   * };
+   * ```
+   */
+  onProgress: z
+    .function()
+    .args(ProgressSchema)
+    .returns(z.union([z.void(), z.promise(z.void())]))
+    .optional(),
+});
+
+export type Interceptor = z.output<typeof interceptorSchema>;

--- a/libs/providers/langchain-mcp-adapters/src/logging.ts
+++ b/libs/providers/langchain-mcp-adapters/src/logging.ts
@@ -1,0 +1,12 @@
+import debug from "debug";
+
+const packageName = "@langchain/mcp-adapters";
+
+const debugLog: Record<string, debug.Debugger> = {};
+export function getDebugLog(instanceName: string = "client") {
+  const key = `${packageName}:${instanceName}`;
+  if (!debugLog[key]) {
+    debugLog[key] = debug(key);
+  }
+  return debugLog[key];
+}

--- a/libs/providers/langchain-mcp-adapters/src/types.ts
+++ b/libs/providers/langchain-mcp-adapters/src/types.ts
@@ -480,6 +480,11 @@ export const clientConfigSchema = z
       )
       .optional()
       .default(false),
+
+    /**
+     * MCP client middleware
+     * Allows users to add custom middleware to the MCP client
+     */
   })
   .and(baseConfigSchema)
   .describe("Configuration for the MCP client");
@@ -638,4 +643,9 @@ export function _resolveAndApplyOverrideHandlingOverrides(
     ...expandedBase,
     ...expandedOverride,
   };
+}
+
+export interface CustomHTTPTransportOptions {
+  authProvider?: OAuthClientProvider;
+  headers?: Record<string, string>;
 }

--- a/libs/providers/langchain-mcp-adapters/src/types.ts
+++ b/libs/providers/langchain-mcp-adapters/src/types.ts
@@ -13,7 +13,7 @@ import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ContentBlock } from "@langchain/core/messages";
 
 import type { UnionToTuple } from "./util.js";
-import { interceptorSchema } from "./interceptor.js";
+import { interceptorSchema, type Interceptor } from "./interceptor.js";
 
 export type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 export type { ContentBlock };
@@ -339,6 +339,7 @@ export const stdioConnectionSchema = z
     restart: stdioRestartSchema.optional(),
   })
   .and(baseConfigSchema)
+  .and(interceptorSchema)
   .describe("Configuration for stdio transport connection");
 
 /**
@@ -412,6 +413,7 @@ export const streamableHttpConnectionSchema = z
     automaticSSEFallback: z.boolean().optional().default(true),
   })
   .and(baseConfigSchema)
+  .and(interceptorSchema)
   .describe("Configuration for streamable HTTP transport connection");
 
 /**
@@ -484,23 +486,9 @@ export const clientConfigSchema = z
       )
       .optional()
       .default(false),
-
-    /**
-     * Allows users to add custom interceptors to the MCP client to modify tool calls,
-     * log messages, and receive tool call progress updates.
-     */
-    interceptor: interceptorSchema
-      .describe(
-        "Allows users to add custom interceptors to the MCP client to modify tool calls, log messages, and receive tool call progress updates."
-      )
-      .optional(),
-
-    /**
-     * MCP client middleware
-     * Allows users to add custom middleware to the MCP client
-     */
   })
   .and(baseConfigSchema)
+  .and(interceptorSchema)
   .describe("Configuration for the MCP client");
 
 /**
@@ -606,6 +594,21 @@ export type LoadMcpToolsOptions = {
    * If not specified, tools will use their own configured timeout values.
    */
   defaultToolTimeout?: number;
+
+  /**
+   * `onProgress` callbacks used for tool calls.
+   */
+  onProgress?: Interceptor["onProgress"][];
+
+  /**
+   * `beforeToolCall` callbacks used for tool calls.
+   */
+  beforeToolCall?: Interceptor["beforeToolCall"][];
+
+  /**
+   * `afterToolCall` callbacks used for tool calls.
+   */
+  afterToolCall?: Interceptor["afterToolCall"][];
 };
 
 /**

--- a/libs/providers/langchain-mcp-adapters/src/types.ts
+++ b/libs/providers/langchain-mcp-adapters/src/types.ts
@@ -10,9 +10,13 @@ import {
 } from "zod/v3";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { ContentBlock } from "@langchain/core/messages";
+
 import type { UnionToTuple } from "./util.js";
+import { interceptorSchema } from "./interceptor.js";
 
 export type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+export type { ContentBlock };
 
 function isZodObject(
   schema: unknown
@@ -480,6 +484,16 @@ export const clientConfigSchema = z
       )
       .optional()
       .default(false),
+
+    /**
+     * Allows users to add custom interceptors to the MCP client to modify tool calls,
+     * log messages, and receive tool call progress updates.
+     */
+    interceptor: interceptorSchema
+      .describe(
+        "Allows users to add custom interceptors to the MCP client to modify tool calls, log messages, and receive tool call progress updates."
+      )
+      .optional(),
 
     /**
      * MCP client middleware


### PR DESCRIPTION
This PR introduces an interceptor system around MCP tool calls and adds the ability to override HTTP/SSE headers and tool arguments at call time. It enables runtime personalization (e.g., per-user auth), centralized policy enforcement (defaults/limits), and better observability (logs and progress), without modifying server-side tool implementations.

### Motivation
- Personalize calls per user/session (auth tokens, tenant headers, flags)
- Enforce org-wide defaults centrally (timeouts, page sizes, safety)
- Improve observability (stream logs/progress to telemetry/UI)
- Do all the above without touching individual MCP tools or servers

### Key changes
- New `Interceptor` API with four hooks:
  - `beforeToolCall(toolInfo)` → optionally return `{ header?: Record[str,str], args?: Any }`
  - `afterToolCall(toolInfoResult)` → side-effect hook after completion
  - `onLog(message)` and `onProgress(progress)` callbacks
- Per-call HTTP/SSE header overrides
  - Implemented by forking the underlying client keyed by `(serverName, serializedHeaders, authProvider)`
  - Not supported for `stdio` transport; attempts will raise a tool exception
- Configuration layering
  - Interceptors can be registered at:
    - Global client level
    - Per-server connection level
    - Tool-loading options level (programmatic)
  - Precedence: arrays are built `[global, server, (optional) per-load/per-call]`; merges are shallow, later entries win
- Request-time merges
  - Args from `beforeToolCall` shallow-merge into original args
  - Headers from `beforeToolCall` shallow-merge and trigger client fork for HTTP/SSE
- Observability
  - `onProgress` is forwarded to MCP request options
  - `onLog`/`onProgress` can be set globally and per-server; both fire
- Connection management
  - New `ConnectionManager` with a pooled set of clients and a `Client.fork(headers)` facility for HTTP/SSE
  - Cleaned reconnection handling and resource cleanup paths

### Public API additions
- New hooks: `beforeToolCall`, `afterToolCall`, `onLog`, `onProgress`
  - At client level, server level, and `LoadMcpToolsOptions`
- Client forking (HTTP/SSE only):
  - `Client.fork(headers: Record<string,string>) => Promise<Client>`
  - Not available for `stdio` (throws if attempted via interceptor headers)

### Behavior and semantics
- Hook ordering and precedence
  - Arrays composed in order: global → server → per-load/per-call (when supported)
  - For merges (args, headers), later entries overwrite earlier keys (shallow)
- Header overrides
  - Only for HTTP/SSE (via `fork`)
  - `stdio` will raise a `ToolException` if headers are set via `beforeToolCall`
- `afterToolCall`
  - Side-effect only; return values ignored
- Performance
  - Forking creates/reuses clients keyed by header/auth; excessive per-call header diversity can increase connections

### Usage examples

- Per-call auth and defaults
```ts
import { MultiServerMCPClient, type ClientConfig } from "@langchain/mcp-adapters";

const config: ClientConfig = {
  mcpServers: {
    search: {
      transport: "http",
      url: "https://api.example.com/mcp",
      beforeToolCall: (info) => {
        if (info.name === "search") {
          return { args: { limit: 10, ...((info.args as any) ?? {}) } };
        }
      },
    },
  },
  beforeToolCall: () => ({
    header: {
      Authorization: `Bearer ${process.env.ACCESS_TOKEN!}`,
      "X-Tenant": "acme",
    },
  }),
  onProgress: (p) => console.log("progress:", p),
};

const client = new MultiServerMCPClient(config);
const tools = await client.getTools("search");
const search = tools.find((t) => t.name.endsWith("__search"))!;
const result = await search.invoke({ query: "langchain" });
```

### Backward compatibility
- No breaking changes to default behavior
- Existing consumers see no change unless they opt into interceptors or pass custom transport options
