### PR TITLE
feat(langchain): Add type inference for ReactAgent stream method

### DIFF
--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -13,7 +13,6 @@ import {
   type LangGraphRunnableConfig,
   type StreamMode,
   type StreamOutputMap,
-  type PregelOptions,
 } from "@langchain/langgraph";
 import type { CheckpointListOptions } from "@langchain/langgraph-checkpoint";
 import { ToolMessage, AIMessage } from "@langchain/core/messages";
@@ -1086,35 +1085,32 @@ export class ReactAgent<
     state: InvokeStateParameter<StateSchema, TMiddleware>,
     config?: StreamConfiguration<
       InferContextInput<ContextSchema> &
-        InferMiddlewareContextInputs<TMiddleware>
-    > & {
-      streamMode?: TStreamMode;
-      encoding?: TEncoding;
-    }
-  ): Promise<
-    IterableReadableStream<
-      StreamOutputMap<
-        TStreamMode,
-        false,
-        any,
-        any,
-        string,
-        unknown,
-        any,
-        TEncoding
-      >
+        InferMiddlewareContextInputs<TMiddleware>,
+      TStreamMode,
+      TEncoding
     >
-  > {
+  ) {
     const initializedState = await this.#initializeMiddlewareStates(
       state,
       config as RunnableConfig
     );
     return this.#graph.stream(
       initializedState,
-      config as Partial<
-        PregelOptions<any, any, any, TStreamMode, false, TEncoding>
+      config as Record<string, any>
+    ) as Promise<
+      IterableReadableStream<
+        StreamOutputMap<
+          TStreamMode,
+          false,
+          MergedAgentState<StateSchema, StructuredResponseFormat, TMiddleware>,
+          MergedAgentState<StateSchema, StructuredResponseFormat, TMiddleware>,
+          string,
+          unknown,
+          unknown,
+          TEncoding
+        >
       >
-    );
+    >;
   }
 
   /**
@@ -1176,7 +1172,9 @@ export class ReactAgent<
     state: InvokeStateParameter<StateSchema, TMiddleware>,
     config?: StreamConfiguration<
       InferContextInput<ContextSchema> &
-        InferMiddlewareContextInputs<TMiddleware>
+        InferMiddlewareContextInputs<TMiddleware>,
+      StreamMode | StreamMode[] | undefined,
+      "text/event-stream" | undefined
     > & { version?: "v1" | "v2" },
     streamOptions?: Parameters<Runnable["streamEvents"]>[2]
   ): IterableReadableStream<StreamEvent> {

--- a/libs/langchain/src/agents/runtime.ts
+++ b/libs/langchain/src/agents/runtime.ts
@@ -4,6 +4,7 @@ import type { InteropZodDefault } from "@langchain/core/utils/types";
 import type {
   Runtime as LangGraphRuntime,
   PregelOptions,
+  StreamMode,
 } from "@langchain/langgraph";
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseCallbackConfig } from "@langchain/core/callbacks/manager";
@@ -151,12 +152,21 @@ export type InvokeConfiguration<ContextSchema extends Record<string, any>> =
         Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> &
         WithMaybeContext<ContextSchema>;
 
-export type StreamConfiguration<ContextSchema extends Record<string, any>> =
+export type StreamConfiguration<
+  ContextSchema extends Record<string, any>,
+  TStreamMode extends StreamMode | StreamMode[] | undefined,
+  TEncoding extends "text/event-stream" | undefined
+> =
   /**
    * If the context schema is a default object, `context` can be optional
    */
   ContextSchema extends InteropZodDefault<any>
-    ? Partial<Pick<PregelOptions<any, any, any>, CreateAgentPregelOptions>> & {
+    ? Partial<
+        Pick<
+          PregelOptions<any, any, any, TStreamMode, boolean, TEncoding>,
+          CreateAgentPregelOptions
+        >
+      > & {
         context?: Partial<ContextSchema>;
       }
     : /**
@@ -165,7 +175,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
     IsAllOptional<ContextSchema> extends true
     ? Partial<
         Pick<
-          PregelOptions<any, any, any>,
+          PregelOptions<any, any, any, TStreamMode, boolean, TEncoding>,
           CreateAgentPregelOptions | CreateAgentPregelStreamOptions
         >
       > & {
@@ -173,7 +183,7 @@ export type StreamConfiguration<ContextSchema extends Record<string, any>> =
       }
     : Partial<
         Pick<
-          PregelOptions<any, any, any>,
+          PregelOptions<any, any, any, TStreamMode, boolean, TEncoding>,
           CreateAgentPregelOptions | CreateAgentPregelStreamOptions
         >
       > &

--- a/libs/langchain/src/agents/tests/reactAgent.test-d.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.test-d.ts
@@ -4,7 +4,7 @@ import { LanguageModelLike } from "@langchain/core/language_models/base";
 import { describe, it, expectTypeOf } from "vitest";
 import type { IterableReadableStream } from "@langchain/core/utils/stream";
 
-import { createAgent } from "../index.js";
+import { type BuiltInState, createAgent } from "../index.js";
 import type { StreamOutputMap } from "@langchain/langgraph";
 
 describe("reactAgent", () => {
@@ -85,14 +85,11 @@ describe("reactAgent", () => {
         StreamOutputMap<
           "values" | "updates" | "messages",
           false,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          any,
+          Record<string, unknown>,
+          Record<string, unknown>,
           string,
           unknown,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          any,
+          unknown,
           "text/event-stream"
         >
       >
@@ -107,22 +104,22 @@ describe("reactAgent", () => {
         messages: [new HumanMessage("Hello, world!")],
       },
       {
-        streamMode: ["updates", "messages", "custom"],
+        streamMode: ["updates", "messages", "values"],
       }
     );
 
     for await (const chunk of multiModeStream) {
       const [mode, value] = chunk;
-      expectTypeOf(mode).toEqualTypeOf<"updates" | "messages" | "custom">();
+      expectTypeOf(mode).toEqualTypeOf<"updates" | "messages" | "values">();
       if (mode === "messages") {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expectTypeOf(value).toExtend<[BaseMessage, Record<string, any>]>();
+        expectTypeOf(value).toEqualTypeOf<[BaseMessage, Record<string, any>]>();
       } else if (mode === "updates") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expectTypeOf(value).toExtend<Record<string, any>>();
+        expectTypeOf(value).toEqualTypeOf<
+          Record<string, Omit<BuiltInState, "jumpTo">>
+        >();
       } else {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expectTypeOf(value).toExtend<any>();
+        expectTypeOf(value.messages).toEqualTypeOf<BaseMessage[]>();
       }
     }
 


### PR DESCRIPTION
### description
This PR improves type safety for the ReactAgent.stream() method by adding generic type parameters that enable TypeScript to infer the correct return type based on the streamMode configuration.

### Before
```ts
const stream = await agent.stream(
  { messages: [{ role: "user", content: "What's the weather?" }] },
  { streamMode: "messages" }
);

// Type inferred: IterableReadableStream<any>
// No type safety at all

for await (const chunk of stream) {
  // chunk: any ❌
  // No autocomplete, no type checking
  const mode = chunk[0];      // any
  const message = chunk[1];   // any
  console.log(message.content); // No error even if accessing wrong properties
}
```
### After
```ts
const stream = await agent.stream(
  { messages: [{ role: "user", content: "What's the weather?" }] },
  { streamMode: "messages" }
);

// Type inferred: IterableReadableStream<["messages", [BaseMessage, Record<string, any>]]>
// Fully typed!

for await (const chunk of stream) {
  // chunk: ["messages", [BaseMessage, Record<string, any>]] ✅
  const [mode, [message, metadata]] = chunk;
  // mode: "messages" (literal type)
  // message: BaseMessage (typed!)
  // metadata: Record<string, any>
  
  console.log(message.content);     // ✅ Type-safe access
  console.log(metadata.langgraph_node); // ✅ Autocomplete available
}
```

### Before
```ts
const stream = await agent.stream(
  { messages: [{ role: "user", content: "Calculate 2+2" }] },
  { streamMode: ["updates", "messages", "custom"] }
);

// Type inferred: IterableReadableStream<any>
// Can't distinguish between different stream modes

for await (const chunk of stream) {
  // chunk: any ❌
  // No way to know what mode we're in
  const mode = chunk[0];  // any
  const value = chunk[1]; // any
  
  // Unsafe type assertions needed
  if (mode === "messages") {
    const [message, metadata] = value as any; // Forced to use 'as any'
    console.log(message.content);
  } else if (mode === "updates") {
    console.log(value); // No idea what type this is
  } else if (mode === "custom") {
    console.log(value); // No idea what type this is
  }
}
```

### After
```ts
const stream = await agent.stream(
  { messages: [{ role: "user", content: "Calculate 2+2" }] },
  { streamMode: ["updates", "messages", "custom"]  }
);

// Type inferred: IterableReadableStream<
//   | ["updates", Record<string, any>]
//   | ["messages", [BaseMessage, Record<string, any>]]
//   | ["custom", any]
// >
// Union type with all possible stream modes! ✅

for await (const chunk of stream) {
  // chunk: ["updates", Record<string, any>] 
  //      | ["messages", [BaseMessage, Record<string, any>]]
  //      | ["custom", any]
  
  const [mode, value] = chunk;
  
  // TypeScript narrows the type based on mode! ✅
  if (mode === "messages") {
    // value: [BaseMessage, Record<string, any>] ✅
    const [message, metadata] = value;
    console.log(message.content); // Fully typed!
    console.log(metadata.langgraph_node);
  } else if (mode === "updates") {
    // value: Record<string, any> ✅
    console.log(value.messages); // Typed as state updates
  } else if (mode === "custom") {
    // value: any
    console.log(value); // Custom events
  }
  
}
```