### PR TITLE
fix(langchain): make PII middleware compatible with Python

### DIFF
--- a/libs/langchain/src/agents/middleware/index.ts
+++ b/libs/langchain/src/agents/middleware/index.ts
@@ -17,9 +17,7 @@ export {
 } from "./llmToolSelector.js";
 export {
   piiMiddleware,
-  piiRedactionMiddleware,
   type PIIMiddlewareConfig,
-  type PIIRedactionMiddlewareConfig,
   type PIIMatch,
   type PIIStrategy,
   type BuiltInPIIType,
@@ -35,6 +33,10 @@ export {
   applyStrategy,
   resolveRedactionRule,
 } from "./pii.js";
+export {
+  piiRedactionMiddleware,
+  type PIIRedactionMiddlewareConfig,
+} from "./piiRedaction.js";
 export {
   contextEditingMiddleware,
   ClearToolUsesEdit,

--- a/libs/langchain/src/agents/middleware/pii.ts
+++ b/libs/langchain/src/agents/middleware/pii.ts
@@ -720,36 +720,3 @@ export function piiMiddleware(
     },
   });
 }
-
-/**
- * @deprecated Use `piiMiddleware` instead. This function is kept for backward compatibility.
- */
-export function piiRedactionMiddleware(
-  options: { rules?: Record<string, RegExp> } = {}
-): ReturnType<typeof createMiddleware> {
-  // For backward compatibility, create multiple middleware instances
-  // This is not ideal but maintains API compatibility
-  const rules = options.rules ?? {};
-
-  if (Object.keys(rules).length === 0) {
-    // Return a no-op middleware if no rules
-    return createMiddleware({
-      name: "PIIRedactionMiddleware",
-      contextSchema: z.object({}),
-    });
-  }
-
-  // Note: This doesn't fully replicate the old behavior (redaction map restoration)
-  // but provides basic functionality
-  throw new Error(
-    "piiRedactionMiddleware is deprecated. Use piiMiddleware instead. " +
-      "For multiple PII types, create multiple piiMiddleware instances."
-  );
-}
-
-/**
- * @deprecated Use `PIIMiddlewareConfig` instead.
- */
-export type PIIRedactionMiddlewareConfig = {
-  rules?: Record<string, RegExp>;
-};

--- a/libs/langchain/src/agents/middleware/piiRedaction.ts
+++ b/libs/langchain/src/agents/middleware/piiRedaction.ts
@@ -1,0 +1,494 @@
+import { z } from "zod/v3";
+import {
+  BaseMessage,
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  RemoveMessage,
+  SystemMessage,
+} from "@langchain/core/messages";
+import type { InferInteropZodInput } from "@langchain/core/utils/types";
+
+import { createMiddleware } from "../middleware.js";
+
+/**
+ * Type for the redaction map that stores original values by ID
+ */
+type RedactionMap = Record<string, string>;
+
+/**
+ * Configuration schema for the Input Guardrails middleware
+ */
+const contextSchema = z.object({
+  /**
+   * A record of PII detection rules to apply
+   * @default DEFAULT_PII_RULES (with enabled rules only)
+   */
+  rules: z
+    .record(
+      z.string(),
+      z.instanceof(RegExp).describe("Regular expression pattern to match PII")
+    )
+    .optional(),
+});
+
+/**
+ * @deprecated
+ */
+export type PIIRedactionMiddlewareConfig = InferInteropZodInput<
+  typeof contextSchema
+>;
+
+/**
+ * Generate a unique ID for a redaction
+ */
+function generateRedactionId(): string {
+  return Math.random().toString(36).substring(2, 11);
+}
+
+/**
+ * Apply PII detection rules to text with ID tracking
+ */
+function applyPIIRules(
+  text: string,
+  rules: Record<string, RegExp>,
+  redactionMap: RedactionMap
+): string {
+  let processedText = text;
+
+  for (const [name, pattern] of Object.entries(rules)) {
+    const replacement = name.toUpperCase().replace(/[^a-zA-Z0-9_-]/g, "");
+    processedText = processedText.replace(pattern, (match) => {
+      const id = generateRedactionId();
+      redactionMap[id] = match;
+      // Create a trackable replacement like [REDACTED_SSN_abc123]
+      return `[REDACTED_${replacement}_${id}]`;
+    });
+  }
+
+  return processedText;
+}
+
+interface ProcessHumanMessageConfig {
+  rules: Record<string, RegExp>;
+  redactionMap: RedactionMap;
+}
+
+/**
+ * Process a single human message for PII detection and redaction
+ */
+async function processMessage(
+  message: BaseMessage,
+  config: ProcessHumanMessageConfig
+): Promise<BaseMessage> {
+  /**
+   * handle basic message types
+   */
+  if (
+    HumanMessage.isInstance(message) ||
+    ToolMessage.isInstance(message) ||
+    SystemMessage.isInstance(message)
+  ) {
+    const content = message.content as string;
+    const processedContent = await applyPIIRules(
+      content,
+      config.rules,
+      config.redactionMap
+    );
+
+    if (processedContent !== content) {
+      const MessageConstructor = Object.getPrototypeOf(message).constructor;
+      return new MessageConstructor({
+        ...message,
+        content: processedContent,
+      });
+    }
+
+    return message;
+  }
+
+  /**
+   * Handle AI messages
+   */
+  if (AIMessage.isInstance(message)) {
+    const content =
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content);
+    const toolCalls = JSON.stringify(message.tool_calls);
+    const processedContent = await applyPIIRules(
+      content,
+      config.rules,
+      config.redactionMap
+    );
+    const processedToolCalls = await applyPIIRules(
+      toolCalls,
+      config.rules,
+      config.redactionMap
+    );
+
+    if (processedContent !== content || processedToolCalls !== toolCalls) {
+      return new AIMessage({
+        ...message,
+        content:
+          typeof message.content === "string"
+            ? processedContent
+            : JSON.parse(processedContent),
+        tool_calls: JSON.parse(processedToolCalls),
+      });
+    }
+
+    return message;
+  }
+
+  throw new Error(`Unsupported message type: ${message.type}`);
+}
+
+/**
+ * Restore original values from redacted text using the redaction map
+ */
+function restoreRedactedValues(
+  text: string,
+  redactionMap: RedactionMap
+): string {
+  let restoredText = text;
+
+  // Pattern to match redacted values like [REDACTED_SSN_abc123]
+  const redactionPattern = /\[REDACTED_[A-Z_]+_(\w+)\]/g;
+
+  restoredText = restoredText.replace(redactionPattern, (match, id) => {
+    if (redactionMap[id]) {
+      return redactionMap[id];
+    }
+    return match; // Keep original if no mapping found
+  });
+
+  return restoredText;
+}
+
+/**
+ * Restore redacted values in a message (creates a new message object)
+ */
+function restoreMessage(
+  message: BaseMessage,
+  redactionMap: RedactionMap
+): { message: BaseMessage; changed: boolean } {
+  /**
+   * handle basic message types
+   */
+  if (
+    HumanMessage.isInstance(message) ||
+    ToolMessage.isInstance(message) ||
+    SystemMessage.isInstance(message)
+  ) {
+    const content = message.content as string;
+    const restoredContent = restoreRedactedValues(content, redactionMap);
+    if (restoredContent !== content) {
+      const MessageConstructor = Object.getPrototypeOf(message).constructor;
+      const newMessage = new MessageConstructor({
+        ...message,
+        content: restoredContent,
+      });
+      return { message: newMessage, changed: true };
+    }
+    return { message, changed: false };
+  }
+
+  /**
+   * handle AI messages
+   */
+  if (AIMessage.isInstance(message)) {
+    const content =
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content);
+    const toolCalls = JSON.stringify(message.tool_calls);
+    const processedContent = restoreRedactedValues(content, redactionMap);
+    const processedToolCalls = restoreRedactedValues(toolCalls, redactionMap);
+    if (processedContent !== content || processedToolCalls !== toolCalls) {
+      return {
+        message: new AIMessage({
+          ...message,
+          content:
+            typeof message.content === "string"
+              ? processedContent
+              : JSON.parse(processedContent),
+          tool_calls: JSON.parse(processedToolCalls),
+        }),
+        changed: true,
+      };
+    }
+
+    return { message, changed: false };
+  }
+
+  throw new Error(`Unsupported message type: ${message.type}`);
+}
+
+/**
+ * Creates a middleware that detects and redacts personally identifiable information (PII)
+ * from messages before they are sent to model providers, and restores original values
+ * in model responses for tool execution.
+ *
+ * ## Mechanism
+ *
+ * The middleware intercepts agent execution at two points:
+ *
+ * ### Request Phase (`wrapModelCall`)
+ * - Applies regex-based pattern matching to all message content (HumanMessage, ToolMessage, SystemMessage, AIMessage)
+ * - Processes both message text and AIMessage tool call arguments
+ * - Each matched pattern generates:
+ *   - Unique identifier: `generateRedactionId()` → `"abc123"`
+ *   - Redaction marker: `[REDACTED_{RULE_NAME}_{ID}]` → `"[REDACTED_SSN_abc123]"`
+ *   - Redaction map entry: `{ "abc123": "123-45-6789" }`
+ * - Returns modified request with redacted message content
+ *
+ * ### Response Phase (`afterModel`)
+ * - Scans AIMessage responses for redaction markers matching pattern: `/\[REDACTED_[A-Z_]+_(\w+)\]/g`
+ * - Replaces markers with original values from redaction map
+ * - Handles both standard responses and structured output (via tool calls or JSON content)
+ * - For structured output, restores values in both the tool call arguments and the `structuredResponse` state field
+ * - Returns new message instances via RemoveMessage/AIMessage to update state
+ *
+ * ## Data Flow
+ *
+ * ```
+ * User Input: "My SSN is 123-45-6789"
+ *     ↓ [beforeModel]
+ * Model Request: "My SSN is [REDACTED_SSN_abc123]"
+ *     ↓ [model invocation]
+ * Model Response: tool_call({ "ssn": "[REDACTED_SSN_abc123]" })
+ *     ↓ [afterModel]
+ * Tool Execution: tool({ "ssn": "123-45-6789" })
+ * ```
+ *
+ * ## Limitations
+ *
+ * This middleware provides model provider isolation only. PII may still be present in:
+ * - LangGraph state checkpoints (memory, databases)
+ * - Network traffic between client and application server
+ * - Application logs and trace data
+ * - Tool execution arguments and responses
+ * - Final agent output
+ *
+ * For comprehensive PII protection, implement additional controls at the application,
+ * network, and storage layers.
+ *
+ * @param options - Configuration options
+ * @param options.rules - Record of detection rules mapping rule names to regex patterns.
+ *   Rule names are normalized to uppercase and used in redaction markers.
+ *   Patterns must use the global flag (`/pattern/g`) to match all occurrences.
+ *
+ * @returns Middleware instance for use with `createAgent`
+ *
+ * @example Basic usage with custom rules
+ * ```typescript
+ * import { piiRedactionMiddleware } from "langchain";
+ * import { createAgent } from "langchain";
+ * import { tool } from "@langchain/core/tools";
+ * import { z } from "zod/v3";
+ *
+ * const PII_RULES = {
+ *   ssn: /\b\d{3}-?\d{2}-?\d{4}\b/g,
+ *   email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+ *   phone: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g,
+ * };
+ *
+ * const lookupUser = tool(async ({ ssn }) => {
+ *   // Receives original value: "123-45-6789"
+ *   return { name: "John Doe", account: "active" };
+ * }, {
+ *   name: "lookup_user",
+ *   description: "Look up user by SSN",
+ *   schema: z.object({ ssn: z.string() })
+ * });
+ *
+ * const agent = createAgent({
+ *   model: new ChatOpenAI({ model: "gpt-4" }),
+ *   tools: [lookupUser],
+ *   middleware: [piiRedactionMiddleware({ rules: PII_RULES })]
+ * });
+ *
+ * const result = await agent.invoke({
+ *   messages: [new HumanMessage("Look up SSN 123-45-6789")]
+ * });
+ * // Model request: "Look up SSN [REDACTED_SSN_abc123]"
+ * // Model response: tool_call({ "ssn": "[REDACTED_SSN_abc123]" })
+ * // Tool receives: { "ssn": "123-45-6789" }
+ * ```
+ *
+ * @example Runtime rule configuration via context
+ * ```typescript
+ * const agent = createAgent({
+ *   model: new ChatOpenAI({ model: "gpt-4" }),
+ *   tools: [someTool],
+ *   middleware: [piiRedactionMiddleware()]
+ * });
+ *
+ * // Configure rules at runtime via middleware context
+ * const result = await agent.invoke(
+ *   { messages: [new HumanMessage("...")] },
+ *   {
+ *     configurable: {
+ *       PIIRedactionMiddleware: {
+ *         rules: {
+ *           ssn: /\b\d{3}-?\d{2}-?\d{4}\b/g,
+ *           email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+ *         }
+ *       }
+ *     }
+ *   }
+ * );
+ * ```
+ *
+ * @example Custom rule patterns
+ * ```typescript
+ * const customRules = {
+ *   employee_id: /EMP-\d{6}/g,
+ *   api_key: /sk-[a-zA-Z0-9]{32}/g,
+ *   credit_card: /\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b/g,
+ * };
+ *
+ * const middleware = piiRedactionMiddleware({ rules: customRules });
+ * // Generates markers like: [REDACTED_EMPLOYEE_ID_xyz789]
+ * ```
+ *
+ * @deprecated
+ */
+export function piiRedactionMiddleware(
+  options: PIIRedactionMiddlewareConfig = {}
+): ReturnType<typeof createMiddleware> {
+  const redactionMap: RedactionMap = {};
+
+  console.warn(
+    "DEPRECATED: piiRedactionMiddleware is deprecated. Please use piiMiddleware instead, go to https://docs.langchain.com/oss/javascript/langchain/middleware/built-in#pii-detection for more information."
+  );
+
+  return createMiddleware({
+    name: "PIIRedactionMiddleware",
+    contextSchema,
+    wrapModelCall: async (request, handler) => {
+      /**
+       * Merge options with context, following bigTool.ts pattern
+       */
+      const rules = request.runtime.context.rules ?? options.rules ?? {};
+
+      /**
+       * If no rules are provided, skip processing
+       */
+      if (Object.keys(rules).length === 0) {
+        return handler(request);
+      }
+
+      const processedMessages = await Promise.all(
+        request.state.messages.map((message: BaseMessage) =>
+          processMessage(message, {
+            rules,
+            redactionMap,
+          })
+        )
+      );
+
+      return handler({
+        ...request,
+        messages: processedMessages,
+      });
+    },
+    afterModel: async (state) => {
+      /**
+       * If no redactions were made, skip processing
+       */
+      if (Object.keys(redactionMap).length === 0) {
+        return;
+      }
+
+      const lastMessage = state.messages.at(-1);
+      if (!AIMessage.isInstance(lastMessage)) {
+        return;
+      }
+
+      /**
+       * In cases where we do structured output via tool calls, we also have to look at the second last message
+       * as we add a custom last message to the messages array.
+       */
+      const secondLastMessage = state.messages.at(-2);
+
+      const { message: restoredLastMessage, changed } = restoreMessage(
+        lastMessage,
+        redactionMap
+      );
+
+      if (!changed) {
+        return;
+      }
+
+      /**
+       * Identify if the last message is a structured response and restore the values if so
+       */
+      let structuredResponse: Record<string, unknown> | undefined;
+      if (
+        AIMessage.isInstance(lastMessage) &&
+        lastMessage?.tool_calls?.length === 0 &&
+        typeof lastMessage.content === "string" &&
+        lastMessage.content.startsWith("{") &&
+        lastMessage.content.endsWith("}")
+      ) {
+        try {
+          structuredResponse = JSON.parse(
+            restoreRedactedValues(lastMessage.content, redactionMap)
+          );
+        } catch {
+          // ignore
+        }
+      }
+
+      /**
+       * Check if the second last message is a structured response tool call
+       */
+      const isStructuredResponseToolCall =
+        AIMessage.isInstance(secondLastMessage) &&
+        secondLastMessage?.tool_calls?.length !== 0 &&
+        secondLastMessage?.tool_calls?.some((call) =>
+          call.name.startsWith("extract-")
+        );
+      if (isStructuredResponseToolCall) {
+        const {
+          message: restoredSecondLastMessage,
+          changed: changedSecondLastMessage,
+        } = restoreMessage(secondLastMessage, redactionMap);
+        const structuredResponseRedacted = secondLastMessage.tool_calls?.find(
+          (call) => call.name.startsWith("extract-")
+        )?.args;
+        const structuredResponse = structuredResponseRedacted
+          ? JSON.parse(
+              restoreRedactedValues(
+                JSON.stringify(structuredResponseRedacted),
+                redactionMap
+              )
+            )
+          : undefined;
+        if (changed || changedSecondLastMessage) {
+          return {
+            ...state,
+            ...(structuredResponse ? { structuredResponse } : {}),
+            messages: [
+              new RemoveMessage({ id: secondLastMessage.id as string }),
+              new RemoveMessage({ id: lastMessage.id as string }),
+              restoredSecondLastMessage,
+              restoredLastMessage,
+            ],
+          };
+        }
+      }
+
+      return {
+        ...state,
+        ...(structuredResponse ? { structuredResponse } : {}),
+        messages: [
+          new RemoveMessage({ id: lastMessage.id as string }),
+          restoredLastMessage,
+        ],
+      };
+    },
+  });
+}

--- a/libs/langchain/src/agents/middleware/tests/piiRedaction.int.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/piiRedaction.int.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { z } from "zod/v3";
+import { ChatOpenAI } from "@langchain/openai";
+import { tool } from "@langchain/core/tools";
+import { ChatAnthropic } from "@langchain/anthropic";
+
+import { createAgent } from "../../index.js";
+import { piiRedactionMiddleware } from "../piiRedaction.js";
+
+const USER_DATA = {
+  id: "userId-123",
+  name: "John Doe",
+  email: "john@example.com",
+  ssn: "123-45-6789",
+  phone: "123-456-7890",
+  address: "123 Main St, Anytown, USA",
+  city: "Anytown",
+  state: "CA",
+  zip: "12345",
+  loanEligible: true,
+};
+
+/**
+ * Prebuilt PII detection rules for common sensitive information
+ */
+export const PII_RULES: Record<string, RegExp> = {
+  ssn: /\b\d{3}-?\d{2}-?\d{4}\b/g,
+  phone:
+    /(?:\+?1[-.\s]?)?(?:\([0-9]{3}\)|[0-9]{3})[-.\s][0-9]{3}[-.\s][0-9]{4}|(?:\+?1[-.\s]?)?\([0-9]{3}\)\s?[0-9]{3}[-.\s]?[0-9]{4}/g,
+  email: /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,253}\.[A-Za-z]{2,}\b/g,
+  creditCard:
+    /(?:\+?1[-.\s]?)?(?:\([0-9]{3}\)|[0-9]{3})[-.\s][0-9]{3}[-.\s][0-9]{4}|(?:\+?1[-.\s]?)?\([0-9]{3}\)\s?[0-9]{3}[-.\s]?[0-9]{4}/g,
+  ip: /\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b/g,
+  driversLicense: /\b[A-Z]{1,2}[0-9]{6,8}\b/g,
+  passport: /\b[0-9]{9}\b/g,
+  bankAccount: /\b[0-9]{8,17}\b/g,
+};
+
+function mockModel(type: "openai" | "anthropic") {
+  const fetchResponse = vi
+    .fn()
+    .mockImplementation((response) => response.clone());
+  const fetchMock = vi.fn().mockImplementation((url, options) => {
+    return fetch(url, options).then(fetchResponse);
+  });
+
+  const model =
+    type === "openai"
+      ? new ChatOpenAI({
+          model: "gpt-4o",
+          temperature: 0,
+          configuration: {
+            fetch: fetchMock,
+          },
+        })
+      : new ChatAnthropic({
+          model: "claude-sonnet-4-0",
+          temperature: 0,
+          clientOptions: {
+            fetch: fetchMock,
+          },
+        });
+
+  return { model, fetchMock, fetchResponse };
+}
+
+describe("piiRedactionMiddleware Integration", () => {
+  it.each(["openai", "anthropic"])(
+    `[%s] should redact PII data from model request bodies`,
+    async (type) => {
+      const { model, fetchMock, fetchResponse } = mockModel(
+        type as "openai" | "anthropic"
+      );
+      const PII_DATA = [USER_DATA.ssn, USER_DATA.phone, USER_DATA.email];
+      const fetchToolMock = vi.fn().mockImplementation(() => {
+        return {
+          [USER_DATA.id]: USER_DATA,
+        };
+      });
+      const fetchUser = tool(fetchToolMock, {
+        name: "fetchUser",
+        description: "Fetch a user",
+        schema: z.object({
+          id: z.string().describe("The ID of the user to fetch"),
+        }),
+      });
+
+      const emailToolMock = vi.fn().mockImplementation(({ email }) => {
+        return `Email sent to ${email}!`;
+      });
+      const emailUser = tool(emailToolMock, {
+        name: "emailUser",
+        description: "Email a user",
+        schema: z.object({
+          email: z.string().describe("The email of the user to email"),
+          subject: z.string().describe("The subject of the email"),
+          message: z.string().describe("The message of the email"),
+        }),
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [fetchUser, emailUser],
+        middleware: [piiRedactionMiddleware({ rules: PII_RULES })],
+        responseFormat: z.object({
+          name: z.string().describe("The name of the user"),
+          email: z.string().describe("The email of the user"),
+        }),
+      });
+
+      const result = await agent.invoke({
+        messages: [
+          new HumanMessage(
+            "Fetch user with id 'userId-123' and send them an email with the subject 'Hello' and the message 'Hello, how are you?'"
+          ),
+        ],
+      });
+
+      /**
+       * actual result contains the original PII data
+       */
+      expect(result.structuredResponse).toEqual({
+        name: "John Doe",
+        email: "john@example.com",
+      });
+
+      /**
+       * tool call arguments contain the original PII data
+       */
+      expect(fetchToolMock).toHaveBeenCalledTimes(1);
+      expect(fetchToolMock).toHaveBeenCalledWith(
+        { id: "userId-123" },
+        expect.any(Object)
+      );
+      expect(emailToolMock).toHaveBeenCalledTimes(1);
+      expect(emailToolMock).toHaveBeenCalledWith(
+        {
+          email: "john@example.com",
+          subject: "Hello",
+          message: "Hello, how are you?",
+        },
+        expect.any(Object)
+      );
+
+      /**
+       * However, the request bodies do not contain the original PII data
+       */
+      expect(fetchMock.mock.calls.length).toBe(3);
+      const [initialRequest, toolCallRequest, toolResponseRequest] =
+        fetchMock.mock.calls.map(([_, options]) => options) as RequestInit[];
+      const [
+        initialRequestResponse,
+        toolCallRequestResponse,
+        toolResponseRequestResponse,
+      ] = (await Promise.all(
+        fetchResponse.mock.calls.map(([res]) => res.text())
+      )) as string[];
+
+      /**
+       * Ensure PII data is not present in the request or response bodies
+       */
+      for (const piiData of PII_DATA) {
+        expect(initialRequest.body).not.toContain(piiData);
+        expect(toolCallRequest.body).not.toContain(piiData);
+        expect(toolResponseRequest.body).not.toContain(piiData);
+        expect(initialRequestResponse).not.toContain(piiData);
+        expect(toolCallRequestResponse).not.toContain(piiData);
+        expect(toolResponseRequestResponse).not.toContain(piiData);
+      }
+    }
+  );
+});


### PR DESCRIPTION
This PR completely rewrites the PII (Personally Identifiable Information) middleware to align with the Python implementation, introducing support for multiple detection strategies, built-in PII types, and configurable application points. The new `piiMiddleware` provides a more flexible and powerful API for handling PII in agent conversations.

## Key Features

### Multiple Detection Strategies

The middleware now supports four strategies for handling detected PII:

- **`block`**: Raises `PIIDetectionError` when PII is detected (prevents processing)
- **`redact`**: Replaces PII with `[REDACTED_TYPE]` placeholders
- **`mask`**: Partially masks PII while preserving some characters (e.g., `****-****-****-1234`)
- **`hash`**: Replaces PII with deterministic SHA256 hashes (e.g., `<email_hash:a1b2c3d4>`)

### Built-in PII Types

Support for five built-in PII types with robust detection:

- **`email`**: Email addresses (validated format)
- **`credit_card`**: Credit card numbers (validated with Luhn algorithm)
- **`ip`**: IP addresses (IPv4 and IPv6)
- **`mac_address`**: MAC addresses
- **`url`**: URLs (both `http`/`https` and bare URLs)

### Configurable Application Points

PII detection can be applied at three different stages:

- **`applyToInput`** (default: `true`): Process user messages before model call
- **`applyToOutput`** (default: `false`): Process AI messages after model call
- **`applyToToolResults`** (default: `false`): Process tool result messages after tool execution

### Custom Detectors

Support for custom PII types with:

- Regex patterns (as strings or RegExp objects)
- Custom detector functions
- Multiple middleware instances for different PII types

## Breaking Changes

### Deprecated API

The old `piiRedactionMiddleware` is now **deprecated** and will throw an error if used. It has been replaced by `piiMiddleware`.

**Old API:**

```typescript
piiRedactionMiddleware({
  rules: {
    email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
  },
});
```

**New API:**

```typescript
piiMiddleware("email", { strategy: "redact" });
```

## Migration Guide

### Basic Migration

**Before:**

```typescript
import { piiRedactionMiddleware } from "langchain";

const agent = createAgent({
  model: "openai:gpt-4",
  middleware: [
    piiRedactionMiddleware({
      rules: { email: EMAIL_REGEX },
    }),
  ],
});
```

**After:**

```typescript
import { piiMiddleware } from "langchain";

const agent = createAgent({
  model: "openai:gpt-4",
  middleware: [piiMiddleware("email", { strategy: "redact" })],
});
```

### Multiple PII Types

The new API requires creating separate middleware instances for each PII type:

```typescript
const agent = createAgent({
  model: "openai:gpt-4o",
  middleware: [
    piiMiddleware("email", { strategy: "redact" }),
    piiMiddleware("credit_card", { strategy: "mask" }),
    piiMiddleware("ip", { strategy: "hash" }),
  ],
});
```

### Custom PII Types

```typescript
// Using regex pattern string
piiMiddleware("api_key", {
  detector: "sk-[a-zA-Z0-9]{32}",
  strategy: "block",
});

// Using RegExp
piiMiddleware("ssn", {
  detector: /\d{3}-\d{2}-\d{4}/g,
  strategy: "redact",
});

// Using custom function
piiMiddleware("custom_type", {
  detector: (content) => {
    // Return PIIMatch[]
    return matches;
  },
  strategy: "hash",
});
```