### PR TITLE
feat(langchain): add withConfig() method to ReactAgent

### DIFF
--- a/.changeset/smooth-peas-cheer.md
+++ b/.changeset/smooth-peas-cheer.md
@@ -1,0 +1,7 @@
+---
+"langchain": patch
+---
+
+feat(langchain): add withConfig() method to ReactAgent
+
+Adds a `withConfig()` method to ReactAgent following the same pattern as LangGraph's `Pregel.withConfig()`. This allows setting default configuration values (like `recursionLimit`, `tags`, or `configurable`) that get merged with invocation-time config.

--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -22,7 +22,11 @@ import {
   MessageStructure,
 } from "@langchain/core/messages";
 import { IterableReadableStream } from "@langchain/core/utils/stream";
-import type { Runnable, RunnableConfig } from "@langchain/core/runnables";
+import {
+  mergeConfigs,
+  type Runnable,
+  type RunnableConfig,
+} from "@langchain/core/runnables";
 import type { StreamEvent } from "@langchain/core/tracers/log_stream";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 import { createAgentState } from "./annotation.js";
@@ -169,13 +173,17 @@ export class ReactAgent<
 
   #stateManager = new StateManager();
 
+  #defaultConfig: RunnableConfig;
+
   constructor(
     public options: CreateAgentParams<
       Types["Response"],
       Types["State"],
       Types["Context"]
-    >
+    >,
+    defaultConfig?: RunnableConfig
   ) {
+    this.#defaultConfig = defaultConfig ?? {};
     this.#toolBehaviorVersion = options.version ?? this.#toolBehaviorVersion;
 
     /**
@@ -677,6 +685,38 @@ export class ReactAgent<
   }
 
   /**
+   * Creates a new ReactAgent with the given config merged into the existing config.
+   * Follows the same pattern as LangGraph's Pregel.withConfig().
+   *
+   * The merged config is applied as a default that gets merged with any config
+   * passed at invocation time (invoke/stream). Invocation-time config takes precedence.
+   *
+   * @param config - Configuration to merge with existing config
+   * @returns A new ReactAgent instance with the merged configuration
+   *
+   * @example
+   * ```typescript
+   * const agent = createAgent({ model: "gpt-4o", tools: [...] });
+   *
+   * // Set a default recursion limit
+   * const configuredAgent = agent.withConfig({ recursionLimit: 1000 });
+   *
+   * // Chain multiple configs
+   * const debugAgent = agent
+   *   .withConfig({ recursionLimit: 1000 })
+   *   .withConfig({ tags: ["debug"] });
+   * ```
+   */
+  withConfig(
+    config: Omit<RunnableConfig, "store" | "writer" | "interrupt">
+  ): ReactAgent<Types> {
+    return new ReactAgent(
+      this.options,
+      mergeConfigs(this.#defaultConfig, config)
+    );
+  }
+
+  /**
    * Get possible edge destinations from model node.
    * @param toolClasses names of tools to call
    * @param includeModelRequest whether to include "model_request" as a valid path (for jumpTo routing)
@@ -1098,14 +1138,15 @@ export class ReactAgent<
     >
   ) {
     type FullState = MergedAgentState<Types>;
+    const mergedConfig = mergeConfigs(this.#defaultConfig, config);
     const initializedState = await this.#initializeMiddlewareStates(
       state,
-      config as RunnableConfig
+      mergedConfig as RunnableConfig
     );
 
     return this.#graph.invoke(
       initializedState,
-      config as unknown as InferContextInput<
+      mergedConfig as unknown as InferContextInput<
         Types["Context"] extends AnyAnnotationRoot | InteropZodObject
           ? Types["Context"]
           : AnyAnnotationRoot
@@ -1172,13 +1213,14 @@ export class ReactAgent<
       TEncoding
     >
   ) {
+    const mergedConfig = mergeConfigs(this.#defaultConfig, config);
     const initializedState = await this.#initializeMiddlewareStates(
       state,
-      config as RunnableConfig
+      mergedConfig as RunnableConfig
     );
     return this.#graph.stream(
       initializedState,
-      config as Record<string, any>
+      mergedConfig as Record<string, any>
     ) as Promise<
       IterableReadableStream<
         StreamOutputMap<
@@ -1264,10 +1306,11 @@ export class ReactAgent<
     > & { version?: "v1" | "v2" },
     streamOptions?: Parameters<Runnable["streamEvents"]>[2]
   ): IterableReadableStream<StreamEvent> {
+    const mergedConfig = mergeConfigs(this.#defaultConfig, config);
     return this.#graph.streamEvents(
       state,
       {
-        ...(config as Partial<
+        ...(mergedConfig as Partial<
           PregelOptions<
             any,
             any,

--- a/libs/langchain/src/agents/tests/reactAgent.test.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.test.ts
@@ -1056,4 +1056,219 @@ describe("createAgent", () => {
     // Verify messages were processed correctly
     expect(result.messages.length).toBeGreaterThan(0);
   });
+
+  describe("withConfig", () => {
+    it("should return a new ReactAgent instance", () => {
+      const model = new FakeToolCallingModel();
+      const agent = createAgent({
+        model,
+        tools: [],
+      });
+
+      const configuredAgent = agent.withConfig({ recursionLimit: 1000 });
+
+      // Should return a new instance, not the same one
+      expect(configuredAgent).not.toBe(agent);
+      // Both should be ReactAgent instances
+      expect(configuredAgent).toHaveProperty("invoke");
+      expect(configuredAgent).toHaveProperty("stream");
+      expect(configuredAgent).toHaveProperty("withConfig");
+    });
+
+    it("should allow chaining multiple withConfig calls", () => {
+      const model = new FakeToolCallingModel();
+      const agent = createAgent({
+        model,
+        tools: [],
+      });
+
+      const configuredAgent = agent
+        .withConfig({ recursionLimit: 500 })
+        .withConfig({ tags: ["test"] });
+
+      // Should return a new instance after chaining
+      expect(configuredAgent).not.toBe(agent);
+      expect(configuredAgent).toHaveProperty("invoke");
+    });
+
+    it("should preserve original agent options", () => {
+      const systemPrompt = "You are a helpful assistant";
+      const model = new FakeToolCallingModel();
+      const agent = createAgent({
+        model,
+        tools: [],
+        systemPrompt,
+      });
+
+      const configuredAgent = agent.withConfig({ recursionLimit: 1000 });
+
+      // Both agents should have the same options
+      expect(configuredAgent.options.systemPrompt).toBe(systemPrompt);
+    });
+
+    it("should propagate configurable values to tools", async () => {
+      // This test verifies that config values set via withConfig()
+      // are actually propagated to the graph and accessible in tools
+      let capturedConfig: Record<string, unknown> | undefined;
+
+      const configCaptureTool = tool(
+        async (_input, config) => {
+          // Capture the config that was passed to this tool
+          capturedConfig = config?.configurable;
+          return "done";
+        },
+        {
+          name: "config_capture_tool",
+          description: "Captures the config for testing",
+          schema: z.object({
+            input: z.string(),
+          }),
+        }
+      );
+
+      const model = new FakeToolCallingChatModel({
+        responses: [
+          new AIMessage({
+            content: "",
+            tool_calls: [
+              {
+                name: "config_capture_tool",
+                id: "test-1",
+                args: { input: "test" },
+              },
+            ],
+          }),
+          new AIMessage("Done"),
+        ],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [configCaptureTool],
+      });
+
+      // Set a custom configurable value via withConfig
+      const configuredAgent = agent.withConfig({
+        configurable: { custom_test_value: "hello-from-withConfig" },
+      });
+
+      await configuredAgent.invoke({
+        messages: [new HumanMessage("test")],
+      });
+
+      // Verify the configurable value was propagated to the tool
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig?.custom_test_value).toBe("hello-from-withConfig");
+    });
+
+    it("should merge withConfig values with invocation config", async () => {
+      // Verify that withConfig values are merged with invocation-time config
+      let capturedConfig: Record<string, unknown> | undefined;
+
+      const configCaptureTool = tool(
+        async (_input, config) => {
+          capturedConfig = config?.configurable;
+          return "done";
+        },
+        {
+          name: "config_capture_tool",
+          description: "Captures the config for testing",
+          schema: z.object({
+            input: z.string(),
+          }),
+        }
+      );
+
+      const model = new FakeToolCallingChatModel({
+        responses: [
+          new AIMessage({
+            content: "",
+            tool_calls: [
+              {
+                name: "config_capture_tool",
+                id: "test-1",
+                args: { input: "test" },
+              },
+            ],
+          }),
+          new AIMessage("Done"),
+        ],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [configCaptureTool],
+      });
+
+      // Set a default value via withConfig
+      const configuredAgent = agent.withConfig({
+        configurable: { default_value: "from-withConfig" },
+      });
+
+      // Invoke with additional configurable values
+      await configuredAgent.invoke(
+        { messages: [new HumanMessage("test")] },
+        { configurable: { invocation_value: "from-invoke" } }
+      );
+
+      // Both values should be present (merged)
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig?.default_value).toBe("from-withConfig");
+      expect(capturedConfig?.invocation_value).toBe("from-invoke");
+    });
+
+    it("should allow invocation config to override withConfig values", async () => {
+      // Verify that invocation-time values override withConfig defaults
+      let capturedConfig: Record<string, unknown> | undefined;
+
+      const configCaptureTool = tool(
+        async (_input, config) => {
+          capturedConfig = config?.configurable;
+          return "done";
+        },
+        {
+          name: "config_capture_tool",
+          description: "Captures the config for testing",
+          schema: z.object({
+            input: z.string(),
+          }),
+        }
+      );
+
+      const model = new FakeToolCallingChatModel({
+        responses: [
+          new AIMessage({
+            content: "",
+            tool_calls: [
+              {
+                name: "config_capture_tool",
+                id: "test-1",
+                args: { input: "test" },
+              },
+            ],
+          }),
+          new AIMessage("Done"),
+        ],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [configCaptureTool],
+      });
+
+      // Set a default value via withConfig
+      const configuredAgent = agent.withConfig({
+        configurable: { shared_key: "default-value" },
+      });
+
+      // Override with invocation config
+      await configuredAgent.invoke(
+        { messages: [new HumanMessage("test")] },
+        { configurable: { shared_key: "overridden-value" } }
+      );
+
+      // Invocation value should win
+      expect(capturedConfig?.shared_key).toBe("overridden-value");
+    });
+  });
 });


### PR DESCRIPTION
Adds a `withConfig()` method to `ReactAgent` that allows setting default configuration values which get merged with invocation-time config. This follows the same pattern as LangGraph's `Pregel.withConfig()`, enabling users to pre-configure agents with defaults like `recursionLimit`, `tags`, or custom `configurable` values.

## Changes

### `libs/langchain/src/agents/ReactAgent.ts`

- Added `#defaultConfig` private field to store default configuration
- Added `withConfig()` method that returns a new `ReactAgent` instance with merged config
- Updated `invoke()`, `stream()`, and `streamEvents()` to merge default config with invocation config using `mergeConfigs` from `@langchain/core/runnables`
- Invocation-time config takes precedence over `withConfig()` defaults

### `libs/langchain/src/agents/tests/reactAgent.test.ts`

- Added comprehensive test suite for `withConfig()`:
  - Returns a new instance (immutability)
  - Supports chaining multiple `withConfig()` calls
  - Preserves original agent options
  - Propagates configurable values to tools
  - Merges `withConfig` values with invocation config
  - Invocation config overrides `withConfig` defaults

## Usage Example

```typescript
const agent = createAgent({ model: "gpt-4o", tools: [...] });

// Set a default recursion limit
const configuredAgent = agent.withConfig({ recursionLimit: 1000 });

// Chain multiple configs
const debugAgent = agent
  .withConfig({ recursionLimit: 1000 })
  .withConfig({ tags: ["debug"] });

// Pass custom configurable values
const agentWithContext = agent.withConfig({
  configurable: { userId: "user-123" }
});
```
