### PR TITLE
feat(core): add streamTimeout option for streaming inactivity timeout

### DIFF
--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -339,6 +339,7 @@ export abstract class Runnable<
         maxConcurrency: options.maxConcurrency,
         runId: options.runId,
         timeout: options.timeout,
+        streamTimeout: options.streamTimeout,
         signal: options.signal,
       });
     }
@@ -352,6 +353,7 @@ export abstract class Runnable<
     delete callOptions.maxConcurrency;
     delete callOptions.runId;
     delete callOptions.timeout;
+    delete callOptions.streamTimeout;
     delete callOptions.signal;
     return [runnableConfig, callOptions];
   }

--- a/libs/langchain-core/src/runnables/tests/stream_timeout.test.ts
+++ b/libs/langchain-core/src/runnables/tests/stream_timeout.test.ts
@@ -1,0 +1,199 @@
+import { test, describe, expect } from "vitest";
+import { RunnableLambda } from "../base.js";
+import { FakeStreamingLLM } from "../../utils/testing/index.js";
+
+describe("streamTimeout", () => {
+  test("Stream should complete when chunks arrive within timeout", async () => {
+    // LLM with 50ms delay between chunks
+    const llm = new FakeStreamingLLM({
+      sleep: 50,
+      responses: ["hello"],
+    });
+
+    const chunks: string[] = [];
+    // 200ms timeout - much longer than the 50ms delay between chunks
+    const stream = await llm.stream("test", {
+      streamTimeout: 200,
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("hello");
+  });
+
+  test("Stream should timeout when no chunks arrive within the timeout period", async () => {
+    // LLM with 500ms delay between chunks
+    const llm = new FakeStreamingLLM({
+      sleep: 500,
+      responses: ["hello world"],
+    });
+
+    // 100ms timeout - shorter than the 500ms delay between chunks
+    await expect(async () => {
+      const stream = await llm.stream("test", {
+        streamTimeout: 100,
+      });
+
+      const chunks: string[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    }).rejects.toThrow(/Stream timeout/);
+  });
+
+  test("Stream should reset timeout on each chunk", async () => {
+    // LLM with 80ms delay between chunks
+    const llm = new FakeStreamingLLM({
+      sleep: 80,
+      responses: ["abcdefgh"], // 8 chunks
+    });
+
+    const chunks: string[] = [];
+    // 150ms timeout - longer than 80ms delay, so each chunk should reset the timer
+    const stream = await llm.stream("test", {
+      streamTimeout: 150,
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    // Should get all chunks because timeout resets on each chunk
+    expect(chunks.join("")).toBe("abcdefgh");
+  });
+
+  test("Stream should work with RunnableLambda that yields chunks", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const slowGenerator = RunnableLambda.from(async function* (
+      _input: unknown
+    ) {
+      for (const char of "test") {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        yield char;
+      }
+    });
+
+    const chunks: unknown[] = [];
+    const stream = await slowGenerator.stream({}, { streamTimeout: 200 });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("test");
+  });
+
+  test("Stream should timeout with RunnableLambda when chunks are too slow", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const verySlowGenerator = RunnableLambda.from(async function* (
+      _input: unknown
+    ) {
+      for (const char of "test") {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        yield char;
+      }
+    });
+
+    await expect(async () => {
+      const stream = await verySlowGenerator.stream({}, { streamTimeout: 100 });
+      for await (const _ of stream) {
+        // consume stream
+      }
+    }).rejects.toThrow(/Stream timeout/);
+  });
+
+  test("streamTimeout should work alongside regular timeout", async () => {
+    // LLM with 50ms delay between chunks
+    const llm = new FakeStreamingLLM({
+      sleep: 50,
+      responses: ["hi"],
+    });
+
+    const chunks: string[] = [];
+    // Both timeouts set
+    const stream = await llm.stream("test", {
+      timeout: 5000, // Long overall timeout
+      streamTimeout: 200, // Per-chunk timeout
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("hi");
+  });
+
+  test("streamTimeout should work with signal", async () => {
+    const llm = new FakeStreamingLLM({
+      sleep: 50,
+      responses: ["hello"],
+    });
+
+    const controller = new AbortController();
+    const chunks: string[] = [];
+    const stream = await llm.stream("test", {
+      streamTimeout: 200,
+      signal: controller.signal,
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("hello");
+  });
+
+  test("streamTimeout in mergeConfigs should take minimum value", async () => {
+    // Create a RunnableLambda that wraps the streaming LLM
+    const llm = new FakeStreamingLLM({
+      sleep: 50,
+      responses: ["hi"],
+    });
+
+    // Create a runnable sequence that has streamTimeout in config
+    const runnable = RunnableLambda.from(async function* (input: string) {
+      for await (const chunk of await llm.stream(input)) {
+        yield chunk;
+      }
+    });
+
+    // Bind with 300ms streamTimeout via withConfig
+    const boundRunnable = runnable.withConfig({
+      streamTimeout: 300,
+    });
+
+    const chunks: unknown[] = [];
+
+    // Call with 200ms timeout - the shorter one should be used via mergeConfigs
+    const stream = await boundRunnable.stream("test", {
+      streamTimeout: 200,
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toBe("hi");
+  });
+
+  test("streamTimeout validation should reject non-positive values", async () => {
+    const llm = new FakeStreamingLLM({
+      sleep: 50,
+      responses: ["hi"],
+    });
+
+    await expect(async () => {
+      await llm.stream("test", {
+        streamTimeout: 0,
+      });
+    }).rejects.toThrow(/Stream timeout must be a positive number/);
+
+    await expect(async () => {
+      await llm.stream("test", {
+        streamTimeout: -100,
+      });
+    }).rejects.toThrow(/Stream timeout must be a positive number/);
+  });
+});

--- a/libs/langchain-core/src/runnables/types.ts
+++ b/libs/langchain-core/src/runnables/types.ts
@@ -101,6 +101,15 @@ export interface RunnableConfig<
   timeout?: number;
 
   /**
+   * Streaming inactivity timeout in milliseconds.
+   * If no new chunk is received within this time period during streaming,
+   * the stream will be aborted. Unlike `timeout` which applies to the total
+   * request time, `streamTimeout` only triggers if the stream becomes inactive.
+   * The timer resets each time a new chunk is received.
+   */
+  streamTimeout?: number;
+
+  /**
    * Abort signal for this call.
    * If provided, the call will be aborted when the signal is aborted.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal


### PR DESCRIPTION
This PR adds a new `streamTimeout` option to `RunnableConfig` that provides streaming inactivity timeout functionality. Unlike the existing `timeout` option which aborts after total elapsed time, `streamTimeout` only aborts if no chunks are received within the specified time period. The timer resets each time a new chunk arrives.

Closes #9088

## Problem

When using the streaming API with the `timeout` option, the stream is aborted after X seconds **total time**, regardless of whether chunks are still actively arriving:

```typescript
// Current behavior: aborts after 3 seconds TOTAL, even if chunks are still coming
await llm.stream("Hello", { timeout: 3000 });
```

This is problematic for:
- Long-running responses from slow models
- Load balancing between providers (need to detect stalled streams, not slow ones)
- Interactive applications that need reasonable timeout limits

## Solution

Add a new `streamTimeout` option that only aborts if the stream becomes **inactive**:

```typescript
// New behavior: aborts only if no chunk arrives for 3 seconds
await llm.stream("Hello", { streamTimeout: 3000 });

// Can be combined with regular timeout
await llm.stream("Hello", {
  timeout: 60000,       // 60s maximum total time
  streamTimeout: 5000   // 5s maximum inactivity
});
```

## How It Works

1. `streamTimeout` is added to `RunnableConfig` alongside `timeout`
2. In `ensureConfig()`, the value is stored in metadata as `streamTimeoutMs`
3. `AsyncGeneratorWithSetup` reads this value and creates an `AbortController`
4. On each chunk received, the timeout timer is reset
5. If no chunk arrives within the timeout period, the stream is aborted

## Testing

Here are some reproduction scripts to use:

<details>
<summary><b>Stream Hangs</b></summary>
This example shows that if a stream hangs, we will have to wait for `timeout` to trigger.

```ts
import * as http from "http";
import { ChatOpenAI } from "@langchain/openai";

// Create a mock server that sends 3 chunks then STALLS (never completes)
const server = http.createServer((req, res) => {
  if (req.method === "POST" && req.url?.includes("/chat/completions")) {
    res.writeHead(200, {
      "Content-Type": "text/event-stream",
      "Cache-Control": "no-cache",
      Connection: "keep-alive",
    });

    const words = ["Hello", "from", "server..."];
    let i = 0;

    const send = () => {
      if (i < words.length) {
        const chunk = {
          id: "test",
          object: "chat.completion.chunk",
          created: Date.now(),
          model: "gpt-4",
          choices: [
            {
              index: 0,
              delta: { content: `${words[i]} ` },
              finish_reason: null,
            },
          ],
        };
        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
        i++;
        setTimeout(send, 100);
      } else {
        // STALL - stop sending, keep connection open
        console.log("   [Server stalled - no more chunks]");
      }
    };
    send();
  }
});

server.listen(0, async () => {
  const port = (server.address() as { port: number }).port;
  console.log("=".repeat(50));
  console.log("ISSUE #9088: streamTimeout detects stalled streams");
  console.log("=".repeat(50));
  console.log();
  console.log("Server sends 3 chunks then STALLS (simulates hung connection)");
  console.log("streamTimeout is set to 500ms");
  console.log();
  console.log("ON MAIN: Will HANG forever (streamTimeout ignored)");
  console.log("WITH FIX: Will abort after 500ms of inactivity");
  console.log();

  const llm = new ChatOpenAI({
    model: "gpt-4",
    apiKey: "sk-mock",
    configuration: { baseURL: `http://localhost:${port}/v1` },
    maxRetries: 0,
  });

  try {
    const start = Date.now();
    const stream = await llm.stream("Hello", {
      // @ts-expect-error streamTimeout is a new option
      streamTimeout: 500,
      timeout: 10000,
    });

    for await (const chunk of stream) {
      const elapsed = ((Date.now() - start) / 1000).toFixed(1);
      process.stdout.write(`[${elapsed}s] ${chunk.content}`);
    }

    clearTimeout(safetyTimer);
    console.log("\n\n✅ Stream completed (unexpected - server stalled!)");
  } catch (e) {
    clearTimeout(safetyTimer);
    console.log(
      `\n\n✅ Correctly aborted: ${e instanceof Error ? e.message : e}`
    );
    console.log("\n^ streamTimeout detected the stall!");
  }

  server.close();
  process.exit(0);
});
```

</details>

<details>
<summary><b>Stream Aborts</b></summary>
If the timeout is low: the stream just aborts even though there are incoming tokens.

```ts
import * as http from "http";
import { ChatOpenAI } from "@langchain/openai";

// Create a mock server that sends chunks every 200ms
const server = http.createServer((req, res) => {
  if (req.method === "POST" && req.url?.includes("/chat/completions")) {
    res.writeHead(200, {
      "Content-Type": "text/event-stream",
      "Cache-Control": "no-cache",
      Connection: "keep-alive",
    });

    const words =
      "This is a slow response that takes about 4 seconds total".split(" ");
    let i = 0;

    const send = () => {
      if (i < words.length) {
        const chunk = {
          id: "test",
          object: "chat.completion.chunk",
          created: Date.now(),
          model: "gpt-4",
          choices: [
            {
              index: 0,
              delta: { content: `${words[i]} ` },
              finish_reason: null,
            },
          ],
        };
        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
        i++;
        setTimeout(send, 200); // 200ms between chunks, ~2.4s total for 12 words
      } else {
        res.write(
          `data: ${JSON.stringify({
            choices: [{ delta: {}, finish_reason: "stop" }],
          })}\n\n`
        );
        res.write("data: [DONE]\n\n");
        res.end();
      }
    };
    send();
  }
});

server.listen(0, async () => {
  const port = (server.address() as { port: number }).port;
  console.log("=".repeat(50));
  console.log("ISSUE #9088: timeout aborts active streams");
  console.log("=".repeat(50));
  console.log();
  console.log("Server sends chunks every 200ms (~2.4s total)");
  console.log("timeout is set to 2000ms (2 seconds)");
  console.log();
  console.log("EXPECTED: Stream aborts after 2s even though chunks are coming");
  console.log();

  const llm = new ChatOpenAI({
    model: "gpt-4",
    apiKey: "sk-mock",
    configuration: { baseURL: `http://localhost:${port}/v1` },
    maxRetries: 0,
  });

  try {
    const start = Date.now();
    const stream = await llm.stream("Hello", { timeout: 2000 });

    for await (const chunk of stream) {
      const elapsed = ((Date.now() - start) / 1000).toFixed(1);
      process.stdout.write(`[${elapsed}s] ${chunk.content}`);
    }

    console.log("\n\n✅ Stream completed (unexpected!)");
  } catch (e) {
    console.log(`\n\n❌ Aborted: ${e instanceof Error ? e.message : e}`);
    console.log("\n^ This is the PROBLEM - chunks were still arriving!");
  }

  server.close();
  process.exit(0);
});
```

</details>