### PR TITLE
fix(openai): pass runManager to _streamResponseChunks in responses API

### DIFF
--- a/.changeset/thirty-kiwis-move.md
+++ b/.changeset/thirty-kiwis-move.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): pass runManager to \_streamResponseChunks in responses API

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -157,11 +157,12 @@ export class ChatOpenAIResponses<
 
   async _generate(
     messages: BaseMessage[],
-    options: this["ParsedCallOptions"]
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     const invocationParams = this.invocationParams(options);
     if (invocationParams.stream) {
-      const stream = this._streamResponseChunks(messages, options);
+      const stream = this._streamResponseChunks(messages, options, runManager);
       let finalChunk: ChatGenerationChunk | undefined;
       for await (const chunk of stream) {
         chunk.message.response_metadata = {


### PR DESCRIPTION
Fixes #9733

This PR fixes an issue where `handleLLMNewToken` callbacks were not being invoked when using `ChatOpenAI` with `useResponsesApi: true` and calling `invoke()` with streaming enabled. The root cause was that the `_generate` method in `ChatOpenAIResponses` was not accepting or passing the `runManager` parameter to `_streamResponseChunks`, which is responsible for emitting token callbacks.

## Changes

The fix adds the missing `runManager` parameter to the `_generate` method signature and passes it through to `_streamResponseChunks` when streaming is enabled. This aligns the behavior with `ChatOpenAICompletions`, which correctly implements this pattern.

### Technical Details

The `_generate` method is called by the base class when `invoke()` is used. The base class passes a `CallbackManagerForLLMRun` instance that handles callback dispatch. Previously, `ChatOpenAIResponses._generate` ignored this parameter, so when it called `_streamResponseChunks`, no callbacks were emitted.

1. Accept the optional `runManager` parameter in `_generate`
2. Pass it to `_streamResponseChunks` which already knows how to use it