### PR TITLE
fix(aws): add lc_aliases for model_id/region_name in ChatBedrockConverse

### DIFF
--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -659,6 +659,8 @@ export class ChatBedrockConverse
   get lc_aliases(): { [key: string]: string } | undefined {
     return {
       apiKey: "API_KEY_NAME",
+      model: "model_id",
+      region: "region_name",
     };
   }
 


### PR DESCRIPTION
## Problem

`ChatBedrockConverse` was missing `lc_aliases` to map Python naming conventions (`model_id`, `region_name`) from LangSmith Hub to JavaScript property names (`model`, `region`). This caused model configuration to not load correctly when pulling prompts with `includeModel: true`.

## Solution

Added `lc_aliases` mapping for `model` → `model_id` and `region` → `region_name`, matching the pattern used in `BedrockChat`.

## Changes

- Add `model` and `region` aliases to `ChatBedrockConverse.lc_aliases()`
- Add test verifying deserialization works correctly
