### PR TITLE
fix(langchain/createAgent): fix LangGraph integration

### DIFF
--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -792,23 +792,17 @@ export type InvokeConfiguration<ContextSchema extends Record<string, any>> =
    * If the context schema is a default object, `context` can be optional
    */
   ContextSchema extends InteropZodDefault<any>
-    ? Partial<
-        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
-      > & {
+    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
         context?: Partial<ContextSchema>;
       }
     : /**
      * If the context schema is all optional, `context` can be optional
      */
     IsAllOptional<ContextSchema> extends true
-    ? Partial<
-        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
-      > & {
+    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
         context?: Partial<ContextSchema>;
       }
-    : Partial<
-        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
-      > &
+    : Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> &
         WithMaybeContext<ContextSchema>;
 
 export type StreamConfiguration<ContextSchema extends Record<string, any>> =
@@ -816,9 +810,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
    * If the context schema is a default object, `context` can be optional
    */
   ContextSchema extends InteropZodDefault<any>
-    ? Partial<
-        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
-      > & {
+    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
         context?: Partial<ContextSchema>;
       }
     : /**
@@ -827,7 +819,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
     IsAllOptional<ContextSchema> extends true
     ? Partial<
         Pick<
-          PregelOptions<any, any, ContextSchema>,
+          PregelOptions<any, any, any>,
           CreateAgentPregelOptions | "streamMode"
         >
       > & {
@@ -835,7 +827,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
       }
     : Partial<
         Pick<
-          PregelOptions<any, any, ContextSchema>,
+          PregelOptions<any, any, any>,
           CreateAgentPregelOptions | "streamMode"
         >
       > &

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -792,17 +792,23 @@ export type InvokeConfiguration<ContextSchema extends Record<string, any>> =
    * If the context schema is a default object, `context` can be optional
    */
   ContextSchema extends InteropZodDefault<any>
-    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
+    ? Partial<
+        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
+      > & {
         context?: Partial<ContextSchema>;
       }
     : /**
      * If the context schema is all optional, `context` can be optional
      */
     IsAllOptional<ContextSchema> extends true
-    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
+    ? Partial<
+        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
+      > & {
         context?: Partial<ContextSchema>;
       }
-    : Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> &
+    : Partial<
+        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
+      > &
         WithMaybeContext<ContextSchema>;
 
 export type StreamConfiguration<ContextSchema extends Record<string, any>> =
@@ -810,7 +816,9 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
    * If the context schema is a default object, `context` can be optional
    */
   ContextSchema extends InteropZodDefault<any>
-    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
+    ? Partial<
+        Pick<PregelOptions<any, any, ContextSchema>, CreateAgentPregelOptions>
+      > & {
         context?: Partial<ContextSchema>;
       }
     : /**
@@ -819,7 +827,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
     IsAllOptional<ContextSchema> extends true
     ? Partial<
         Pick<
-          PregelOptions<any, any, any>,
+          PregelOptions<any, any, ContextSchema>,
           CreateAgentPregelOptions | "streamMode"
         >
       > & {
@@ -827,7 +835,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
       }
     : Partial<
         Pick<
-          PregelOptions<any, any, any>,
+          PregelOptions<any, any, ContextSchema>,
           CreateAgentPregelOptions | "streamMode"
         >
       > &


### PR DESCRIPTION
Instead of using a Proxy as proposed in #9016 this patch just adds additional methods needed by LangGraph to fetch graph information, making it run successfully:

```
npx @langchain/langgraph-cli dev

          Welcome to

╦  ┌─┐┌┐┌┌─┐╔═╗┬─┐┌─┐┌─┐┬ ┬
║  ├─┤││││ ┬║ ╦├┬┘├─┤├─┘├─┤
╩═╝┴ ┴┘└┘└─┘╚═╝┴└─┴ ┴┴  ┴ ┴.js

- 🚀 API: http://localhost:2024
- 🎨 Studio UI: https://smith.langchain.com/studio?baseUrl=http://localhost:2024

This in-memory server is designed for development and testing.
For production use, please use LangGraph Cloud.


info:    ▪ Starting server...
warn:    ┏ Some LangGraph.js dependencies are not up to date. Please make sure to update them to the required version.
warn:    ┗ [1] { '@langchain/langgraph-checkpoint': { version: '0.0.0', required: '~0.0.16 || ^0.1.0' } }
info:    ▪ Initializing storage...
info:    ▪ Registering graphs from /Users/christian.bromann/Sites/LangChain/langchainjs
info:    ┏ Registering graph with id 'agent'
info:    ┗ [1] { graph_id: 'agent' }
info:    ▪ Starting 10 workers
info:    ▪ Server running at ::1:2024
info:    ▪ <-- POST /assistants/search
info:    ▪ --> POST /assistants/search 200 5ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca 200 0ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/schemas
info:    ▪ <-- POST /assistants/search
info:    ▪ --> POST /assistants/search 200 1ms
info:    ▪ <-- GET /info
info:    ▪ <-- POST /assistants/search
info:    ▪ --> POST /assistants/search 200 0ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/graph?xray=true
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/graph?xray=true 200 5ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/subgraphs?recurse=true
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/subgraphs?recurse=true 200 0ms
info:    ▪ --> GET /info 200 11ms
Failed to obtain symbol "__langgraph__agent_simple__update": Unsupported type: never
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/schemas 200 2s
info:    ▪ <-- POST /assistants/search
info:    ▪ --> POST /assistants/search 200 1ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/schemas
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/graph?xray=true
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/graph?xray=true 200 0ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/subgraphs?recurse=true
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/subgraphs?recurse=true 200 0ms
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca/schemas 200 2ms
info:    ▪ <-- GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca
info:    ▪ --> GET /assistants/fe096781-5601-53d2-b2f6-0d3403f7e9ca 200 0ms
info:    ▪ <-- POST /assistants/search
info:    ▪ --> POST /assistants/search 200 1ms
```