### PR TITLE
fix(google-genai): normalize Gemini tool schemas before API call

### DIFF
--- a/libs/providers/langchain-google-genai/src/tests/tool_schema_normalization.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/tool_schema_normalization.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "@jest/globals";
+import { convertToolsToGenAI } from "../utils/tools.js";
+import { removeAdditionalProperties } from "../utils/zod_to_genai_parameters.js";
+
+type NormalizedTool = {
+  functionDeclarations?: Array<{
+    parameters?: {
+      properties?: Record<
+        string,
+        {
+          type?: unknown;
+          nullable?: unknown;
+        }
+      >;
+    };
+  }>;
+};
+
+describe("Gemini tool schema normalization", () => {
+  test("converts type array nullable schema to type + nullable", () => {
+    const parsed = removeAdditionalProperties({
+      type: "object",
+      properties: {
+        value: {
+          type: ["string", "null"],
+        },
+      },
+    });
+
+    expect(parsed.properties?.value?.type).toBe("string");
+    expect(parsed.properties?.value?.nullable).toBe(true);
+  });
+
+  test("converts anyOf nullable schema to type + nullable", () => {
+    const parsed = removeAdditionalProperties({
+      anyOf: [{ type: "number", description: "A number value" }, { type: "null" }],
+    });
+
+    expect(parsed.type).toBe("number");
+    expect(parsed.nullable).toBe(true);
+    expect("anyOf" in parsed).toBe(false);
+  });
+
+  test("throws for unsupported non-null union schemas", () => {
+    expect(() =>
+      removeAdditionalProperties({
+        anyOf: [{ type: "number" }, { type: "string" }],
+      })
+    ).toThrow(/Gemini cannot handle union types/);
+  });
+
+  test("normalizes direct functionDeclarations tool parameters", () => {
+    const inputTool = {
+      functionDeclarations: [
+        {
+          name: "lookup_weather",
+          description: "Get weather by city",
+          parameters: {
+            type: "object",
+            properties: {
+              city: {
+                type: ["string", "null"],
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof convertToolsToGenAI>[0][number];
+
+    const { tools } = convertToolsToGenAI([
+      inputTool,
+    ]);
+
+    const normalizedTool = tools[0] as NormalizedTool;
+    const citySchema =
+      normalizedTool.functionDeclarations?.[0]?.parameters?.properties?.city;
+    expect(citySchema?.type).toBe("string");
+    expect(citySchema?.nullable).toBe(true);
+  });
+});

--- a/libs/providers/langchain-google-genai/src/utils/tools.ts
+++ b/libs/providers/langchain-google-genai/src/utils/tools.ts
@@ -58,7 +58,7 @@ function processTools(tools: GoogleGenerativeAIToolType[]): GenerativeAITool[] {
         );
       }
     } else {
-      genAITools.push(tool as GenerativeAITool);
+      genAITools.push(normalizeDirectGenAITool(tool as GenerativeAITool));
     }
   });
 
@@ -95,6 +95,29 @@ function processTools(tools: GoogleGenerativeAIToolType[]): GenerativeAITool[] {
         ]
       : []),
   ];
+}
+
+function normalizeDirectGenAITool(tool: GenerativeAITool): GenerativeAITool {
+  if ("functionDeclarations" in tool && Array.isArray(tool.functionDeclarations)) {
+    return {
+      ...tool,
+      functionDeclarations: tool.functionDeclarations.map(
+        (declaration): FunctionDeclaration => {
+          if (!declaration.parameters) {
+            return declaration;
+          }
+          return {
+            ...declaration,
+            parameters: removeAdditionalProperties(
+              declaration.parameters as Record<string, unknown>
+            ) as FunctionDeclarationSchema,
+          };
+        }
+      ),
+    };
+  }
+
+  return tool;
 }
 
 function convertOpenAIToolToGenAI(


### PR DESCRIPTION
## Summary

This PR fixes Gemini tool schema normalization gaps in `@langchain/google-genai`.

### Root cause
`removeAdditionalProperties()` stripped unsupported keys (like `additionalProperties`) but did not normalize JSON Schema unions that Gemini rejects at runtime, such as:

- `type: ["string", "null"]`
- nullable unions encoded via `anyOf` / `oneOf`

Additionally, when tools were provided as direct `functionDeclarations`, parameters could bypass normalization.

### What changed
- Add type-array normalization (`[T, "null"] -> type: T + nullable: true`) in `zod_to_genai_parameters.ts`
- Add nullable `anyOf` / `oneOf` normalization and reject unsupported unions with explicit errors
- Normalize `functionDeclarations[].parameters` for direct Gemini tool inputs in `utils/tools.ts`
- Add unit tests covering:
  - type-array nullable normalization
  - nullable `anyOf` normalization
  - unsupported union rejection
  - direct `functionDeclarations` normalization

### Why this matters
This prevents Gemini runtime payload errors for tool schemas that are valid in broader JSON Schema ecosystems but need Gemini-specific normalization before API submission.

## Validation
- `pnpm --filter @langchain/core build`
- `pnpm --filter @langchain/google-genai lint:eslint`
- `pnpm --filter @langchain/google-genai build:compile`
- `pnpm --filter @langchain/google-genai test:single src/tests/tool_schema_normalization.test.ts`

## Context
- Related downstream issue: https://github.com/n8n-io/n8n/issues/15553
