### PR TITLE
feat(anthropic): Add support for container reuse for code execution

### DIFF
--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -62,6 +62,11 @@ export interface ChatAnthropicCallOptions
    * when making a request.
    */
   headers?: Record<string, string>;
+  /**
+   * Container ID for file persistence across turns with code execution.
+   * Used with the code_execution_20250825 tool.
+   */
+  container?: string;
 }
 
 function _toolsInParams(
@@ -856,6 +861,7 @@ export class ChatAnthropicMessages<
         tool_choice,
         thinking: this.thinking,
         ...this.invocationKwargs,
+        container: options?.container,
       };
     }
     return {
@@ -870,6 +876,7 @@ export class ChatAnthropicMessages<
       tool_choice,
       thinking: this.thinking,
       ...this.invocationKwargs,
+      container: options?.container,
     };
   }
 

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -191,3 +191,41 @@ test("Can properly format anthropic messages when given two tool results", async
     system: undefined,
   });
 });
+
+test("invocationParams includes container when provided in call options", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-3-haiku-20240307",
+    temperature: 0,
+    anthropicApiKey: "testing",
+  });
+
+  const params = model.invocationParams({ container: "container_123" });
+
+  expect(params.container).toBe("container_123");
+});
+
+test("invocationParams does not include container when not provided", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-3-haiku-20240307",
+    temperature: 0,
+    anthropicApiKey: "testing",
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.container).toBeUndefined();
+});
+
+test("invocationParams includes container with thinking enabled", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-3-haiku-20240307",
+    temperature: 1,
+    anthropicApiKey: "testing",
+    thinking: { type: "enabled", budget_tokens: 1000 },
+  });
+
+  const params = model.invocationParams({ container: "container_456" });
+
+  expect(params.container).toBe("container_456");
+  expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 1000 });
+});


### PR DESCRIPTION
Adds `container` parameter to `ChatAnthropicCallOptions` and passes it through to Anthropic client.

See https://docs.claude.com/en/docs/agents-and-tools/tool-use/code-execution-tool#container-reuse