### PR TITLE
feat(langchain/createAgent): implement retry model request hook in middleware

### DIFF
--- a/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
+++ b/libs/langchain/src/agents/middlewareAgent/ReactAgent.ts
@@ -173,6 +173,13 @@ export class ReactAgent<
        */
       () => any
     ][] = [];
+    const retryModelRequestHookMiddleware: [
+      AgentMiddleware,
+      /**
+       * ToDo: better type to get the state of middleware
+       */
+      () => any
+    ][] = [];
 
     this.#agentNode = new AgentNode({
       model: this.options.model,
@@ -185,6 +192,7 @@ export class ReactAgent<
       shouldReturnDirect,
       signal: this.options.signal,
       modifyModelRequestHookMiddleware,
+      retryModelRequestHookMiddleware,
     });
 
     const middlewareNames = new Set<string>();
@@ -233,6 +241,16 @@ export class ReactAgent<
 
       if (m.modifyModelRequest) {
         modifyModelRequestHookMiddleware.push([
+          m,
+          () => ({
+            ...beforeModelNode?.getState(),
+            ...afterModelNode?.getState(),
+          }),
+        ]);
+      }
+
+      if (m.retryModelRequest) {
+        retryModelRequestHookMiddleware.push([
           m,
           () => ({
             ...beforeModelNode?.getState(),

--- a/libs/langchain/src/agents/middlewareAgent/middleware/index.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/index.ts
@@ -30,4 +30,8 @@ export {
   modelCallLimitMiddleware,
   type ModelCallLimitMiddlewareConfig,
 } from "./callLimit.js";
+export {
+  modelFallbackMiddleware,
+  type ModelFallbackMiddlewareConfig,
+} from "./modelFallback.js";
 export { type AgentMiddleware } from "../types.js";

--- a/libs/langchain/src/agents/middlewareAgent/middleware/index.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/index.ts
@@ -30,8 +30,5 @@ export {
   modelCallLimitMiddleware,
   type ModelCallLimitMiddlewareConfig,
 } from "./callLimit.js";
-export {
-  modelFallbackMiddleware,
-  type ModelFallbackMiddlewareConfig,
-} from "./modelFallback.js";
+export { modelFallbackMiddleware } from "./modelFallback.js";
 export { type AgentMiddleware } from "../types.js";

--- a/libs/langchain/src/agents/middlewareAgent/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/modelFallback.ts
@@ -1,0 +1,99 @@
+import type { LanguageModelLike } from "@langchain/core/language_models/base";
+import { initChatModel } from "../../../chat_models/universal.js";
+import type { ModelRequest, AgentMiddleware } from "../types.js";
+import { createMiddleware } from "../middleware.js";
+
+/**
+ * Configuration options for the model fallback middleware.
+ */
+export interface ModelFallbackMiddlewareConfig {
+  /**
+   * The first fallback model to try when the primary model fails.
+   * Can be a model name string or a LanguageModelLike instance.
+   */
+  firstModel: string | LanguageModelLike;
+  /**
+   * Additional fallback models to try, in order.
+   * Can be model name strings or LanguageModelLike instances.
+   */
+  additionalModels?: (string | LanguageModelLike)[];
+}
+
+/**
+ * Middleware that provides automatic model fallback on errors.
+ *
+ * This middleware attempts to retry failed model calls with alternative models
+ * in sequence. When a model call fails, it tries the next model in the fallback
+ * list until either a call succeeds or all models have been exhausted.
+ *
+ * @example
+ * ```ts
+ * import { createAgent, modelFallbackMiddleware } from "langchain";
+ *
+ * // Create middleware with fallback models (not including primary)
+ * const fallback = modelFallbackMiddleware({
+ *   firstModel: "openai:gpt-4o-mini",  // First fallback
+ *   additionalModels: ["anthropic:claude-3-5-sonnet-20241022"],  // Second fallback
+ * });
+ *
+ * const agent = createAgent({
+ *   model: "openai:gpt-4o",  // Primary model
+ *   middleware: [fallback],
+ *   tools: [],
+ * });
+ *
+ * // If gpt-4o fails, automatically tries gpt-4o-mini, then claude
+ * const result = await agent.invoke({ messages: [{ role: "user", content: "Hello" }] });
+ * ```
+ *
+ * @param config - Configuration for the model fallback middleware
+ * @returns A middleware instance that handles model failures with fallbacks
+ */
+export function modelFallbackMiddleware(
+  config: ModelFallbackMiddlewareConfig
+): AgentMiddleware {
+  const { firstModel, additionalModels = [] } = config;
+
+  // Store models (both strings and instances)
+  const allModels = [firstModel, ...additionalModels];
+
+  return createMiddleware({
+    name: "modelFallbackMiddleware",
+    retryModelRequest: async (
+      _error,
+      request,
+      _state,
+      _runtime,
+      attempt
+    ): Promise<ModelRequest | undefined> => {
+      /**
+       * attempt 1 = primary model failed, try models[0] (first fallback)
+       */
+      const fallbackIndex = attempt - 1;
+
+      /**
+       * All fallback models exhausted
+       */
+      if (fallbackIndex >= allModels.length) {
+        return undefined;
+      }
+
+      /**
+       * Get or initialize the fallback model
+       */
+      const fallbackModel = allModels[fallbackIndex];
+      const model =
+        typeof fallbackModel === "string"
+          ? await initChatModel(fallbackModel)
+          : fallbackModel;
+
+      /**
+       * Try next fallback model
+       */
+      return {
+        ...request,
+        model,
+      };
+    },
+  });
+}

--- a/libs/langchain/src/agents/middlewareAgent/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middlewareAgent/middleware/tests/modelFallback.test.ts
@@ -1,0 +1,76 @@
+import { expect, describe, it, vi } from "vitest";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import { LanguageModelLike } from "@langchain/core/language_models/base";
+
+import { createAgent } from "../../index.js";
+import { modelFallbackMiddleware } from "../modelFallback.js";
+
+function createMockModel(name = "ChatAnthropic", model = "anthropic") {
+  // Mock Anthropic model
+  const invokeCallback = vi
+    .fn()
+    .mockResolvedValue(new AIMessage("Response from model"));
+  return {
+    getName: () => name,
+    bindTools: vi.fn().mockReturnThis(),
+    _streamResponseChunks: vi.fn().mockReturnThis(),
+    bind: vi.fn().mockReturnThis(),
+    invoke: invokeCallback,
+    lc_runnable: true,
+    _modelType: model,
+    _generate: vi.fn(),
+    _llmType: () => model,
+  } as unknown as LanguageModelLike;
+}
+
+describe("modelFallbackMiddleware", () => {
+  it("should retry the model request with the new model", async () => {
+    const model = createMockModel();
+    model.invoke = vi.fn().mockRejectedValue(new Error("Model error"));
+    const retryModel = createMockModel("ChatAnthropic", "anthropic");
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [
+        modelFallbackMiddleware({
+          firstModel: retryModel,
+        }),
+      ] as const,
+    });
+    await agent.invoke({ messages: [new HumanMessage("Hello, world!")] });
+    expect(model.invoke).toHaveBeenCalledTimes(1);
+    expect(retryModel.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("should allow to configure additional models", async () => {
+    const model = createMockModel();
+    model.invoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Model error"))
+      .mockResolvedValueOnce(new AIMessage("Response from model"));
+    const anotherFailingModel = createMockModel();
+    anotherFailingModel.invoke = vi
+      .fn()
+      .mockRejectedValue(new Error("Model error"));
+    const retryModel = createMockModel("ChatAnthropic", "anthropic");
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [
+        modelFallbackMiddleware({
+          firstModel: anotherFailingModel,
+          additionalModels: [
+            anotherFailingModel,
+            anotherFailingModel,
+            retryModel,
+          ],
+        }),
+      ] as const,
+    });
+
+    await agent.invoke({ messages: [new HumanMessage("Hello, world!")] });
+    expect(model.invoke).toHaveBeenCalledTimes(1);
+    expect(anotherFailingModel.invoke).toHaveBeenCalledTimes(3);
+    expect(retryModel.invoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/langchain/src/agents/middlewareAgent/types.ts
+++ b/libs/langchain/src/agents/middlewareAgent/types.ts
@@ -378,6 +378,26 @@ export interface AgentMiddleware<
       AgentBuiltInState,
     runtime: Runtime<TFullContext>
   ): Promise<Partial<ModelRequest> | void> | Partial<ModelRequest> | void;
+  /**
+   * Logic to handle model invocation errors and optionally retry.
+   *
+   * @param error - The exception that occurred during model invocation.
+   * @param request - The original model request that failed.
+   * @param state - The current agent state.
+   * @param runtime - The runtime context.
+   * @param attempt - The current attempt number (1-indexed).
+   * @returns Modified request to retry with, or undefined/null to propagate the error (re-raise).
+   */
+  retryModelRequest?(
+    error: Error,
+    request: ModelRequest,
+    state: (TSchema extends InteropZodObject
+      ? InferInteropZodInput<TSchema>
+      : {}) &
+      AgentBuiltInState,
+    runtime: Runtime<TFullContext>,
+    attempt: number
+  ): Promise<ModelRequest | void> | ModelRequest | void;
   beforeModel?(
     state: (TSchema extends InteropZodObject
       ? InferInteropZodInput<TSchema>


### PR DESCRIPTION
This PR implements the `retryModelRequest` middleware hook and `ModelFallbackMiddleware`, mirroring the [Python implementation](https://github.com/langchain-ai/langchain/pull/33275).

### Changes

#### 1. **New `retryModelRequest` Middleware Hook**

Added a new optional hook to the `AgentMiddleware` interface that allows middleware to intercept model invocation errors and optionally retry with modified requests:

```typescript
retryModelRequest?(
  error: Error,
  request: ModelRequest,
  state: AgentBuiltInState,
  runtime: Runtime,
  attempt: number
): Promise<ModelRequest | void> | ModelRequest | void;
```

- **Parameters:**
  - `error`: The exception that occurred during model invocation
  - `request`: The original model request that failed
  - `state`: The current agent state
  - `runtime`: The runtime context
  - `attempt`: The current attempt number (1-indexed)

- **Return value:**
  - `ModelRequest`: Modified request to retry with
  - `void`: Propagate the error (no retry)

#### 2. **ModelFallbackMiddleware**

New middleware that provides automatic model fallback on errors:

```typescript
import { createAgent, modelFallbackMiddleware } from "langchain";

const agent = createAgent({
  model: "openai:gpt-4o",  // Primary model
  middleware: [
    modelFallbackMiddleware(
      "openai:gpt-4o-mini",      // First fallback
      "anthropic:claude-3-5-sonnet-20241022"  // Second fallback
    )
  ],
  tools: [],
});

// If gpt-4o fails, automatically tries gpt-4o-mini, then claude
const result = await agent.invoke({
  messages: [{ role: "user", content: "Hello" }]
});
```

**Features:**
- Accepts variadic arguments for fallback models (strings or model instances)
- Tries each fallback model in sequence until one succeeds or all are exhausted
- Lazy initialization of model instances from strings

#### 3. **AgentNode Retry Logic**

Modified `AgentNode#invokeModel` to implement retry loop:
- Wraps model invocation in try-catch with retry loop
- On error, iterates through middleware with `retryModelRequest` hooks
- First middleware that returns a modified request triggers a retry
- Hard limit of 100 attempts prevents infinite loops from buggy middleware
- If no middleware wants to retry, re-raises the original error
