### PR TITLE
feat(openai): add reasoningEffort call option for reasoning models

### DIFF
--- a/.changeset/reasoning-effort-option.md
+++ b/.changeset/reasoning-effort-option.md
@@ -1,0 +1,10 @@
+---
+"@langchain/openai": patch
+---
+
+Add `reasoningEffort` call option as a convenience shorthand for `reasoning.effort`
+
+- Adds `reasoningEffort` to `BaseChatOpenAICallOptions` for easier configuration of reasoning models
+- Automatically coalesces `reasoningEffort` into `reasoning.effort` when calling reasoning models (o1, o3, etc.)
+- If both `reasoningEffort` and `reasoning.effort` are provided, `reasoning.effort` takes precedence
+- Marked as `@deprecated` to encourage use of the full `reasoning.effort` option

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -185,6 +185,17 @@ export interface BaseChatOpenAICallOptions
   reasoning?: OpenAIClient.Reasoning;
 
   /**
+   * Constrains effort on reasoning for reasoning models. Reduces reasoning in responses,
+   * which can reduce latency and cost at the expense of quality.
+   *
+   * Accepts values: "low", "medium", or "high".
+   *
+   * @deprecated This is a convenience option that will be merged into the `reasoning` object.
+   * Use `reasoning.effort` instead.
+   */
+  reasoningEffort?: OpenAIClient.Reasoning["effort"];
+
+  /**
    * Service tier to use for this request. Can be "auto", "default", or "flex"
    * Specifies the service tier for prioritization and latency optimization.
    */
@@ -340,6 +351,7 @@ export abstract class BaseChatOpenAI<
       "response_format",
       "seed",
       "reasoning",
+      "reasoning_effort",
       "service_tier",
     ];
   }
@@ -528,6 +540,17 @@ export abstract class BaseChatOpenAI<
       reasoning = {
         ...reasoning,
         ...options.reasoning,
+      };
+    }
+
+    // Coalesce reasoningEffort into reasoning.effort if reasoning.effort is not already set
+    if (
+      options?.reasoningEffort !== undefined &&
+      reasoning?.effort === undefined
+    ) {
+      reasoning = {
+        ...reasoning,
+        effort: options.reasoningEffort,
       };
     }
 


### PR DESCRIPTION
Adds `reasoningEffort` as a convenience call option for OpenAI chat models that gets coalesced into `reasoning.effort`. This provides a simpler API for users who just want to set the reasoning effort level without constructing the full `reasoning` object.

## Changes

### `libs/providers/langchain-openai/src/chat_models/base.ts`
- Added `reasoningEffort` property to `BaseChatOpenAICallOptions` interface
- Added `reasoning_effort` to `callKeys` array for proper call option recognition
- Updated `_getReasoningParams()` to coalesce `reasoningEffort` into `reasoning.effort` when the latter is not already set

### `libs/providers/langchain-openai/src/chat_models/tests/index.test.ts`
- Added test suite for `reasoningEffort` call option with 3 tests:
  - Verifies `reasoningEffort` is coalesced into `reasoning.effort`
  - Verifies `reasoning.effort` takes precedence when both are provided
  - Verifies non-reasoning models don't have `reasoning_effort` applied

## Notes

- We optimistically removed this param without having an update for langsmith hub, so reasoning effort params still need to be respected for the time being.
- The `reasoningEffort` option is marked as `@deprecated` to encourage use of the full `reasoning.effort` option
- Only applies to reasoning models (o1, o3, etc.) - ignored for non-reasoning models
- If both `reasoningEffort` and `reasoning.effort` are provided, `reasoning.effort` takes precedence
