### PR TITLE
feat(langchain/createAgent): introduce call counts through private state

### DIFF
--- a/libs/langchain/src/agents/RunnableCallable.ts
+++ b/libs/langchain/src/agents/RunnableCallable.ts
@@ -51,6 +51,13 @@ export class RunnableCallable<I = unknown, O = unknown> extends Runnable<I, O> {
     return this.#state;
   }
 
+  setState(state: Awaited<O>) {
+    this.#state = {
+      ...this.#state,
+      ...state,
+    };
+  }
+
   async invoke(
     input: I,
     options?: Partial<RunnableConfig> | undefined

--- a/libs/langchain/src/agents/middlewareAgent/nodes/AfterModalNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/AfterModalNode.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { MiddlewareNode } from "./middleware.js";
+import { MiddlewareNode, MiddlewareNodeOptions } from "./middleware.js";
 import type {
   AgentBuiltInState,
   AgentMiddleware,
@@ -19,12 +19,18 @@ export class AfterModelNode<
 
   name: string;
 
-  constructor(public middleware: AgentMiddleware<any, any, any>) {
-    super({
-      name: `AfterModelNode_${middleware.name}`,
-      func: async (state: TStateSchema, config?: LangGraphRunnableConfig) =>
-        this.invokeMiddleware(state, config),
-    });
+  constructor(
+    public middleware: AgentMiddleware<any, any, any>,
+    options: MiddlewareNodeOptions
+  ) {
+    super(
+      {
+        name: `AfterModelNode_${middleware.name}`,
+        func: async (state: TStateSchema, config?: LangGraphRunnableConfig) =>
+          this.invokeMiddleware(state, config),
+      },
+      options
+    );
     this.name = `AfterModelNode_${middleware.name}`;
   }
 

--- a/libs/langchain/src/agents/middlewareAgent/nodes/BeforeModalNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/BeforeModalNode.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { RunnableConfig } from "@langchain/core/runnables";
-import { MiddlewareNode } from "./middleware.js";
+import { MiddlewareNode, type MiddlewareNodeOptions } from "./middleware.js";
 import type {
   AgentBuiltInState,
   AgentMiddleware,
@@ -17,14 +17,20 @@ export class BeforeModelNode<
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "beforeModalNodes"];
 
-  constructor(public middleware: AgentMiddleware<any, any, any>) {
-    super({
-      name: `BeforeModelNode_${middleware.name}`,
-      func: async (
-        state: TStateSchema,
-        config?: RunnableConfig<TContextSchema>
-      ) => this.invokeMiddleware(state, config),
-    });
+  constructor(
+    public middleware: AgentMiddleware<any, any, any>,
+    options: MiddlewareNodeOptions
+  ) {
+    super(
+      {
+        name: `BeforeModelNode_${middleware.name}`,
+        func: async (
+          state: TStateSchema,
+          config?: RunnableConfig<TContextSchema>
+        ) => this.invokeMiddleware(state, config),
+      },
+      options
+    );
   }
 
   runHook(state: TStateSchema, runtime: Runtime<TStateSchema, TContextSchema>) {

--- a/libs/langchain/src/agents/middlewareAgent/tests/runtime.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/runtime.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+
+import { createMiddleware, createAgent } from "../index.js";
+import { FakeToolCallingModel } from "../../tests/utils.js";
+
+describe("runtime", () => {
+  it("should throw on the attempt to write to the runtime", async () => {
+    const model = new FakeToolCallingModel({});
+    const middleware = createMiddleware({
+      name: "middleware",
+      beforeModel: async (_, runtime) => {
+        runtime.runModelCallCount = 123;
+      },
+      modifyModelRequest: async (_, __, runtime) => {
+        runtime.runModelCallCount = 123;
+      },
+      afterModel: async (_, runtime) => {
+        runtime.runModelCallCount = 123;
+      },
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createAgent({
+      model,
+      middleware: [middleware] as const,
+      checkpointer,
+    });
+
+    await expect(
+      agent.invoke({
+        messages: [new HumanMessage("What is the weather in Tokyo?")],
+      })
+    ).rejects.toThrow("Cannot assign to read only property");
+  });
+});

--- a/libs/langchain/src/agents/middlewareAgent/tests/state.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/state.test.ts
@@ -1,9 +1,17 @@
 import { z } from "zod/v3";
 import { describe, it, expect } from "vitest";
 import { HumanMessage } from "@langchain/core/messages";
-import { createMiddleware, createAgent } from "../index.js";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
 
+import { createMiddleware, createAgent } from "../index.js";
 import { FakeToolCallingModel } from "../../tests/utils.js";
+
+const checkpointer = new MemorySaver();
+const config = {
+  configurable: {
+    thread_id: "test-123",
+  },
+};
 
 describe("middleware state management", () => {
   it("should allow to define private state props with _ that doesn't leak out", async () => {
@@ -131,5 +139,94 @@ describe("middleware state management", () => {
       middlewareCBeforeModelState: "CBefore",
       middlewareCAfterModelState: "middlewareCAfterModelState",
     });
+  });
+
+  it("should track thread level call count and run model call count as part of a private state", async () => {
+    expect.assertions(9);
+    const model = new FakeToolCallingModel({});
+    const middleware = createMiddleware({
+      name: "middleware",
+      beforeModel: async (_, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(0);
+        expect(runtime.runModelCallCount).toBe(0);
+
+        /**
+         * try to override the private state
+         */
+        return {
+          _privateState: {
+            threadLevelCallCount: 123,
+            runModelCallCount: 123,
+          },
+        };
+      },
+      modifyModelRequest: async (_, __, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(0);
+        expect(runtime.runModelCallCount).toBe(0);
+      },
+      afterModel: async (_, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(1);
+        expect(runtime.runModelCallCount).toBe(1);
+        return {
+          _privateState: {
+            threadLevelCallCount: 123,
+            runModelCallCount: 123,
+          },
+        };
+      },
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware] as const,
+      checkpointer,
+    });
+
+    const result = await agent.invoke(
+      {
+        messages: [new HumanMessage("What is the weather in Tokyo?")],
+      },
+      config
+    );
+
+    // @ts-expect-error should not be defined in the state
+    expect(result.threadLevelCallCount).toBe(undefined);
+    // @ts-expect-error should not be defined in the state
+    expect(result.runModelCallCount).toBe(undefined);
+    // @ts-expect-error should not be defined in the state
+    expect(result._privateState).toBe(undefined);
+  });
+
+  it("should allow to continue counting thread level call count and run model call count across multiple invocations", async () => {
+    expect.assertions(6);
+    const model = new FakeToolCallingModel({});
+    const middleware = createMiddleware({
+      name: "middleware",
+      beforeModel: async (_, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(1);
+        expect(runtime.runModelCallCount).toBe(0);
+      },
+      modifyModelRequest: async (_, __, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(1);
+        expect(runtime.runModelCallCount).toBe(0);
+      },
+      afterModel: async (_, runtime) => {
+        expect(runtime.threadLevelCallCount).toBe(2);
+        expect(runtime.runModelCallCount).toBe(1);
+      },
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware] as const,
+      checkpointer,
+    });
+
+    await agent.invoke(
+      {
+        messages: [new HumanMessage("What is the weather in Tokyo?")],
+      },
+      config
+    );
   });
 });

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -171,7 +171,8 @@ export type Runtime<TState = unknown, TContext = unknown> = Partial<
    * @param result - The result to terminate the agent with.
    */
   terminate(result: Partial<TState> | Error): ControlAction<TState>;
-} & WithMaybeContext<TContext>;
+} & WithMaybeContext<TContext> &
+  PrivateState;
 
 /**
  * Control action type returned by control methods.
@@ -741,6 +742,17 @@ export type InferAgentConfig<
         InferMiddlewareContextInputs<TMiddleware>;
     }>;
 
+export interface RunLevelPrivateState {
+  runModelCallCount: number;
+}
+export interface ThreadLevelPrivateState {
+  threadLevelCallCount: number;
+}
+
+export interface PrivateState
+  extends ThreadLevelPrivateState,
+    RunLevelPrivateState {}
+
 export type InternalAgentState<
   StructuredResponseType extends Record<string, unknown> | undefined = Record<
     string,
@@ -748,7 +760,7 @@ export type InternalAgentState<
   >
 > = {
   messages: BaseMessage[];
-  __preparedModelOptions?: ModelRequest;
+  _privateState?: PrivateState;
 } & (StructuredResponseType extends ResponseFormatUndefined
   ? Record<string, never>
   : { structuredResponse: StructuredResponseType });


### PR DESCRIPTION
This patch introduces `threadLevelCallCount` and `runModelCallCount` as _readonly` runtime properties. The values are managed as following:

- `runModelCallCount`: class property of the `AgentNode` - value is not persisted
- `threadLevelCallCount`: private state property of the AgentNode

The behavior can be showcased with the following basic test:

```ts
const model = new FakeToolCallingModel({});
const middleware = createMiddleware({
  name: "middleware",
  beforeModel: async (_, runtime) => {
    expect(runtime.threadLevelCallCount).toBe(0);
    expect(runtime.runModelCallCount).toBe(0);

    /**
     * try to override the private state
     */
    return {
      _privateState: {
        threadLevelCallCount: 123,
        runModelCallCount: 123,
      },
    };
  },
  modifyModelRequest: async (_, __, runtime) => {
    expect(runtime.threadLevelCallCount).toBe(0);
    expect(runtime.runModelCallCount).toBe(0);
  },
  afterModel: async (_, runtime) => {
    expect(runtime.threadLevelCallCount).toBe(1);
    expect(runtime.runModelCallCount).toBe(1);
        /**
         * try to override the private state
         */
    return {
      _privateState: {
        threadLevelCallCount: 123,
        runModelCallCount: 123,
      },
    };
  },
});

const agent = createAgent({
  model,
  middleware: [middleware] as const,
  checkpointer,
});

const result = await agent.invoke(
  {
    messages: [new HumanMessage("What is the weather in Tokyo?")],
  },
  config
);

// @ts-expect-error should not be defined in the state
expect(result.threadLevelCallCount).toBe(undefined);
// @ts-expect-error should not be defined in the state
expect(result.runModelCallCount).toBe(undefined);
// @ts-expect-error should not be defined in the state
expect(result._privateState).toBe(undefined);
```

Creating a new agent and passing the checkpointer and config along should result in the following:
```ts
const model = new FakeToolCallingModel({});
    const middleware = createMiddleware({
      name: "middleware",
      beforeModel: async (_, runtime) => {
        expect(runtime.threadLevelCallCount).toBe(1);
        expect(runtime.runModelCallCount).toBe(0);
      },
      modifyModelRequest: async (_, __, runtime) => {
        expect(runtime.threadLevelCallCount).toBe(1);
        expect(runtime.runModelCallCount).toBe(0);
      },
      afterModel: async (_, runtime) => {
        expect(runtime.threadLevelCallCount).toBe(2);
        expect(runtime.runModelCallCount).toBe(1);
      },
    });

    const agent = createAgent({
      model,
      middleware: [middleware] as const,
      checkpointer,
    });

    await agent.invoke(
      {
        messages: [new HumanMessage("What is the weather in Tokyo?")],
      },
      config
    );
```