### PR TITLE
fix: support parsing model names with tags

### DIFF
--- a/libs/langchain-classic/src/chat_models/universal.ts
+++ b/libs/langchain-classic/src/chat_models/universal.ts
@@ -851,10 +851,10 @@ export async function initChatModel<
     ...(fields ?? {}),
   };
   if (modelProvider === undefined && model?.includes(":")) {
-    const modelComponents = model.split(":", 2);
-    if (SUPPORTED_PROVIDERS.includes(modelComponents[0] as ChatModelProvider)) {
+    const [provider, modelName] = model.split(/:(.+)/); // "ollama:gpt-oss:20b" -> ["ollama", "gpt-oss:20b"]
+    if (SUPPORTED_PROVIDERS.includes(provider as ChatModelProvider)) {
       // eslint-disable-next-line no-param-reassign
-      [modelProvider, model] = modelComponents;
+      [modelProvider, model] = [provider, modelName];
     }
   }
   let configurableFieldsCopy = Array.isArray(configurableFields)

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -855,10 +855,10 @@ export async function initChatModel<
     ...(fields ?? {}),
   };
   if (modelProvider === undefined && model?.includes(":")) {
-    const modelComponents = model.split(":", 2);
-    if (SUPPORTED_PROVIDERS.includes(modelComponents[0] as ChatModelProvider)) {
+    const [provider, modelName] = model.split(/:(.+)/); // "ollama:gpt-oss:20b" -> ["ollama", "gpt-oss:20b"]
+    if (SUPPORTED_PROVIDERS.includes(provider as ChatModelProvider)) {
       // eslint-disable-next-line no-param-reassign
-      [modelProvider, model] = modelComponents;
+      [modelProvider, model] = [provider, modelName];
     }
   }
   let configurableFieldsCopy = Array.isArray(configurableFields)


### PR DESCRIPTION
### What does this PR do?

This PR improves the parsing logic in `initChatModel` to better support model strings that include a tag (such as `ollama:gpt-oss:20b`). Specifically, it updates the code to split the model string only on the first colon, so that the part before the first colon is always treated as the provider, and the remainder (which may include additional colons, e.g., tags or variants) is treated as the full model name.

### Why is this needed?

- Some model providers (like Ollama) use tags or variants in the model name, separated by colons (e.g., `gpt-oss:20b`).
- The previous implementation using `split(":", 2)` could lose information after the second colon, resulting in incorrect parsing of the model name and tag.
- The new approach uses `split(/:(.+)/)`, which ensures the provider is always the part before the first colon, and the full model name (including any tags) is preserved.

### How was this fixed?

- The code now uses:
  ```typescript
  const [provider, modelName] = model.split(/:(.+)/); // "ollama:gpt-oss:20b" -> ["ollama", "gpt-oss:20b"]
  ```

- This ensures that for a string like `ollama:gpt-oss:20b`, provider is `ollama` and `modelName` is `gpt-oss:20b`.

### Impact

- Backwards compatible: existing usages like `openai:gpt-4` still work as before.

- Now supports model names with tags, such as `ollama:gpt-oss:20b`.

- Only affects provider/model parsing in `initChatModel`.