### PR TITLE
fix(ci): fix dev release pipeline

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -58,7 +58,8 @@ jobs:
       - name: 🧹 Prepare for snapshot release
         run: |
           # Disable changelog generation for snapshot releases
-          pnpm dlx json -I -f .changeset/config.json -e "this.changelog = false"
+          # Enable useCalculatedVersion to preserve current version (e.g., 1.2.0-dev-xxx instead of 0.0.0-dev-xxx)
+          pnpm dlx json -I -f .changeset/config.json -e "this.changelog = false; this.snapshot = { useCalculatedVersion: true, prereleaseTemplate: '{tag}-{timestamp}' }"
 
       - name: 📦 Version packages (snapshot)
         id: version
@@ -90,6 +91,8 @@ jobs:
         run: pnpm changeset publish --tag ${{ inputs.npm_tag }} --no-git-tag
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Enable npm provenance for OIDC-based publishing (bypasses OTP requirement)
+          NPM_CONFIG_PROVENANCE: true
 
       - name: 📋 Get published packages
         if: steps.version.outputs.success == '1'


### PR DESCRIPTION
Two fixes on the dev release pipeline:

### 1. Fix for Version Issue (Line 62)
Added snapshot configuration with `useCalculatedVersion: true`:

```62:62:.github/workflows/dev-release.yml
pnpm dlx json -I -f .changeset/config.json -e "this.changelog = false; this.snapshot = { useCalculatedVersion: true, prereleaseTemplate: '{tag}-{timestamp}' }"
```

This tells changesets to use the **calculated next version** (based on changeset bump types) instead of defaulting to `0.0.0`. Now if `langchain` is at `1.2.0` with a patch changeset, it will become `1.2.1-dev-20251210201900`.

### 2. Fix for OTP Issue (Lines 93-95)
Added npm provenance support:

```93:95:.github/workflows/dev-release.yml
env:
  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
  # Enable npm provenance for OIDC-based publishing (bypasses OTP requirement)
  NPM_CONFIG_PROVENANCE: true
```

This enables npm provenance which uses OIDC to authenticate with npm (using the `id-token: write` permission already configured), bypassing the OTP requirement.
