### PR TITLE
Avoid summing 'index' in _mergeDicts. This was breaking tool responses to the model after 1.3.3

### DIFF
--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -463,6 +463,10 @@ export function _mergeDicts(
         merged[key] += value;
       }
     } else if (typeof merged[key] === "number") {
+      if (key === "index") {
+        // Preserve index field, don't add - index is used for matching content blocks
+        continue;
+      }
       merged[key] = merged[key] + value;
     } else if (typeof merged[key] === "object" && !Array.isArray(merged[key])) {
       merged[key] = _mergeDicts(merged[key], value);

--- a/libs/langchain-core/src/messages/tests/base_message.test.ts
+++ b/libs/langchain-core/src/messages/tests/base_message.test.ts
@@ -1099,6 +1099,10 @@ describe("_mergeDicts", () => {
     expect(_mergeDicts({ id: "old" }, { id: "" })).toEqual({ id: "old" });
   });
 
+  it("preserves 'index' field (does not add)", () => {
+    expect(_mergeDicts({ index: 1 }, { index: 1 })).toEqual({ index: 1 });
+  });
+
   it("throws error when merging different types for same key", () => {
     expect(() => _mergeDicts({ a: "string" }, { a: 123 })).toThrow(
       "field[a] already exists in the message chunk, but with a different type"


### PR DESCRIPTION
I searched for an existing issue but didn't find one.

Our tool was working fine with @langchain/anthropic 1.3.3. Any version after that would fail with something like the following:

```
BadRequestError: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.2.tool_use.id: Field required"},"request_id":"req_011CX2FguTz2PcFFoGP3RUTa"}

Troubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/INVALID_TOOL_RESULTS/

    at APIError.generate (file:///Users/kevingalligan/temp/testlangchain/node_modules/@anthropic-ai/sdk/core/error.mjs:37:20)
    at Anthropic.makeStatusError (file:///Users/kevingalligan/temp/testlangchain/node_modules/@anthropic-ai/sdk/client.mjs:155:32)
    at Anthropic.makeRequest (file:///Users/kevingalligan/temp/testlangchain/node_modules/@anthropic-ai/sdk/client.mjs:309:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async makeCompletionRequest (file:///Users/kevingalligan/temp/testlangchain/node_modules/@langchain/anthropic/dist/chat_models.js:857:12)
    at async pRetry (file:///Users/kevingalligan/temp/testlangchain/node_modules/@langchain/core/dist/utils/p-retry/index.js:123:19)
    at async run (/Users/kevingalligan/temp/testlangchain/node_modules/p-queue/dist/index.js:163:29) {
  status: 400,
  headers: Headers {},
  requestID: 'req_011CX2FguTz2PcFFoGP3RUTa',
  error: {
    type: 'error',
    error: {
      type: 'invalid_request_error',
      message: 'messages.1.content.2.tool_use.id: Field required'
    },
    request_id: 'req_011CX2FguTz2PcFFoGP3RUTa'
  },
  lc_error_code: 'INVALID_TOOL_RESULTS',
  pregelTaskId: '0cf0b5a4-4405-56aa-b139-dbc99d571673'
}
```

After quite a bit of digging, the root cause seems to be summing number values from tools when streaming. The issue did not happen when calling `invoke`, at least on the test graph I ran.

The commit that introduced the issue seems to be `56600b94f`.

This change checks if they key is `index`, in which case the value isn't changed.

I'm not deeply familiar with the code, nor why the original change was made, so there may be more that needs to be done here.

You can run a simple repro here: https://github.com/kpgalligan/anthropic-tools-streaming-fail

Changing `stream` to `invoke` in that sample avoids the issue. Testing with the change in this PR happened in our larger app, and that seems to work fine after the fix.