### PR TITLE
Add `providerToolDefinition` field to support built-in client tools

### DIFF
--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -389,12 +389,15 @@ export class DynamicTool<
 
   func: DynamicToolInput<ToolOutputT>["func"];
 
+  providerToolDefinition?: Record<string, unknown>;
+
   constructor(fields: DynamicToolInput<ToolOutputT>) {
     super(fields);
     this.name = fields.name;
     this.description = fields.description;
     this.func = fields.func;
     this.returnDirect = fields.returnDirect ?? this.returnDirect;
+    this.providerToolDefinition = fields.providerToolDefinition;
   }
 
   /**
@@ -453,6 +456,8 @@ export class DynamicStructuredTool<
 
   schema: SchemaT;
 
+  providerToolDefinition?: Record<string, unknown>;
+
   constructor(
     fields: DynamicStructuredToolInput<SchemaT, SchemaOutputT, ToolOutputT>
   ) {
@@ -462,6 +467,7 @@ export class DynamicStructuredTool<
     this.func = fields.func;
     this.returnDirect = fields.returnDirect ?? this.returnDirect;
     this.schema = fields.schema;
+    this.providerToolDefinition = fields.providerToolDefinition;
   }
 
   /**
@@ -552,6 +558,33 @@ interface ToolWrapperParams<RunInput = ToolInputSchemaBase | undefined>
    * an agent should stop looping.
    */
   returnDirect?: boolean;
+  /**
+   * Provider-specific tool definition to override the tool definition sent to the provider.
+   *
+   * This allows you to define a tool with client-side execution while using provider-specific
+   * built-in tool formats. For example, with Anthropic's memory tool:
+   *
+   * ```ts
+   * tool(
+   *   ({ content }, config) => { ... },
+   *   {
+   *     name: "memory",
+   *     description: "Store or retrieve information",
+   *     schema: z.object({ content: z.string() }),
+   *     providerToolDefinition: {
+   *       type: "memory_20250818",
+   *       name: "memory",
+   *     },
+   *   }
+   * );
+   * ```
+   *
+   * When this field is present:
+   * - The tool will be treated as a client tool that requires local execution
+   * - The provider-specific definition will be sent to the API instead of auto-generated definition
+   * - Your handler function will be called when the model uses the tool
+   */
+  providerToolDefinition?: Record<string, unknown>;
 }
 
 /**

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -180,6 +180,38 @@ test("Does not double wrap a returned tool message even if a tool call with id i
   expect(toolResult.name).toBe("baz");
 });
 
+test("tool retains providerToolDefinition metadata when provided", () => {
+  const providerDefinition = { type: "memory_20250818", name: "memory" };
+
+  const memoryTool = tool(
+    (input: string) => input,
+    {
+      name: "memory",
+      providerToolDefinition: providerDefinition,
+    }
+  );
+
+  expect(memoryTool.providerToolDefinition).toBe(providerDefinition);
+
+  const structuredProviderDefinition = {
+    type: "memory_structured_20250818",
+    name: "memory_structured",
+  };
+
+  const structuredTool = tool(
+    (input: { content: string }) => input.content,
+    {
+      name: "memory_structured",
+      schema: z.object({ content: z.string() }),
+      providerToolDefinition: structuredProviderDefinition,
+    }
+  );
+
+  expect(structuredTool.providerToolDefinition).toBe(
+    structuredProviderDefinition
+  );
+});
+
 test("Tool can accept single string input", async () => {
   const toolCall = {
     id: "testid",

--- a/libs/langchain-core/src/tools/types.ts
+++ b/libs/langchain-core/src/tools/types.ts
@@ -311,6 +311,33 @@ export interface BaseDynamicToolInput extends ToolParams {
    * an agent should stop looping.
    */
   returnDirect?: boolean;
+  /**
+   * Provider-specific tool definition to override the tool definition sent to the provider.
+   *
+   * This allows you to define a tool with client-side execution while using provider-specific
+   * built-in tool formats. For example, with Anthropic's memory tool:
+   *
+   * ```ts
+   * tool(
+   *   ({ content }, config) => { ... },
+   *   {
+   *     name: "memory",
+   *     description: "Store or retrieve information",
+   *     schema: z.object({ content: z.string() }),
+   *     providerToolDefinition: {
+   *       type: "memory_20250818",
+   *       name: "memory",
+   *     },
+   *   }
+   * );
+   * ```
+   *
+   * When this field is present:
+   * - The tool will be treated as a client tool that requires local execution
+   * - The provider-specific definition will be sent to the API instead of auto-generated definition
+   * - Your handler function will be called when the model uses the tool
+   */
+  providerToolDefinition?: Record<string, unknown>;
 }
 
 /**

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -796,6 +796,11 @@ export class ChatAnthropicMessages<
       return undefined;
     }
     return tools.map((tool) => {
+      // Check if tool has providerToolDefinition FIRST (built-in client tools)
+      // This must come before isBuiltinTool check because LangChain tools are not plain objects
+      if (isLangChainTool(tool) && tool.providerToolDefinition) {
+        return tool.providerToolDefinition as Anthropic.Messages.ToolUnion;
+      }
       if (isBuiltinTool(tool)) {
         return tool;
       }


### PR DESCRIPTION
# Why?

Today, the way we determine whether a tool is a server or client tool is based on its shape: it it has `{type: ..., name: ...}` then it is server, otherwise client. This heuristic breaks for Anthropic memory and text editor tools, which have that shape, but are client tools

# What?

This PR introduces the `providerToolDefinition` field on client tools, allowing you to define a client tool but override the way it presents itself to the provider, rather than automatically generating based on schema