### PR TITLE
Fix broken Learn documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ LangChain.js is written in TypeScript and can be used in:
 ## 📖 Additional Resources
 
 - [Getting started](https://docs.langchain.com/oss/javascript/langchain/overview): Installation, setting up the environment, simple examples
-- [Learn](https://docs.langchain.com/oss/javascript/langchain/learn): Learn about the core concepts of LangChain.
+- [Learn](https://docs.langchain.com/oss/javascript/learn): Learn about the core concepts of LangChain.
 - [LangChain Forum](https://forum.langchain.com): Connect with the community and share all of your technical questions, ideas, and feedback.
 - [Chat LangChain](https://chat.langchain.com): Ask questions & chat with our documentaiton.
 


### PR DESCRIPTION
This PR fixes the broken link on line 51 of README.md. The link was pointing to `https://docs.langchain.com/oss/javascript/langchain/learn` which returns a 404. The correct URL is `https://docs.langchain.com/oss/javascript/learn`.

I verified that all other links in the README are working correctly.