### PR TITLE
fix(google): case insensitive reasoning effort values

### DIFF
--- a/.changeset/fix-google-reasoning-effort-case.md
+++ b/.changeset/fix-google-reasoning-effort-case.md
@@ -1,0 +1,13 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): accept both uppercase and lowercase reasoning effort/thinking level values
+
+Previously, passing uppercase values like `reasoningEffort: "HIGH"` or `"MEDIUM"` would silently
+fail to configure thinking, because `convertReasoningEffortToReasoningTokens` only matched lowercase
+strings. This caused the `thinkingConfig` to be omitted entirely from the API request.
+
+- Normalize effort input to lowercase in `convertReasoningEffortToReasoningTokens`
+- Extend `Gemini.ThinkingLevel` type to include lowercase variants for better DX
+- Add `LowercaseLiteral` utility type to derive lowercase members from the auto-generated API types

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1317,6 +1317,30 @@ describe.each(thinkingModelInfo)(
       // const textStepsText: string = textSteps.reduce((acc: string, val: ContentBlock.Text) => acc + val.text, "");
       // expect(textStepsText).toEqual(result.text);
     });
+
+    test("thinking - invoke with uppercase reasoningEffort", async () => {
+      const llm = newChatGoogle({
+        reasoningEffort: "HIGH",
+      });
+      const result = await llm.invoke("Why is the sky blue?");
+      const reasoningSteps = result.contentBlocks.filter(
+        (b) => b.type === "reasoning"
+      );
+      const textSteps = result.contentBlocks.filter((b) => b.type === "text");
+      expect(reasoningSteps?.length).toBeGreaterThan(0);
+      expect(textSteps?.length).toBeGreaterThan(0);
+    });
+
+    test("thinking - invoke with uppercase thinkingLevel", async () => {
+      const llm = newChatGoogle({
+        thinkingLevel: "LOW",
+      });
+      const result = await llm.invoke("What is 1 + 1?");
+      const hasThoughtSignature = result.contentBlocks.some(
+        (b) => "thoughtSignature" in b
+      );
+      expect(hasThoughtSignature).toBe(true);
+    });
   }
 );
 

--- a/libs/providers/langchain-google/src/chat_models/types.ts
+++ b/libs/providers/langchain-google/src/chat_models/types.ts
@@ -3,7 +3,7 @@
 import type { InteropZodType } from "@langchain/core/utils/types";
 import type { BindToolsInput } from "@langchain/core/language_models/chat_models";
 import type { Gemini as GeminiBase } from "./api-types.js";
-import type { Prettify } from "../utils/misc.js";
+import type { LowercaseLiteral, Prettify } from "../utils/misc.js";
 
 export interface ChatGoogleFields {
   /**
@@ -239,9 +239,12 @@ declare module "./api-types.js" {
     /**
      * The level of "thinking" or reasoning configured for the model.
      *
-     * Corresponds to GeminiBase.ThinkingConfig["thinkingLevel"].
+     * Extends GeminiBase.ThinkingConfig["thinkingLevel"] to also accept
+     * lowercase variants (e.g. "high" in addition to "HIGH").
      */
-    export type ThinkingLevel = GeminiBase.ThinkingConfig["thinkingLevel"];
+    export type ThinkingLevel =
+      | GeminiBase.ThinkingConfig["thinkingLevel"]
+      | LowercaseLiteral<GeminiBase.ThinkingConfig["thinkingLevel"]>;
 
     /**
      * The role of a content message. The spec types this as `string`, but

--- a/libs/providers/langchain-google/src/converters/params.ts
+++ b/libs/providers/langchain-google/src/converters/params.ts
@@ -32,8 +32,8 @@ import type { Gemini } from "../chat_models/api-types.js";
  * @param {string | undefined} modelName
  *   The Gemini model name (e.g., "gemini-2.5-flash"). Used to determine token range constraints.
  * @param {string | undefined} effort
- *   The reasoning effort level: one of "none", "minimal", "low", "medium", "high".
- *   If undefined, the function returns undefined.
+ *   The reasoning effort level: one of "none", "minimal", "low", "medium", "high"
+ *   (case-insensitive). If undefined, the function returns undefined.
  * @returns {number | undefined}
  *   The corresponding token count for the given effort and model. Returns undefined if
  *   the effort is not recognized or not provided.
@@ -59,7 +59,8 @@ export function convertReasoningEffortToReasoningTokens(
     ? 24 * 1024
     : 32 * 1024;
 
-  switch (effort) {
+  const normalizedEffort = effort.toLowerCase();
+  switch (normalizedEffort) {
     case "none":
     case "minimal":
       return minTokens;

--- a/libs/providers/langchain-google/src/utils/misc.ts
+++ b/libs/providers/langchain-google/src/utils/misc.ts
@@ -14,3 +14,13 @@ export const iife = <T>(fn: () => T): T => fn();
 export type Prettify<T> = T extends object
   ? { [K in keyof T]: Prettify<T[K]> }
   : T;
+
+/**
+ * Distributes over a string union and applies Lowercase only to
+ * string-literal members, filtering out wide `string` / `string & {}`.
+ */
+export type LowercaseLiteral<T> = T extends string
+  ? string extends T
+    ? never
+    : Lowercase<T>
+  : never;


### PR DESCRIPTION
## Summary

Fixes a bug where passing uppercase `reasoningEffort` or `thinkingLevel` values (e.g. `"HIGH"`, `"MEDIUM"`) to `ChatGoogle` would silently fail to configure thinking. The `thinkingConfig` was omitted entirely from the API request because `convertReasoningEffortToReasoningTokens` only matched lowercase strings in its switch statement, while the types and documentation suggested uppercase values.

## Changes

### Bug fix: case-insensitive reasoning effort matching (`params.ts`)

`convertReasoningEffortToReasoningTokens` now normalizes the input to lowercase before the switch statement. This ensures `"HIGH"`, `"High"`, and `"high"` all resolve to the correct token budget.

### Type improvement: accept both cases in `ThinkingLevel` (`types.ts`, `misc.ts`)

- Added a `LowercaseLiteral<T>` utility type that distributes over a string union and applies `Lowercase` only to string-literal members, filtering out wide `string & {}`.
- Extended `Gemini.ThinkingLevel` to include lowercase variants derived from the auto-generated API types, so users get autocomplete for both `"HIGH"` and `"high"`.
- The auto-generated `api-types.ts` is **not** modified.

### Integration tests (`index.int.test.ts`)

Added two new tests in the thinking model suite:
- `"thinking - invoke with uppercase reasoningEffort"` — verifies `reasoningEffort: "HIGH"` produces reasoning + text content blocks
- `"thinking - invoke with uppercase thinkingLevel"` — verifies `thinkingLevel: "LOW"` produces thought signatures
