### PR TITLE
fix(core): add defensive null checks in AsyncCaller error handler

### DIFF
--- a/.changeset/fuzzy-cougars-invent.md
+++ b/.changeset/fuzzy-cougars-invent.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+add defensive null checks in AsyncCaller error handler

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -17,10 +17,12 @@ const STATUS_NO_RETRY = [
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const defaultFailedAttemptHandler = (error: any) => {
+  const errorMessage =
+    typeof error?.message === "string" ? error.message : "";
   if (
-    error.message.startsWith("Cancel") ||
-    error.message.startsWith("AbortError") ||
-    error.name === "AbortError"
+    errorMessage.startsWith("Cancel") ||
+    errorMessage.startsWith("AbortError") ||
+    error?.name === "AbortError"
   ) {
     throw error;
   }


### PR DESCRIPTION
Adds defensive null checking to the `defaultFailedAttemptHandler` function in `AsyncCaller` to prevent potential runtime errors when the error object doesn't have the expected structure.

## Changes

- **`libs/langchain-core/src/utils/async_caller.ts`**: Updated the error handler to safely access `error.message` and `error.name` using optional chaining and type checking, preventing crashes when errors lack expected properties.