### PR TITLE
chore: update devcontainer image to typescript-node:4.0.3-24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1.1.0-20",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:4.0.3-24",
   "customizations": {
     "vscode": {
       "extensions": ["ms-vscode.vscode-typescript-next"]


### PR DESCRIPTION
Fixes #9604

The version of Node.js in the currently used DevContainer image is v20.13.1, which doesn't meet the required version v24.x in the [Contributing Guidelines](https://github.com/langchain-ai/langchainjs?tab=contributing-ov-file#setup). And this seems to lead to an incompatibility issue when using certain Node.js APIs.

Problem solved after upgrading the image variant to `4.0.3-24`.

See available image variants here: https://github.com/devcontainers/images/tree/main/src/typescript-node
