### PR TITLE
fix(CONTRIBUTING.md): update directory path for langchain-core build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ pnpm install
 Then, you will need to switch directories into `langchain-core` and build core by running:
 
 ```bash
-cd ../../langchain-core
+cd libs/langchain-core
 pnpm install
 pnpm build
 ```


### PR DESCRIPTION
It appears it was using the old location of langchain-core