### PR TITLE
fix(openai): pass service_tier in Responses API request params

### DIFF
--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -153,6 +153,13 @@ export class ChatOpenAIResponses<
       params.reasoning = reasoning;
     }
 
+    if (this.service_tier !== undefined) {
+      params.service_tier = this.service_tier;
+    }
+    if (options?.service_tier !== undefined) {
+      params.service_tier = options.service_tier;
+    }
+
     return params;
   }
 

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -1,6 +1,39 @@
 import { describe, it, expect } from "vitest";
 import { ChatOpenAIResponses } from "../responses.js";
 
+describe("service_tier configuration", () => {
+  it("includes service_tier from constructor", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+      service_tier: "auto",
+    });
+
+    const params = model.invocationParams({});
+    expect(params.service_tier).toBe("auto");
+  });
+
+  it("omits service_tier when not set", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+    });
+
+    const params = model.invocationParams({});
+    expect(params.service_tier).toBeUndefined();
+  });
+
+  it("allows call options to override constructor service_tier", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+      service_tier: "auto",
+    });
+
+    const params = model.invocationParams({
+      service_tier: "flex",
+    });
+    expect(params.service_tier).toBe("flex");
+  });
+});
+
 describe("strict tool-calling configuration", () => {
   it("falls back to supportsStrictToolCalling when strict is undefined", () => {
     const model = new ChatOpenAIResponses({


### PR DESCRIPTION
Fixes #9897. The service_tier parameter was silently ignored when using useResponsesApi: true. Added forwarding in ChatOpenAIResponses.invocationParams() to match the completions path pattern.