### PR TITLE
fix(langchain/createAgent): export all symbols so TypeScript can properly infer types

### DIFF
--- a/libs/langchain/src/agents/index.ts
+++ b/libs/langchain/src/agents/index.ts
@@ -33,6 +33,7 @@ import type {
 export * from "./types.js";
 export * from "./errors.js";
 export * from "./interrupt.js";
+export * from "./annotation.js";
 export { ToolNode } from "./nodes/ToolNode.js";
 export {
   toolStrategy,

--- a/libs/langchain/src/agents/interrupt.ts
+++ b/libs/langchain/src/agents/interrupt.ts
@@ -1,4 +1,5 @@
 export { interrupt } from "@langchain/langgraph";
+import type { ActionRequest } from "./middlewareAgent/middleware/hitl.js";
 
 /**
  * Represents information about an interrupt.
@@ -35,22 +36,6 @@ export interface HumanInterruptConfig {
    * Whether the human can accept/approve the current state
    */
   allow_accept: boolean;
-}
-
-/**
- * Represents a request for human action within the graph execution.
- * Contains the action type and any associated arguments needed for the action.
- */
-export interface ActionRequest {
-  /**
-   * The type or name of action being requested (e.g., "Approve XYZ action")
-   */
-  action: string;
-  /**
-   * Key-value pairs of arguments needed for the action
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: Record<string, any>;
 }
 
 /**

--- a/libs/langchain/src/agents/middlewareAgent/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/hitl.ts
@@ -32,20 +32,6 @@ type ToolConfigSchema = z.input<typeof ToolConfigSchema>;
 type ToolCall = NonNullable<AIMessage["tool_calls"]>[number];
 
 /**
- * Represents information about an interrupt.
- */
-export interface Interrupt<TValue = unknown> {
-  /**
-   * The ID of the interrupt.
-   */
-  id: string;
-  /**
-   * The requests for human input.
-   */
-  value: TValue;
-}
-
-/**
  * Configuration that defines which reviewer response types are permitted during a human interrupt.
  * These flags control what the human reviewer may do (e.g., accept/edit/respond),
  * not the tool action the agent has requested.

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -33,7 +33,7 @@ import type {
   JsonSchemaFormat,
 } from "../responses.js";
 import type { ResponseFormatUndefined } from "../annotation.js";
-import type { Interrupt } from "../interrupt.js";
+import type { Interrupt } from "./middleware/hitl.js";
 import type { ToolNode } from "../nodes/ToolNode.js";
 import type { ClientTool, ServerTool } from "../types.js";
 

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -33,11 +33,24 @@ import type {
   JsonSchemaFormat,
 } from "../responses.js";
 import type { ResponseFormatUndefined } from "../annotation.js";
-import type { Interrupt } from "./middleware/hitl.js";
 import type { ToolNode } from "../nodes/ToolNode.js";
 import type { ClientTool, ServerTool } from "../types.js";
 
 export type N = typeof START | "model_request" | "tools";
+
+/**
+ * Represents information about an interrupt.
+ */
+export interface Interrupt<TValue = unknown> {
+  /**
+   * The ID of the interrupt.
+   */
+  id: string;
+  /**
+   * The requests for human input.
+   */
+  value: TValue;
+}
 
 export interface BuiltInState {
   messages: BaseMessage[];

--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -36,22 +36,7 @@ export {
 /**
  * LangChain Agents
  */
-export {
-  createAgent,
-  createMiddleware,
-  toolStrategy,
-  providerStrategy,
-  ToolNode,
-  type ReactAgent,
-  type AgentState,
-  type AgentRuntime,
-  type AgentMiddleware,
-  type HumanInterrupt,
-  type HumanInterruptConfig,
-  type ActionRequest,
-  type HumanResponse,
-  type Interrupt,
-} from "./agents/index.js";
+export * from "./agents/index.js";
 
 /**
  * `createAgent` pre-built middleware


### PR DESCRIPTION
This patch ensures we properly export all external symbols to allow TypeScript to properly infer all types correctly. See this fix in deepagentjs: https://github.com/langchain-ai/deepagentsjs/pull/32/commits/08b561d8496f2d8d78136183dd8d1c489faba8fc