### PR TITLE
fix(openai): Fix broken OpenAI documentation link

### DIFF
--- a/libs/langchain-openai/src/chat_models.ts
+++ b/libs/langchain-openai/src/chat_models.ts
@@ -622,7 +622,7 @@ export abstract class BaseChatOpenAI<
    * OpenAI organization or project. This must be configured directly with OpenAI.
    *
    * See:
-   * https://help.openai.com/en/articles/10503543-data-residency-for-the-openai-api
+   * https://platform.openai.com/docs/guides/your-data
    * https://platform.openai.com/docs/api-reference/responses/create#responses-create-store
    *
    * @default false


### PR DESCRIPTION
I noticed that the current URL in the JSDoc comment (https://help.openai.com/en/articles/10503543-data-residency-for-the-openai-api) shows that it has been moved to a new location:

<img width="707" height="375" alt="image" src="https://github.com/user-attachments/assets/e450560b-7406-45b0-8ff5-04fdb4bcaa62" />

I updated the link with the updated one provided by OpenAI (https://platform.openai.com/docs/guides/your-data)

