### PR TITLE
fix: support sonnet 4.5 by allowing pass topP as null (default to undefined)

### DIFF
--- a/libs/langchain-anthropic/src/chat_models.ts
+++ b/libs/langchain-anthropic/src/chat_models.ts
@@ -160,7 +160,7 @@ export interface AnthropicInput {
    * To not set this field, pass `null`. If `undefined` is passed,
    * the default (-1) will be used.
    *
-   * For Opus 4.1, this defaults to `null`.
+   * For Opus 4.1 and Sonnet 4.5, this defaults to `null`.
    */
   topP?: number | null;
 
@@ -720,8 +720,8 @@ export class ChatAnthropicMessages<
 
     this.invocationKwargs = fields?.invocationKwargs ?? {};
 
-    if (this.model.includes("opus-4-1")) {
-      // Default to `undefined` for `topP` for Opus 4.1 models
+    if (this.model.includes("opus-4-1") || this.model.includes("sonnet-4-5")) {
+      // Default to `undefined` for `topP` for Opus 4.1 models and Sonnet 4.5
       this.topP = fields?.topP === null ? undefined : fields?.topP;
     } else {
       this.topP = fields?.topP ?? this.topP;


### PR DESCRIPTION
## Context

top_p cannot be set to -1 for claude-sonnet-4-5-20250929. Sonnet 4.5 requires support for null instead.

## Problem

The earlier change only handled Opus 4.1. Without a similar exception, Sonnet 4.5 has no valid way to disable top_p.

## Change
	•	Updated AnthropicInput docs to state that both Opus 4.1 and Sonnet 4.5 default top_p to null.
	•	Updated ChatAnthropicMessages so that for both models, passing null for top_p sets it to undefined.

## Rationale

This is still a model-specific branch, but it’s the safest and lowest-impact fix right now. It aligns Sonnet 4.5 with the existing Opus handling without broader refactoring.