### PR TITLE
Backport uuid7 to v0.3

### DIFF
--- a/.changeset/wise-rats-admire.md
+++ b/.changeset/wise-rats-admire.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+use uuid7 for run ids

--- a/langchain-core/src/callbacks/base.ts
+++ b/langchain-core/src/callbacks/base.ts
@@ -403,7 +403,7 @@ export abstract class BaseCallbackHandler
 
   static fromMethods(methods: CallbackHandlerMethods) {
     class Handler extends BaseCallbackHandler {
-      name = uuid.v4();
+      name = uuid.v7();
 
       constructor() {
         super();

--- a/langchain-core/src/callbacks/manager.ts
+++ b/langchain-core/src/callbacks/manager.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { v7 as uuidv7 } from "uuid";
 import { AgentAction, AgentFinish } from "../agents.js";
 import type { ChainValues } from "../utils/types/index.js";
 import { LLMResult } from "../outputs.js";
@@ -682,7 +682,7 @@ export class CallbackManager
     return Promise.all(
       prompts.map(async (prompt, idx) => {
         // Can't have duplicate runs with the same run ID (if provided)
-        const runId_ = idx === 0 && runId ? runId : uuidv4();
+        const runId_ = idx === 0 && runId ? runId : uuidv7();
 
         await Promise.all(
           this.handlers.map((handler) => {
@@ -758,7 +758,7 @@ export class CallbackManager
     return Promise.all(
       messages.map(async (messageGroup, idx) => {
         // Can't have duplicate runs with the same run ID (if provided)
-        const runId_ = idx === 0 && runId ? runId : uuidv4();
+        const runId_ = idx === 0 && runId ? runId : uuidv7();
 
         await Promise.all(
           this.handlers.map((handler) => {
@@ -838,7 +838,7 @@ export class CallbackManager
   async handleChainStart(
     chain: Serialized,
     inputs: ChainValues,
-    runId = uuidv4(),
+    runId = uuidv7(),
     runType: string | undefined = undefined,
     _tags: string[] | undefined = undefined,
     _metadata: Record<string, unknown> | undefined = undefined,
@@ -905,7 +905,7 @@ export class CallbackManager
   async handleToolStart(
     tool: Serialized,
     input: string,
-    runId = uuidv4(),
+    runId = uuidv7(),
     _parentRunId: string | undefined = undefined,
     _tags: string[] | undefined = undefined,
     _metadata: Record<string, unknown> | undefined = undefined,
@@ -970,7 +970,7 @@ export class CallbackManager
   async handleRetrieverStart(
     retriever: Serialized,
     query: string,
-    runId: string = uuidv4(),
+    runId: string = uuidv7(),
     _parentRunId: string | undefined = undefined,
     _tags: string[] | undefined = undefined,
     _metadata: Record<string, unknown> | undefined = undefined,
@@ -1155,7 +1155,7 @@ export class CallbackManager
 
   static fromHandlers(handlers: CallbackHandlerMethods) {
     class Handler extends BaseCallbackHandler {
-      name = uuidv4();
+      name = uuidv7();
 
       constructor() {
         super();


### PR DESCRIPTION
Backport of 1cfe603e97d8711343ae5f1f5a75648e7bd2a16e to v0.3 branch.

This replaces uuid v4 with uuid v7 for run ID generation, providing monotonic, time-ordered UUIDs for improved tracing and sorting.
