### PR TITLE
fix(langchain/createAgent): add graph support for jumps that are statically typed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ bun.lock
 coverage/
 
 examples/src/createAgent/*.png
+# LangGraph API
+.langgraph_api

--- a/libs/langchain/.gitignore
+++ b/libs/langchain/.gitignore
@@ -329,3 +329,4 @@ schema/prompt_template.d.cts
 node_modules
 dist
 .yarn
+graph-matrix.mermaid.md

--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -21,7 +21,10 @@ import { AgentNode } from "./nodes/AgentNode.js";
 import { ToolNode } from "../nodes/ToolNode.js";
 import { BeforeModelNode } from "./nodes/BeforeModalNode.js";
 import { AfterModelNode } from "./nodes/AfterModalNode.js";
-import { initializeMiddlewareStates } from "./nodes/utils.js";
+import {
+  initializeMiddlewareStates,
+  parseJumpToTarget,
+} from "./nodes/utils.js";
 
 import type { ClientTool, ServerTool, WithStateGraphNodes } from "../types.js";
 
@@ -131,8 +134,16 @@ export class ReactAgent<
     >;
 
     // Generate node names for middleware nodes that have hooks
-    const beforeModelNodes: { index: number; name: string }[] = [];
-    const afterModelNodes: { index: number; name: string }[] = [];
+    const beforeModelNodes: {
+      index: number;
+      name: string;
+      allowed?: string[];
+    }[] = [];
+    const afterModelNodes: {
+      index: number;
+      name: string;
+      allowed?: string[];
+    }[] = [];
     const modifyModelRequestHookMiddleware: [
       AgentMiddleware,
       /**
@@ -141,17 +152,24 @@ export class ReactAgent<
       () => any
     ][] = [];
 
+    const middlewareNames = new Set<string>();
     const middleware = this.options.middleware ?? [];
     for (let i = 0; i < middleware.length; i++) {
       let beforeModelNode: BeforeModelNode | undefined;
       let afterModelNode: AfterModelNode | undefined;
       const m = middleware[i];
+      if (middlewareNames.has(m.name)) {
+        throw new Error(`Middleware ${m.name} is defined multiple times`);
+      }
+
+      middlewareNames.add(m.name);
       if (m.beforeModel) {
         beforeModelNode = new BeforeModelNode(m);
-        const name = `before_model_${m.name}_${i}`;
+        const name = `${m.name}.before_model`;
         beforeModelNodes.push({
           index: i,
           name,
+          allowed: m.beforeModelJumpTo,
         });
         allNodeWorkflows.addNode(
           name,
@@ -161,10 +179,11 @@ export class ReactAgent<
       }
       if (m.afterModel) {
         afterModelNode = new AfterModelNode(m);
-        const name = `after_model_${m.name}_${i}`;
+        const name = `${m.name}.after_model`;
         afterModelNodes.push({
           index: i,
           name,
+          allowed: m.afterModelJumpTo,
         });
         allNodeWorkflows.addNode(
           name,
@@ -226,18 +245,35 @@ export class ReactAgent<
       allNodeWorkflows.addEdge(START, "model_request");
     }
 
-    // Connect beforeModel nodes in sequence
-    for (let i = 0; i < beforeModelNodes.length - 1; i++) {
-      allNodeWorkflows.addEdge(
-        beforeModelNodes[i].name,
-        beforeModelNodes[i + 1].name
-      );
-    }
+    // Connect beforeModel nodes; add conditional routing ONLY if allowed jumps are specified
+    for (let i = 0; i < beforeModelNodes.length; i++) {
+      const node = beforeModelNodes[i];
+      const current = node.name;
+      const isLast = i === beforeModelNodes.length - 1;
+      const nextDefault = isLast
+        ? "model_request"
+        : beforeModelNodes[i + 1].name;
 
-    // Connect last beforeModel node to agent
-    const lastBeforeModelNode = beforeModelNodes.at(-1);
-    if (beforeModelNodes.length > 0 && lastBeforeModelNode) {
-      allNodeWorkflows.addEdge(lastBeforeModelNode.name, "model_request");
+      if (node.allowed && node.allowed.length > 0) {
+        const hasTools = toolClasses.filter(isClientTool).length > 0;
+        const allowedMapped = node.allowed
+          .map((t) => parseJumpToTarget(t))
+          .filter((dest) => dest !== "tools" || hasTools);
+        const destinations = Array.from(
+          new Set([nextDefault, ...allowedMapped])
+        ) as ("tools" | "model_request" | typeof END)[];
+
+        allNodeWorkflows.addConditionalEdges(
+          current,
+          this.#createBeforeModelRouter(
+            toolClasses.filter(isClientTool),
+            nextDefault
+          ),
+          destinations
+        );
+      } else {
+        allNodeWorkflows.addEdge(current, nextDefault);
+      }
     }
 
     // Connect agent to last afterModel node (for reverse order execution)
@@ -258,27 +294,59 @@ export class ReactAgent<
       }
     }
 
-    // Connect afterModel nodes in reverse sequence
+    // Connect afterModel nodes in reverse sequence; add conditional routing ONLY if allowed jumps are specified per node
     for (let i = afterModelNodes.length - 1; i > 0; i--) {
-      allNodeWorkflows.addEdge(
-        afterModelNodes[i].name,
-        afterModelNodes[i - 1].name
-      );
+      const node = afterModelNodes[i];
+      const current = node.name;
+      const nextDefault = afterModelNodes[i - 1].name;
+
+      if (node.allowed && node.allowed.length > 0) {
+        const hasTools = toolClasses.filter(isClientTool).length > 0;
+        const allowedMapped = node.allowed
+          .map((t) => parseJumpToTarget(t))
+          .filter((dest) => dest !== "tools" || hasTools);
+        const destinations = Array.from(
+          new Set([nextDefault, ...allowedMapped])
+        ) as ("tools" | "model_request" | typeof END)[];
+
+        allNodeWorkflows.addConditionalEdges(
+          current,
+          this.#createAfterModelSequenceRouter(
+            toolClasses.filter(isClientTool),
+            node.allowed,
+            nextDefault
+          ),
+          destinations
+        );
+      } else {
+        allNodeWorkflows.addEdge(current, nextDefault);
+      }
     }
 
     // Connect first afterModel node (last to execute) to model paths with jumpTo support
     if (afterModelNodes.length > 0) {
-      const firstAfterModelNode = afterModelNodes[0].name;
+      const firstAfterModel = afterModelNodes[0];
+      const firstAfterModelNode = firstAfterModel.name;
       const modelPaths = this.#getModelPaths(
         toolClasses.filter(isClientTool),
         true
+      ).filter(
+        (p) => p !== "tools" || toolClasses.filter(isClientTool).length > 0
       );
 
-      // Use afterModel router which includes jumpTo logic
+      const allowJump = Boolean(
+        firstAfterModel.allowed && firstAfterModel.allowed.length > 0
+      );
+
+      const destinations = modelPaths;
+
       allNodeWorkflows.addConditionalEdges(
         firstAfterModelNode,
-        this.#createAfterModelRouter(toolClasses.filter(isClientTool)),
-        modelPaths
+        this.#createAfterModelRouter(
+          toolClasses.filter(isClientTool),
+          allowJump
+        ),
+        destinations
       );
     }
 
@@ -444,7 +512,10 @@ export class ReactAgent<
    * @param toolClasses - Available tool classes for validation
    * @returns Router function that handles jumpTo logic and normal routing
    */
-  #createAfterModelRouter(toolClasses: (ClientTool | ServerTool)[]) {
+  #createAfterModelRouter(
+    toolClasses: (ClientTool | ServerTool)[],
+    allowJump: boolean
+  ) {
     const hasStructuredResponse = Boolean(this.options.responseFormat);
 
     return (state: BuiltInState) => {
@@ -459,33 +530,22 @@ export class ReactAgent<
         return END;
       }
 
-      // Check if jumpTo is set in the state
-      if (state.jumpTo) {
+      // Check if jumpTo is set in the state and allowed
+      if (allowJump && state.jumpTo) {
         const jumpTarget = state.jumpTo;
-
-        // If jumpTo is "model", go to model_request node
-        if (jumpTarget === "model") {
-          return "model_request";
+        const destination = parseJumpToTarget(jumpTarget);
+        if (destination === END) {
+          return END;
         }
-
-        // If jumpTo is "tools", go to tools node
-        if (jumpTarget === "tools") {
+        if (destination === "tools") {
           // If trying to jump to tools but no tools are available, go to END
           if (toolClasses.length === 0) {
             return END;
           }
-
-          return "tools";
+          return new Send("tools", { ...state, jumpTo: undefined });
         }
-
-        // If jumpTo is END, go to END
-        if (jumpTarget === END) {
-          return END;
-        }
-
-        throw new Error(
-          `Invalid jump target: ${jumpTarget}, must be "model" or "tools".`
-        );
+        // destination === "model_request"
+        return new Send("model_request", { ...state, jumpTo: undefined });
       }
 
       // check if there are pending tool calls
@@ -542,6 +602,61 @@ export class ReactAgent<
        * The Send API is handled at the model_request node level
        */
       return "tools";
+    };
+  }
+
+  /**
+   * Router for afterModel sequence nodes (connecting later middlewares to earlier ones),
+   * honoring allowed jump targets and defaulting to the next node.
+   */
+  #createAfterModelSequenceRouter(
+    toolClasses: (ClientTool | ServerTool)[],
+    allowed: string[],
+    nextDefault: string
+  ) {
+    const allowedSet = new Set(allowed.map((t) => parseJumpToTarget(t)));
+    return (state: BuiltInState) => {
+      if (state.jumpTo) {
+        const dest = parseJumpToTarget(state.jumpTo);
+        if (dest === END && allowedSet.has(END)) {
+          return END;
+        }
+        if (dest === "tools" && allowedSet.has("tools")) {
+          if (toolClasses.length === 0) return END;
+          return new Send("tools", { ...state, jumpTo: undefined });
+        }
+        if (dest === "model_request" && allowedSet.has("model_request")) {
+          return new Send("model_request", { ...state, jumpTo: undefined });
+        }
+      }
+      return nextDefault as any;
+    };
+  }
+
+  /**
+   * Create routing function for jumpTo functionality after beforeModel hooks.
+   * Falls back to the default next node if no jumpTo is present.
+   */
+  #createBeforeModelRouter(
+    toolClasses: (ClientTool | ServerTool)[],
+    nextDefault: string
+  ) {
+    return (state: BuiltInState) => {
+      if (!state.jumpTo) {
+        return nextDefault;
+      }
+      const destination = parseJumpToTarget(state.jumpTo);
+      if (destination === END) {
+        return END;
+      }
+      if (destination === "tools") {
+        if (toolClasses.length === 0) {
+          return END;
+        }
+        return new Send("tools", { ...state, jumpTo: undefined });
+      }
+      // destination === "model_request"
+      return new Send("model_request", { ...state, jumpTo: undefined });
     };
   }
 

--- a/libs/langchain/src/agents/middlewareAgent/constants.ts
+++ b/libs/langchain/src/agents/middlewareAgent/constants.ts
@@ -1,0 +1,1 @@
+export const JUMP_TO_TARGETS = ["model", "tools", "end"] as const;

--- a/libs/langchain/src/agents/middlewareAgent/nodes/utils.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/utils.ts
@@ -5,8 +5,14 @@ import {
   AIMessage,
 } from "@langchain/core/messages";
 import { z, type ZodIssue, type ZodTypeAny } from "zod/v3";
+import { END } from "@langchain/langgraph";
 
-import type { AgentMiddleware, ToolCall, ToolResult } from "../types.js";
+import type {
+  AgentMiddleware,
+  ToolCall,
+  ToolResult,
+  JumpToDestination,
+} from "../types.js";
 
 /**
  * Helper function to initialize middleware state defaults.
@@ -158,4 +164,29 @@ function parseToolResults(messages: BaseMessage[]): ToolResult[] {
       id: (message as ToolMessage).tool_call_id,
       result: (message as ToolMessage).content,
     }));
+}
+
+/**
+ * Parse jumpTo target to a LangGraph target
+ */
+export function parseJumpToTarget(target: string): JumpToDestination;
+export function parseJumpToTarget(
+  target?: string
+): JumpToDestination | undefined {
+  if (!target) {
+    return undefined;
+  }
+  if (target === "model") {
+    return "model_request";
+  }
+  if (target === "tools") {
+    return "tools";
+  }
+  if (target === "end") {
+    return END;
+  }
+
+  throw new Error(
+    `Invalid jump target: ${target}, must be "model", "tools" or "end".`
+  );
 }

--- a/libs/langchain/src/agents/middlewareAgent/tests/__snapshots__/graph.test.ts.snap
+++ b/libs/langchain/src/agents/middlewareAgent/tests/__snapshots__/graph.test.ts.snap
@@ -1,0 +1,3889 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`graph (A before: [ 'end' ], A after: [ 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model' ] | B before: [ 'end' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model' ] | B before: [ 'end' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model' ] | B before: [ 'end' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model', 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model', 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'model', 'end' ] | B before: [ 'end' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools' ] | B before: [ 'end' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools' ] | B before: [ 'end' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools' ] | B before: [ 'end' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'end' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'end' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'end' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'end' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'end' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'end' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [] | B before: [ 'end' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [] | B before: [ 'end' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: [] | B before: [ 'end' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: undefined | B before: [ 'end' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: undefined | B before: [ 'end' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'end' ], A after: undefined | B before: [ 'end' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model' ] | B before: [ 'model' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model' ] | B before: [ 'model' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model' ] | B before: [ 'model' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model', 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model', 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'model', 'end' ] | B before: [ 'model' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools' ] | B before: [ 'model' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools' ] | B before: [ 'model' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools' ] | B before: [ 'model' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'model' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'model' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'model' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'model' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'model' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'model' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [] | B before: [ 'model' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [] | B before: [ 'model' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: [] | B before: [ 'model' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: undefined | B before: [ 'model' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: undefined | B before: [ 'model' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model' ], A after: undefined | B before: [ 'model' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'model', 'end' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'model', 'end' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'model', 'end' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'model', 'end' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'model', 'end' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'model', 'end' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'model', 'end' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [] | B before: [ 'model', 'end' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [] | B before: [ 'model', 'end' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: [] | B before: [ 'model', 'end' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: undefined | B before: [ 'model', 'end' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: undefined | B before: [ 'model', 'end' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'model', 'end' ], A after: undefined | B before: [ 'model', 'end' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model' ] | B before: [ 'tools' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model' ] | B before: [ 'tools' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model' ] | B before: [ 'tools' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model', 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model', 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'model', 'end' ] | B before: [ 'tools' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools' ] | B before: [ 'tools' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools' ] | B before: [ 'tools' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools' ] | B before: [ 'tools' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'end' ] | B before: [ 'tools' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'end' ] | B before: [ 'tools' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'end' ] | B before: [ 'tools' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model' ] | B before: [ 'tools' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model' ] | B before: [ 'tools' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model' ] | B before: [ 'tools' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [] | B before: [ 'tools' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [] | B before: [ 'tools' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: [] | B before: [ 'tools' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: undefined | B before: [ 'tools' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: undefined | B before: [ 'tools' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools' ], A after: undefined | B before: [ 'tools' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'end' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'end' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'end' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'end' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'end' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model', 'end' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model', 'end' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'model', 'end' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [] | B before: [ 'tools', 'end' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [] | B before: [ 'tools', 'end' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: [] | B before: [ 'tools', 'end' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: undefined | B before: [ 'tools', 'end' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: undefined | B before: [ 'tools', 'end' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'end' ], A after: undefined | B before: [ 'tools', 'end' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools' ] | B before: [ 'tools', 'model' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools' ] | B before: [ 'tools', 'model' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools' ] | B before: [ 'tools', 'model' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'end' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'end' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [ 'tools', 'model', 'end' ] | B before: [ 'end' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [] | B before: [ 'tools', 'model' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [] | B before: [ 'tools', 'model' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: [] | B before: [ 'tools', 'model' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: undefined | B before: [ 'tools', 'model' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: undefined | B before: [ 'tools', 'model' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model' ], A after: undefined | B before: [ 'tools', 'model' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'model', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'end' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model' ] | B before: [ 'tools', 'model', 'end' ], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: undefined, B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: undefined, B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [ 'tools', 'model', 'end' ] | B before: undefined, B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: [] | B before: [ 'tools', 'model', 'end' ], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: undefined | B before: [ 'tools', 'model', 'end' ], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: undefined | B before: [ 'tools', 'model', 'end' ], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [ 'tools', 'model', 'end' ], A after: undefined | B before: [ 'tools', 'model', 'end' ], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'end' ] | B before: [], B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'end' ] | B before: [], B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'end' ] | B before: [], B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model' ] | B before: [], B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model' ] | B before: [], B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model' ] | B before: [], B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model', 'end' ] | B before: [], B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model', 'end' ] | B before: [], B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'model', 'end' ] | B before: [], B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools' ] | B before: [], B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools' ] | B before: [], B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools' ] | B before: [], B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'end' ] | B before: [], B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'end' ] | B before: [], B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'end' ] | B before: [], B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model' ] | B before: [], B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model' ] | B before: [], B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model' ] | B before: [], B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools' ], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools' ], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [ 'tools', 'model', 'end' ] | B before: [ 'tools' ], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [] | B before: [], B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [] | B before: [], B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: [] | B before: [], B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: undefined | B before: [], B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: undefined | B before: [], B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: [], A after: undefined | B before: [], B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'end' ] | B before: undefined, B after: [ 'tools', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'end' ] | B before: undefined, B after: [ 'tools', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'end' ] | B before: undefined, B after: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model' ] | B before: undefined, B after: [ 'tools', 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model' ] | B before: undefined, B after: [ 'tools', 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model' ] | B before: undefined, B after: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model', 'end' ] | B before: undefined, B after: [ 'tools', 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model', 'end' ] | B before: undefined, B after: [ 'tools', 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'model', 'end' ] | B before: undefined, B after: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools' ] | B before: undefined, B after: [ 'model' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools' ] | B before: undefined, B after: [ 'model' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools' ] | B before: undefined, B after: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'end' ] | B before: undefined, B after: [ 'model', 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'end' ] | B before: undefined, B after: [ 'model', 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'end' ] | B before: undefined, B after: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model' ] | B before: undefined, B after: [ 'end' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model' ] | B before: undefined, B after: [ 'end' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model' ] | B before: undefined, B after: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model', 'end' ] | B before: [], B after: undefined | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model', 'end' ] | B before: [], B after: undefined | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [ 'tools', 'model', 'end' ] | B before: [], B after: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [] | B before: undefined, B after: [ 'tools' ] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [] | B before: undefined, B after: [ 'tools' ] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: [] | B before: undefined, B after: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: undefined | B before: undefined, B after: [] | tools: false) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: undefined | B before: undefined, B after: [] | tools: true) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (A before: undefined, A after: undefined | B before: undefined, B after: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'end' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'model', 'end' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'end' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [ 'tools', 'model', 'end' ], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: [], afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'tools' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'tools', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'tools', 'model' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: [ 'tools', 'model', 'end' ]) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: []) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;
+
+exports[`graph (beforeModelJumpTo: undefined, afterModelJumpTo: undefined) > should create correct graph structure 1`] = `
+{
+  "id": [
+    "langgraph",
+    "pregel",
+    "CompiledStateGraph",
+  ],
+  "lc": 1,
+  "type": "not_implemented",
+}
+`;

--- a/libs/langchain/src/agents/middlewareAgent/tests/graph.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/graph.test.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import { describe, it, expect, afterAll } from "vitest";
+import { tool } from "@langchain/core/tools";
+import { createAgent, createMiddleware } from "../index.js";
+import type { JumpToTarget } from "../types.js";
+
+function powerSet<T>(arr: T[]): T[][] {
+  const result: T[][] = [[]];
+  for (const item of arr) {
+    const len = result.length;
+    for (let i = 0; i < len; i++) {
+      result.push([...result[i], item]);
+    }
+  }
+  return result;
+}
+
+const jumpTargets: JumpToTarget[] = ["tools", "model", "end"];
+const allSets: JumpToTarget[][] = powerSet(jumpTargets);
+const beforeOptions: (JumpToTarget[] | undefined)[] = [undefined, ...allSets];
+const afterOptions: (JumpToTarget[] | undefined)[] = [undefined, ...allSets];
+
+const pairs = beforeOptions.flatMap((before) =>
+  afterOptions.map((after) => ({ before, after }))
+);
+
+type Case = {
+  aBefore?: JumpToTarget[];
+  aAfter?: JumpToTarget[];
+  bBefore?: JumpToTarget[];
+  bAfter?: JumpToTarget[];
+  hasTool: boolean;
+};
+
+const hasToolOptions = [false, true];
+const matrix: Case[] = hasToolOptions.flatMap((hasTool) =>
+  pairs.map((a, i) => {
+    const b = pairs[(i + 1) % pairs.length];
+    return {
+      aBefore: a.before,
+      aAfter: a.after,
+      bBefore: b.before,
+      bAfter: b.after,
+      hasTool,
+    };
+  })
+);
+
+const collected: {
+  aBeforeLabel: string;
+  aAfterLabel: string;
+  bBeforeLabel: string;
+  bAfterLabel: string;
+  toolsLabel: string;
+  mermaid: string;
+}[] = [];
+
+const someTool = tool(async () => "Hello, world!", {
+  name: "someTool",
+});
+
+describe.each(matrix)(
+  "graph (A before: $aBefore, A after: $aAfter | B before: $bBefore, B after: $bAfter | tools: $hasTool)",
+  ({ aBefore, aAfter, bBefore, bAfter, hasTool }) => {
+    it("should create correct graph structure", async () => {
+      const middleware1 = createMiddleware({
+        name: "MiddlewareA",
+        beforeModelJumpTo: aBefore,
+        afterModelJumpTo: aAfter,
+        beforeModel: () => {},
+        afterModel: () => {},
+      });
+
+      const middleware2 = createMiddleware({
+        name: "MiddlewareB",
+        beforeModelJumpTo: bBefore,
+        afterModelJumpTo: bAfter,
+        beforeModel: () => {},
+        afterModel: () => {},
+      });
+
+      const agent = createAgent({
+        model: "openai:gpt-4o-mini",
+        tools: hasTool ? [someTool] : [],
+        middleware: [middleware1, middleware2] as const,
+      });
+
+      expect(agent.graph).toMatchSnapshot();
+      const fmt = (v?: JumpToTarget[]) =>
+        v === undefined
+          ? "undefined"
+          : v.length === 0
+          ? "empty"
+          : `<code>${v.join("</code>, <code>")}</code>`;
+      const aBeforeLabel = fmt(aBefore);
+      const aAfterLabel = fmt(aAfter);
+      const bBeforeLabel = fmt(bBefore);
+      const bAfterLabel = fmt(bAfter);
+      const toolsLabel = hasTool ? "yes" : "no";
+      const mermaid = await agent.drawMermaid({ withStyles: false });
+      collected.push({
+        aBeforeLabel,
+        aAfterLabel,
+        bBeforeLabel,
+        bAfterLabel,
+        toolsLabel,
+        mermaid,
+      });
+    });
+  }
+);
+
+afterAll(() => {
+  const content = `# Graph Matrix (Mermaid)\n\n
+This test creates a matrix of all possible combinations of before and after model jump targets for two middleware instances.
+The basic test setup is as follows:
+
+\`\`\`ts
+const middleware1 = createMiddleware({
+    name: "MiddlewareA",
+    beforeModelJumpTo: aBefore,
+    afterModelJumpTo: aAfter,
+    beforeModel: () => {},
+    afterModel: () => {},
+});
+
+const middleware2 = createMiddleware({
+    name: "MiddlewareB",
+    beforeModelJumpTo: bBefore,
+    afterModelJumpTo: bAfter,
+    beforeModel: () => {},
+    afterModel: () => {},
+});
+
+const agent = createAgent({
+    model: "openai:gpt-4o-mini",
+    tools: [someTool],
+    middleware: [middleware1, middleware2] as const,
+});
+\`\`\`
+
+${collected
+  .map(
+    ({
+      aBeforeLabel,
+      aAfterLabel,
+      bBeforeLabel,
+      bAfterLabel,
+      toolsLabel,
+      mermaid,
+    }) =>
+      `<details>
+<summary>
+
+MiddlewareA before: ${aBeforeLabel}<br/>
+MiddlewareA after: ${aAfterLabel}<br/>
+MiddlewareB before: ${bBeforeLabel}<br/>
+MiddlewareB after: ${bAfterLabel}<br/>
+Tools: <code>${toolsLabel}</code>
+
+</summary>
+
+\`\`\`mermaid
+${mermaid}
+\`\`\`
+
+</details>`
+  )
+  .join("\n\n")}`;
+  fs.writeFileSync("graph-matrix.mermaid.md", content);
+});

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
@@ -232,5 +232,79 @@ describe("middleware", () => {
       expect(toolFn).toHaveBeenCalledTimes(0);
       expect(beforeModel).toHaveBeenCalledTimes(1);
     });
+
+    it("should throw if middleware jumps but target is not defined", async () => {
+      const model = new FakeToolCallingChatModel({
+        responses: [new AIMessage("The weather in Tokyo is 25°C")],
+      });
+      const middleware = createMiddleware({
+        name: "foobar",
+        beforeModel: () => {
+          return {
+            jumpTo: "model",
+          };
+        },
+      });
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [middleware] as const,
+      });
+      await expect(
+        agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
+      ).rejects.toThrow(
+        "Invalid jump target: model, no beforeModelJumpTo defined in middleware foobar."
+      );
+    });
+
+    it("should throw if middleware jumps but target is not defined", async () => {
+      const model = new FakeToolCallingChatModel({
+        responses: [new AIMessage("The weather in Tokyo is 25°C")],
+      });
+      const middleware = createMiddleware({
+        name: "foobar",
+        beforeModelJumpTo: [],
+        beforeModel: () => {
+          return {
+            jumpTo: "model",
+          };
+        },
+      });
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [middleware] as const,
+      });
+      await expect(
+        agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
+      ).rejects.toThrow(
+        "Invalid jump target: model, no beforeModelJumpTo defined in middleware foobar."
+      );
+    });
+
+    it("should throw if middleware jumps but target is not valid", async () => {
+      const model = new FakeToolCallingChatModel({
+        responses: [new AIMessage("The weather in Tokyo is 25°C")],
+      });
+      const middleware = createMiddleware({
+        name: "foobar",
+        beforeModelJumpTo: ["tools", "end"],
+        beforeModel: () => {
+          return {
+            jumpTo: "model",
+          };
+        },
+      });
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [middleware] as const,
+      });
+      await expect(
+        agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
+      ).rejects.toThrow(
+        "Invalid jump target: model, must be one of: tools, end."
+      );
+    });
   });
 });

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -10,6 +10,7 @@ import type {
   START,
   PregelOptions,
   Runtime as LangGraphRuntime,
+  END,
 } from "@langchain/langgraph";
 
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
@@ -19,8 +20,8 @@ import type {
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
 
+import { JUMP_TO_TARGETS } from "./constants.js";
 import type { AnyAnnotationRoot, ToAnnotationRoot } from "../annotation.js";
-
 import type {
   ResponseFormat,
   ToolStrategy,
@@ -46,7 +47,7 @@ export interface BuiltInState {
    * - "model_request": Jump back to the model for another LLM call
    * - "tools": Jump to tool execution (requires tools to be available)
    */
-  jumpTo?: "model" | "tools";
+  jumpTo?: JumpToTarget;
 }
 
 /**
@@ -332,6 +333,9 @@ export type InferMiddlewareContextInputs<
     : {}
   : {};
 
+export type JumpToTarget = (typeof JUMP_TO_TARGETS)[number];
+export type JumpToDestination = "model_request" | "tools" | typeof END;
+
 /**
  * Base middleware interface.
  */
@@ -347,6 +351,8 @@ export interface AgentMiddleware<
   stateSchema?: TSchema;
   contextSchema?: TContextSchema;
   name: string;
+  beforeModelJumpTo?: JumpToTarget[];
+  afterModelJumpTo?: JumpToTarget[];
   /**
    * Runs before each LLM call, can modify call parameters, changes are not persistent
    * e.g. if you change `model`, it will only be changed for the next model call


### PR DESCRIPTION
This patch updates the jump behavior of the agent, forcing user to statically type valid targets and allows us to better draw graphs from it. This introduces 2 new options to the middleware: `beforeModelJumpTo` and `afterModelJumpTo` which are lists and can contain jump targets: `model`, `end` and `tools`. Only if the jump target is defined the `beforeModel` or `afterModel` hook is allowed to jump to it.

I created a test to verify all combination of what user can provide:

- 2 agents
-`beforeModelJumpTo` and `afterModelJumpTo` set to `undefined`, `[]` or either combination of the allowed values
- a tool is set or not

You can review the results and graphs in this gist: https://gist.github.com/christian-bromann/8a167bff41925364eda9c15807780b2b