### PR TITLE
chore(openai): bump default model to gpt-4o-mini

### DIFF
--- a/libs/providers/langchain-openai/src/chat_models.ts
+++ b/libs/providers/langchain-openai/src/chat_models.ts
@@ -267,7 +267,7 @@ export abstract class BaseChatOpenAI<
 
   logitBias?: Record<string, number>;
 
-  model = "gpt-3.5-turbo";
+  model = "gpt-4o-mini";
 
   modelKwargs?: OpenAIChatInput["modelKwargs"];
 


### PR DESCRIPTION
related issue #8982