### PR TITLE
fix: add support for ContentBlock.Multimodal.Image and File

### DIFF
--- a/libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts
@@ -182,4 +182,111 @@ describe("ContentBlock.Multimodal support", () => {
       "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q=="
     );
   });
+
+  test("should handle ContentBlock.Multimodal.Image with URL (DataRecordUrl)", () => {
+    const humanMessage = new HumanMessage({
+      contentBlocks: [
+        {
+          type: "image",
+          url: "https://example.com/image.jpg",
+          mimeType: "image/jpeg",
+        } satisfies ContentBlock.Multimodal.Image &
+          ContentBlock.Multimodal.DataRecordUrl,
+      ],
+    });
+
+    const result = convertBaseMessagesToContent(
+      [humanMessage],
+      true,
+      undefined,
+      "gemini-1.5-flash"
+    );
+
+    expect(result).toBeDefined();
+    expect(result.length).toBe(1);
+    const part = result[0].parts[0];
+    expect(part.fileData).toBeDefined();
+    expect(part.fileData?.fileUri).toBe("https://example.com/image.jpg");
+    expect(part.fileData?.mimeType).toBe("image/jpeg");
+  });
+
+  test("should handle ContentBlock.Multimodal.Video with YouTube URL", () => {
+    const humanMessage = new HumanMessage({
+      contentBlocks: [
+        {
+          type: "video",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          mimeType: "video/mp4",
+        } satisfies ContentBlock.Multimodal.Video &
+          ContentBlock.Multimodal.DataRecordUrl,
+      ],
+    });
+
+    const result = convertBaseMessagesToContent(
+      [humanMessage],
+      true,
+      undefined,
+      "gemini-1.5-flash"
+    );
+
+    expect(result).toBeDefined();
+    const part = result[0].parts[0];
+    expect(part.fileData).toBeDefined();
+    expect(part.fileData?.fileUri).toBe(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+    expect(part.fileData?.mimeType).toBe("video/mp4");
+  });
+
+  test("should handle ContentBlock.Multimodal.Audio with URL", () => {
+    const humanMessage = new HumanMessage({
+      contentBlocks: [
+        {
+          type: "audio",
+          url: "https://example.com/audio.mp3",
+          mimeType: "audio/mpeg",
+        } satisfies ContentBlock.Multimodal.Audio &
+          ContentBlock.Multimodal.DataRecordUrl,
+      ],
+    });
+
+    const result = convertBaseMessagesToContent(
+      [humanMessage],
+      true,
+      undefined,
+      "gemini-1.5-flash"
+    );
+
+    expect(result).toBeDefined();
+    const part = result[0].parts[0];
+    expect(part.fileData).toBeDefined();
+    expect(part.fileData?.fileUri).toBe("https://example.com/audio.mp3");
+    expect(part.fileData?.mimeType).toBe("audio/mpeg");
+  });
+
+  test("should handle ContentBlock.Multimodal.File with URL (PDF)", () => {
+    const humanMessage = new HumanMessage({
+      contentBlocks: [
+        {
+          type: "file",
+          url: "https://example.com/document.pdf",
+          mimeType: "application/pdf",
+        } satisfies ContentBlock.Multimodal.File &
+          ContentBlock.Multimodal.DataRecordUrl,
+      ],
+    });
+
+    const result = convertBaseMessagesToContent(
+      [humanMessage],
+      true,
+      undefined,
+      "gemini-1.5-flash"
+    );
+
+    expect(result).toBeDefined();
+    const part = result[0].parts[0];
+    expect(part.fileData).toBeDefined();
+    expect(part.fileData?.fileUri).toBe("https://example.com/document.pdf");
+    expect(part.fileData?.mimeType).toBe("application/pdf");
+  });
 });


### PR DESCRIPTION
## Description
Adds support for `ContentBlock.Multimodal.Image` and `ContentBlock.Multimodal.File` types in the ChatGoogleGenerativeAI integration.

## Problem
The `_convertLangChainContentToPart` function was throwing "Unknown content type image/file" errors when users tried to pass images or files using the ContentBlock.Multimodal format, even though the documentation claimed image input was supported.

## Solution
Added handlers for `type === "image"` and `type === "file"` that convert them to Google GenAI's `inlineData` format with proper mimeType and base64 data.

## Changes
- Added image type handler in `src/utils/common.ts`
- Added file type handler in `src/utils/common.ts`
- Added unit tests in `src/tests/tool_call_conversion.test.ts`

## Testing
- All existing tests pass
- Added 3 new tests for multimodal content blocks
- Tested with both image and PDF file inputs

Fixes #9936 
