### PR TITLE
fix(langchain): typo taks -> task

### DIFF
--- a/libs/langchain/src/agents/middleware/todoListMiddleware.ts
+++ b/libs/langchain/src/agents/middleware/todoListMiddleware.ts
@@ -11,7 +11,7 @@ import { createMiddleware } from "../index.js";
  */
 const WRITE_TODOS_DESCRIPTION = `Use this tool to create and manage a structured task list for your current work session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
 It also helps the user understand the progress of the task and overall progress of their requests.
-Only use this tool if you think it will be helpful in staying organized. If the user's request is trivial and takes less than 3 steps, it is better to NOT use this tool and just do the taks directly.
+Only use this tool if you think it will be helpful in staying organized. If the user's request is trivial and takes less than 3 steps, it is better to NOT use this tool and just do the task directly.
 
 ## When to Use This Tool
 Use this tool in these scenarios:


### PR DESCRIPTION
### Summary
This PR fixes a minor typo where `taks` was incorrectly used instead of `task`.