### PR TITLE
fix(internal): remove more langchain-scripts artifacts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -19,5 +19,4 @@ paths-ignore:
   - "**/*.test.ts"
   - "**/tests/**/*.ts"
   - "**/__tests__/**/*.ts"
-  - "/libs/langchain-scripts/**/*.ts"
   - "docs/core_docs/scripts/*.js"

--- a/.github/contributing/INTEGRATIONS.md
+++ b/.github/contributing/INTEGRATIONS.md
@@ -122,10 +122,6 @@ Above, we have a document loader that we're sure will always require a specific 
 
 We highly appreciate documentation and integration tests showing how to set up and use your integration. Providing this will make it much easier for reviewers to verify that your integration works and will streamline the review process.
 
-New docs pages should be added as the appropriate template from here:
-
-https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-scripts/src/cli/docs/templates
-
 ### Linting and formatting
 
 As with all contributions, make sure you run `pnpm lint` and `pnpm format` so that everything conforms to our established style.

--- a/.github/workflows/unit-tests-integrations.yml
+++ b/.github/workflows/unit-tests-integrations.yml
@@ -42,7 +42,7 @@ jobs:
     needs: get-changed-files
     runs-on: ubuntu-latest
     env:
-      PACKAGES: "anthropic,aws,azure-cosmosdb,azure-dynamic-sessions,baidu-qianfan,cerebras,cloudflare,cohere,core,community,deepseek,exa,google-cloud-sql-pg,google-common,google-gauth,google-genai,google-vertexai,google-vertexai-web,google-webauth,groq,mcp-adapters,mistralai,mixedbread-ai,mongodb,nomic,ollama,openai,pinecone,qdrant,redis,scripts,standard-tests,tavily,textsplitters,weaviate,xai,yandex"
+      PACKAGES: "anthropic,aws,azure-cosmosdb,azure-dynamic-sessions,baidu-qianfan,cerebras,cloudflare,cohere,core,community,deepseek,exa,google-cloud-sql-pg,google-common,google-gauth,google-genai,google-vertexai,google-vertexai-web,google-webauth,groq,mcp-adapters,mistralai,mixedbread-ai,mongodb,nomic,ollama,openai,pinecone,qdrant,redis,standard-tests,tavily,textsplitters,weaviate,xai,yandex"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       matrix_length: ${{ steps.set-matrix.outputs.matrix_length }}


### PR DESCRIPTION
PRs are still trying to run `@langchain/scripts` unit tests. This PR attempts to fix that.