### PR TITLE
feat(google-genai): add outputDimensionality parameter to GoogleGenerativeAIEmbeddings

### DIFF
--- a/.changeset/itchy-chairs-wave.md
+++ b/.changeset/itchy-chairs-wave.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+feat(google-genai): add `outputDimensionality` parameter to `GoogleGenerativeAIEmbeddings`

--- a/libs/providers/langchain-google-genai/src/tests/embeddings.int.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/embeddings.int.test.ts
@@ -58,3 +58,28 @@ test("Test GooglePalmEmbeddings.embedDocuments with baseUrl set", async () => {
     expect(typeof r[0]).toBe("number");
   });
 });
+
+test("Test GoogleGenerativeAIEmbeddings.embedQuery with outputDimensionality", async () => {
+  const embeddings = new GoogleGenerativeAIEmbeddings({
+    model: "gemini-embedding-001",
+    outputDimensionality: 768,
+    maxRetries: 1,
+  });
+  const res = await embeddings.embedQuery("Hello world");
+  expect(res).toHaveLength(768);
+  expect(typeof res[0]).toBe("number");
+});
+
+test("Test GoogleGenerativeAIEmbeddings.embedDocuments with outputDimensionality", async () => {
+  const embeddings = new GoogleGenerativeAIEmbeddings({
+    model: "gemini-embedding-001",
+    outputDimensionality: 768,
+    maxRetries: 1,
+  });
+  const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
+  expect(res).toHaveLength(2);
+  res.forEach((r) => {
+    expect(r).toHaveLength(768);
+    expect(typeof r[0]).toBe("number");
+  });
+});


### PR DESCRIPTION
## Summary

Add support for specifying custom embedding dimensions via the `outputDimensionality` parameter in `GoogleGenerativeAIEmbeddings`. This allows users to configure the number of dimensions for embedding models like `gemini-embedding-001` which support variable output dimensions.

### Changes
- Added `outputDimensionality` parameter to `GoogleGenerativeAIEmbeddingsParams` interface
- Added `outputDimensionality` class property
- Updated `_convertToContent` method to include `outputDimensionality` in the request
- Added integration tests for the new parameter

### Usage

```typescript
const embeddings = new GoogleGenerativeAIEmbeddings({
  model: "gemini-embedding-001",
  outputDimensionality: 768, // Specify custom dimensions
});

const res = await embeddings.embedQuery("Hello world");
// res.length === 768
```

### Note

The Google SDK's `EmbedContentRequest` type doesn't currently include `outputDimensionality`, but the Google REST API accepts it. A type assertion is used to include the field.

Fixes #9378