### PR TITLE
fix(ollama): separate thinking content into reasoning_content field

### DIFF
--- a/libs/providers/langchain-ollama/src/chat_models.ts
+++ b/libs/providers/langchain-ollama/src/chat_models.ts
@@ -690,6 +690,7 @@ export class ChatOllama
     const nonChunkMessage = new AIMessage({
       id: finalChunk?.id,
       content: finalChunk?.content ?? "",
+      additional_kwargs: finalChunk?.additional_kwargs,
       tool_calls: finalChunk?.tool_calls,
       response_metadata: finalChunk?.response_metadata,
       usage_metadata: finalChunk?.usage_metadata,

--- a/libs/providers/langchain-ollama/src/tests/chat_models_think.int.test.ts
+++ b/libs/providers/langchain-ollama/src/tests/chat_models_think.int.test.ts
@@ -25,6 +25,9 @@ test("test deep seek model with think=false", async () => {
   // s means allow . to match new line character
   expect(responseContent).not.toMatch(/<think>.*?<\/think>/is);
 
+  // Ensure reasoning is not present when think is disabled
+  expect(res.additional_kwargs?.reasoning_content).toBeUndefined();
+
   // Ensure the response is concise and directly answers the question
   expect(responseContent).toMatch(/photosynthesis/i); // Check it includes the topic
   expect(responseContent.length).toBeGreaterThan(1);
@@ -51,4 +54,14 @@ test("test deep seek model with think=true (default)", async () => {
   // Ensure the response is concise and directly answers the question
   expect(responseContent).toMatch(/photosynthesis/i); // Check it includes the topic
   expect(responseContent.length).toBeGreaterThan(1);
-});
+
+  // Ensure reasoning content is captured separately when think is enabled
+  const reasoning = res.additional_kwargs?.reasoning_content as
+    | string
+    | undefined;
+  expect(typeof reasoning === "string" ? reasoning.length : 0).toBeGreaterThan(
+    0
+  );
+  // And ensure content does not contain raw <think> tags
+  expect(responseContent).not.toMatch(/<think>.*?<\/think>/is);
+}, 120_000);

--- a/libs/providers/langchain-ollama/src/tests/utils.test.ts
+++ b/libs/providers/langchain-ollama/src/tests/utils.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "vitest";
+import { convertOllamaMessagesToLangChain } from "../utils.js";
+
+test("convertOllamaMessagesToLangChain separates thinking into reasoning_content", () => {
+  const msg = {
+    role: "assistant",
+    content: "Hello! How can I help?",
+    thinking: "We should respond politely.",
+  } as unknown as Parameters<typeof convertOllamaMessagesToLangChain>[0];
+
+  const chunk = convertOllamaMessagesToLangChain(msg);
+
+  expect(typeof chunk.content === "string" ? chunk.content : "").toBe(
+    "Hello! How can I help?"
+  );
+  expect(chunk.additional_kwargs?.reasoning_content).toBe(
+    "We should respond politely."
+  );
+});

--- a/libs/providers/langchain-ollama/src/utils.ts
+++ b/libs/providers/langchain-ollama/src/utils.ts
@@ -23,7 +23,11 @@ export function convertOllamaMessagesToLangChain(
   }
 ): AIMessageChunk {
   return new AIMessageChunk({
-    content: messages.thinking ?? messages.content ?? "",
+    content: messages.content ?? "",
+    additional_kwargs:
+      messages.thinking && messages.thinking !== ""
+        ? { reasoning_content: messages.thinking }
+        : {},
     tool_call_chunks: messages.tool_calls?.map((tc) => ({
       name: tc.function.name,
       args: JSON.stringify(tc.function.arguments),


### PR DESCRIPTION
What has been done:

- Store Ollama model "thinking" responses in additional_kwargs.reasoning_content instead of mixing with main content
- Preserve additional_kwargs when constructing non-chunk messages from streams
- Add unit test verifying thinking content is properly separated
- Add integration tests ensuring reasoning_content is populated when think=true and absent when think=false
- Fixes issue where thinking tags or content were appearing in the main response content

Fixes #9089 
