### PR TITLE
fix: Correctly identify ConfigurableModel for JSON schema support check

### DIFF
--- a/.changeset/loud-hornets-battle.md
+++ b/.changeset/loud-hornets-battle.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Fix detection of models with native support for structured output

--- a/libs/langchain/src/agents/model.ts
+++ b/libs/langchain/src/agents/model.ts
@@ -3,7 +3,7 @@ import type { BaseChatModel } from "@langchain/core/language_models/chat_models"
 
 export interface ConfigurableModelInterface {
   _queuedMethodOperations: Record<string, unknown>;
-  _model: () => Promise<BaseChatModel>;
+  _getModelInstance: () => Promise<BaseChatModel>;
 }
 
 export function isBaseChatModel(
@@ -23,7 +23,8 @@ export function isConfigurableModel(
     typeof model === "object" &&
     model != null &&
     "_queuedMethodOperations" in model &&
-    "_model" in model &&
-    typeof model._model === "function"
+    "_getModelInstance" in model &&
+    typeof (model as { _getModelInstance: unknown })._getModelInstance ===
+      "function"
   );
 }

--- a/libs/langchain/src/agents/tests/model.test.ts
+++ b/libs/langchain/src/agents/tests/model.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { ConfigurableModel } from "../../chat_models/universal.js";
+import { isConfigurableModel } from "../model.js";
+
+describe("isConfigurableModel", () => {
+  it("should return true for a ConfigurableModel instance", () => {
+    const model = new ConfigurableModel({});
+    expect(isConfigurableModel(model)).toBe(true);
+  });
+
+  it("should return false for a plain object", () => {
+    const model = {};
+    expect(isConfigurableModel(model)).toBe(false);
+  });
+
+  it("should return false for null", () => {
+    expect(isConfigurableModel(null)).toBe(false);
+  });
+
+  it("should return false for undefined", () => {
+    expect(isConfigurableModel(undefined)).toBe(false);
+  });
+
+  it("should return false for an object missing required properties", () => {
+    const model = {
+      _queuedMethodOperations: {},
+      // Missing _getModelInstance
+    };
+    expect(isConfigurableModel(model)).toBe(false);
+  });
+});

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -388,7 +388,11 @@ export async function bindTools(
   if (model) return model;
 
   if (isConfigurableModel(llm)) {
-    const model = _simpleBindTools(await llm._model(), toolClasses, options);
+    const model = _simpleBindTools(
+      await llm._getModelInstance(),
+      toolClasses,
+      options
+    );
     if (model) return model;
   }
 


### PR DESCRIPTION
Previously, `isConfigurableModel` checked for a `_model` property, but `ConfigurableModel` instances returned by `initChatModel` use `_getModelInstance`. This caused `hasSupportForJsonSchemaOutput` to fail to unwrap the underlying model, leading to `createAgent` defaulting to `ToolStrategy` instead of `ProviderStrategy` even for supported models like GPT-4o/GPT-5 when initialized via string.

This change updates `isConfigurableModel` to check for `_getModelInstance` and adds tests.

Fixes #9522