### PR TITLE
fix(langchain): don't concatenate middleware error, instead use cause

### DIFF
--- a/libs/langchain/src/agents/errors.ts
+++ b/libs/langchain/src/agents/errors.ts
@@ -67,3 +67,36 @@ export class ToolInvocationError extends Error {
     this.toolError = error;
   }
 }
+
+/**
+ * Error thrown when a middleware fails.
+ */
+export class MiddlewareError extends Error {
+  static readonly "~brand" = "MiddlewareError";
+
+  constructor(error: unknown, middlewareName: string) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    super(errorMessage);
+    this.name =
+      error instanceof Error
+        ? error.name
+        : `${middlewareName[0].toUpperCase() + middlewareName.slice(1)}Error`;
+
+    if (error instanceof Error) {
+      this.cause = error;
+    }
+  }
+
+  /**
+   * Check if the error is a MiddlewareError.
+   * @param error - The error to check
+   * @returns Whether the error is a MiddlewareError
+   */
+  isInstance(error: unknown): error is MiddlewareError {
+    return (
+      error instanceof Error &&
+      "~brand" in error &&
+      error["~brand"] === "MiddlewareError"
+    );
+  }
+}

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -20,7 +20,7 @@ import type { ToolCall } from "@langchain/core/messages/tool";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import { initChatModel } from "../../chat_models/universal.js";
-import { MultipleStructuredOutputsError } from "../errors.js";
+import { MultipleStructuredOutputsError, MiddlewareError } from "../errors.js";
 import { RunnableCallable } from "../RunnableCallable.js";
 import {
   bindTools,
@@ -563,16 +563,7 @@ export class AgentNode<
 
             return middlewareResponse;
           } catch (error) {
-            /**
-             * Add middleware context to error if not already added
-             */
-            if (
-              error instanceof Error &&
-              !error.message.includes(`middleware "${currentMiddleware.name}"`)
-            ) {
-              error.message = `Error in middleware "${currentMiddleware.name}": ${error.message}`;
-            }
-            throw error;
+            throw new MiddlewareError(error, currentMiddleware.name);
           }
         };
       }

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -30,7 +30,7 @@ import {
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import { isBaseChatModel, isConfigurableModel } from "./model.js";
-import { MultipleToolsBoundError } from "./errors.js";
+import { MultipleToolsBoundError, MiddlewareError } from "./errors.js";
 import type { AgentBuiltInState } from "./runtime.js";
 import type {
   ToolCallHandler,
@@ -551,17 +551,7 @@ export function wrapToolCall(
 
           return result;
         } catch (error) {
-          /**
-           * Add middleware context to error if not already added
-           */
-          if (
-            // eslint-disable-next-line no-instanceof/no-instanceof
-            error instanceof Error &&
-            !error.message.includes(`middleware "${m.name}"`)
-          ) {
-            error.message = `Error in middleware "${m.name}": ${error.message}`;
-          }
-          throw error;
+          throw new MiddlewareError(error, m.name);
         }
       };
       return wrappedHandler;


### PR DESCRIPTION
Using a cleaner approach to allow error traces via `cause`.