### PR TITLE
fix(agents): improve middleware type inference with const type parameters

### DIFF
--- a/examples/src/createAgent/dynamicTools/advanced.ts
+++ b/examples/src/createAgent/dynamicTools/advanced.ts
@@ -80,7 +80,7 @@ const selectToolsMiddleware = createMiddleware({
 const semanticAgent = createAgent({
   model: "openai:gpt-4o",
   tools: fullCatalog, // superset for validation and typing
-  middleware: [selectToolsMiddleware] as const,
+  middleware: [selectToolsMiddleware],
 });
 
 const result = await semanticAgent.invoke({

--- a/examples/src/createAgent/middleware/hitl.ts
+++ b/examples/src/createAgent/middleware/hitl.ts
@@ -72,7 +72,7 @@ const agent = createAgent({
   systemPrompt:
     "You are a helpful assistant. Use the tools provided to help the user.",
   tools: [calculateTool, writeFileTool],
-  middleware: [hitlMiddleware] as const,
+  middleware: [hitlMiddleware],
 });
 const config = {
   configurable: {

--- a/examples/src/createAgent/middleware/promptCaching.ts
+++ b/examples/src/createAgent/middleware/promptCaching.ts
@@ -5,7 +5,7 @@ import { anthropicPromptCachingMiddleware } from "langchain";
 const agent = createAgent({
   model: "anthropic:claude-sonnet-4-20250514",
   tools: [],
-  middleware: [anthropicPromptCachingMiddleware({ ttl: "5m" })] as const,
+  middleware: [anthropicPromptCachingMiddleware({ ttl: "5m" })],
 });
 
 // Usage example with a long chat history for testing caching

--- a/examples/src/createAgent/middleware/simpleHitl.ts
+++ b/examples/src/createAgent/middleware/simpleHitl.ts
@@ -48,7 +48,7 @@ const agent = createAgent({
   model: "openai:gpt-4o-mini",
   tools: [],
   checkpointer,
-  middleware: [humanInTheLoopMiddleware] as const,
+  middleware: [humanInTheLoopMiddleware],
 });
 
 console.log("🚀 Human in the Loop Example - Missing Information Flow");

--- a/examples/src/createAgent/middleware/simpleSummarization.ts
+++ b/examples/src/createAgent/middleware/simpleSummarization.ts
@@ -56,7 +56,7 @@ const agent = createAgent({
     userId: z.string(),
   }),
   tools: [],
-  middleware: [summarizationMiddleware] as const,
+  middleware: [summarizationMiddleware],
 });
 
 const config = {

--- a/examples/src/createAgent/middleware/summarization.ts
+++ b/examples/src/createAgent/middleware/summarization.ts
@@ -33,7 +33,7 @@ const summaryMiddleware = summarizationMiddleware({
 const agent = createAgent({
   model: "openai:gpt-4o-mini",
   tools: [],
-  middleware: [summaryMiddleware] as const,
+  middleware: [summaryMiddleware],
 });
 
 console.log("🚀 Summarization Middleware Example");

--- a/libs/langchain/src/agents/index.ts
+++ b/libs/langchain/src/agents/index.ts
@@ -146,7 +146,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     T,
@@ -169,7 +169,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     ExtractZodArrayTypes<T> extends Record<string, any>
@@ -200,7 +200,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     Record<string, unknown>,
@@ -222,7 +222,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     Record<string, unknown>,
@@ -244,7 +244,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     Record<string, unknown>,
@@ -267,7 +267,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     T,
@@ -290,7 +290,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<T, StateSchema, ContextSchema, ToolStrategy<T>> & {
     responseFormat: ToolStrategy<T>;
@@ -308,7 +308,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     T,
@@ -330,7 +330,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: Omit<
     CreateAgentParams<
@@ -352,7 +352,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: Omit<
     CreateAgentParams<
@@ -378,7 +378,7 @@ export function createAgent<
   ContextSchema extends
     | AnyAnnotationRoot
     | InteropZodObject = AnyAnnotationRoot,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
+  const TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[]
 >(
   params: CreateAgentParams<
     StructuredResponseFormat,

--- a/libs/langchain/src/agents/middleware/tests/callLimit.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/callLimit.test.ts
@@ -76,7 +76,7 @@ describe("ModelCallLimitMiddleware", () => {
         const agent = createAgent({
           model,
           tools,
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
 
         const result = await agent.invoke({ messages: ["Hello, world!"] });
@@ -130,7 +130,7 @@ describe("ModelCallLimitMiddleware", () => {
           model,
           tools,
           checkpointer,
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
         await expect(
           agent.invoke({ messages: ["Hello, world!"] }, config)
@@ -139,7 +139,7 @@ describe("ModelCallLimitMiddleware", () => {
         const agent2 = createAgent({
           model,
           tools,
-          middleware: [middleware] as const,
+          middleware: [middleware],
           checkpointer,
         });
         if (exitBehavior === "throw") {
@@ -165,7 +165,7 @@ describe("ModelCallLimitMiddleware", () => {
           model,
           tools,
           checkpointer,
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
         if (exitBehavior === "throw") {
           await expect(

--- a/libs/langchain/src/agents/middleware/tests/contextEditing.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/contextEditing.test.ts
@@ -65,7 +65,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       // Create a conversation that doesn't exceed default 100K token threshold
@@ -113,7 +113,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -156,7 +156,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -189,7 +189,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -221,7 +221,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages: BaseMessage[] = [
@@ -289,7 +289,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -342,7 +342,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -376,7 +376,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -442,7 +442,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = createToolCallConversation();
@@ -496,7 +496,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = [new HumanMessage("Hello"), new AIMessage("Hi there!")];
@@ -521,7 +521,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages = [
@@ -549,7 +549,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const messages: BaseMessage[] = [
@@ -585,7 +585,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       // Create a message that's already marked as cleared
@@ -638,7 +638,7 @@ describe("contextEditingMiddleware", () => {
 
       const agent = createAgent({
         model,
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       // Tool message without a corresponding AI message (malformed conversation)

--- a/libs/langchain/src/agents/middleware/tests/dynamicSystemPrompt.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/dynamicSystemPrompt.test.ts
@@ -41,7 +41,7 @@ describe("dynamicSystemPrompt", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
       contextSchema,
     });
 
@@ -81,7 +81,7 @@ describe("dynamicSystemPrompt", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
       contextSchema,
     });
 

--- a/libs/langchain/src/agents/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/hitl.test.ts
@@ -106,7 +106,7 @@ describe("humanInTheLoopMiddleware", () => {
       systemPrompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
       tools: [calculateTool, writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -264,7 +264,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -336,7 +336,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -407,7 +407,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -487,7 +487,7 @@ describe("humanInTheLoopMiddleware", () => {
       systemPrompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
       tools: [calculateTool, writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -592,7 +592,7 @@ describe("humanInTheLoopMiddleware", () => {
       systemPrompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
       tools: [calculateTool, writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -660,7 +660,7 @@ describe("humanInTheLoopMiddleware", () => {
       systemPrompt:
         "You are a helpful assistant. Use the tools provided to help the user.",
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -723,7 +723,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -810,7 +810,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -879,7 +879,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -948,7 +948,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -1012,7 +1012,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {
@@ -1073,7 +1073,7 @@ describe("humanInTheLoopMiddleware", () => {
       model,
       checkpointer,
       tools: [writeFileTool],
-      middleware: [hitlMiddleware] as const,
+      middleware: [hitlMiddleware],
     });
 
     const config = {

--- a/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
@@ -31,7 +31,7 @@ describe("modelFallbackMiddleware", () => {
     const agent = createAgent({
       model,
       tools: [],
-      middleware: [modelFallbackMiddleware(retryModel)] as const,
+      middleware: [modelFallbackMiddleware(retryModel)],
     });
     await agent.invoke({ messages: [new HumanMessage("Hello, world!")] });
     expect(model.invoke).toHaveBeenCalledTimes(1);

--- a/libs/langchain/src/agents/middleware/tests/promptCaching.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/promptCaching.test.ts
@@ -52,7 +52,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Test with enough messages to trigger caching
@@ -87,7 +87,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Test with enough messages to trigger caching
@@ -126,7 +126,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Test with fewer messages than threshold
@@ -151,7 +151,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     const messages = [
@@ -177,7 +177,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
         const agent = createAgent({
           model: new ChatOpenAI({ model: "gpt-4o" }),
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
 
         // Should throw error
@@ -193,7 +193,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
         const agent = createAgent({
           model: "openai:gpt-4o",
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
 
         // Should throw error
@@ -215,7 +215,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
         const agent = createAgent({
           model,
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
 
         const messages = [
@@ -249,7 +249,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
         const agent = createAgent({
           model,
-          middleware: [middleware] as const,
+          middleware: [middleware],
         });
 
         const messages = [
@@ -280,7 +280,7 @@ describe("anthropicPromptCachingMiddleware", () => {
     const agent = createAgent({
       model,
       systemPrompt: "You are a helpful assistant", // Counts as 1 message
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Only 2 user messages, but with system message makes 3 total
@@ -304,7 +304,7 @@ describe("anthropicPromptCachingMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     const messages = [

--- a/libs/langchain/src/agents/middleware/tests/summarization.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/summarization.test.ts
@@ -71,7 +71,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Create a conversation with enough tokens to trigger summarization
@@ -116,7 +116,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Short conversation
@@ -160,7 +160,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Create messages with AI/Tool pairs that should stay together
@@ -205,7 +205,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Messages with existing system message containing a previous summary
@@ -257,7 +257,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Create messages with more than 50 words
@@ -292,7 +292,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     const result = await agent.invoke({ messages: [] });
@@ -315,7 +315,7 @@ describe("summarizationMiddleware", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     // Create many messages

--- a/libs/langchain/src/agents/middleware/tests/todoList.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/todoList.test.ts
@@ -31,7 +31,7 @@ describe("todoListMiddleware", () => {
     const agent = createAgent({
       model,
       systemPrompt: "You are a helpful assistant.",
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     const result = await agent.invoke({
@@ -115,7 +115,7 @@ describe("todoListMiddleware", () => {
     const agent = createAgent({
       model,
       systemPrompt: "You are a helpful assistant.",
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     const result = await agent.invoke({

--- a/libs/langchain/src/agents/middleware/tests/toolCallLimit.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/toolCallLimit.test.ts
@@ -181,7 +181,7 @@ describe("toolCallLimitMiddleware", () => {
       const agent = createAgent({
         model,
         tools: [searchTool, calculatorTool],
-        middleware: [middleware] as const,
+        middleware: [middleware],
         checkpointer,
       });
 
@@ -202,7 +202,7 @@ describe("toolCallLimitMiddleware", () => {
       const agent2 = createAgent({
         model,
         tools: [searchTool, calculatorTool],
-        middleware: [middleware] as const,
+        middleware: [middleware],
         checkpointer,
       });
 

--- a/libs/langchain/src/agents/tests/graph.test.ts
+++ b/libs/langchain/src/agents/tests/graph.test.ts
@@ -363,7 +363,7 @@ describe.each(matrix)(
       const agent = createAgent({
         model: "openai:gpt-4o-mini",
         tools: hasTool ? [someTool] : [],
-        middleware: [middleware1, middleware2] as const,
+        middleware: [middleware1, middleware2],
       });
 
       expect(await agent.drawMermaid()).toMatchSnapshot();
@@ -448,7 +448,7 @@ const middleware2 = createMiddleware({
 const agent = createAgent({
     model: "openai:gpt-4o-mini",
     tools: [someTool],
-    middleware: [middleware1, middleware2] as const,
+    middleware: [middleware1, middleware2],
 });
 \`\`\`
 

--- a/libs/langchain/src/agents/tests/middleware.int.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.int.test.ts
@@ -21,7 +21,7 @@ describe("afterAgent hook", () => {
     });
     const agent = createAgent({
       model: "openai:gpt-4o-mini",
-      middleware: [structuredOutputMiddleware] as const,
+      middleware: [structuredOutputMiddleware],
       responseFormat: z.object({
         name: z.string(),
         age: z.number(),

--- a/libs/langchain/src/agents/tests/middleware.test-d.ts
+++ b/libs/langchain/src/agents/tests/middleware.test-d.ts
@@ -25,7 +25,7 @@ describe("middleware types", () => {
     });
 
     const agent = createAgent({
-      middleware: [middleware, middleware2] as const,
+      middleware: [middleware, middleware2],
       tools: [],
       model: "gpt-4",
       responseFormat: z.object({
@@ -77,7 +77,7 @@ describe("middleware types", () => {
           customAgentOptionalContextProp: z.string().default("default value"),
           customAgentRequiredContextProp: z.string(),
         }),
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });
@@ -111,7 +111,7 @@ describe("middleware types", () => {
       });
 
       const agent = createAgent({
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });
@@ -140,7 +140,7 @@ describe("middleware types", () => {
       });
 
       const agent = createAgent({
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });
@@ -201,7 +201,7 @@ describe("middleware types", () => {
       });
 
       const agent = createAgent({
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });
@@ -261,7 +261,7 @@ describe("middleware types", () => {
       });
 
       const agent = createAgent({
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });
@@ -310,7 +310,7 @@ describe("middleware types", () => {
       });
 
       const agent = createAgent({
-        middleware: [middleware] as const,
+        middleware: [middleware],
         tools: [],
         model: "gpt-4",
       });

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -101,7 +101,7 @@ describe("middleware", () => {
     const agent = createAgent({
       model,
       tools: [],
-      middleware: [middlewareA, middlewareB, middlewareC] as const,
+      middleware: [middlewareA, middlewareB, middlewareC],
     });
 
     const result = await agent.invoke(initialState);
@@ -160,7 +160,7 @@ describe("middleware", () => {
         customContext: z.string(),
         customContext2: z.number().default(42),
       }),
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     await agent.invoke(
@@ -199,7 +199,7 @@ describe("middleware", () => {
             }),
           }),
         ],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
       await expect(
         agent.invoke({
@@ -233,7 +233,7 @@ describe("middleware", () => {
             }),
           }),
         ],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
       await expect(
         agent.invoke({
@@ -259,7 +259,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
       await expect(
         agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
@@ -286,7 +286,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
       await expect(
         agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
@@ -313,7 +313,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
       await expect(
         agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
@@ -437,7 +437,7 @@ describe("middleware", () => {
         model,
         tools: [],
         systemPrompt: "You are helpful",
-        middleware: [authMiddleware, retryMiddleware, cacheMiddleware] as const,
+        middleware: [authMiddleware, retryMiddleware, cacheMiddleware],
       });
 
       const result = await agent.invoke({
@@ -536,7 +536,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [inspectorMiddleware] as const,
+        middleware: [inspectorMiddleware],
         contextSchema: z.object({
           globalContext: z.number(),
         }),
@@ -699,7 +699,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         systemPrompt: "You are helpful",
-        middleware: [modifyingMiddleware] as const,
+        middleware: [modifyingMiddleware],
       });
 
       const result = await agent.invoke({
@@ -723,7 +723,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         systemPrompt: "You are helpful",
-        middleware: [modifyingMiddleware] as const,
+        middleware: [modifyingMiddleware],
       });
 
       await expect(
@@ -749,7 +749,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         systemPrompt: "You are helpful",
-        middleware: [modifyingMiddleware] as const,
+        middleware: [modifyingMiddleware],
       });
 
       await expect(
@@ -1048,7 +1048,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [weatherTool],
-        middleware: [loggingMiddleware] as const,
+        middleware: [loggingMiddleware],
       });
 
       const result = await agent.invoke(
@@ -1409,7 +1409,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [tool1, tool2],
-        middleware: [trackingMiddleware] as const,
+        middleware: [trackingMiddleware],
       });
 
       await agent.invoke({
@@ -2024,7 +2024,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const result = await agent.invoke({
@@ -2127,7 +2127,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware1, middleware2] as const,
+        middleware: [middleware1, middleware2],
       });
 
       const result = await agent.invoke({
@@ -2327,7 +2327,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       const result = await agent.invoke({
@@ -2353,7 +2353,7 @@ describe("middleware", () => {
       const agent = createAgent({
         model,
         tools: [],
-        middleware: [middleware] as const,
+        middleware: [middleware],
       });
 
       await agent.invoke({

--- a/libs/langchain/src/agents/tests/modelSettings.test.ts
+++ b/libs/langchain/src/agents/tests/modelSettings.test.ts
@@ -49,7 +49,7 @@ describe("modelSettings middleware support", () => {
     const agent = createAgent({
       model,
       tools: [],
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     await agent.invoke({

--- a/libs/langchain/src/agents/tests/runtime.test.ts
+++ b/libs/langchain/src/agents/tests/runtime.test.ts
@@ -16,7 +16,7 @@ describe("runtime", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     await expect(
@@ -37,7 +37,7 @@ describe("runtime", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     await expect(
@@ -59,7 +59,7 @@ describe("runtime", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
     });
 
     await expect(

--- a/libs/langchain/src/agents/tests/state.test.ts
+++ b/libs/langchain/src/agents/tests/state.test.ts
@@ -117,7 +117,7 @@ describe("middleware state management", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middlewareA, middlewareB, middlewareC] as const,
+      middleware: [middlewareA, middlewareB, middlewareC],
     });
 
     const { messages, ...rest } = await agent.invoke({
@@ -183,7 +183,7 @@ describe("middleware state management", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
       checkpointer,
     });
 
@@ -224,7 +224,7 @@ describe("middleware state management", () => {
 
     const agent = createAgent({
       model,
-      middleware: [middleware] as const,
+      middleware: [middleware],
       checkpointer,
     });
 


### PR DESCRIPTION
Add `const` modifier to `TMiddleware` type parameter in all `createAgent` overloads to properly infer middleware arrays as readonly tuples. This enables typescript to correctly infer middleware state types without requiring `as const` workarounds.

Changes:
- Add `const` to `TMiddleware` in all 10 `createAgent` overloads
- Remove redundant `as const` from middleware arrays in examples and tests

See: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters