### PR TITLE
docs: add AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ LangChain.js is a framework and ecosystem for building context-aware, LLM-powere
 
 - TypeScript targeting Node.js v20+ (repo `.nvmrc` pins v24.6.0)
 - pnpm workspaces (`pnpm-workspace.yaml`) with TurboRepo task orchestration (`turbo.json`)
-- Vitest and Jest (via Turbo) for unit and integration testing
+- Vitest for unit and integration testing
 - ESLint and Prettier for linting/formatting
 - Docker Compose for environment and integration test matrices
 - Documentation generation: TypeDoc (API refs) and Docusaurus (site)
@@ -41,13 +41,11 @@ LangChain.js is a framework and ecosystem for building context-aware, LLM-powere
   - Environment/exports matrix (Docker required): `pnpm test:exports:docker`
   - Dependency range tests (Docker required): `pnpm test:ranges:docker`
 - Watch build utilities: `pnpm --filter @langchain/build watch`
-- Release a package (maintainers): `pnpm release <workspace>` run on a clean `main`
 
 ## Coding Guidelines
 
 - Follow TypeScript strictness defined in package `tsconfig` files; prefer composable abstractions aligned with `@langchain/core`
 - Use Prettier (`.prettierrc`) and ESLint (`@langchain/eslint` presets) before submitting PRs
-- Add new public entrypoints in `langchain/langchain.config.js` or `libs/langchain-community/langchain.config.js`, and flag integrations requiring optional deps
 - Place tests alongside source (`tests/*.test.ts` for unit, `*.int.test.ts` for integration)
 
 ## Pull Request Guidelines


### PR DESCRIPTION
This PR adds a root AGENTS.md file to help AI code agents works with this repository by giving them context and structure info about the project.

Note that AGENTS.md is an open format supported by 20+ AI code agents, see: https://agents.md

As I wasn't sure whether you would be open to add this to the repo, I only went with the main file for now.
But if you'd be open to it, I can also add AGENTS.md file for the main packages with more detailed info for each of this (closest AGENTS.md file applies in the case of a monorepo), just let me know.
