### PR TITLE
feat: Add Perplexity support to universal chat model

### DIFF
--- a/.changeset/green-squids-fetch.md
+++ b/.changeset/green-squids-fetch.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+feat: Add Perplexity support to universal chat model

--- a/langchain/src/chat_models/tests/universal.int.test.ts
+++ b/langchain/src/chat_models/tests/universal.int.test.ts
@@ -598,6 +598,17 @@ describe("Works with all model providers", () => {
     expect(deepSeekResult).toBeDefined();
     expect(deepSeekResult.content.length).toBeGreaterThan(0);
   });
+
+  it("Can invoke perplexity", async () => {
+    const perplexity = await initChatModel("sonar-pro", {
+      modelProvider: "perplexity",
+      temperature: 0,
+    });
+
+    const perplexityResult = await perplexity.invoke("what's your name");
+    expect(perplexityResult).toBeDefined();
+    expect(perplexityResult.content.length).toBeGreaterThan(0);
+  });
 });
 
 test("Is compatible with agents", async () => {

--- a/langchain/src/chat_models/universal.ts
+++ b/langchain/src/chat_models/universal.ts
@@ -117,19 +117,6 @@ async function _initChatModelHelper(
         const { ChatOllama } = await import("@langchain/ollama");
         return new ChatOllama({ model, ...passedParams });
       }
-      case "perplexity": {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - Can not install as a proper dependency due to circular dependency
-        const { ChatPerplexity } = await import(
-          // We can not 'expect-error' because if you explicitly build `@langchain/community`
-          // this import will be able to be resolved, thus there will be no error. However
-          // this will never be the case in CI.
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore - Can not install as a proper dependency due to circular dependency
-          "@langchain/community/chat_models/perplexity"
-        );
-        return new ChatPerplexity({ model, ...passedParams });
-      }
       case "mistralai": {
         const { ChatMistralAI } = await import("@langchain/mistralai");
         return new ChatMistralAI({ model, ...passedParams });
@@ -179,6 +166,19 @@ async function _initChatModelHelper(
           "@langchain/community/chat_models/togetherai"
         );
         return new ChatTogetherAI({ model, ...passedParams });
+      }
+      case "perplexity": {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - Can not install as a proper dependency due to circular dependency
+        const { ChatPerplexity } = await import(
+          // We can not 'expect-error' because if you explicitly build `@langchain/community`
+          // this import will be able to be resolved, thus there will be no error. However
+          // this will never be the case in CI.
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore - Can not install as a proper dependency due to circular dependency
+          "@langchain/community/chat_models/perplexity"
+        );
+        return new ChatPerplexity({ model, ...passedParams });
       }
       default: {
         const supported = _SUPPORTED_PROVIDERS.join(", ");

--- a/langchain/src/chat_models/universal.ts
+++ b/langchain/src/chat_models/universal.ts
@@ -118,7 +118,16 @@ async function _initChatModelHelper(
         return new ChatOllama({ model, ...passedParams });
       }
       case "perplexity": {
-        const { ChatPerplexity } = await import("@langchain/community/chat_models/perplexity");
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - Can not install as a proper dependency due to circular dependency
+        const { ChatPerplexity } = await import(
+          // We can not 'expect-error' because if you explicitly build `@langchain/community`
+          // this import will be able to be resolved, thus there will be no error. However
+          // this will never be the case in CI.
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore - Can not install as a proper dependency due to circular dependency
+          "@langchain/community/chat_models/perplexity"
+        );
         return new ChatPerplexity({ model, ...passedParams });
       }
       case "mistralai": {
@@ -645,6 +654,7 @@ export async function initChatModel<
  *   - mistralai (@langchain/mistralai)
  *   - groq (@langchain/groq)
  *   - ollama (@langchain/ollama)
+ *   - perplexity (@langchain/community/chat_models/perplexity)
  *   - cerebras (@langchain/cerebras)
  *   - deepseek (@langchain/deepseek)
  *   - xai (@langchain/xai)

--- a/langchain/src/chat_models/universal.ts
+++ b/langchain/src/chat_models/universal.ts
@@ -51,6 +51,7 @@ const _SUPPORTED_PROVIDERS = [
   "cerebras",
   "deepseek",
   "xai",
+  "perplexity",
 ] as const;
 
 export type ChatModelProvider = (typeof _SUPPORTED_PROVIDERS)[number];
@@ -115,6 +116,10 @@ async function _initChatModelHelper(
       case "ollama": {
         const { ChatOllama } = await import("@langchain/ollama");
         return new ChatOllama({ model, ...passedParams });
+      }
+      case "perplexity": {
+        const { ChatPerplexity } = await import("@langchain/community/chat_models/perplexity");
+        return new ChatPerplexity({ model, ...passedParams });
       }
       case "mistralai": {
         const { ChatMistralAI } = await import("@langchain/mistralai");
@@ -220,6 +225,8 @@ export function _inferModelProvider(modelName: string): string | undefined {
     return "bedrock";
   } else if (modelName.startsWith("mistral")) {
     return "mistralai";
+  } else if (modelName.startsWith("sonar") || modelName.startsWith("pplx")) {
+    return "perplexity";
   } else {
     return undefined;
   }


### PR DESCRIPTION
   ## Summary
   Adds support for Perplexity AI models in the universal chat model factory.
   
   ## Changes
   - Added 'perplexity' to `_SUPPORTED_PROVIDERS` array
   - Added perplexity case to `initChatModel()` switch statement
   - Updated `_inferModelProvider()` to recognize `sonar*` and `pplx*` model names
   - Added integration test for Perplexity support
   
   ## Usage
   ```typescript
   import { initChatModel } from "langchain/chat_models/universal";
   
   // Auto-inferred from model name
   const model = await initChatModel("sonar-pro", {
     apiKey: "your-perplexity-key"
   });
   
   // Or explicitly specified
   const model2 = await initChatModel("sonar-deep-research", {
     modelProvider: "perplexity",
     apiKey: "your-perplexity-key"
   });
   ```
   
   ## Testing
   - Added integration test that verifies perplexity models work with the universal API
   - Test covers model initialization and basic invocation

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

