### PR TITLE
Correct baseURL configuration usage

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -2904,7 +2904,9 @@ export interface ChatOpenAIFields extends BaseChatOpenAIFields {
  *   timeout: undefined,
  *   maxRetries: 2,
  *   // apiKey: "...",
- *   // baseUrl: "...",
+ *   // configuration: {
+ *   //   baseURL: "...",
+ *   // }
  *   // organization: "...",
  *   // other params...
  * });


### PR DESCRIPTION
This pull request makes a minor update to the example configuration for the `ChatOpenAIFields` interface in `chat_models.ts`. The change clarifies how to specify the `baseURL` using the `configuration` object instead of a direct property.

* Updated the example for setting `baseURL` to use the `configuration` object, improving clarity for users configuring the API client.

[@recabasic](https://x.com/recabasic)

Fixes #3565 #3086 