### PR TITLE
Fix: Add langsmith to import map to resolve Issue #9049

### DIFF
--- a/langchain/langchain.config.js
+++ b/langchain/langchain.config.js
@@ -354,6 +354,11 @@ export const config = {
       modules: ["ChatGenerationChunk", "GenerationChunk"],
       alias: ["schema", "output"],
       path: "@langchain/core/outputs",
+    },
+    {
+      modules: ["Client"],
+      alias: ["langsmith"],
+      path: "langsmith",
     }
   ],
   shouldTestExports: true,


### PR DESCRIPTION
Fix: Add langsmith to import map to resolve Issue #9049

Problem
In version 1.0.0-alpha.5, users experience errors when using the pull() function from langchain/hub:

Error loading "langsmith" package, install it via `npm install langsmith`
Error: require_range is not a function. (In 'require_range()', 'require_range' is undefined)

The issue occurs because langsmith components are not properly available in the import map during deserialization.

### Solution
Added langsmith entry to `extraImportMapEntries` in `langchain.config.js` to ensure langsmith components are properly resolved in the import map.

### Changes
- Added langsmith entry to `extraImportMapEntries` (lines 358-362):
  ```javascript
  {
    modules: ["Client"],
    alias: ["langsmith"],
    path: "langsmith",
  }
  ```
- Ensures langsmith components are available during deserialization
- Maintains backward compatibility

### Testing
- ✅ Import map contains langsmith entry
- ✅ Hub pull function works without errors
- ✅ Agent creation works with langsmith components
- ✅ Serialization/deserialization works properly

### Impact
- Resolves the specific error mentioned in issue #9049
- Improves robustness of hub functionality
- Prevents similar import path issues in the future

Fixes #9049