### PR TITLE
feat(langchain): support SystemMessage in createAgent

### DIFF
--- a/internal/eslint/src/configs/base.ts
+++ b/internal/eslint/src/configs/base.ts
@@ -90,7 +90,15 @@ const config: ConfigArray = tseslint.config(
       "import/extensions": ["error", "ignorePackages"],
       "import/no-extraneous-dependencies": [
         "error",
-        { devDependencies: ["**/*.test.ts", "**/*.test-d.ts", "**/*.spec.ts"] },
+        {
+          devDependencies: [
+            "**/*.test.ts",
+            "**/*.test-d.ts",
+            "**/*.spec.ts",
+            "**/tests/**/*.ts",
+            "**/__mocks__/**/*.ts",
+          ],
+        },
       ],
       "import/no-unresolved": "off",
       "import/prefer-default-export": "off",
@@ -145,7 +153,13 @@ const config: ConfigArray = tseslint.config(
   {
     // Test file overrides
     name: "test",
-    files: ["**/*.test.ts", "**/*.test-d.ts", "**/*.spec.ts"],
+    files: [
+      "**/*.test.ts",
+      "**/*.test-d.ts",
+      "**/*.spec.ts",
+      "**/tests/**/*.ts",
+      "**/__mocks__/**/*.ts",
+    ],
     rules: {
       "@typescript-eslint/no-unused-vars": "off",
       "no-process-env": "off",

--- a/libs/langchain/src/agents/middleware/contextEditing.ts
+++ b/libs/langchain/src/agents/middleware/contextEditing.ts
@@ -9,11 +9,7 @@
 
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseLanguageModel } from "@langchain/core/language_models/base";
-import {
-  AIMessage,
-  ToolMessage,
-  SystemMessage,
-} from "@langchain/core/messages";
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
 
 import { countTokensApproximately } from "./utils.js";
 import { createMiddleware } from "../middleware.js";
@@ -898,9 +894,7 @@ export function contextEditingMiddleware(
       /**
        * Use model's token counting method
        */
-      const systemMsg = request.systemPrompt
-        ? [new SystemMessage(request.systemPrompt)]
-        : [];
+      const systemMsg = request.systemPrompt ? [request.systemPrompt] : [];
 
       const countTokens: TokenCounter =
         tokenCountMethod === "approx"

--- a/libs/langchain/src/agents/middleware/dynamicSystemPrompt.ts
+++ b/libs/langchain/src/agents/middleware/dynamicSystemPrompt.ts
@@ -1,10 +1,12 @@
+import { SystemMessage } from "@langchain/core/messages";
+
 import { createMiddleware } from "../middleware.js";
 import type { Runtime, AgentBuiltInState } from "../runtime.js";
 
 export type DynamicSystemPromptMiddlewareConfig<TContextSchema> = (
   state: AgentBuiltInState,
   runtime: Runtime<TContextSchema>
-) => string | Promise<string>;
+) => string | SystemMessage | Promise<string | SystemMessage>;
 
 /**
  * Dynamic System Prompt Middleware
@@ -55,13 +57,22 @@ export function dynamicSystemPromptMiddleware<TContextSchema = unknown>(
         request.runtime as Runtime<TContextSchema>
       );
 
-      if (typeof systemPrompt !== "string") {
+      const isExpectedType =
+        typeof systemPrompt === "string" ||
+        SystemMessage.isInstance(systemPrompt);
+      if (!isExpectedType) {
         throw new Error(
-          "dynamicSystemPromptMiddleware function must return a string"
+          "dynamicSystemPromptMiddleware function must return a string or SystemMessage"
         );
       }
 
-      return handler({ ...request, systemPrompt });
+      return handler({
+        ...request,
+        systemPrompt:
+          typeof systemPrompt === "string"
+            ? new SystemMessage({ content: systemPrompt })
+            : systemPrompt,
+      });
     },
   });
 }

--- a/libs/langchain/src/agents/middleware/tests/__mocks__/@langchain/anthropic.ts
+++ b/libs/langchain/src/agents/middleware/tests/__mocks__/@langchain/anthropic.ts
@@ -1,13 +1,16 @@
+import { vi } from "vitest";
 import { AIMessage } from "@langchain/core/messages";
 class MockChatAnthropic {
   lc_kwargs: Record<string, unknown>;
 
+  bindTools = vi.fn().mockReturnThis();
+  invoke = vi
+    .fn()
+    .mockResolvedValue(new AIMessage({ content: "Mocked response" }));
+  _streamResponseChunks = vi.fn().mockReturnThis();
+
   constructor(params?: Record<string, unknown>) {
     this.lc_kwargs = params || ({} as Record<string, unknown>);
-  }
-
-  async invoke() {
-    return new AIMessage({ content: "Mocked response" });
   }
 
   getName() {

--- a/libs/langchain/src/agents/middleware/tests/dynamicSystemPrompt.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/dynamicSystemPrompt.test.ts
@@ -65,19 +65,53 @@ describe("dynamicSystemPrompt", () => {
     );
   });
 
-  it("should throw if the function does not return a string", async () => {
+  it("should support returning a SystemMessage", async () => {
     const model = createMockModel() as unknown as LanguageModelLike;
     const contextSchema = z.object({ region: z.string().optional() });
 
     const middleware = dynamicSystemPromptMiddleware<
       z.infer<typeof contextSchema>
-      // @ts-expect-error - we want to test the error case
     >((_state, runtime) => {
       const region = runtime.context.region ?? "n/a";
       return new SystemMessage(
         `You are a helpful assistant. Region: ${region}`
       );
     });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware],
+      contextSchema,
+    });
+
+    const messages = [new HumanMessage("Hello"), new AIMessage("Hi there!")];
+
+    await agent.invoke(
+      { messages },
+      {
+        context: {
+          region: "EU",
+        },
+      }
+    );
+
+    expect(model.invoke).toHaveBeenCalled();
+    const callArgs = (model.invoke as any).mock.calls[0];
+    const [firstMessage] = callArgs[0];
+    expect(firstMessage.type).toBe("system");
+    expect(firstMessage.content).toBe(
+      "You are a helpful assistant. Region: EU"
+    );
+  });
+
+  it("should throw if the function does not return an expected type", async () => {
+    const model = createMockModel() as unknown as LanguageModelLike;
+    const contextSchema = z.object({ region: z.string().optional() });
+
+    const middleware = dynamicSystemPromptMiddleware<
+      z.infer<typeof contextSchema>
+      // @ts-expect-error - we want to test the error case
+    >((_state, runtime) => 123);
 
     const agent = createAgent({
       model,
@@ -97,7 +131,7 @@ describe("dynamicSystemPrompt", () => {
         }
       )
     ).rejects.toThrow(
-      "dynamicSystemPromptMiddleware function must return a string"
+      "dynamicSystemPromptMiddleware function must return a string or SystemMessage"
     );
   });
 });

--- a/libs/langchain/src/agents/middleware/tests/todoList.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/todoList.test.ts
@@ -41,7 +41,7 @@ describe("todoListMiddleware", () => {
     expect(result.todos).toEqual([]);
     const [messages] = (model.invoke as unknown as MockInstance).mock
       .calls[0][0];
-    expect(messages.content).toContain(
+    expect(messages.text).toContain(
       "You are a helpful assistant.\n\n## `write_todos`\n\nYou have "
     );
   });
@@ -137,7 +137,20 @@ describe("todoListMiddleware", () => {
       (msg: { role: string; content: string }) => msg.role === "system"
     );
     expect(systemMessage).toBeDefined();
-    expect(systemMessage.content).toContain("Custom system prompt");
+    expect(systemMessage.content).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "You are a helpful assistant.",
+          "type": "text",
+        },
+        {
+          "text": "
+
+      Custom system prompt",
+          "type": "text",
+        },
+      ]
+    `);
     expect(requestBody.tools[0].function.description).toContain(
       "Custom tool description"
     );

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-instanceof/no-instanceof */
 import { Runnable, RunnableConfig } from "@langchain/core/runnables";
-import { BaseMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  BaseMessage,
+  AIMessage,
+  ToolMessage,
+  SystemMessage,
+} from "@langchain/core/messages";
 import { Command, type LangGraphRunnableConfig } from "@langchain/langgraph";
 import { type LanguageModelLike } from "@langchain/core/language_models/base";
 import { type BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
@@ -517,7 +522,12 @@ export class AgentNode<
       unknown
     > = {
       model,
-      systemPrompt: this.#options.systemPrompt,
+      systemPrompt:
+        typeof this.#options.systemPrompt === "string"
+          ? new SystemMessage({
+              content: this.#options.systemPrompt,
+            })
+          : this.#options.systemPrompt,
       messages: state.messages,
       tools: this.#options.toolClasses,
       state,

--- a/libs/langchain/src/agents/tests/reactAgent.int.test.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.int.test.ts
@@ -3,7 +3,11 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
-import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import {
+  HumanMessage,
+  AIMessage,
+  SystemMessage,
+} from "@langchain/core/messages";
 
 import { createMiddleware, createAgent, providerStrategy } from "../index.js";
 
@@ -71,7 +75,7 @@ Please provide a clear, direct, and authoritative answer, as this information wi
           ...request,
           model: anthropicModel,
           messages: newMessages,
-          systemPrompt: "You are a geography expert.",
+          systemPrompt: new SystemMessage("You are a geography expert."),
           toolChoice: "none",
           tools: [],
         });

--- a/libs/langchain/src/agents/tests/utils.ts
+++ b/libs/langchain/src/agents/tests/utils.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable import/no-extraneous-dependencies */
 import { expect } from "vitest";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import {
@@ -409,7 +408,28 @@ export class FakeToolCallingModel extends BaseChatModel {
     // Handle prompt concatenation
     if (messages.length > 1) {
       const parts = messages.map((m) => m.content).filter(Boolean);
-      content = parts.join("-");
+      content = parts
+        .map((part) => {
+          if (typeof part === "string") {
+            return part;
+          } else if (typeof part === "object" && "text" in part) {
+            return part.text;
+          } else if (Array.isArray(part)) {
+            return part
+              .map((p) => {
+                if (typeof p === "string") {
+                  return p;
+                } else if (typeof p === "object" && "text" in p) {
+                  return p.text;
+                }
+                return "";
+              })
+              .join("-");
+          } else {
+            return JSON.stringify(part);
+          }
+        })
+        .join("-");
     }
 
     // Reset index at the start of a new conversation (only human message)

--- a/libs/langchain/src/agents/types.ts
+++ b/libs/langchain/src/agents/types.ts
@@ -6,7 +6,7 @@ import type {
 import type { START, END, StateGraph } from "@langchain/langgraph";
 
 import type { LanguageModelLike } from "@langchain/core/language_models/base";
-import type { BaseMessage } from "@langchain/core/messages";
+import type { BaseMessage, SystemMessage } from "@langchain/core/messages";
 import type {
   BaseCheckpointSaver,
   BaseStore,
@@ -212,8 +212,74 @@ export type CreateAgentParams<
 
   /**
    * An optional system message for the model.
+   *
+   * **Use a `string`** for simple, static system prompts. This is the most common use case
+   * and works well with template literals for dynamic content. When a string is provided,
+   * it's converted to a single text block internally.
+   *
+   * **Use a `SystemMessage`** when you need advanced features that require structured content:
+   * - **Anthropic cache control**: Use `SystemMessage` with array content to enable per-block
+   *   cache control settings (e.g., `cache_control: { type: "ephemeral" }`). This allows you
+   *   to have different cache settings for different parts of your system prompt.
+   * - **Multiple content blocks**: When you need multiple text blocks with different metadata
+   *   or formatting requirements.
+   * - **Integration with existing code**: When working with code that already produces
+   *   `SystemMessage` instances.
+   *
+   * @example Using a string (recommended for most cases)
+   * ```ts
+   * const agent = createAgent({
+   *   model: "anthropic:claude-3-5-sonnet",
+   *   systemPrompt: "You are a helpful assistant.",
+   *   // ...
+   * });
+   * ```
+   *
+   * @example Using a string with template literals
+   * ```ts
+   * const userRole = "premium";
+   * const agent = createAgent({
+   *   model: "anthropic:claude-3-5-sonnet",
+   *   systemPrompt: `You are a helpful assistant for ${userRole} users.`,
+   *   // ...
+   * });
+   * ```
+   *
+   * @example Using SystemMessage with cache control (Anthropic)
+   * ```ts
+   * import { SystemMessage } from "@langchain/core/messages";
+   *
+   * const agent = createAgent({
+   *   model: "anthropic:claude-3-5-sonnet",
+   *   systemPrompt: new SystemMessage({
+   *     content: [
+   *       {
+   *         type: "text",
+   *         text: "You are a helpful assistant.",
+   *       },
+   *       {
+   *         type: "text",
+   *         text: "Today's date is 2024-06-01.",
+   *         cache_control: { type: "ephemeral" },
+   *       },
+   *     ],
+   *   }),
+   *   // ...
+   * });
+   * ```
+   *
+   * @example Using SystemMessage (simple)
+   * ```ts
+   * import { SystemMessage } from "@langchain/core/messages";
+   *
+   * const agent = createAgent({
+   *   model: "anthropic:claude-3-5-sonnet",
+   *   systemPrompt: new SystemMessage("You are a helpful assistant."),
+   *   // ...
+   * });
+   * ```
    */
-  systemPrompt?: string;
+  systemPrompt?: string | SystemMessage;
 
   /**
    * An optional schema for the agent state. It allows you to define custom state properties that persist

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -354,12 +354,14 @@ export function getPromptRunnable(prompt?: Prompt): Runnable {
     promptRunnable = RunnableLambda.from(
       (state: typeof MessagesAnnotation.State) => state.messages
     ).withConfig({ runName: PROMPT_RUNNABLE_NAME });
-  } else if (typeof prompt === "string") {
-    const systemMessage = new SystemMessage(prompt);
+  } else if (typeof prompt === "string" || SystemMessage.isInstance(prompt)) {
     promptRunnable = RunnableLambda.from(
-      (state: typeof MessagesAnnotation.State) => {
-        return [systemMessage, ...(state.messages ?? [])];
-      }
+      (state: typeof MessagesAnnotation.State) => [
+        typeof prompt === "string"
+          ? new SystemMessage({ content: prompt })
+          : prompt,
+        ...(state.messages ?? []),
+      ]
     ).withConfig({ runName: PROMPT_RUNNABLE_NAME });
   } else {
     throw new Error(`Got unexpected type for 'prompt': ${typeof prompt}`);


### PR DESCRIPTION
This PR adds support for `SystemMessage` objects (in addition to strings) in `createAgent` and related agent middleware. This enables advanced features like Anthropic's per-block cache control and provides better type safety and flexibility when working with system prompts.

Note: this PR requires https://github.com/langchain-ai/langchainjs/pull/9453 to land first.

## Key Changes

### Core Functionality

- **`SystemMessage` support in `createAgent`**: The `systemPrompt` parameter now accepts both `string` and `SystemMessage` types
- **Middleware updates**: All middleware now works with `SystemMessage` objects, enabling chaining and composition

### Bug Fixes

- **ESLint configuration**: Updated to allow dev dependencies in test directories and mocks
