### PR TITLE
feat: Add ContentBlock.Multimodal.Image support for ChatGoogleGenerativeAI

### DIFF
--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -333,9 +333,10 @@ function _convertLangChainContentToPart(
     } else if ("data" in content) {
       if (typeof content.data === "string") {
         source = content.data;
+        // eslint-disable-next-line no-instanceof/no-instanceof
       } else if (content.data instanceof Uint8Array) {
         const base64Data = Buffer.from(content.data).toString("base64");
-        let mimeType = content.mimeType;
+        const mimeType = content.mimeType;
 
         if (!mimeType) {
           throw new Error(


### PR DESCRIPTION
Added handling for `type: "image"` content blocks in `_convertLangChainContentToPart`

## Usage Example
``` typescript
import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
import { HumanMessage } from "@langchain/core/messages";
import type { ContentBlock } from "@langchain/core/messages";
import fs from "fs";

const model = new ChatGoogleGenerativeAI({
  model: "gemini-2.5-flash",
});

const imageBuffer = fs.readFileSync("image.jpg");
const base64Image = imageBuffer.toString("base64");
const dataUrl = `data:image/jpeg;base64,${base64Image}`;

const message = new HumanMessage({
  contentBlocks: [
    {
      type: "text",
      text: "What is in this image?",
    } satisfies ContentBlock.Text,
    {
      type: "image",
      url: dataUrl,
    } satisfies ContentBlock.Multimodal.Image & 
      ContentBlock.Multimodal.DataRecordUrl,
  ],
});

const response = await model.invoke([message]);
```

Fixes #9936 
