### PR TITLE
fix(core): use dynamic import for p-retry to support CJS

### DIFF
--- a/.changeset/long-mails-own.md
+++ b/.changeset/long-mails-own.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix: use dynamic import for p-retry to support CommonJS environments


### PR DESCRIPTION
## Description

`p-retry` v7 is ESM-only, which breaks CommonJS users. This change uses dynamic `import()` with module caching, as recommended by the [p-retry author](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) for async contexts.

### Why this approach?
- Recommended by Sindre Sorhus (p-retry author) for async contexts
- Pattern already used in this codebase (e.g., Mistral, Chroma integrations)
- `AsyncCaller` is already async, so no API changes needed
- Negligible performance impact (~1-5ms first import, cached thereafter)
- Keeps the memory leak fix from p-retry v7

### Tested
- CJS require works: `require('@langchain/core')`
- `AsyncCaller.call()` works correctly

Fixes #9493