### PR TITLE
feat(openai): add support for shell tool

### DIFF
--- a/.changeset/kind-jokes-attack.md
+++ b/.changeset/kind-jokes-attack.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": minor
+---
+
+feat(openai): add support for shell tool

--- a/libs/providers/langchain-openai/src/tools/index.ts
+++ b/libs/providers/langchain-openai/src/tools/index.ts
@@ -68,6 +68,16 @@ export type {
   LocalShellAction,
 } from "./localShell.js";
 
+import { shell } from "./shell.js";
+export type {
+  ShellTool,
+  ShellOptions,
+  ShellAction,
+  ShellResult,
+  ShellCommandOutput,
+  ShellCallOutcome,
+} from "./shell.js";
+
 import { applyPatch } from "./applyPatch.js";
 export type {
   ApplyPatchTool,
@@ -86,5 +96,6 @@ export const tools = {
   imageGeneration,
   computerUse,
   localShell,
+  shell,
   applyPatch,
 };

--- a/libs/providers/langchain-openai/src/tools/shell.ts
+++ b/libs/providers/langchain-openai/src/tools/shell.ts
@@ -1,0 +1,266 @@
+import { OpenAI as OpenAIClient } from "openai";
+import { tool } from "@langchain/core/tools";
+
+/**
+ * Re-export action type from OpenAI SDK for convenience.
+ * The action contains command details like commands array, timeout, and max output length.
+ */
+export type ShellAction =
+  OpenAIClient.Responses.ResponseFunctionShellToolCall.Action;
+
+/**
+ * Result of a single shell command execution.
+ * Contains stdout, stderr, and the outcome (exit code or timeout).
+ */
+export type ShellCommandOutput =
+  OpenAIClient.Responses.ResponseFunctionShellCallOutputContent;
+
+/**
+ * Outcome type for shell command execution - either exit with code or timeout.
+ */
+export type ShellCallOutcome = ShellCommandOutput["outcome"];
+
+/**
+ * Result of executing shell commands.
+ * Contains an array of outputs (one per command) and the max_output_length parameter.
+ */
+export interface ShellResult {
+  /**
+   * Array of command outputs. Each entry corresponds to a command from the action.
+   * The order should match the order of commands in the action.
+   */
+  output: ShellCommandOutput[];
+  /**
+   * The max_output_length from the action, which must be passed back to the API.
+   * If not provided in the action, can be omitted.
+   */
+  maxOutputLength?: number | null;
+}
+
+/**
+ * Options for the Shell tool.
+ */
+export interface ShellOptions {
+  /**
+   * Execute function that handles shell command execution.
+   * This function receives the action input containing the commands and limits,
+   * and should return a ShellResult with stdout, stderr, and outcome for each command.
+   *
+   * @example
+   * ```typescript
+   * execute: async (action) => {
+   *   const outputs = await Promise.all(
+   *     action.commands.map(async (cmd) => {
+   *       try {
+   *         const { stdout, stderr } = await exec(cmd, {
+   *           timeout: action.timeout_ms ?? undefined,
+   *         });
+   *         return {
+   *           stdout,
+   *           stderr,
+   *           outcome: { type: "exit" as const, exit_code: 0 },
+   *         };
+   *       } catch (error) {
+   *         const timedOut = error.killed && error.signal === "SIGTERM";
+   *         return {
+   *           stdout: error.stdout ?? "",
+   *           stderr: error.stderr ?? String(error),
+   *           outcome: timedOut
+   *             ? { type: "timeout" as const }
+   *             : { type: "exit" as const, exit_code: error.code ?? 1 },
+   *         };
+   *       }
+   *     })
+   *   );
+   *   return {
+   *     output: outputs,
+   *     maxOutputLength: action.max_output_length,
+   *   };
+   * }
+   * ```
+   */
+  execute: (action: ShellAction) => ShellResult | Promise<ShellResult>;
+}
+
+/**
+ * OpenAI Shell tool type for the Responses API.
+ */
+export type ShellTool = OpenAIClient.Responses.FunctionShellTool;
+
+const TOOL_NAME = "shell";
+
+/**
+ * Creates a Shell tool that allows models to run shell commands through your integration.
+ *
+ * The shell tool allows the model to interact with your local computer through a controlled
+ * command-line interface. The model proposes shell commands; your integration executes them
+ * and returns the outputs. This creates a simple plan-execute loop that lets models inspect
+ * the system, run utilities, and gather data until they can finish the task.
+ *
+ * **Important**: The shell tool is available through the Responses API for use with `GPT-5.1`.
+ * It is not available on other models, or via the Chat Completions API.
+ *
+ * **When to use**:
+ * - **Automating filesystem or process diagnostics** – For example, "find the largest PDF
+ *   under ~/Documents" or "show running gunicorn processes."
+ * - **Extending the model's capabilities** – Using built-in UNIX utilities, python runtime
+ *   and other CLIs in your environment.
+ * - **Running multi-step build and test flows** – Chaining commands like `pip install` and `pytest`.
+ * - **Complex agentic coding workflows** – Using other tools like `apply_patch` to complete
+ *   workflows that involve complex file operations.
+ *
+ * **How it works**:
+ * The tool operates in a continuous loop:
+ * 1. Model sends shell commands (`shell_call` with `commands` array)
+ * 2. Your code executes the commands (can be concurrent)
+ * 3. You return stdout, stderr, and outcome for each command
+ * 4. Repeat until the task is complete
+ *
+ * **Security Warning**: Running arbitrary shell commands can be dangerous.
+ * Always sandbox execution or add strict allow/deny-lists before forwarding
+ * a command to the system shell.
+ *
+ * @see {@link https://platform.openai.com/docs/guides/tools-shell | OpenAI Shell Documentation}
+ * @see {@link https://github.com/openai/codex | Codex CLI} for reference implementation.
+ *
+ * @param options - Configuration for the Shell tool
+ * @returns A Shell tool that can be passed to `bindTools`
+ *
+ * @example
+ * ```typescript
+ * import { ChatOpenAI, tools } from "@langchain/openai";
+ * import { exec } from "child_process/promises";
+ *
+ * const model = new ChatOpenAI({ model: "gpt-5.1" });
+ *
+ * // With execute callback for automatic command handling
+ * const shellTool = tools.shell({
+ *   execute: async (action) => {
+ *     const outputs = await Promise.all(
+ *       action.commands.map(async (cmd) => {
+ *         try {
+ *           const { stdout, stderr } = await exec(cmd, {
+ *             timeout: action.timeout_ms ?? undefined,
+ *           });
+ *           return {
+ *             stdout,
+ *             stderr,
+ *             outcome: { type: "exit" as const, exit_code: 0 },
+ *           };
+ *         } catch (error) {
+ *           const timedOut = error.killed && error.signal === "SIGTERM";
+ *           return {
+ *             stdout: error.stdout ?? "",
+ *             stderr: error.stderr ?? String(error),
+ *             outcome: timedOut
+ *               ? { type: "timeout" as const }
+ *               : { type: "exit" as const, exit_code: error.code ?? 1 },
+ *           };
+ *         }
+ *       })
+ *     );
+ *     return {
+ *       output: outputs,
+ *       maxOutputLength: action.max_output_length,
+ *     };
+ *   },
+ * });
+ *
+ * const llmWithShell = model.bindTools([shellTool]);
+ * const response = await llmWithShell.invoke(
+ *   "Find the largest PDF file in ~/Documents"
+ * );
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Full shell loop example
+ * async function shellLoop(model, task) {
+ *   let response = await model.invoke(task, {
+ *     tools: [tools.shell({ execute: myExecutor })],
+ *   });
+ *
+ *   while (true) {
+ *     const shellCall = response.additional_kwargs.tool_outputs?.find(
+ *       (output) => output.type === "shell_call"
+ *     );
+ *
+ *     if (!shellCall) break;
+ *
+ *     // Execute commands (with proper sandboxing!)
+ *     const result = await executeCommands(shellCall.action);
+ *
+ *     // Send output back to model
+ *     response = await model.invoke([
+ *       response,
+ *       {
+ *         type: "shell_call_output",
+ *         call_id: shellCall.call_id,
+ *         output: result.output,
+ *         max_output_length: result.maxOutputLength,
+ *       },
+ *     ], {
+ *       tools: [tools.shell({ execute: myExecutor })],
+ *     });
+ *   }
+ *
+ *   return response;
+ * }
+ * ```
+ *
+ * @remarks
+ * - Only available through the Responses API (not Chat Completions)
+ * - Designed for use with `gpt-5.1` model
+ * - Commands are provided as an array of strings that can be executed concurrently
+ * - Action includes: `commands`, `timeout_ms`, `max_output_length`
+ * - Always sandbox or validate commands before execution
+ * - The `timeout_ms` from the model is only a hint—enforce your own limits
+ * - If `max_output_length` exists in the action, always pass it back in the output
+ * - Many CLI tools return non-zero exit codes for warnings; still capture stdout/stderr
+ */
+export function shell(options: ShellOptions) {
+  // Wrapper that converts ShellResult to string for LangChain tool compatibility
+  const executeWrapper = async (action: ShellAction): Promise<string> => {
+    const result = await options.execute(action);
+    // Return a JSON string representation for the tool result
+    return JSON.stringify({
+      output: result.output,
+      max_output_length: result.maxOutputLength,
+    });
+  };
+
+  const shellTool = tool(executeWrapper, {
+    name: TOOL_NAME,
+    description:
+      "Execute shell commands in a managed environment. Commands can be run concurrently.",
+    schema: {
+      type: "object",
+      properties: {
+        commands: {
+          type: "array",
+          items: { type: "string" },
+          description: "Array of shell commands to execute",
+        },
+        timeout_ms: {
+          type: "number",
+          description: "Optional timeout in milliseconds for the commands",
+        },
+        max_output_length: {
+          type: "number",
+          description:
+            "Optional maximum number of characters to return from each command",
+        },
+      },
+      required: ["commands"],
+    },
+  });
+
+  shellTool.extras = {
+    ...(shellTool.extras ?? {}),
+    providerToolDefinition: {
+      type: "shell",
+    } as ShellTool,
+  };
+
+  return shellTool;
+}

--- a/libs/providers/langchain-openai/src/tools/tests/shell.int.test.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/shell.int.test.ts
@@ -1,0 +1,50 @@
+import { expect, it, describe } from "vitest";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+
+import { tools } from "../index.js";
+import type { ShellAction } from "../index.js";
+import { ChatOpenAI } from "../../chat_models/index.js";
+
+describe("OpenAI Shell Tool Integration Tests", () => {
+  it("shell tool can be bound and invoked with gpt-5.1", async () => {
+    const executedCommands: string[][] = [];
+    const shellTool = tools.shell({
+      execute: async (action) => {
+        executedCommands.push(action.commands);
+        // Simulate command execution
+        return {
+          output: action.commands.map((cmd) => ({
+            /**
+             * let's not actually execute the command, just return a mock output
+             * (who knows what the command does)
+             */
+            stdout: cmd === "echo hello" ? "hello\n" : `executed: ${cmd}`,
+            stderr: "",
+            outcome: { type: "exit" as const, exit_code: 0 },
+          })),
+          maxOutputLength: action.max_output_length,
+        };
+      },
+    });
+
+    const llm = new ChatOpenAI({ model: "gpt-5.1" });
+    const llmWithShell = llm.bindTools([shellTool]);
+
+    const response = await llmWithShell.invoke([
+      new HumanMessage(
+        'Use the shell tool to run "echo hello" and tell me what it outputs.'
+      ),
+    ]);
+
+    expect(response).toBeInstanceOf(AIMessage);
+    expect((response as AIMessage).tool_calls).toHaveLength(1);
+    const result = await shellTool.func(
+      (response as AIMessage).tool_calls?.[0].args as unknown as ShellAction &
+        string
+    );
+    expect(result).toMatchInlineSnapshot(
+      `"{"output":[{"stdout":"hello\\n","stderr":"","outcome":{"type":"exit","exit_code":0}}],"max_output_length":2000}"`
+    );
+    expect(executedCommands).toEqual([["echo hello"]]);
+  });
+});

--- a/libs/providers/langchain-openai/src/tools/tests/shell.test-d.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/shell.test-d.ts
@@ -1,0 +1,81 @@
+import { expectTypeOf, it, describe } from "vitest";
+import {
+  tools,
+  ShellAction,
+  ShellResult,
+  ShellCommandOutput,
+} from "../index.js";
+
+describe("OpenAI Shell Tool Type Tests", () => {
+  it("shell execute callback receives correct action types", () => {
+    tools.shell({
+      execute: async (action) => {
+        expectTypeOf(action.commands).toEqualTypeOf<string[]>();
+        expectTypeOf(action.timeout_ms).toEqualTypeOf<number | null>();
+        expectTypeOf(action.max_output_length).toEqualTypeOf<number | null>();
+
+        return {
+          output: [
+            {
+              stdout: "test",
+              stderr: "",
+              outcome: { type: "exit" as const, exit_code: 0 },
+            },
+          ],
+        };
+      },
+    });
+  });
+
+  it("ShellAction type matches expected structure", () => {
+    const action: ShellAction = {
+      commands: ["ls -la"],
+      timeout_ms: 5000,
+      max_output_length: 4096,
+    };
+
+    expectTypeOf(action.commands).toEqualTypeOf<string[]>();
+    expectTypeOf(action.timeout_ms).toEqualTypeOf<number | null>();
+    expectTypeOf(action.max_output_length).toEqualTypeOf<number | null>();
+  });
+
+  it("ShellResult type matches expected structure", () => {
+    const result: ShellResult = {
+      output: [
+        {
+          stdout: "hello",
+          stderr: "",
+          outcome: { type: "exit", exit_code: 0 },
+        },
+      ],
+      maxOutputLength: 4096,
+    };
+
+    expectTypeOf(result.output).toEqualTypeOf<ShellCommandOutput[]>();
+    expectTypeOf(result.maxOutputLength).toEqualTypeOf<
+      number | null | undefined
+    >();
+  });
+
+  it("ShellCommandOutput supports exit outcome", () => {
+    const output: ShellCommandOutput = {
+      stdout: "success",
+      stderr: "",
+      outcome: { type: "exit", exit_code: 0 },
+    };
+
+    expectTypeOf(output.stdout).toEqualTypeOf<string>();
+    expectTypeOf(output.stderr).toEqualTypeOf<string>();
+  });
+
+  it("ShellCommandOutput supports timeout outcome", () => {
+    const output: ShellCommandOutput = {
+      stdout: "",
+      stderr: "timed out",
+      outcome: { type: "timeout" },
+    };
+
+    expectTypeOf(output.stdout).toEqualTypeOf<string>();
+    expectTypeOf(output.stderr).toEqualTypeOf<string>();
+  });
+});

--- a/libs/providers/langchain-openai/src/tools/tests/shell.test.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/shell.test.ts
@@ -1,0 +1,152 @@
+import { expect, it, describe } from "vitest";
+import { tools } from "../index.js";
+
+describe("OpenAI Shell Tool Tests", () => {
+  it("shell creates valid tool definitions", () => {
+    const shellTool = tools.shell({
+      execute: async () => ({
+        output: [
+          {
+            stdout: "output",
+            stderr: "",
+            outcome: { type: "exit" as const, exit_code: 0 },
+          },
+        ],
+      }),
+    });
+
+    expect(shellTool.name).toBe("shell");
+    expect(shellTool.extras?.providerToolDefinition).toMatchObject({
+      type: "shell",
+    });
+  });
+
+  it("shell execute callback receives action correctly", async () => {
+    const actions: Array<{
+      commands: string[];
+      timeout_ms?: number | null;
+      max_output_length?: number | null;
+    }> = [];
+
+    const shellTool = tools.shell({
+      execute: async (action) => {
+        actions.push(action);
+        return {
+          output: action.commands.map((cmd) => ({
+            stdout: `executed: ${cmd}`,
+            stderr: "",
+            outcome: { type: "exit" as const, exit_code: 0 },
+          })),
+          maxOutputLength: action.max_output_length,
+        };
+      },
+    });
+
+    const testAction = {
+      commands: ["ls -la", "pwd"],
+      timeout_ms: 5000,
+      max_output_length: 4096,
+    };
+
+    const executeFunc = shellTool.func;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await executeFunc(testAction as any);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].commands).toEqual(["ls -la", "pwd"]);
+    expect(actions[0].timeout_ms).toBe(5000);
+    expect(actions[0].max_output_length).toBe(4096);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.output).toHaveLength(2);
+    expect(parsed.output[0].stdout).toBe("executed: ls -la");
+    expect(parsed.output[1].stdout).toBe("executed: pwd");
+    expect(parsed.max_output_length).toBe(4096);
+  });
+
+  it("shell handles timeout outcome", async () => {
+    const shellTool = tools.shell({
+      execute: async () => ({
+        output: [
+          {
+            stdout: "",
+            stderr: "Command timed out",
+            outcome: { type: "timeout" as const },
+          },
+        ],
+      }),
+    });
+
+    const testAction = {
+      commands: ["sleep 1000"],
+      timeout_ms: 100,
+      max_output_length: null,
+    };
+
+    const executeFunc = shellTool.func;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await executeFunc(testAction as any);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.output).toHaveLength(1);
+    expect(parsed.output[0].outcome.type).toBe("timeout");
+  });
+
+  it("shell handles exit outcome with non-zero exit code", async () => {
+    const shellTool = tools.shell({
+      execute: async () => ({
+        output: [
+          {
+            stdout: "",
+            stderr: "command not found",
+            outcome: { type: "exit" as const, exit_code: 127 },
+          },
+        ],
+      }),
+    });
+
+    const testAction = {
+      commands: ["nonexistent-command"],
+      timeout_ms: null,
+      max_output_length: null,
+    };
+
+    const executeFunc = shellTool.func;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await executeFunc(testAction as any);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.output).toHaveLength(1);
+    expect(parsed.output[0].outcome.type).toBe("exit");
+    expect(parsed.output[0].outcome.exit_code).toBe(127);
+    expect(parsed.output[0].stderr).toBe("command not found");
+  });
+
+  it("shell handles multiple commands", async () => {
+    const shellTool = tools.shell({
+      execute: async (action) => ({
+        output: action.commands.map((_cmd, idx) => ({
+          stdout: `output ${idx}`,
+          stderr: "",
+          outcome: { type: "exit" as const, exit_code: 0 },
+        })),
+      }),
+    });
+
+    const testAction = {
+      commands: ["echo hello", "echo world", "ls"],
+      timeout_ms: null,
+      max_output_length: null,
+    };
+
+    const executeFunc = shellTool.func;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await executeFunc(testAction as any);
+
+    const parsed = JSON.parse(result);
+    expect(parsed.output).toHaveLength(3);
+    expect(parsed.output[0].stdout).toBe("output 0");
+    expect(parsed.output[1].stdout).toBe("output 1");
+    expect(parsed.output[2].stdout).toBe("output 2");
+  });
+});


### PR DESCRIPTION
This PR adds support for OpenAI's Shell tool, which allows `gpt-5.1` models to execute shell commands through the Responses API. Unlike the existing `localShell` tool (designed for Codex CLI), this tool supports executing multiple commands concurrently and uses a different interface optimized for the newer model.

### Usage

```typescript
import { ChatOpenAI, tools } from "@langchain/openai";
import { exec } from "node:child_process/promises";

const model = new ChatOpenAI({ model: "gpt-5.1" });

const shellTool = tools.shell({
  execute: async (action) => {
    const outputs = await Promise.all(
      action.commands.map(async (cmd) => {
        const { stdout, stderr } = await exec(cmd);
        return {
          stdout,
          stderr,
          outcome: { type: "exit" as const, exit_code: 0 },
        };
      })
    );
    return { output: outputs, maxOutputLength: action.max_output_length };
  },
});

const llmWithShell = model.bindTools([shellTool]);
const response = await llmWithShell.invoke("List all TypeScript files");
```

### Key Differences from `localShell`

| Feature | `localShell` | `shell` |
|---------|--------------|---------|
| Model | `codex-mini-latest` | `gpt-5.1` |
| Commands | Single command (argv array) | Multiple commands (string array) |
| Execution | Sequential | Concurrent support |
| Return format | String output | Structured `ShellResult` |

