### PR TITLE
feat(langchain): use model profiles to for structured output in createAgent

### DIFF
--- a/libs/langchain/src/agents/model.ts
+++ b/libs/langchain/src/agents/model.ts
@@ -1,10 +1,7 @@
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 
-export interface ConfigurableModelInterface {
-  _queuedMethodOperations: Record<string, unknown>;
-  _model: () => Promise<BaseChatModel>;
-}
+import type { ConfigurableModel } from "../chat_models/universal.js";
 
 export function isBaseChatModel(
   model: LanguageModelLike
@@ -18,7 +15,7 @@ export function isBaseChatModel(
 
 export function isConfigurableModel(
   model: unknown
-): model is ConfigurableModelInterface {
+): model is ConfigurableModel {
   return (
     typeof model === "object" &&
     model != null &&

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -308,7 +308,7 @@ describe("structured output handling", () => {
   });
   describe("providerStrategy", () => {
     describe("use provider strategy directly", () => {
-      it("should not throw error if use provider strategy directly", async () => {
+      it.only("should not throw error if use provider strategy directly", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
             [{ name: "extract-16", args: { foo: "bar" }, id: "call_2" }],
@@ -335,46 +335,50 @@ describe("structured output handling", () => {
 });
 
 describe("hasSupportForJsonSchemaOutput", () => {
-  it("should return false for undefined model", () => {
-    expect(hasSupportForJsonSchemaOutput(undefined)).toBe(false);
+  it("should return false for undefined model", async () => {
+    expect(await hasSupportForJsonSchemaOutput(undefined)).toBe(false);
   });
 
-  it("should return true for models that support JSON schema output", () => {
+  it("should return true for models that support JSON schema output", async () => {
     const model = new FakeToolCallingModel({});
-    expect(hasSupportForJsonSchemaOutput(model)).toBe(false);
+    expect(await hasSupportForJsonSchemaOutput(model)).toBe(false);
     const model2 = new FakeToolCallingChatModel({});
-    expect(hasSupportForJsonSchemaOutput(model2)).toBe(true);
+    expect(await hasSupportForJsonSchemaOutput(model2)).toBe(true);
   });
 
-  it("should return true for OpenAI models that support JSON schema output", () => {
+  it("should return true for OpenAI models that support JSON schema output", async () => {
     const model = new ChatOpenAI({
       model: "gpt-4o",
     });
-    expect(hasSupportForJsonSchemaOutput(model)).toBe(true);
-    expect(hasSupportForJsonSchemaOutput("openai:gpt-4o")).toBe(true);
-    expect(hasSupportForJsonSchemaOutput("gpt-4o-mini")).toBe(true);
+    expect(await hasSupportForJsonSchemaOutput(model)).toBe(true);
+    expect(await hasSupportForJsonSchemaOutput("openai:gpt-4o")).toBe(true);
+    expect(await hasSupportForJsonSchemaOutput("gpt-4o-mini")).toBe(true);
   });
 
-  it("should return false for OpenAI models that do not support JSON schema output", () => {
+  it("should return false for OpenAI models that do not support JSON schema output", async () => {
     const model = new ChatOpenAI({
       model: "gpt-3.5-turbo",
     });
-    expect(hasSupportForJsonSchemaOutput(model)).toBe(false);
-    expect(hasSupportForJsonSchemaOutput("openai:gpt-3.5-turbo")).toBe(false);
-    expect(hasSupportForJsonSchemaOutput("gpt-3.5-turbo")).toBe(false);
+    expect(await hasSupportForJsonSchemaOutput(model)).toBe(false);
+    expect(await hasSupportForJsonSchemaOutput("openai:gpt-3.5-turbo")).toBe(
+      false
+    );
+    expect(await hasSupportForJsonSchemaOutput("gpt-3.5-turbo")).toBe(false);
   });
 
-  it("should return false for Anthropic models that don't support JSON schema output", () => {
+  it("should return false for Anthropic models that don't support JSON schema output", async () => {
     const model = new ChatAnthropic({
       model: "claude-sonnet-4-5-20250929",
       anthropicApiKey: "foobar",
     });
-    expect(hasSupportForJsonSchemaOutput(model)).toBe(false);
+    expect(await hasSupportForJsonSchemaOutput(model)).toBe(true);
     expect(
-      hasSupportForJsonSchemaOutput("anthropic:claude-sonnet-4-5-20250929")
+      await hasSupportForJsonSchemaOutput(
+        "anthropic:claude-sonnet-4-5-20250929"
+      )
+    ).toBe(true);
+    expect(
+      await hasSupportForJsonSchemaOutput("claude-sonnet-4-5-20250929")
     ).toBe(false);
-    expect(hasSupportForJsonSchemaOutput("claude-sonnet-4-5-20250929")).toBe(
-      false
-    );
   });
 });

--- a/libs/langchain/src/agents/tests/utils.ts
+++ b/libs/langchain/src/agents/tests/utils.ts
@@ -175,6 +175,12 @@ export class FakeToolCallingChatModel extends BaseChatModel {
     return "fake";
   }
 
+  get profile() {
+    return {
+      structuredOutput: true,
+    };
+  }
+
   async _generate(
     messages: BaseMessage[],
     _options: this["ParsedCallOptions"],

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -2,6 +2,7 @@ import {
   BaseLanguageModelInput,
   ToolDefinition,
 } from "@langchain/core/language_models/base";
+import type { ModelProfile } from "@langchain/core/language_models/profile";
 import {
   BaseChatModel,
   BaseChatModelParams,
@@ -414,6 +415,11 @@ export class ConfigurableModel<
     }
 
     return modelParams;
+  }
+
+  async _getProfile(): Promise<ModelProfile> {
+    const model = await this._model();
+    return model.profile;
   }
 
   _removePrefix(str: string, prefix: string): string {

--- a/libs/providers/langchain-anthropic/src/profiles.ts
+++ b/libs/providers/langchain-anthropic/src/profiles.ts
@@ -151,7 +151,7 @@ const PROFILES: Record<string, ModelProfile> = {
     audioOutputs: false,
     videoOutputs: false,
     toolCalling: true,
-    structuredOutput: false,
+    structuredOutput: true,
     imageUrlInputs: true,
     pdfToolMessage: true,
     imageToolMessage: true,


### PR DESCRIPTION
Improve the `createAgent` to:

- use model profiles when to determine the default behavior for structured output strategy
- use the native `withStructuredOutput` function to handle getting structured ouput

I am currently blocked here as I can't bind tool when using `withStructuredOutput`.