### PR TITLE
fix(vscode): remove experimental `useTsgo` setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "https://json.schemastore.org/github-workflow.json": "./.github/workflows/deploy.yml"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.experimental.useTsgo": true,
   "cSpell.words": ["AILLM", "Upstash"],
   "cSpell.enabledFileTypes": {
     "mdx": true,


### PR DESCRIPTION
This setting was causing VSCode typescript extension to hang on startup, so all autocomplete, hover, etc was broken