### PR TITLE
fix(ci): fix ready workflow

### DIFF
--- a/.github/workflows/pr-approval-label.yml
+++ b/.github/workflows/pr-approval-label.yml
@@ -11,8 +11,12 @@ permissions:
 jobs:
   add-ready-label:
     runs-on: ubuntu-latest
-    # Only run when an org member approves
-    if: github.event.review.state == 'approved' && github.event.review.author_association == 'MEMBER'
+    # Only run when an org member approves and PR is not from a fork
+    # (fork PRs don't have write permissions to add labels)
+    if: |
+      github.event.review.state == 'approved' &&
+      github.event.review.author_association == 'MEMBER' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Add ready label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
The issue is that this workflow fails when the pull request comes from a fork. When a PR originates from a fork, the `GITHUB_TOKEN` has restricted permissions and cannot write labels to the base repository - this is a GitHub security feature.

The fix adds a new condition: github.event.pull_request.head.repo.full_name == github.repository

This checks if the PR's source repository matches the base repository. Now:
- PRs from the main repo's branches → condition passes, label gets added ✓
- PRs from forks → condition fails, job is skipped gracefully (no error) ✓