### PR TITLE
fix(langchain/createAgent): tools in ModelRequest back to tool instance

### DIFF
--- a/examples/src/createAgent/dynamicTools/advanced.ts
+++ b/examples/src/createAgent/dynamicTools/advanced.ts
@@ -69,11 +69,11 @@ const selectToolsMiddleware = createMiddleware({
   name: "SelectToolsMiddleware",
   modifyModelRequest: async (request, state) => {
     const last = state.messages.at(-1);
-    const active = last?.content
+    const tools = last?.content
       ? // only give me the most relevant tool
         await selectTopKBySimilarity(last.content as string, 1)
       : fullCatalog.slice(0, 5);
-    return { ...request, tools: active.map((t) => t.name) };
+    return { ...request, tools };
   },
 });
 

--- a/examples/src/createAgent/dynamicTools/simple.ts
+++ b/examples/src/createAgent/dynamicTools/simple.ts
@@ -35,9 +35,9 @@ const vcsToolGate = createMiddleware({
   contextSchema: z.object({ vcsProvider: z.string() }),
   modifyModelRequest: (request, _state, runtime) => {
     const provider = runtime.context.vcsProvider.toLowerCase();
-    const active =
+    const tools =
       provider === "gitlab" ? [gitlabCreateIssue] : [githubCreateIssue];
-    return { ...request, tools: active.map((t) => t.name) };
+    return { ...request, tools };
   },
 });
 

--- a/libs/langchain/src/agents/middlewareAgent/middleware.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware.ts
@@ -107,8 +107,6 @@ export function createMiddleware<
       : {}) &
       AgentBuiltInState,
     runtime: Runtime<
-      (TSchema extends InteropZodObject ? InferInteropZodInput<TSchema> : {}) &
-        AgentBuiltInState,
       TContextSchema extends InteropZodObject
         ? InferInteropZodOutput<TContextSchema>
         : TContextSchema extends InteropZodDefault<any>
@@ -132,8 +130,6 @@ export function createMiddleware<
       : {}) &
       AgentBuiltInState,
     runtime: Runtime<
-      (TSchema extends InteropZodObject ? InferInteropZodInput<TSchema> : {}) &
-        AgentBuiltInState,
       TContextSchema extends InteropZodObject
         ? InferInteropZodOutput<TContextSchema>
         : TContextSchema extends InteropZodDefault<any>
@@ -171,8 +167,6 @@ export function createMiddleware<
       : {}) &
       AgentBuiltInState,
     runtime: Runtime<
-      (TSchema extends InteropZodObject ? InferInteropZodInput<TSchema> : {}) &
-        AgentBuiltInState,
       TContextSchema extends InteropZodObject
         ? InferInteropZodOutput<TContextSchema>
         : TContextSchema extends InteropZodDefault<any>
@@ -213,10 +207,6 @@ export function createMiddleware<
           options,
           state,
           runtime as Runtime<
-            (TSchema extends InteropZodObject
-              ? InferInteropZodInput<TSchema>
-              : {}) &
-              AgentBuiltInState,
             TContextSchema extends InteropZodObject
               ? InferInteropZodOutput<TContextSchema>
               : TContextSchema extends InteropZodDefault<any>
@@ -235,10 +225,6 @@ export function createMiddleware<
         config.beforeModel!(
           state,
           runtime as Runtime<
-            (TSchema extends InteropZodObject
-              ? InferInteropZodInput<TSchema>
-              : {}) &
-              AgentBuiltInState,
             TContextSchema extends InteropZodObject
               ? InferInteropZodOutput<TContextSchema>
               : TContextSchema extends InteropZodDefault<any>
@@ -257,10 +243,6 @@ export function createMiddleware<
         config.afterModel!(
           state,
           runtime as Runtime<
-            (TSchema extends InteropZodObject
-              ? InferInteropZodInput<TSchema>
-              : {}) &
-              AgentBuiltInState,
             TContextSchema extends InteropZodObject
               ? InferInteropZodOutput<TContextSchema>
               : TContextSchema extends InteropZodDefault<any>

--- a/libs/langchain/src/agents/middlewareAgent/middleware/dynamicSystemPrompt.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/dynamicSystemPrompt.ts
@@ -3,7 +3,7 @@ import type { Runtime, AgentBuiltInState } from "../types.js";
 
 export type DynamicSystemPromptMiddlewareConfig<TContextSchema> = (
   state: AgentBuiltInState,
-  runtime: Runtime<AgentBuiltInState, TContextSchema>
+  runtime: Runtime<TContextSchema>
 ) => string | Promise<string>;
 
 /**
@@ -52,7 +52,7 @@ export function dynamicSystemPromptMiddleware<TContextSchema = unknown>(
     modifyModelRequest: async (options, state, runtime) => {
       const systemPrompt = await fn(
         state as AgentBuiltInState,
-        runtime as Runtime<AgentBuiltInState, TContextSchema>
+        runtime as Runtime<TContextSchema>
       );
 
       if (typeof systemPrompt !== "string") {

--- a/libs/langchain/src/agents/middlewareAgent/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/hitl.ts
@@ -67,7 +67,7 @@ export type DescriptionFactory<
 > = (
   toolCall: ToolCall,
   state: State,
-  runtime: Runtime<State>
+  runtime: Runtime<unknown>
 ) => string | Promise<string>;
 
 /**

--- a/libs/langchain/src/agents/middlewareAgent/middleware/llmToolSelector.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/llmToolSelector.ts
@@ -226,6 +226,13 @@ export function llmToolSelectorMiddleware(
       }
 
       /**
+       * If no tools were selected after all retries, fall back to all tools
+       */
+      if (selectedToolNames.length === 0) {
+        return request;
+      }
+
+      /**
        * Filter tools based on selection
        */
       const selectedTools = toolInfo.filter(({ name }) =>

--- a/libs/langchain/src/agents/middlewareAgent/middleware/llmToolSelector.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/llmToolSelector.ts
@@ -110,7 +110,7 @@ export function llmToolSelectorMiddleware(
       /**
        * Extract tool information
        */
-      const toolInfo = runtime.tools.map((tool) => ({
+      const toolInfo = request.tools.map((tool) => ({
         name: tool.name as string,
         description: tool.description,
         tool,
@@ -228,9 +228,9 @@ export function llmToolSelectorMiddleware(
       /**
        * Filter tools based on selection
        */
-      const selectedTools = toolInfo
-        .filter(({ name }) => selectedToolNames.includes(name))
-        .map(({ name }) => name);
+      const selectedTools = toolInfo.filter(({ name }) =>
+        selectedToolNames.includes(name)
+      );
 
       return {
         ...request,

--- a/libs/langchain/src/agents/middlewareAgent/nodes/AfterModalNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/AfterModalNode.ts
@@ -28,10 +28,10 @@ export class AfterModelNode<
     this.name = `AfterModelNode_${middleware.name}`;
   }
 
-  runHook(state: TStateSchema, runtime: Runtime<TStateSchema, TContextSchema>) {
+  runHook(state: TStateSchema, runtime: Runtime<TContextSchema>) {
     return this.middleware.afterModel!(
       state as Record<string, any> & AgentBuiltInState,
-      runtime as Runtime<TStateSchema, unknown>
+      runtime as Runtime<unknown>
     ) as Promise<MiddlewareResult<TStateSchema>>;
   }
 }

--- a/libs/langchain/src/agents/middlewareAgent/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/AgentNode.ts
@@ -610,8 +610,6 @@ export class AgentNode<
         })
       );
 
-      console.log("result", result?.tools?.[0]?.description);
-
       if (result) {
         const modifiedTools = result.tools ?? [];
 
@@ -638,14 +636,6 @@ export class AgentNode<
          * Verify that user has not added or modified a tool with the same name.
          * We can't allow this as the ToolNode is already initiated with given tools.
          */
-        console.log(
-          "Before",
-          this.#options.toolClasses.map((t) => t.name)
-        );
-        console.log(
-          "Modified",
-          modifiedTools.map((t) => t.name)
-        );
         const invalidTools = modifiedTools.filter(
           (tool) =>
             isClientTool(tool) &&
@@ -665,7 +655,6 @@ export class AgentNode<
       }
     }
 
-    console.log("currentOptions", currentOptions.tools[0].name);
     return currentOptions;
   }
 

--- a/libs/langchain/src/agents/middlewareAgent/nodes/BeforeModalNode.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/BeforeModalNode.ts
@@ -27,10 +27,10 @@ export class BeforeModelNode<
     });
   }
 
-  runHook(state: TStateSchema, runtime: Runtime<TStateSchema, TContextSchema>) {
+  runHook(state: TStateSchema, runtime: Runtime<TContextSchema>) {
     return this.middleware.beforeModel!(
       state as Record<string, any> & AgentBuiltInState,
-      runtime as Runtime<TStateSchema, unknown>
+      runtime as Runtime<unknown>
     ) as Promise<MiddlewareResult<TStateSchema>>;
   }
 }

--- a/libs/langchain/src/agents/middlewareAgent/nodes/middleware.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/middleware.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-instanceof/no-instanceof */
 import { z } from "zod/v3";
 import { LangGraphRunnableConfig, Command } from "@langchain/langgraph";
 import { interopParse } from "@langchain/core/utils/types";
@@ -7,16 +6,11 @@ import { interopParse } from "@langchain/core/utils/types";
 import { RunnableCallable } from "../../RunnableCallable.js";
 import type {
   Runtime,
-  ControlAction,
   AgentMiddleware,
   MiddlewareResult,
   JumpToTarget,
 } from "../types.js";
-import {
-  derivePrivateState,
-  parseToolCalls,
-  parseJumpToTarget,
-} from "./utils.js";
+import { derivePrivateState, parseJumpToTarget } from "./utils.js";
 
 type NodeOutput<TStateSchema extends Record<string, any>> =
   | TStateSchema
@@ -33,7 +27,7 @@ export abstract class MiddlewareNode<
 
   abstract runHook(
     state: TStateSchema,
-    config?: Runtime<TStateSchema, TContextSchema>
+    config?: Runtime<TContextSchema>
   ): Promise<MiddlewareResult<TStateSchema>>;
 
   async invokeMiddleware(
@@ -74,21 +68,11 @@ export abstract class MiddlewareNode<
     /**
      * ToDo: implement later
      */
-    const runtime: Runtime<TStateSchema, TContextSchema> = {
-      toolCalls: parseToolCalls(state.messages),
+    const runtime: Runtime<TContextSchema> = {
       context: filteredContext,
       writer: config?.writer,
       interrupt: config?.interrupt,
       signal: config?.signal,
-      tools: this.middleware.tools ?? [],
-      terminate: (
-        result?: Partial<TStateSchema> | Error
-      ): ControlAction<TStateSchema> => {
-        if (result instanceof Error) {
-          throw result;
-        }
-        return { type: "terminate", result };
-      },
     };
 
     const result = await this.runHook(state, runtime);

--- a/libs/langchain/src/agents/middlewareAgent/nodes/utils.ts
+++ b/libs/langchain/src/agents/middlewareAgent/nodes/utils.ts
@@ -1,10 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from "zod/v3";
-import {
-  type BaseMessage,
-  ToolMessage,
-  AIMessage,
-} from "@langchain/core/messages";
+import { type BaseMessage } from "@langchain/core/messages";
 import {
   interopSafeParseAsync,
   interopZodObjectMakeFieldsOptional,
@@ -12,12 +8,7 @@ import {
 import { type ZodIssue } from "zod/v3";
 import { END } from "@langchain/langgraph";
 
-import type {
-  AgentMiddleware,
-  ToolCall,
-  ToolResult,
-  JumpTo,
-} from "../types.js";
+import type { AgentMiddleware, JumpTo } from "../types.js";
 
 /**
  * Helper function to initialize middleware state defaults.
@@ -117,48 +108,6 @@ export function derivePrivateState(
 
   // Return a new schema with only private properties (all optional)
   return z.object(privateShape);
-}
-
-/**
- * Parse out all tool calls from the messages and populate the results
- * @param messages - The messages to parse
- * @returns The tool calls
- */
-export function parseToolCalls(messages: BaseMessage[]): ToolCall[] {
-  const calls =
-    messages
-      .filter(
-        (message) =>
-          AIMessage.isInstance(message) && (message as AIMessage).tool_calls
-      )
-      .map((message) => (message as AIMessage).tool_calls as ToolCall[])
-      .flat() || [];
-
-  const results = parseToolResults(messages);
-  return calls.map((call) => {
-    const callResult = results.find((result) => result.id === call.id);
-    if (callResult) {
-      return {
-        ...call,
-        result: callResult.result,
-      };
-    }
-    return call;
-  });
-}
-
-/**
- * Parse out all tool results from the messages
- * @param messages - The messages to parse
- * @returns The tool results
- */
-function parseToolResults(messages: BaseMessage[]): ToolResult[] {
-  return messages
-    .filter((message) => ToolMessage.isInstance(message))
-    .map((message) => ({
-      id: (message as ToolMessage).tool_call_id,
-      result: (message as ToolMessage).content,
-    }));
 }
 
 /**

--- a/libs/langchain/src/agents/middlewareAgent/tests/middleware.test-d.ts
+++ b/libs/langchain/src/agents/middlewareAgent/tests/middleware.test-d.ts
@@ -1,8 +1,10 @@
 import { describe, it, expectTypeOf } from "vitest";
 import { z } from "zod/v3";
 import { HumanMessage, BaseMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
 
 import { createAgent, createMiddleware } from "../index.js";
+import type { ServerTool, ClientTool } from "../../types.js";
 
 describe("middleware types", () => {
   it("a middleware can define a state schema which is propagated to the result", async () => {
@@ -182,7 +184,9 @@ describe("middleware types", () => {
           }>();
         },
         modifyModelRequest: async (request, _state, runtime) => {
-          expectTypeOf(request.tools).toEqualTypeOf<string[]>();
+          expectTypeOf(request.tools).toEqualTypeOf<
+            (ServerTool | ClientTool)[]
+          >();
           expectTypeOf(runtime.context).toEqualTypeOf<{
             customDefaultContextProp: string;
             customOptionalContextProp?: string;
@@ -191,7 +195,7 @@ describe("middleware types", () => {
 
           return {
             ...request,
-            tools: ["toolA"],
+            tools: [tool(() => "result", { name: "toolA" })],
           };
         },
       });

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -151,7 +151,7 @@ export interface ModelRequest {
   /**
    * The tools to make available for this step.
    */
-  tools: string[];
+  tools: (ServerTool | ClientTool)[];
 }
 
 /**
@@ -171,31 +171,10 @@ export type WithMaybeContext<TContext> = undefined extends TContext
 /**
  * Runtime information available to middleware (readonly).
  */
-export type Runtime<TState = unknown, TContext = unknown> = Partial<
+export type Runtime<TContext = unknown> = Partial<
   Omit<LangGraphRuntime<TContext>, "context" | "configurable">
-> & {
-  readonly toolCalls: ToolCall[];
-  /**
-   * All tool instances that are provided to the agent.
-   */
-  readonly tools: (ClientTool | ServerTool)[];
-  /**
-   * Terminates the agent with an update to the state or throws an error.
-   * @param result - The result to terminate the agent with.
-   */
-  terminate(result: Partial<TState> | Error): ControlAction<TState>;
-} & WithMaybeContext<TContext>;
-
-/**
- * Control action type returned by control methods.
- */
-export type ControlAction<TStateSchema> = {
-  type: "terminate";
-  target?: string;
-  stateUpdate?: Partial<TStateSchema>;
-  result?: any;
-  error?: Error;
-};
+> &
+  WithMaybeContext<TContext>;
 
 /**
  * Result type for middleware functions.


### PR DESCRIPTION
We've decided to keep `tools` in `ModelRequest` a list of tool instances so users have access on more tool information. This also removes `tools` and `toolCalls` from runtime as it differs from our middleware designs.