### PR TITLE
feat(openai): update openai SDK to ^6.18.0

### DIFF
--- a/.changeset/anthropic-opus-4-6-support.md
+++ b/.changeset/anthropic-opus-4-6-support.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/anthropic": minor
+"@langchain/anthropic": patch
 ---
 
 feat(anthropic): add Claude Opus 4.6 support with adaptive thinking, effort parameter, compaction API, output_config migration, inference_geo, and structured outputs GA

--- a/.changeset/openai-sdk-6-18.md
+++ b/.changeset/openai-sdk-6-18.md
@@ -1,0 +1,12 @@
+---
+"@langchain/openai": patch
+---
+
+feat(openai): update openai SDK to ^6.18.0
+
+- Adds support for codex 5.3
+- Added `action` option to image generation tool (`generate`, `edit`, `auto`)
+- Removed `@ts-expect-error` for `gpt-image-1.5` model (now in SDK types)
+- Auto-route codex models (`codex-mini-latest`, `gpt-5-codex`, `gpt-5.1-codex`, etc.) to Responses API
+- Added `shell_call` and `local_shell_call` to streaming converter and input reconstruction
+- Added unit tests for `isReasoningModel` and `_modelPrefersResponsesAPI`

--- a/.pr-description.md
+++ b/.pr-description.md
@@ -1,0 +1,11 @@
+## Summary
+
+Bumps the `openai` SDK dependency from `^6.16.0` to `^6.18.0` and adds support for new API features introduced in v6.17.0 and v6.18.0.
+
+## Changes
+
+- **Bump `openai` to `^6.18.0`** — picks up abort signal memory leak fix, new image generation options, and updated types
+- **Image generation `action` field** — new `action` option (`generate`, `edit`, `auto`) on the image generation tool, and removed a `@ts-expect-error` now that `gpt-image-1.5` is in the SDK types
+- **Auto-route codex models to Responses API** — `_modelPrefersResponsesAPI` now returns `true` for codex models (`codex-mini-latest`, `gpt-5-codex`, `gpt-5.1-codex`, etc.) which are Responses API-only
+- **Shell/local shell streaming support** — added `shell_call` and `local_shell_call` to the streaming converter's recognized output types and to `fallthroughCallTypes` for multi-turn input reconstruction
+- **Tests** — added unit tests for `isReasoningModel`, `_modelPrefersResponsesAPI`, and image generation `action` field

--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "js-tiktoken": "^1.0.12",
-    "openai": "^6.16.0",
+    "openai": "^6.18.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -6,6 +6,10 @@ import { load } from "@langchain/core/load";
 import { tool } from "@langchain/core/tools";
 import { ChatOpenAI } from "../index.js";
 import { _convertOpenAIResponsesUsageToLangChainUsage } from "../../utils/output.js";
+import {
+  isReasoningModel,
+  _modelPrefersResponsesAPI,
+} from "../../utils/misc.js";
 import { NewTokenIndices } from "@langchain/core/callbacks/base";
 
 describe("ChatOpenAI", () => {
@@ -577,6 +581,88 @@ describe("ChatOpenAI", () => {
           url: "data:image/png;base64,image2",
         },
       ]);
+    });
+  });
+
+  describe("isReasoningModel", () => {
+    it("should return true for o-series models", () => {
+      expect(isReasoningModel("o1")).toBe(true);
+      expect(isReasoningModel("o1-mini")).toBe(true);
+      expect(isReasoningModel("o1-preview")).toBe(true);
+      expect(isReasoningModel("o3")).toBe(true);
+      expect(isReasoningModel("o3-mini")).toBe(true);
+      expect(isReasoningModel("o3-pro")).toBe(true);
+      expect(isReasoningModel("o4-mini")).toBe(true);
+    });
+
+    it("should return true for gpt-5 family models", () => {
+      expect(isReasoningModel("gpt-5")).toBe(true);
+      expect(isReasoningModel("gpt-5-mini")).toBe(true);
+      expect(isReasoningModel("gpt-5-nano")).toBe(true);
+      expect(isReasoningModel("gpt-5-pro")).toBe(true);
+      expect(isReasoningModel("gpt-5.1")).toBe(true);
+      expect(isReasoningModel("gpt-5.1-mini")).toBe(true);
+      expect(isReasoningModel("gpt-5.2")).toBe(true);
+      expect(isReasoningModel("gpt-5.2-pro")).toBe(true);
+    });
+
+    it("should return true for codex models based on gpt-5", () => {
+      expect(isReasoningModel("gpt-5-codex")).toBe(true);
+      expect(isReasoningModel("gpt-5.1-codex")).toBe(true);
+      expect(isReasoningModel("gpt-5.1-codex-max")).toBe(true);
+      expect(isReasoningModel("gpt-5.2-codex")).toBe(true);
+      expect(isReasoningModel("gpt-5.2-codex-max")).toBe(true);
+      expect(isReasoningModel("gpt-5.3-codex")).toBe(true);
+    });
+
+    it("should return false for gpt-5-chat models", () => {
+      expect(isReasoningModel("gpt-5-chat-latest")).toBe(false);
+    });
+
+    it("should return false for non-reasoning models", () => {
+      expect(isReasoningModel("gpt-4o")).toBe(false);
+      expect(isReasoningModel("gpt-4o-mini")).toBe(false);
+      expect(isReasoningModel("gpt-4.1")).toBe(false);
+      expect(isReasoningModel("gpt-4.1-mini")).toBe(false);
+      expect(isReasoningModel("gpt-3.5-turbo")).toBe(false);
+    });
+
+    it("should return false for codex-mini-latest", () => {
+      // codex-mini-latest doesn't start with gpt-5 or o-series
+      expect(isReasoningModel("codex-mini-latest")).toBe(false);
+    });
+
+    it("should return false for undefined/empty", () => {
+      expect(isReasoningModel(undefined)).toBe(false);
+      expect(isReasoningModel("")).toBe(false);
+    });
+  });
+
+  describe("_modelPrefersResponsesAPI", () => {
+    it("should return true for gpt-5.2-pro", () => {
+      expect(_modelPrefersResponsesAPI("gpt-5.2-pro")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.2-pro-2025-12-11")).toBe(true);
+    });
+
+    it("should return true for codex models", () => {
+      expect(_modelPrefersResponsesAPI("codex-mini-latest")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5-codex")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.1-codex")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.1-codex-max")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.2-codex")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.2-codex-max")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.3-codex")).toBe(true);
+    });
+
+    it("should return false for standard chat models", () => {
+      expect(_modelPrefersResponsesAPI("gpt-4o")).toBe(false);
+      expect(_modelPrefersResponsesAPI("gpt-4o-mini")).toBe(false);
+      expect(_modelPrefersResponsesAPI("gpt-4.1")).toBe(false);
+      expect(_modelPrefersResponsesAPI("gpt-5")).toBe(false);
+      expect(_modelPrefersResponsesAPI("gpt-5.1")).toBe(false);
+      expect(_modelPrefersResponsesAPI("gpt-5.2")).toBe(false);
+      expect(_modelPrefersResponsesAPI("o3")).toBe(false);
+      expect(_modelPrefersResponsesAPI("o4-mini")).toBe(false);
     });
   });
 

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -637,6 +637,8 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       "web_search_call",
       "file_search_call",
       "code_interpreter_call",
+      "shell_call",
+      "local_shell_call",
       "mcp_call",
       "mcp_list_tools",
       "mcp_approval_request",
@@ -1433,6 +1435,8 @@ export const convertMessagesToResponsesInput: Converter<
           "mcp_call",
           "code_interpreter_call",
           "image_generation_call",
+          "shell_call",
+          "local_shell_call",
         ];
 
         if (toolOutputs != null) {

--- a/libs/providers/langchain-openai/src/tools/imageGeneration.ts
+++ b/libs/providers/langchain-openai/src/tools/imageGeneration.ts
@@ -21,6 +21,15 @@ export interface ImageGenerationInputMask {
  */
 export interface ImageGenerationOptions {
   /**
+   * Whether to generate a new image or edit an existing image.
+   * - `generate`: Generate a new image from scratch
+   * - `edit`: Edit an existing image
+   * - `auto`: Let the model decide based on the input
+   * @default "auto"
+   */
+  action?: "generate" | "edit" | "auto";
+
+  /**
    * Background type for the generated image.
    * - `transparent`: Generate image with transparent background
    * - `opaque`: Generate image with opaque background
@@ -219,10 +228,10 @@ function convertInputImageMask(
 export function imageGeneration(options?: ImageGenerationOptions): ServerTool {
   return {
     type: "image_generation",
+    action: options?.action,
     background: options?.background,
     input_fidelity: options?.inputFidelity,
     input_image_mask: convertInputImageMask(options?.inputImageMask),
-    // @ts-expect-error - type issue with openai not supporting gpt-image-1.5
     model: options?.model,
     moderation: options?.moderation,
     output_compression: options?.outputCompression,

--- a/libs/providers/langchain-openai/src/tools/tests/imageGeneration.test.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/imageGeneration.test.ts
@@ -5,6 +5,7 @@ describe("OpenAI Image Generation Tool Tests", () => {
   it("imageGeneration creates valid tool definitions", () => {
     expect(
       tools.imageGeneration({
+        action: "edit",
         background: "opaque",
         inputFidelity: "high",
         inputImageMask: {
@@ -21,6 +22,7 @@ describe("OpenAI Image Generation Tool Tests", () => {
       })
     ).toMatchObject({
       type: "image_generation",
+      action: "edit",
       background: "opaque",
       input_fidelity: "high",
       input_image_mask: {
@@ -35,5 +37,18 @@ describe("OpenAI Image Generation Tool Tests", () => {
       quality: "medium",
       size: "1536x1024",
     });
+  });
+
+  it("imageGeneration omits action when not provided", () => {
+    const tool = tools.imageGeneration();
+    expect(tool).toMatchObject({ type: "image_generation" });
+    expect(tool).not.toHaveProperty("action", expect.anything());
+  });
+
+  it("imageGeneration supports all action values", () => {
+    for (const action of ["generate", "edit", "auto"] as const) {
+      const tool = tools.imageGeneration({ action });
+      expect(tool).toMatchObject({ type: "image_generation", action });
+    }
   });
 });

--- a/libs/providers/langchain-openai/src/utils/misc.ts
+++ b/libs/providers/langchain-openai/src/utils/misc.ts
@@ -85,5 +85,8 @@ export function messageToOpenAIRole(
 }
 
 export function _modelPrefersResponsesAPI(model: string): boolean {
-  return model.includes("gpt-5.2-pro");
+  if (model.includes("gpt-5.2-pro")) return true;
+  // Codex models are Responses API only
+  if (model.includes("codex")) return true;
+  return false;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1648,7 +1648,7 @@ importers:
         version: 1.0.20
       langsmith:
         specifier: '>=0.4.0 <1.0.0'
-        version: 0.4.0(@opentelemetry/api@1.9.0)(openai@6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))
+        version: 0.4.0(@opentelemetry/api@1.9.0)(openai@6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3072,8 +3072,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.20
       openai:
-        specifier: ^6.16.0
-        version: 6.16.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
+        specifier: ^6.18.0
+        version: 6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
       zod:
         specifier: ^3.25.76 || ^4
         version: 3.25.76
@@ -13474,9 +13474,6 @@ packages:
   magic-bytes.js@1.12.1:
     resolution: {integrity: sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==}
 
-  magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -14179,20 +14176,8 @@ packages:
       zod:
         optional: true
 
-  openai@6.16.0:
-    resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openai@6.17.0:
-    resolution: {integrity: sha512-NHRpPEUPzAvFOAFs9+9pC6+HCw/iWsYsKCMPXH5Kw7BpMxqd8g/A07/1o7Gx2TWtCnzevVRyKMRFqyiHyAlqcA==}
+  openai@6.18.0:
+    resolution: {integrity: sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -16444,10 +16429,6 @@ packages:
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
-    engines: {node: '>=18.12.0'}
-
-  unplugin@2.3.5:
-    resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
     engines: {node: '>=18.12.0'}
 
   unrun@0.2.19:
@@ -22469,7 +22450,7 @@ snapshots:
     dependencies:
       '@langchain/core': link:libs/langchain-core
       js-tiktoken: 1.0.21
-      openai: 6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.3.6)
+      openai: 6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - ws
@@ -30929,7 +30910,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       openai: 5.12.2(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
 
-  langsmith@0.4.0(@opentelemetry/api@1.9.0)(openai@6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)):
+  langsmith@0.4.0(@opentelemetry/api@1.9.0)(openai@6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -30939,7 +30920,7 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      openai: 6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
+      openai: 6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
 
   lazystream@1.0.1:
     dependencies:
@@ -31209,10 +31190,6 @@ snapshots:
   macos-release@3.4.0: {}
 
   magic-bytes.js@1.12.1: {}
-
-  magic-string@0.30.17:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -32038,18 +32015,12 @@ snapshots:
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       zod: 3.25.76
 
-  openai@6.16.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76):
+  openai@6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76):
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       zod: 3.25.76
 
-  openai@6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-      zod: 3.25.76
-    optional: true
-
-  openai@6.17.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.3.6):
+  openai@6.18.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       zod: 4.3.6
@@ -34605,8 +34576,8 @@ snapshots:
     dependencies:
       acorn: 8.15.0
       estree-walker: 3.0.3
-      magic-string: 0.30.17
-      unplugin: 2.3.5
+      magic-string: 0.30.21
+      unplugin: 2.3.11
 
   underscore@1.12.1: {}
 
@@ -34683,12 +34654,6 @@ snapshots:
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      acorn: 8.15.0
-      picomatch: 4.0.3
-      webpack-virtual-modules: 0.6.2
-
-  unplugin@2.3.5:
-    dependencies:
       acorn: 8.15.0
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2


### PR DESCRIPTION
Bumps the `openai` SDK dependency from `^6.16.0` to `^6.18.0` and adds support for new API features introduced in v6.17.0 and v6.18.0.

## Changes

- **Bump `openai` to `^6.18.0`** — picks up abort signal memory leak fix, new image generation options, and updated types
- **Image generation `action` field** — new `action` option (`generate`, `edit`, `auto`) on the image generation tool, and removed a `@ts-expect-error` now that `gpt-image-1.5` is in the SDK types
- **Auto-route codex models to Responses API** — `_modelPrefersResponsesAPI` now returns `true` for codex models (`codex-mini-latest`, `gpt-5-codex`, `gpt-5.1-codex`, etc.) which are Responses API-only
- **Shell/local shell streaming support** — added `shell_call` and `local_shell_call` to the streaming converter's recognized output types and to `fallthroughCallTypes` for multi-turn input reconstruction
- **Tests** — added unit tests for `isReasoningModel`, `_modelPrefersResponsesAPI`, and image generation `action` field
