### PR TITLE
Cb/tools in modelrequest

### DIFF
--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -100,17 +100,19 @@ export class ReactAgent<
     public options: CreateAgentParams<StructuredResponseFormat, ContextSchema>
   ) {
     this.#toolBehaviorVersion = options.version ?? this.#toolBehaviorVersion;
-    const toolClasses =
-      (Array.isArray(options.tools) ? options.tools : options.tools?.tools) ??
-      [];
 
     /**
-     * append tools from middleware
+     * define complete list of tools based on options and middleware
      */
     const middlewareTools = (this.options.middleware
       ?.filter((m) => m.tools)
       .flatMap((m) => m.tools) ?? []) as (ClientTool | ServerTool)[];
-    toolClasses.push(...middlewareTools);
+    const toolClasses = [
+      ...((Array.isArray(options.tools)
+        ? options.tools
+        : options.tools?.tools) ?? []),
+      ...middlewareTools,
+    ];
 
     /**
      * If any of the tools are configured to return_directly after running,

--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -105,6 +105,14 @@ export class ReactAgent<
       [];
 
     /**
+     * append tools from middleware
+     */
+    const middlewareTools = (this.options.middleware
+      ?.filter((m) => m.tools)
+      .flatMap((m) => m.tools) ?? []) as (ClientTool | ServerTool)[];
+    toolClasses.push(...middlewareTools);
+
+    /**
      * If any of the tools are configured to return_directly after running,
      * our graph needs to check if these were called
      */

--- a/libs/langchain/src/agents/middlewareAgent/middleware.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware.ts
@@ -8,6 +8,7 @@ import type {
   ModelRequest,
   JumpToTarget,
 } from "./types.js";
+import type { ClientTool, ServerTool } from "../types.js";
 
 /**
  * Creates a middleware instance with automatic schema inference.
@@ -75,6 +76,10 @@ export function createMiddleware<
    * Explitictly defines which targets are allowed to be jumped to from the `afterModel` hook.
    */
   afterModelJumpTo?: JumpToTarget[];
+  /**
+   * Additional tools registered by the middleware.
+   */
+  tools?: (ClientTool | ServerTool)[];
   /**
    * The function to modify the model request. This function is called after the `beforeModel` hook of this middleware and before the model is invoked.
    * It allows to modify the model request before it is passed to the model.
@@ -174,6 +179,7 @@ export function createMiddleware<
     contextSchema: config.contextSchema,
     beforeModelJumpTo: config.beforeModelJumpTo,
     afterModelJumpTo: config.afterModelJumpTo,
+    tools: config.tools ?? [],
   };
 
   if (config.modifyModelRequest) {

--- a/libs/langchain/src/agents/middlewareAgent/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/AgentNode.ts
@@ -240,9 +240,7 @@ export class AgentNode<
       return this.#options.model;
     }
 
-    throw new Error(
-      "No model option was provided, either via `model` or via `llm` option."
-    );
+    throw new Error("No model option was provided, either via `model` option.");
   }
 
   async #invokeModel(
@@ -623,7 +621,12 @@ export class AgentNode<
     // Use tools from preparedOptions if provided, otherwise use default tools
     const preparedTools = preparedOptions?.tools ?? [];
     const allTools = (
-      preparedTools.length > 0 ? preparedTools : this.#options.toolClasses
+      preparedTools.length > 0
+        ? this.#options.toolClasses.filter(
+            (tool) =>
+              typeof tool.name === "string" && preparedTools.includes(tool.name)
+          )
+        : this.#options.toolClasses
     ).concat(...structuredTools.map((toolStrategy) => toolStrategy.tool));
 
     /**

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test-d.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test-d.ts
@@ -181,12 +181,18 @@ describe("middleware types", () => {
             customRequiredContextProp: string;
           }>();
         },
-        modifyModelRequest: async (_request, _state, runtime) => {
+        modifyModelRequest: async (request, _state, runtime) => {
+          expectTypeOf(request.tools).toEqualTypeOf<string[]>();
           expectTypeOf(runtime.context).toEqualTypeOf<{
             customDefaultContextProp: string;
             customOptionalContextProp?: string;
             customRequiredContextProp: string;
           }>();
+
+          return {
+            ...request,
+            tools: ["toolA"],
+          };
         },
       });
 

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
@@ -328,20 +328,21 @@ describe("middleware", () => {
   });
 
   describe("modifyModelRequest", () => {
+    const tools = [
+      tool(async () => "Tool response", {
+        name: "toolA",
+      }),
+      tool(async () => "Tool response", {
+        name: "toolB",
+      }),
+      tool(async () => "Tool response", {
+        name: "toolC",
+      }),
+    ];
+
     it("should allow to add", async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const model = createMockModel() as any;
-      const tools = [
-        tool(async () => "Tool response", {
-          name: "toolA",
-        }),
-        tool(async () => "Tool response", {
-          name: "toolB",
-        }),
-        tool(async () => "Tool response", {
-          name: "toolC",
-        }),
-      ];
       const middleware = createMiddleware({
         name: "middleware",
         tools: [
@@ -370,6 +371,38 @@ describe("middleware", () => {
         {
           tool_choice: "required",
         }
+      );
+    });
+
+    it("should throw if unknown tools were selected", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const model = createMockModel() as any;
+      const middleware = createMiddleware({
+        name: "testMiddleware",
+        tools: [
+          tool(async () => "Tool response", {
+            name: "toolD",
+          }),
+        ],
+        modifyModelRequest: async (request) => {
+          return {
+            ...request,
+            tools: ["foobar"],
+            toolChoice: "required",
+          };
+        },
+      });
+      const agent = createAgent({
+        model,
+        tools,
+        middleware: [middleware] as const,
+      });
+      await expect(
+        agent.invoke({
+          messages: [new HumanMessage("Hello, world!")],
+        })
+      ).rejects.toThrow(
+        'Unknown tools selected in middleware "testMiddleware": foobar, available tools: toolA, toolB, toolC, toolD!'
       );
     });
   });

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test.ts
@@ -344,14 +344,15 @@ describe("middleware", () => {
       ];
       const middleware = createMiddleware({
         name: "middleware",
+        tools: [
+          tool(async () => "Tool response", {
+            name: "toolD",
+          }),
+        ],
         modifyModelRequest: async (request) => {
           return {
             ...request,
-            tools: [
-              tool(async () => "Tool response", {
-                name: "toolD",
-              }),
-            ],
+            tools: ["toolD"],
             toolChoice: "required",
           };
         },

--- a/libs/langchain/src/agents/middlewareAgent/tests/reactAgent.int.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/reactAgent.int.test.ts
@@ -3,11 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
-import {
-  HumanMessage,
-  SystemMessage,
-  AIMessage,
-} from "@langchain/core/messages";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
 
 import { createMiddleware, createAgent } from "../index.js";
 
@@ -164,13 +160,10 @@ Please provide a clear, direct, and authoritative answer, as this information wi
     // Create middleware that adds tools and sets toolChoice
     const toolsMiddleware = {
       name: "toolsModifier",
+      tools: [weatherTool, newsTool],
       modifyModelRequest: async () => {
-        // Add tools dynamically
-        const tools = [weatherTool, newsTool];
-
         // Set toolChoice to force specific tool
         return {
-          tools,
           toolChoice: {
             type: "function" as const,
             function: {

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -127,9 +127,8 @@ export interface ModelRequest {
 
   /**
    * The tools to make available for this step.
-   * Can be tool names (strings) or tool instances.
    */
-  tools: (ClientTool | ServerTool)[];
+  tools: string[];
 }
 
 /**
@@ -359,6 +358,7 @@ export interface AgentMiddleware<
   name: string;
   beforeModelJumpTo?: JumpToTarget[];
   afterModelJumpTo?: JumpToTarget[];
+  tools?: (ClientTool | ServerTool)[];
   /**
    * Runs before each LLM call, can modify call parameters, changes are not persistent
    * e.g. if you change `model`, it will only be changed for the next model call

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -174,10 +174,7 @@ export class ToolNode<
         }
       );
 
-      if (
-        (isBaseMessage(output) && output.getType() === "tool") ||
-        isCommand(output)
-      ) {
+      if (ToolMessage.isInstance(output) || isCommand(output)) {
         return output as ToolMessage | Command;
       }
 

--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -52,6 +52,11 @@ export {
 } from "./agents/index.js";
 
 /**
+ * `createAgent` pre-built middleware
+ */
+export * from "./agents/middlewareAgent/middleware/index.js";
+
+/**
  * LangChain Stores
  */
 export { InMemoryStore } from "@langchain/core/stores";


### PR DESCRIPTION
This patch implements 2 new features:

- middleware can register their own tools
- `ModelRequest` now provides and expects a `string[]` for `tools` - this avoids that user define new tools in that hook