### PR TITLE
fix(google-genai): convert cache_read to delta in streaming usage metadata

### DIFF
--- a/.changeset/swift-clouds-swim.md
+++ b/.changeset/swift-clouds-swim.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): convert cache_read to delta in streaming usage metadata

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -941,6 +941,7 @@ export class ChatGoogleGenerativeAI
     let prevPromptTokenCount = 0;
     let prevCandidatesTokenCount = 0;
     let prevTotalTokenCount = 0;
+    let prevCachedContentTokenCount = 0;
     let index = 0;
     for await (const response of stream) {
       if (
@@ -963,6 +964,16 @@ export class ChatGoogleGenerativeAI
           newPromptTokenCount - prevPromptTokenCount
         );
         prevPromptTokenCount = newPromptTokenCount;
+
+        // Convert cache_read to delta as well (it's set as cumulative by convertUsageMetadata)
+        if (usageMetadata.input_token_details?.cache_read !== undefined) {
+          const newCacheRead = usageMetadata.input_token_details.cache_read;
+          usageMetadata.input_token_details.cache_read = Math.max(
+            0,
+            newCacheRead - prevCachedContentTokenCount
+          );
+          prevCachedContentTokenCount = newCacheRead;
+        }
 
         const newCandidatesTokenCount =
           response.usageMetadata.candidatesTokenCount ?? 0;

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.int.test.ts
@@ -486,6 +486,9 @@ test("Stream token count usage_metadata", async () => {
   expect(res.usage_metadata.total_tokens).toBe(
     res.usage_metadata.input_tokens + res.usage_metadata.output_tokens
   );
+  // cache_read (if present) must be <= input_tokens after summing deltas across chunks
+  const cacheRead = res.usage_metadata.input_token_details?.cache_read ?? 0;
+  expect(cacheRead).toBeLessThanOrEqual(res.usage_metadata.input_tokens);
 });
 
 describe("ChatGoogleGenerativeAI should count tokens correctly", () => {


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchainjs/issues/9731

When streaming, input_tokens was converted to a delta (per-chunk difference) but input_token_details.cache_read remained cumulative, causing impossible states like cache_read > input_tokens.

This adds the same delta calculation for cache_read that already exists for input_tokens, output_tokens, and total_tokens.

Changes: 11 lines added to libs/providers/langchain-google-genai/src/chat_models.ts.

Verification:

All 39 unit tests pass

Manual test with repro script confirms fix works (cache_read=0 on chunks 2+ instead of cumulative value)