### PR TITLE
fix(aws): target output_version for standard content

### DIFF
--- a/.changeset/proud-pillows-tickle.md
+++ b/.changeset/proud-pillows-tickle.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+target standard content trigger appropriately

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -400,6 +400,140 @@ describe("convertToConverseMessages", () => {
         ],
       },
     },
+    {
+      name: "standard v1 format with tool_call blocks (e.g., from Anthropic provider)",
+      input: [
+        new SystemMessage("You're an advanced AI assistant."),
+        new HumanMessage("What's the weather in SF?"),
+        new AIMessage({
+          content: [
+            { type: "text", text: "Let me check the weather for you." },
+            {
+              type: "tool_call",
+              id: "call_123",
+              name: "get_weather",
+              args: { location: "San Francisco" },
+            },
+          ],
+          response_metadata: {
+            output_version: "v1",
+            model_provider: "anthropic",
+          },
+        }),
+        new ToolMessage({
+          tool_call_id: "call_123",
+          content: "72°F and sunny",
+        }),
+      ],
+      output: {
+        converseSystem: [
+          {
+            text: "You're an advanced AI assistant.",
+          },
+        ],
+        converseMessages: [
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "What's the weather in SF?",
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.ASSISTANT,
+            content: [
+              {
+                text: "Let me check the weather for you.",
+              },
+              {
+                toolUse: {
+                  toolUseId: "call_123",
+                  name: "get_weather",
+                  input: { location: "San Francisco" },
+                },
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                toolResult: {
+                  toolUseId: "call_123",
+                  content: [
+                    {
+                      text: "72°F and sunny",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      name: "standard v1 format with reasoning blocks (e.g., from Anthropic provider)",
+      input: [
+        new SystemMessage("You're an advanced AI assistant."),
+        new HumanMessage("What is 2+2?"),
+        new AIMessage({
+          content: [
+            {
+              type: "reasoning",
+              reasoning: "I need to add 2 and 2 together.",
+            },
+            { type: "text", text: "The answer is 4." },
+          ],
+          response_metadata: {
+            output_version: "v1",
+            model_provider: "anthropic",
+          },
+        }),
+        new HumanMessage("Thanks! What about 3+3?"),
+      ],
+      output: {
+        converseSystem: [
+          {
+            text: "You're an advanced AI assistant.",
+          },
+        ],
+        converseMessages: [
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "What is 2+2?",
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.ASSISTANT,
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: "I need to add 2 and 2 together.",
+                  },
+                },
+              },
+              {
+                text: "The answer is 4.",
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "Thanks! What about 3+3?",
+              },
+            ],
+          },
+        ],
+      },
+    },
   ];
 
   it.each(testCases.map((tc) => [tc.name, tc]))(

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -362,7 +362,7 @@ function convertSystemMessageToConverseMessage(
 }
 
 function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
-  if (msg.response_metadata.response_format === "v1") {
+  if (msg.response_metadata?.output_version === "v1") {
     return {
       role: "assistant",
       content: convertFromV1ToChatBedrockConverseMessage(msg),


### PR DESCRIPTION
Fixes an issue where `ChatBedrockConverse` failed to properly handle standard v1 content blocks (like `tool_call` and `reasoning`) when continuing conversations that were started with other providers such as Anthropic.

The root cause was that Bedrock was checking the wrong discriminator field (`response_metadata.response_format`) instead of the standard field (`response_metadata.output_version`) to detect v1 format messages.

## Changes

### `libs/providers/langchain-aws/src/utils/message_inputs.ts`

Changed the discriminator check in `convertAIMessageToConverseMessage` from:
```typescript
if (msg.response_metadata.response_format === "v1")
```
to:
```typescript
if (msg.response_metadata?.output_version === "v1")
```

This ensures that messages from other providers using the standard v1 format are properly routed to `convertFromV1ToChatBedrockConverseMessage`, which already correctly handles all standard content block types (`tool_call`, `reasoning`, etc.).

### `libs/providers/langchain-aws/src/tests/chat_models.test.ts`

Added 2 new test cases to `convertToConverseMessages`:
- **Standard v1 format with `tool_call` blocks** - Verifies that messages from other providers (e.g., Anthropic) with tool calls in content are properly converted
- **Standard v1 format with `reasoning` blocks** - Verifies that extended thinking/reasoning blocks are properly converted to Bedrock's `reasoningContent` format

---

## Problem

When using `initChatModel` to switch providers mid-conversation, users encountered errors like:
- `Unsupported content block type: tool_call`
- `Unsupported content block type: reasoning`

This happened because the v1 converter path wasn't being triggered for messages from other providers.

## Solution

The standard content format uses `response_metadata.output_version === "v1"` as the discriminator, which is what Anthropic and other providers set. The existing v1 converter (`convertFromV1ToChatBedrockConverseMessage` in `compat.ts`) already handles all standard block types correctly - it just wasn't being invoked due to the wrong field being checked.

