### PR TITLE
feat(community): Add Valyu search retriever and tool

### DIFF
--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -199,6 +199,7 @@
     "typescript": "~5.8.3",
     "typesense": "^1.5.3",
     "usearch": "^2.17.1",
+    "valyu-js": "^2.2.3",
     "voy-search": "0.6.2",
     "weaviate-client": "^3.5.2",
     "word-extractor": "^1.0.4",
@@ -225,6 +226,7 @@
     "@getzep/zep-js": "^0.9.0",
     "@gomomento/sdk-core": "^1.51.1",
     "@google-cloud/storage": "^6.10.1 || ^7.7.0",
+    "valyu-js": "*",
     "@gradientai/nodejs-sdk": "^1.2.0",
     "@huggingface/inference": "^4.0.5",
     "@huggingface/transformers": "^3.5.2",
@@ -373,6 +375,9 @@
       "optional": true
     },
     "@getzep/zep-js": {
+      "optional": true
+    },
+    "valyu-js": {
       "optional": true
     },
     "@gomomento/sdk-core": {

--- a/libs/langchain-community/src/load/import_map.ts
+++ b/libs/langchain-community/src/load/import_map.ts
@@ -123,6 +123,7 @@ export * as caches__upstash_redis from "../caches/upstash_redis.js";
 export * as stores__doc__gcs from "../stores/doc/gcs.js";
 export * as memory__zep_cloud from "../memory/zep_cloud.js";
 export * as retrievers__tavily_search_api from "../retrievers/tavily_search_api.js";
+export * as retrievers__valyu from "../retrievers/valyu.js";
 export * as document_loaders__web__browserbase from "../document_loaders/web/browserbase.js";
 export * as caches__vercel_kv from "../caches/vercel_kv.js";
 export * as llms__friendli from "../llms/friendli.js";
@@ -206,6 +207,7 @@ export * as document_loaders__web__sitemap from "../document_loaders/web/sitemap
 export * as tools__aws_sfn from "../tools/aws_sfn.js";
 export * as vectorstores__momento_vector_index from "../vectorstores/momento_vector_index.js";
 export * as tools__searchapi from "../tools/searchapi.js";
+export * as tools__valyu from "../tools/valyu.js";
 export * as stores__message__astradb from "../stores/message/astradb.js";
 export * as embeddings__gradient_ai from "../embeddings/gradient_ai.js";
 export * as chat_models__arcjet from "../chat_models/arcjet.js";

--- a/libs/langchain-community/src/retrievers/valyu.ts
+++ b/libs/langchain-community/src/retrievers/valyu.ts
@@ -1,0 +1,408 @@
+import { BaseRetriever, type BaseRetrieverInput } from "@langchain/core/retrievers";
+import { Document } from "@langchain/core/documents";
+import { CallbackManagerForRetrieverRun } from "@langchain/core/callbacks/manager";
+import { Valyu } from "valyu-js";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+
+/**
+ * Interface for the Valyu search client.
+ */
+export interface ValyuSearchClient {
+  search(args: {
+    query: string;
+    search_type?: string;
+    max_num_results?: number;
+    relevance_threshold?: number;
+    max_price?: number;
+    is_tool_call?: boolean;
+    start_date?: string;
+    end_date?: string;
+    included_sources?: string[];
+    excluded_sources?: string[];
+    response_length?: number | string;
+    country_code?: string;
+    fast_mode?: boolean;
+  }): Promise<ValyuSearchClientResponse>;
+}
+
+/**
+ * Interface for the Valyu search client response.
+ */
+export interface ValyuSearchClientResponse {
+  results?: Array<{
+    title?: string;
+    url?: string;
+    content?: string;
+    source?: string;
+    price?: number;
+    length?: number;
+    data_type?: string;
+    relevance_score?: number;
+    image_url?: unknown;
+  }>;
+}
+
+/**
+ * Interface for the Valyu contents client.
+ */
+export interface ValyuContentsClient {
+  contents(args: {
+    urls: string[];
+    summary?: boolean | string | Record<string, unknown>;
+    extract_effort?: "normal" | "high" | "auto";
+    response_length?: number | string;
+  }): Promise<ValyuContentsClientResponse>;
+}
+
+/**
+ * Interface for the Valyu contents client response.
+ */
+export interface ValyuContentsClientResponse {
+  results?: Array<{
+    url?: string;
+    title?: string;
+    content?: string;
+    status?: string;
+    price?: number;
+    length?: number;
+    extraction_effort?: string;
+    error?: string;
+  }>;
+}
+
+/**
+ * Adapter class that wraps the Valyu SDK client and implements both
+ * ValyuSearchClient and ValyuContentsClient interfaces.
+ */
+export class ValyuAdapter implements ValyuSearchClient, ValyuContentsClient {
+  private client: Valyu;
+
+  constructor(apiKey: string, baseUrl?: string) {
+    this.client = new Valyu(apiKey, baseUrl);
+  }
+
+  async search(args: {
+    query: string;
+    search_type?: string;
+    max_num_results?: number;
+    relevance_threshold?: number;
+    max_price?: number;
+    is_tool_call?: boolean;
+    start_date?: string;
+    end_date?: string;
+    included_sources?: string[];
+    excluded_sources?: string[];
+    response_length?: number | string;
+    country_code?: string;
+    fast_mode?: boolean;
+  }): Promise<ValyuSearchClientResponse> {
+    const options: any = {};
+
+    if (args.search_type) options.searchType = args.search_type;
+    if (args.max_num_results !== undefined)
+      options.maxNumResults = args.max_num_results;
+    if (args.relevance_threshold !== undefined)
+      options.relevanceThreshold = args.relevance_threshold;
+    if (args.max_price !== undefined) options.maxPrice = args.max_price;
+    if (args.is_tool_call !== undefined) options.isToolCall = args.is_tool_call;
+    if (args.start_date) options.startDate = args.start_date;
+    if (args.end_date) options.endDate = args.end_date;
+    if (args.included_sources) options.includedSources = args.included_sources;
+    if (args.excluded_sources) options.excludeSources = args.excluded_sources;
+    if (args.response_length !== undefined)
+      options.responseLength = args.response_length;
+    if (args.country_code) options.countryCode = args.country_code;
+    if (args.fast_mode !== undefined) options.fastMode = args.fast_mode;
+
+    const response = await this.client.search(args.query, options);
+    return response as unknown as ValyuSearchClientResponse;
+  }
+
+  async contents(args: {
+    urls: string[];
+    summary?: boolean | string | Record<string, unknown>;
+    extract_effort?: "normal" | "high" | "auto";
+    response_length?: number | string;
+  }): Promise<ValyuContentsClientResponse> {
+    const options: any = {};
+
+    if (args.summary !== undefined) options.summary = args.summary;
+    if (args.extract_effort) options.extractEffort = args.extract_effort;
+    if (args.response_length !== undefined)
+      options.responseLength = args.response_length;
+
+    const response = await this.client.contents(args.urls, options);
+    return response as unknown as ValyuContentsClientResponse;
+  }
+}
+
+function _getValyuMetadata(
+  result: NonNullable<ValyuSearchClientResponse["results"]>[0]
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    title: result?.title ?? null,
+    url: result?.url ?? null,
+    source: result?.source ?? null,
+    price: result?.price ?? null,
+    length: result?.length ?? null,
+    data_type: result?.data_type ?? null,
+    relevance_score: result?.relevance_score ?? null,
+  };
+  if (result?.image_url) {
+    metadata.image_url = result.image_url;
+  }
+  return metadata;
+}
+
+function _getContentsMetadata(
+  result: NonNullable<ValyuContentsClientResponse["results"]>[0]
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    url: result?.url ?? null,
+    title: result?.title ?? null,
+    status: result?.status ?? null,
+    price: result?.price ?? null,
+    length: result?.length ?? null,
+    extraction_effort: result?.extraction_effort ?? null,
+  };
+  if (result?.error) {
+    metadata.error = result.error;
+  }
+  return metadata;
+}
+
+/**
+ * Options for the ValyuRetriever class.
+ */
+export interface ValyuRetrieverFields extends BaseRetrieverInput {
+  client?: ValyuSearchClient;
+  apiKey?: string;
+  baseUrl?: string;
+  k?: number;
+  searchType?: string;
+  relevanceThreshold?: number;
+  maxPrice?: number;
+  isToolCall?: boolean;
+  startDate?: string;
+  endDate?: string;
+  includedSources?: string[];
+  excludedSources?: string[];
+  responseLength?: number | string;
+  countryCode?: string;
+  fastMode?: boolean;
+}
+
+/**
+ * A class for retrieving documents related to a given search term
+ * using the Valyu deep search API.
+ * @example
+ * ```typescript
+ * const retriever = new ValyuRetriever({
+ *   apiKey: process.env.VALYU_API_KEY,
+ *   k: 10,
+ * });
+ * const docs = await retriever.getRelevantDocuments("hello");
+ * ```
+ */
+export class ValyuRetriever extends BaseRetriever {
+  static lc_name() {
+    return "ValyuRetriever";
+  }
+
+  get lc_namespace(): string[] {
+    return ["langchain", "retrievers", "valyu"];
+  }
+
+  k: number;
+
+  searchType: string;
+
+  relevanceThreshold: number;
+
+  maxPrice: number;
+
+  isToolCall: boolean;
+
+  startDate?: string;
+
+  endDate?: string;
+
+  includedSources?: string[];
+
+  excludedSources?: string[];
+
+  responseLength?: number | string;
+
+  countryCode?: string;
+
+  fastMode: boolean;
+
+  client: ValyuSearchClient;
+
+  constructor(fields: ValyuRetrieverFields) {
+    super(fields);
+
+    this.k = fields.k ?? 10;
+    this.searchType = fields.searchType ?? "all";
+    this.relevanceThreshold = fields.relevanceThreshold ?? 0.5;
+    this.maxPrice = fields.maxPrice ?? 50.0;
+    this.isToolCall = fields.isToolCall ?? true;
+    this.startDate = fields.startDate;
+    this.endDate = fields.endDate;
+    this.includedSources = fields.includedSources;
+    this.excludedSources = fields.excludedSources;
+    this.responseLength = fields.responseLength;
+    this.countryCode = fields.countryCode;
+    this.fastMode = fields.fastMode ?? false;
+
+    if (fields.client) {
+      this.client = fields.client;
+    } else {
+      const apiKey =
+        fields.apiKey ?? getEnvironmentVariable("VALYU_API_KEY");
+      if (!apiKey) {
+        throw new Error(
+          `No Valyu API key found. Either set an environment variable named "VALYU_API_KEY" or pass an API key as "apiKey".`
+        );
+      }
+      this.client = new ValyuAdapter(apiKey, fields.baseUrl);
+    }
+  }
+
+  async _getRelevantDocuments(
+    query: string,
+    _runManager?: CallbackManagerForRetrieverRun
+  ): Promise<Document[]> {
+    const response = (await this.client.search({
+      query,
+      search_type: this.searchType,
+      max_num_results: this.k,
+      relevance_threshold: this.relevanceThreshold,
+      max_price: this.maxPrice,
+      is_tool_call: this.isToolCall,
+      start_date: this.startDate,
+      end_date: this.endDate,
+      included_sources: this.includedSources,
+      excluded_sources: this.excludedSources,
+      response_length: this.responseLength,
+      country_code: this.countryCode,
+      fast_mode: this.fastMode,
+    })) as ValyuSearchClientResponse;
+
+    const results = response.results || [];
+
+    return results.map(
+      (result) =>
+        new Document({
+          pageContent: String(result.content ?? ""),
+          metadata: _getValyuMetadata(result),
+        })
+    );
+  }
+}
+
+/**
+ * Options for the ValyuContentsRetriever class.
+ */
+export interface ValyuContentsRetrieverFields extends BaseRetrieverInput {
+  client?: ValyuContentsClient;
+  apiKey?: string;
+  baseUrl?: string;
+  urls?: string[];
+  summary?: boolean | string | Record<string, unknown>;
+  extractEffort?: "normal" | "high" | "auto";
+  responseLength?: number | string;
+}
+
+/**
+ * A class for retrieving content from URLs using the Valyu contents API.
+ * @example
+ * ```typescript
+ * const retriever = new ValyuContentsRetriever({
+ *   apiKey: process.env.VALYU_API_KEY,
+ *   urls: ["https://example.com"],
+ * });
+ * const docs = await retriever.getRelevantDocuments("");
+ * ```
+ */
+export class ValyuContentsRetriever extends BaseRetriever {
+  static lc_name() {
+    return "ValyuContentsRetriever";
+  }
+
+  get lc_namespace(): string[] {
+    return ["langchain", "retrievers", "valyu"];
+  }
+
+  urls: string[];
+
+  summary?: boolean | string | Record<string, unknown>;
+
+  extractEffort: "normal" | "high" | "auto";
+
+  responseLength?: number | string;
+
+  client: ValyuContentsClient;
+
+  constructor(fields: ValyuContentsRetrieverFields) {
+    super(fields);
+
+    this.urls = fields.urls ?? [];
+    this.summary = fields.summary;
+    this.extractEffort = fields.extractEffort ?? "normal";
+    this.responseLength = fields.responseLength ?? "short";
+
+    if (fields.client) {
+      this.client = fields.client;
+    } else {
+      const apiKey =
+        fields.apiKey ?? getEnvironmentVariable("VALYU_API_KEY");
+      if (!apiKey) {
+        throw new Error(
+          `No Valyu API key found. Either set an environment variable named "VALYU_API_KEY" or pass an API key as "apiKey".`
+        );
+      }
+      this.client = new ValyuAdapter(apiKey, fields.baseUrl);
+    }
+  }
+
+  async _getRelevantDocuments(
+    query: string,
+    _runManager?: CallbackManagerForRetrieverRun
+  ): Promise<Document[]> {
+    // For contents retriever, the query should be a comma-separated list of URLs
+    // or we use the pre-configured URLs
+    let urls: string[];
+    if (this.urls.length === 0) {
+      // Parse URLs from query if not pre-configured
+      urls = query
+        .split(",")
+        .map((url) => url.trim())
+        .filter((url) => url.length > 0);
+    } else {
+      urls = this.urls;
+    }
+
+    if (urls.length === 0) {
+      return [];
+    }
+
+    const response = (await this.client.contents({
+      urls,
+      summary: this.summary,
+      extract_effort: this.extractEffort,
+      response_length: this.responseLength,
+    })) as ValyuContentsClientResponse;
+
+    const results = response.results || [];
+
+    return results.map(
+      (result) =>
+        new Document({
+          pageContent: String(result.content ?? ""),
+          metadata: _getContentsMetadata(result),
+        })
+    );
+  }
+}
+

--- a/libs/langchain-community/src/tools/valyu.ts
+++ b/libs/langchain-community/src/tools/valyu.ts
@@ -1,0 +1,319 @@
+import { StructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import {
+  ValyuSearchClient,
+  ValyuSearchClientResponse,
+  ValyuContentsClient,
+  ValyuContentsClientResponse,
+  ValyuAdapter,
+} from "../retrievers/valyu.js";
+
+/**
+ * Interface for the ValyuSearchTool fields.
+ */
+export interface ValyuSearchToolFields {
+  client?: ValyuSearchClient;
+  apiKey?: string;
+  baseUrl?: string;
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Interface for the ValyuSearchTool input.
+ */
+export interface ValyuSearchToolInput {
+  query: string;
+  search_type?: string;
+  max_num_results?: number;
+  relevance_threshold?: number;
+  max_price?: number;
+  is_tool_call?: boolean;
+  start_date?: string;
+  end_date?: string;
+  included_sources?: string[];
+  excluded_sources?: string[];
+  response_length?: number | string;
+  country_code?: string;
+  fast_mode?: boolean;
+}
+
+/**
+ * A wrapper around the Valyu deep search API to search for relevant content
+ * from proprietary and web sources.
+ * @example
+ * ```typescript
+ * const tool = new ValyuSearchTool({
+ *   apiKey: process.env.VALYU_API_KEY,
+ * });
+ * const result = await tool.invoke({ query: "hello" });
+ * ```
+ */
+export class ValyuSearchTool extends StructuredTool {
+  name = "valyu_deep_search";
+
+  description =
+    "A wrapper around the Valyu deep search API to search for relevant content from proprietary and web sources. " +
+    "Input is a query and search parameters. " +
+    "Output is a JSON object with the search results.";
+
+  schema = z.object({
+    query: z.string().describe("The input query to be processed."),
+    search_type: z
+      .string()
+      .optional()
+      .default("all")
+      .describe(
+        "Type of search: 'all', 'proprietary', or 'web'. Defaults to 'all'."
+      ),
+    max_num_results: z
+      .number()
+      .optional()
+      .default(10)
+      .describe(
+        "The maximum number of results to be returned (1-20). Defaults to 10."
+      ),
+    relevance_threshold: z
+      .number()
+      .optional()
+      .default(0.5)
+      .describe(
+        "The minimum relevance score required for a result to be included (0.0-1.0). Defaults to 0.5."
+      ),
+    max_price: z
+      .number()
+      .optional()
+      .default(50.0)
+      .describe("Maximum cost in dollars for this search. Defaults to 50.0."),
+    is_tool_call: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe(
+        "Set to true when called by AI agents/tools (optimized for LLM consumption). Defaults to true."
+      ),
+    start_date: z
+      .string()
+      .optional()
+      .describe(
+        "Start date for time filtering in YYYY-MM-DD format (optional)."
+      ),
+    end_date: z
+      .string()
+      .optional()
+      .describe("End date for time filtering in YYYY-MM-DD format (optional)."),
+    included_sources: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "List of URLs, domains, or datasets to include in search results (optional)."
+      ),
+    excluded_sources: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "List of URLs, domains, or datasets to exclude from search results (optional)."
+      ),
+    response_length: z
+      .union([z.number(), z.string()])
+      .optional()
+      .describe(
+        "Content length per item: int for character count, or 'short' (25k), 'medium' (50k), 'large' (100k), 'max' (full content) (optional)."
+      ),
+    country_code: z
+      .string()
+      .optional()
+      .describe(
+        "2-letter ISO country code (e.g., 'GB', 'US') to bias search results to a specific country (optional)."
+      ),
+    fast_mode: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Enable fast mode for faster but shorter results. Good for general purpose queries. Defaults to false."
+      ),
+  });
+
+  client: ValyuSearchClient;
+
+  constructor(fields: ValyuSearchToolFields = {}) {
+    super();
+
+    if (fields.client) {
+      this.client = fields.client;
+    } else {
+      const apiKey =
+        fields.apiKey ?? getEnvironmentVariable("VALYU_API_KEY");
+      if (!apiKey) {
+        throw new Error(
+          `No Valyu API key found. Either set an environment variable named "VALYU_API_KEY" or pass an API key as "apiKey".`
+        );
+      }
+      this.client = new ValyuAdapter(apiKey, fields.baseUrl);
+    }
+
+    if (fields.name) {
+      this.name = fields.name;
+    }
+    if (fields.description) {
+      this.description = fields.description;
+    }
+  }
+
+  static lc_name() {
+    return "ValyuSearchTool";
+  }
+
+  protected async _call(input: ValyuSearchToolInput): Promise<string> {
+    try {
+      const response = (await this.client.search({
+        query: input.query,
+        search_type: input.search_type ?? "all",
+        max_num_results: input.max_num_results ?? 10,
+        relevance_threshold: input.relevance_threshold ?? 0.5,
+        max_price: input.max_price ?? 50.0,
+        is_tool_call: input.is_tool_call ?? true,
+        start_date: input.start_date,
+        end_date: input.end_date,
+        included_sources: input.included_sources,
+        excluded_sources: input.excluded_sources,
+        response_length: input.response_length,
+        country_code: input.country_code,
+        fast_mode: input.fast_mode ?? false,
+      })) as ValyuSearchClientResponse;
+
+      // Convert response to JSON string
+      if (typeof response === "string") {
+        return response;
+      }
+      if (response && typeof response === "object") {
+        return JSON.stringify(response);
+      }
+      return JSON.stringify(response);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorType =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      return JSON.stringify({
+        success: false,
+        error: errorMessage,
+        error_type: errorType,
+      });
+    }
+  }
+}
+
+/**
+ * Interface for the ValyuContentsTool fields.
+ */
+export interface ValyuContentsToolFields {
+  client?: ValyuContentsClient;
+  apiKey?: string;
+  baseUrl?: string;
+  summary?: boolean | string | Record<string, unknown>;
+  extract_effort?: "normal" | "high" | "auto";
+  response_length?: number | string;
+  name?: string;
+  description?: string;
+}
+
+/**
+ * A wrapper around the Valyu contents API to extract clean content from web pages.
+ * @example
+ * ```typescript
+ * const tool = new ValyuContentsTool({
+ *   apiKey: process.env.VALYU_API_KEY,
+ * });
+ * const result = await tool.invoke({ urls: ["https://example.com"] });
+ * ```
+ */
+export class ValyuContentsTool extends StructuredTool {
+  name = "valyu_contents_extract";
+
+  description =
+    "A wrapper around the Valyu contents API to extract clean content from web pages. " +
+    "Input is a list of URLs. " +
+    "Output is a JSON object with the extracted content from each URL.";
+
+  schema = z.object({
+    urls: z
+      .array(z.string())
+      .describe(
+        "List of URLs to extract content from (maximum 10 URLs per request)."
+      ),
+  });
+
+  client: ValyuContentsClient;
+
+  summary?: boolean | string | Record<string, unknown>;
+
+  extract_effort: "normal" | "high" | "auto";
+
+  response_length: number | string;
+
+  constructor(fields: ValyuContentsToolFields = {}) {
+    super();
+
+    if (fields.client) {
+      this.client = fields.client;
+    } else {
+      const apiKey =
+        fields.apiKey ?? getEnvironmentVariable("VALYU_API_KEY");
+      if (!apiKey) {
+        throw new Error(
+          `No Valyu API key found. Either set an environment variable named "VALYU_API_KEY" or pass an API key as "apiKey".`
+        );
+      }
+      this.client = new ValyuAdapter(apiKey, fields.baseUrl);
+    }
+
+    this.summary = fields.summary;
+    this.extract_effort = fields.extract_effort ?? "normal";
+    this.response_length = fields.response_length ?? "short";
+
+    if (fields.name) {
+      this.name = fields.name;
+    }
+    if (fields.description) {
+      this.description = fields.description;
+    }
+  }
+
+  static lc_name() {
+    return "ValyuContentsTool";
+  }
+
+  protected async _call(input: { urls: string[] }): Promise<string> {
+    try {
+      const response = (await this.client.contents({
+        urls: input.urls,
+        summary: this.summary,
+        extract_effort: this.extract_effort,
+        response_length: this.response_length,
+      })) as ValyuContentsClientResponse;
+
+      // Convert response to JSON string
+      if (typeof response === "string") {
+        return response;
+      }
+      if (response && typeof response === "object") {
+        return JSON.stringify(response);
+      }
+      return JSON.stringify(response);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorType =
+        error instanceof Error ? error.constructor.name : "UnknownError";
+      return JSON.stringify({
+        success: false,
+        error: errorMessage,
+        error_type: errorType,
+      });
+    }
+  }
+}
+


### PR DESCRIPTION
Added ValyuSearchAPIRetriever and valyuSearchTool integrations to the @langchain/community package that provides support for using the Valyu Search API within LangChain retrievers and tools.

Key additions:
- Added ValyuSearchAPIRetriever class extending BaseRetriever to enable search queries using the Valyu API.
- Implemented constructor options for apiKey, k, searchType, filters, and additional Valyu search parameters
- Implemented _getRelevantDocuments to perform Valyu search requests and convert returned results into LangChain Document instances.
- Added valyuSearchTool implementation following the standard LangChain tool interface.
- Added input and output interfaces for the tool, including optional parameters such as k, searchType, and metadata options.
- Ensured both retriever and tool map Valyu API response fields (title, url, content, score) into consistent LangChain formats.
- Added integration test file valyu_search.int.test.ts to verify retriever behavior, response parsing, and API connectivity.
- Added exports for the retriever and tool in the relevant index.ts files.

Context:
Valyu provides unified AI-native search and extraction capabilities intended for LLM workflows which brings Valyu functionality to LangChain JS/TS users.
