### PR TITLE
fix(langchain): remove getContextVariable and setContextVariable from langchain

### DIFF
--- a/examples/src/createAgent/accessExternalContextInTools.ts
+++ b/examples/src/createAgent/accessExternalContextInTools.ts
@@ -22,12 +22,11 @@
  */
 
 import fs from "node:fs/promises";
+import { createAgent, tool } from "langchain";
 import {
-  createAgent,
-  tool,
-  setContextVariable,
   getContextVariable,
-} from "langchain";
+  setContextVariable,
+} from "@langchain/core/context";
 import { z } from "zod";
 
 /**

--- a/libs/langchain/src/index.ts
+++ b/libs/langchain/src/index.ts
@@ -49,14 +49,6 @@ export * from "./agents/middleware/index.js";
 export { InMemoryStore } from "@langchain/core/stores";
 
 /**
- * LangChain Context
- */
-export {
-  setContextVariable,
-  getContextVariable,
-} from "@langchain/core/context";
-
-/**
  * LangChain Documents
  */
 export { type DocumentInput, Document } from "@langchain/core/documents";


### PR DESCRIPTION
These primitives have a dependency to Node.js which we don't want to depend on.