### PR TITLE
fix(langchain/agents): use channels when defining StateGraph schema

### DIFF
--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -3,7 +3,6 @@
 import { InteropZodObject } from "@langchain/core/utils/types";
 
 import {
-  AnnotationRoot,
   StateGraph,
   END,
   START,
@@ -185,7 +184,7 @@ export class ReactAgent<
     );
 
     const workflow = new StateGraph(
-      schema as unknown as AnnotationRoot<any>,
+      schema as unknown as AnyAnnotationRoot,
       this.options.contextSchema
     );
 


### PR DESCRIPTION
Before we were passing in a zod object into the internal StateGraph used by createAgent, which LangGraph was internally assuming was one consistent object that could be parsed by using interopParse. This isn't always the case since createAgent technically doesn't get in the way of defining zod 3 + 4 schemas in the same createAgent composition (with middleware states + agent states). This escapes the internal LG parsing check by converting to the generic channels definition API in LG.

Fixes #9299
Fixes #9325