### PR TITLE
chore(google-*): rollback to 1.0.4

### DIFF
--- a/libs/providers/langchain-google-common/CHANGELOG.md
+++ b/libs/providers/langchain-google-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @langchain/google-common
 
-## 2.0.0
+## 1.0.4
 
 ### Patch Changes
 

--- a/libs/providers/langchain-google-common/package.json
+++ b/libs/providers/langchain-google-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/google-common",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "Core types and classes for Google services.",
   "type": "module",
   "engines": {

--- a/libs/providers/langchain-google-gauth/CHANGELOG.md
+++ b/libs/providers/langchain-google-gauth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @langchain/google-gauth
 
-## 2.0.0
+## 1.0.4
 
 ### Patch Changes
 

--- a/libs/providers/langchain-google-gauth/package.json
+++ b/libs/providers/langchain-google-gauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/google-gauth",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "Google auth based authentication support for Google services",
   "author": "LangChain",
   "license": "MIT",

--- a/libs/providers/langchain-google-vertexai-web/CHANGELOG.md
+++ b/libs/providers/langchain-google-vertexai-web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @langchain/google-vertexai-web
 
-## 2.0.0
+## 1.0.4
 
 ### Patch Changes
 

--- a/libs/providers/langchain-google-vertexai-web/package.json
+++ b/libs/providers/langchain-google-vertexai-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/google-vertexai-web",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "LangChain.js support for Google Vertex AI Web",
   "author": "LangChain",
   "license": "MIT",

--- a/libs/providers/langchain-google-vertexai/CHANGELOG.md
+++ b/libs/providers/langchain-google-vertexai/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @langchain/google-vertexai
 
-## 2.0.0
+## 1.0.4
 
 ### Patch Changes
 

--- a/libs/providers/langchain-google-vertexai/package.json
+++ b/libs/providers/langchain-google-vertexai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/google-vertexai",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "LangChain.js support for Google Vertex AI",
   "author": "LangChain",
   "license": "MIT",

--- a/libs/providers/langchain-google-webauth/CHANGELOG.md
+++ b/libs/providers/langchain-google-webauth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @langchain/google-webauth
 
-## 2.0.0
+## 1.0.4
 
 ### Patch Changes
 

--- a/libs/providers/langchain-google-webauth/package.json
+++ b/libs/providers/langchain-google-webauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/google-webauth",
-  "version": "2.0.0",
+  "version": "1.0.4",
   "description": "Web-based authentication support for Google services",
   "author": "LangChain",
   "license": "MIT",


### PR DESCRIPTION
Changsets decided to publish a major version for the google packages. We'll be deprecating those versions and staying on v1