### PR TITLE
fix: handle undefined output_index in tool call chunks

### DIFF
--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -592,7 +592,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       name: event.item.name,
       args: event.item.arguments,
       id: event.item.call_id,
-      index: event.output_index,
+      index: event.output_index ?? 0,
     });
 
     additional_kwargs[_FUNCTION_CALL_IDS_MAP_KEY] = {
@@ -608,7 +608,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       name: "computer_use",
       args: JSON.stringify({ action: event.item.action }),
       id: event.item.call_id,
-      index: event.output_index,
+      index: event.output_index ?? 0,
     });
     // Also store the raw item for additional context (pending_safety_checks, etc.)
     additional_kwargs.tool_outputs = [event.item];
@@ -665,7 +665,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     tool_call_chunks.push({
       type: "tool_call_chunk",
       args: event.delta,
-      index: event.output_index,
+      index: event.output_index ?? 0,
     });
   } else if (
     event.type === "response.web_search_call.completed" ||

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -283,6 +283,46 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
         customResultMessage.tool_call_chunks
       );
     });
+
+    it("should handle events with undefined output_index by defaulting to 0", () => {
+      // Test function call with undefined output_index
+      const functionCallEvent = {
+        type: "response.output_item.added",
+        item: {
+          type: "function_call",
+          id: "fc_123",
+          call_id: "call_1",
+          name: "test_tool",
+          arguments: '{"param": "value"}',
+        },
+        // output_index is intentionally undefined
+      };
+
+      const result = convertResponsesDeltaToChatGenerationChunk(
+        functionCallEvent as any
+      );
+      const aiMessageChunk = result?.message as AIMessageChunk;
+
+      expect(aiMessageChunk.tool_call_chunks).toBeDefined();
+      expect(aiMessageChunk.tool_call_chunks).toHaveLength(1);
+      expect(aiMessageChunk.tool_call_chunks?.[0]?.index).toBe(0);
+
+      // Test delta event with undefined output_index
+      const deltaEvent = {
+        type: "response.function_call_arguments.delta",
+        delta: '{"key": "value"}',
+        // output_index is intentionally undefined
+      };
+
+      const deltaResult = convertResponsesDeltaToChatGenerationChunk(
+        deltaEvent as any
+      );
+      const deltaMessageChunk = deltaResult?.message as AIMessageChunk;
+
+      expect(deltaMessageChunk.tool_call_chunks).toBeDefined();
+      expect(deltaMessageChunk.tool_call_chunks).toHaveLength(1);
+      expect(deltaMessageChunk.tool_call_chunks?.[0]?.index).toBe(0);
+    });
   });
 
   describe("reasoning streaming elevation", () => {


### PR DESCRIPTION
- Set default index to 0 when event.output_index is undefined
- Ensures tool call chunks are properly merged even when output_index is missing
- Add test case for undefined output_index scenarios

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
