### PR TITLE
fix(anthropic): support Haiku 4.5 topP parameter

### DIFF
--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -732,8 +732,8 @@ export class ChatAnthropicMessages<
 
     this.invocationKwargs = fields?.invocationKwargs ?? {};
 
-    if (this.model.includes("opus-4-1") || this.model.includes("sonnet-4-5")) {
-      // Default to `undefined` for `topP` for Opus 4.1 models
+    if (this.model.includes("opus-4-1") || this.model.includes("sonnet-4-5") || this.model.includes("haiku-4-5")) {
+      // Default to `undefined` for `topP` for Claude 4 models (Opus 4.1, Sonnet 4.5, Haiku 4.5)
       this.topP = fields?.topP === null ? undefined : fields?.topP;
     } else {
       this.topP = fields?.topP ?? this.topP;
@@ -851,7 +851,7 @@ export class ChatAnthropicMessages<
         throw new Error("topK is not supported when thinking is enabled");
       }
       if (
-        this.model.includes("opus-4-1") || this.model.includes("sonnet-4-5")
+        this.model.includes("opus-4-1") || this.model.includes("sonnet-4-5") || this.model.includes("haiku-4-5")
           ? this.topP !== undefined
           : this.topP !== -1
       ) {


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue with Claude Haiku 4.5 models where the default `topP` parameter value of `-1` was causing a `BadRequestError` when making API calls.

## Issue

Claude Haiku 4.5 models throw the following error when used with the current configuration:
```
BadRequestError: 400 {"type":"error","error":{"type":"invalid_request_error","message":"top_p cannot be set to -1 for this model."}}
```

## Root Cause

The issue occurred because:
1. `topP` defaults to `-1` in the constructor
2. Only `opus-4-1` and `sonnet-4-5` models were configured to use `undefined` for `topP`
3. **Haiku 4.5 was missing** from this configuration, causing the API to receive `top_p: -1` which is not supported

According to [Anthropic's Claude 4.5 migration guide](https://docs.anthropic.com/claude/docs/claude-4-5-migration), Claude 4.5 models (including Haiku 4.5) require either `temperature` OR `top_p` to be used, but not both, and `top_p` cannot be set to `-1`.

## Changes

- Added `haiku-4-5` to the list of models that default `topP` to `undefined` in two locations:
  1. Constructor logic (lines 735-740)
  2. `invocationParams` thinking logic (line 854)
- Updated comments to reflect that Haiku 4.5 is now included in Claude 4 models

## Testing

- ✅ Haiku 4.5 models now work without the `top_p` error
- ✅ Existing Opus 4.1 and Sonnet 4.5 behavior remains unchanged  
- ✅ Other Claude models continue to work as expected
- ✅ No breaking changes to existing APIs

## Backward Compatibility

This change is fully backward compatible - it only adds support for the previously unsupported Haiku 4.5 model without modifying behavior for existing models.