### PR TITLE
fix(internal/build): pass in cwd to enable watch mode

### DIFF
--- a/internal/build/README.md
+++ b/internal/build/README.md
@@ -173,11 +173,15 @@ Entrypoint paths are transformed to namespace aliases using double underscores: 
 **Usage:**
 
 ```typescript
+import path from "node:path";
 import { getBuildConfig, importMapPlugin } from "@langchain/build";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 export default getBuildConfig({
   plugins: [
     importMapPlugin({
+      cwd: __dirname,
       nodeOnly: ["node-specific-tool"],
       importsOptionalDependencies: ["openai", "anthropic"],
       extraEntries: [

--- a/internal/build/src/plugins/import-constants.ts
+++ b/internal/build/src/plugins/import-constants.ts
@@ -51,6 +51,9 @@ export interface ImportConstantsPluginOptions {
    * ```
    */
   entrypoints?: string[];
+
+  /** The working directory to use for the plugin. Defaults to `process.env.INIT_CWD || ""`. */
+  cwd?: string;
 }
 
 /**
@@ -133,17 +136,12 @@ export function importConstantsPlugin(
     enabled: true,
     outputPath: "src/load/import_constants.ts",
     entrypoints: [],
+    cwd: process.env.INIT_CWD ?? "",
     ...param,
   } as Required<ImportConstantsPluginOptions>;
 
-  const packageJsonPath = path.resolve(
-    process.env.INIT_CWD ?? "",
-    "./package.json"
-  );
-  const outputPath = path.resolve(
-    process.env.INIT_CWD ?? "",
-    options.outputPath
-  );
+  const packageJsonPath = path.resolve(options.cwd, "./package.json");
+  const outputPath = path.resolve(options.cwd, options.outputPath);
 
   return {
     name: "import-constants",

--- a/internal/build/src/plugins/import-map.ts
+++ b/internal/build/src/plugins/import-map.ts
@@ -33,6 +33,9 @@ export interface ImportMapPluginOptions {
 
   /** Additional import map entries to include beyond the standard entrypoints. */
   extraEntries?: ExtraImportMapEntry[];
+
+  /** The working directory to use for the plugin. Defaults to `process.env.INIT_CWD || ""`. */
+  cwd?: string;
 }
 
 /**
@@ -83,13 +86,11 @@ export function importMapPlugin(param: ImportMapPluginOptions = {}): Plugin {
     nodeOnly: [],
     omitFromImportMap: [],
     extraEntries: [],
+    cwd: process.env.INIT_CWD ?? "",
     ...param,
   } as Required<ImportMapPluginOptions>;
 
-  const outputPath = path.resolve(
-    process.env.INIT_CWD ?? "",
-    options.outputPath
-  );
+  const outputPath = path.resolve(options.cwd, options.outputPath);
 
   return {
     name: "import-map",
@@ -128,7 +129,7 @@ export function importMapPlugin(param: ImportMapPluginOptions = {}): Plugin {
         ...entrypoints.map(([key, entrypointPath]) => {
           // Get relative path of the entrypoint from the package root
           const relativePath = path.relative(
-            path.join(process.env.INIT_CWD ?? "", "src"),
+            path.join(options.cwd, "src"),
             entrypointPath
           );
 

--- a/libs/langchain-classic/tsdown.config.ts
+++ b/libs/langchain-classic/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   getBuildConfig,
   cjsCompatPlugin,
@@ -5,6 +6,8 @@ import {
   importMapPlugin,
   importConstantsPlugin,
 } from "@langchain/build";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 export default getBuildConfig({
   entry: [
@@ -109,6 +112,7 @@ export default getBuildConfig({
     }),
     lcSecretsPlugin(),
     importMapPlugin({
+      cwd: __dirname,
       omitFromImportMap: ["hub/index", "hub/node", "load/index"],
       extraEntries: [
         {
@@ -119,6 +123,7 @@ export default getBuildConfig({
       ],
     }),
     importConstantsPlugin({
+      cwd: __dirname,
       entrypoints: [
         "agents/load",
         "agents/toolkits/sql",

--- a/libs/langchain-core/tsdown.config.ts
+++ b/libs/langchain-core/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   getBuildConfig,
   cjsCompatPlugin,
@@ -5,6 +6,8 @@ import {
   importMapPlugin,
   importConstantsPlugin,
 } from "@langchain/build";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 export default getBuildConfig({
   entry: [
@@ -75,6 +78,7 @@ export default getBuildConfig({
     }),
     lcSecretsPlugin(),
     importMapPlugin({
+      cwd: __dirname,
       omitFromImportMap: [
         "load/index",
         "context",
@@ -82,6 +86,8 @@ export default getBuildConfig({
         "callbacks/dispatch/index",
       ],
     }),
-    importConstantsPlugin(),
+    importConstantsPlugin({
+      cwd: __dirname,
+    }),
   ],
 });

--- a/libs/langchain/tsdown.config.ts
+++ b/libs/langchain/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   getBuildConfig,
   cjsCompatPlugin,
@@ -5,6 +6,8 @@ import {
   importMapPlugin,
   importConstantsPlugin,
 } from "@langchain/build";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 export default getBuildConfig({
   entry: [
@@ -24,6 +27,7 @@ export default getBuildConfig({
     }),
     lcSecretsPlugin(),
     importMapPlugin({
+      cwd: __dirname,
       extraEntries: [
         {
           modules: ["PromptTemplate"],
@@ -105,6 +109,7 @@ export default getBuildConfig({
       omitFromImportMap: ["hub/index", "hub/node", "load/index"],
     }),
     importConstantsPlugin({
+      cwd: __dirname,
       entrypoints: [
         "chat_models/universal",
         "cache/file_system",


### PR DESCRIPTION
I like to keep a watch task running in the background from the root directory via:

```sh
pnpm --filter langchain build:compile --watch
```

The setup currently doesn't allow for that as it requires a `INIT_CWD` env to be set. This patch extends the options to allow passing that in.