### PR TITLE
docs(chroma): Update Chroma Cloud connection example

### DIFF
--- a/docs/core_docs/docs/integrations/vectorstores/chroma.ipynb
+++ b/docs/core_docs/docs/integrations/vectorstores/chroma.ipynb
@@ -212,9 +212,14 @@
     "\n",
     "const vectorStore = new Chroma(embeddings, {\n",
     "  collectionName: \"a-test-collection\",\n",
-    "  tenant: process.env.CHROMA_TENANT,\n",
-    "  database: process.env.CHROMA_DATABASE,\n",
-    "  chromaCloudAPIKey: process.env.CHROMA_API_KEY\n",
+    "  chromaCloudAPIKey: process.env.CHROMA_API_KEY,\n",
+    "  clientParams: {\n",
+    "    host: \"api.trychroma.com\",\n",
+    "    port: 8000,\n",
+    "    ssl: true,  \n",
+    "    tenant: process.env.CHROMA_TENANT,\n",
+    "    database: process.env.CHROMA_DATABASE,\n",
+    "  }\n",
     "});"
    ]
   },


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This PR updates the example code snippet for connecting to Chroma Cloud within the official documentation.

**Description of Changes:**

The primary change is in the `docs/core_docs/docs/integrations/vectorstores/chroma.ipynb` notebook, where the example for instantiating a `Chroma` vector store for a Chroma Cloud connection has been revised.

**Reason for Change:**

The previous example was not aligned with the latest implementation for connecting to Chroma Cloud. This update ensures that the documentation provides users with a correct and easy-to-follow example.

Fixes [issue#9053](https://github.com/langchain-ai/langchainjs/issues/9053)
