### PR TITLE
feat(openai): add WebSocket transport support for Responses API

### DIFF
--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "js-tiktoken": "^1.0.12",
     "openai": "^6.22.0",
+    "ws": "^8.19.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {
@@ -49,6 +50,7 @@
     "@langchain/tsconfig": "workspace:*",
     "@tsconfig/recommended": "^1.0.10",
     "@types/node": "^25.2.3",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.4",
     "dotenv": "^17.2.1",
     "dpdm": "^3.14.0",

--- a/libs/providers/langchain-openai/src/chat_models/tests/websocket.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/websocket.int.test.ts
@@ -1,0 +1,101 @@
+import { z } from "zod/v3";
+import { it, expect, describe, afterEach } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+
+import { ChatOpenAI } from "../index.js";
+
+describe("ChatOpenAI WebSocket integration tests", () => {
+  let model: ChatOpenAI;
+
+  afterEach(() => {
+    model?.closeWebSocket();
+  });
+
+  it("Can invoke via WebSocket", async () => {
+    model = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      maxTokens: 50,
+      useWebSocket: true,
+      useResponsesApi: true,
+    });
+
+    const response = await model.invoke([
+      new HumanMessage("Say hello in one word."),
+    ]);
+
+    expect(response.content).toBeTruthy();
+    expect(typeof response.content === "string").toBe(true);
+  });
+
+  it("Can stream via WebSocket", async () => {
+    model = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      maxTokens: 50,
+      useWebSocket: true,
+      useResponsesApi: true,
+      streaming: true,
+    });
+
+    const stream = await model.stream([new HumanMessage("Count to 5.")]);
+
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      if (typeof chunk.content === "string" && chunk.content) {
+        chunks.push(chunk.content);
+      }
+    }
+
+    expect(chunks.length).toBeGreaterThan(0);
+    const fullResponse = chunks.join("");
+    expect(fullResponse).toBeTruthy();
+  });
+
+  it("Can make multiple requests over the same WebSocket", async () => {
+    model = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      maxTokens: 20,
+      useWebSocket: true,
+      useResponsesApi: true,
+    });
+
+    const response1 = await model.invoke([new HumanMessage("Say 'first'.")]);
+    expect(response1.text).toBe("first");
+
+    const response2 = await model.invoke([new HumanMessage("Say 'second'.")]);
+    expect(response2.text).toBe("second");
+  });
+
+  it("Can use tool calling via WebSocket", async () => {
+    model = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      maxTokens: 200,
+      useWebSocket: true,
+      useResponsesApi: true,
+    });
+
+    const modelWithTools = model.bindTools([
+      tool(
+        async (input: { location: string }) => {
+          return `The weather in ${input.location} is sunny, 72°F.`;
+        },
+        {
+          name: "get_weather",
+          description: "Get the weather for a location",
+          schema: z.object({
+            location: z.string(),
+          }),
+        }
+      ),
+    ]);
+
+    const response = await modelWithTools.invoke([
+      new HumanMessage("What's the weather in San Francisco?"),
+    ]);
+
+    expect(response.tool_calls).toBeDefined();
+    expect(response.tool_calls!.length).toBeGreaterThan(0);
+    expect(response.tool_calls![0].name).toBe("get_weather");
+    expect(response.text).toContain("72");
+  });
+});

--- a/libs/providers/langchain-openai/src/chat_models/tests/websocket.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/websocket.test.ts
@@ -1,0 +1,196 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { it, expect, describe, beforeEach, afterEach } from "vitest";
+import { ChatOpenAI } from "../index.js";
+import { OpenAIWebSocketManager } from "../../utils/websocket.js";
+
+describe("ChatOpenAI WebSocket mode", () => {
+  let oldLangChainTracingValue: string | undefined;
+
+  beforeEach(() => {
+    oldLangChainTracingValue = process.env.LANGCHAIN_TRACING_V2;
+    process.env.LANGCHAIN_TRACING_V2 = "false";
+  });
+
+  afterEach(() => {
+    if (oldLangChainTracingValue !== undefined) {
+      process.env.LANGCHAIN_TRACING_V2 = oldLangChainTracingValue;
+    } else {
+      delete process.env.LANGCHAIN_TRACING_V2;
+    }
+  });
+
+  it("useWebSocket forces useResponsesApi to true", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    expect(model.useWebSocket).toBe(true);
+    expect(model.useResponsesApi).toBe(true);
+  });
+
+  it("useWebSocket defaults to false", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+    });
+    expect(model.useWebSocket).toBe(false);
+  });
+
+  it("useWebSocket is included in serialized keys", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    const serialized = JSON.stringify(model);
+    expect(serialized).toContain("use_web_socket");
+  });
+
+  it("_useResponseApi returns true when useWebSocket is set", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    expect((model as any)._useResponsesApi({})).toBe(true);
+  });
+
+  it("closeWebSocket cleans up the manager", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    const manager = (model as any)._getOrCreateWsManager();
+    expect(manager).toBeInstanceOf(OpenAIWebSocketManager);
+    expect((model as any).wsManager).toBeDefined();
+
+    model.closeWebSocket();
+    expect((model as any).wsManager).toBeNull();
+  });
+
+  it("_getOrCreateWsManager creates a manager with correct config", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-api-key",
+      configuration: { organization: "test-org" },
+      useWebSocket: true,
+    });
+    const manager = (model as any)._getOrCreateWsManager();
+    expect(manager).toBeInstanceOf(OpenAIWebSocketManager);
+    expect((manager as any).apiKey).toBe("test-api-key");
+    expect((manager as any).organization).toBe("test-org");
+    model.closeWebSocket();
+  });
+
+  it("_getOrCreateWsManager reuses existing manager", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    const manager1 = (model as any)._getOrCreateWsManager();
+    const manager2 = (model as any)._getOrCreateWsManager();
+    expect(manager1).toBe(manager2);
+    model.closeWebSocket();
+  });
+});
+
+describe("OpenAIWebSocketManager", () => {
+  it("constructs with default baseURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+    });
+    expect((manager as any).apiKey).toBe("test-key");
+    expect((manager as any).baseURL).toBe("wss://api.openai.com/v1/responses");
+  });
+
+  it("constructs with custom baseURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "https://my-proxy.example.com/v1",
+    });
+    expect((manager as any).baseURL).toBe("https://my-proxy.example.com/v1");
+  });
+
+  it("converts HTTP URLs to WSS in getWebSocketURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "https://api.openai.com/v1",
+    });
+    const url = (manager as any).getWebSocketURL();
+    expect(url).toBe("wss://api.openai.com/v1/responses");
+  });
+
+  it("converts http:// URLs to ws:// in getWebSocketURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "http://localhost:8080/v1",
+    });
+    const url = (manager as any).getWebSocketURL();
+    expect(url).toBe("ws://localhost:8080/v1/responses");
+  });
+
+  it("preserves wss:// URLs in getWebSocketURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "wss://api.openai.com/v1/responses",
+    });
+    const url = (manager as any).getWebSocketURL();
+    expect(url).toBe("wss://api.openai.com/v1/responses");
+  });
+
+  it("appends /responses if not already present", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "wss://api.openai.com/v1",
+    });
+    const url = (manager as any).getWebSocketURL();
+    expect(url).toBe("wss://api.openai.com/v1/responses");
+  });
+
+  it("handles trailing slash in baseURL", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+      baseURL: "wss://api.openai.com/v1/",
+    });
+    const url = (manager as any).getWebSocketURL();
+    expect(url).toBe("wss://api.openai.com/v1/responses");
+  });
+
+  it("isConnected returns false initially", () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+    });
+    expect(manager.isConnected).toBe(false);
+  });
+
+  it("throws after close", async () => {
+    const manager = new OpenAIWebSocketManager({
+      apiKey: "test-key",
+    });
+    manager.close();
+    await expect(async () => {
+      for await (const _ of manager.stream({
+        model: "gpt-4o",
+        input: [],
+        stream: true,
+      })) {
+        // should not reach here
+      }
+    }).rejects.toThrow("WebSocket manager is closed");
+  });
+});
+
+describe("ChatOpenAI WebSocket serialization", () => {
+  it("serializes useWebSocket when true", () => {
+    const model = new ChatOpenAI({
+      model: "gpt-4o",
+      apiKey: "test-key",
+      useWebSocket: true,
+    });
+    const serialized = JSON.parse(JSON.stringify(model));
+    expect(serialized.kwargs).toHaveProperty("use_web_socket", true);
+  });
+});

--- a/libs/providers/langchain-openai/src/index.ts
+++ b/libs/providers/langchain-openai/src/index.ts
@@ -33,6 +33,8 @@ export * from "./embeddings.js";
 export * from "./types.js";
 export * from "./utils/client.js";
 export * from "./utils/azure.js";
+export { OpenAIWebSocketManager } from "./utils/websocket.js";
+export type { OpenAIWebSocketManagerOptions, WebSocketRequest } from "./utils/websocket.js";
 export * from "./tools/index.js";
 export { customTool } from "./tools/custom.js";
 export { convertPromptToOpenAI } from "./utils/prompts.js";

--- a/libs/providers/langchain-openai/src/types.ts
+++ b/libs/providers/langchain-openai/src/types.ts
@@ -221,6 +221,18 @@ export interface OpenAIChatInput extends OpenAIBaseInput {
    * Used by OpenAI to set cache retention time
    */
   promptCacheRetention?: OpenAICacheRetentionParam;
+
+  /**
+   * Whether to use WebSocket transport for the Responses API. When enabled, a persistent
+   * WebSocket connection is used instead of HTTP requests, which can reduce latency for
+   * multiple sequential requests.
+   *
+   * Requires `useResponsesApi` to be `true` (or will automatically enable it).
+   *
+   * @default false
+   * @see https://developers.openai.com/api/docs/guides/websocket-mode
+   */
+  useWebSocket?: boolean;
 }
 
 export interface AzureOpenAIInput {

--- a/libs/providers/langchain-openai/src/utils/websocket.ts
+++ b/libs/providers/langchain-openai/src/utils/websocket.ts
@@ -1,0 +1,258 @@
+import WebSocket from "ws";
+
+export interface OpenAIWebSocketManagerOptions {
+  apiKey: string;
+  baseURL?: string;
+  organization?: string;
+}
+
+export interface WebSocketRequest {
+  model: string;
+  input: unknown;
+  stream: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Manages a persistent WebSocket connection to the OpenAI Responses API.
+ *
+ * The WebSocket mode allows reusing a single connection for multiple requests,
+ * reducing latency compared to establishing a new HTTP connection each time.
+ *
+ * @see https://developers.openai.com/api/docs/guides/websocket-mode
+ */
+export class OpenAIWebSocketManager {
+  private ws: WebSocket | null = null;
+
+  private connectPromise: Promise<WebSocket> | null = null;
+
+  private apiKey: string;
+
+  private baseURL: string;
+
+  private organization?: string;
+
+  private closed = false;
+
+  constructor(options: OpenAIWebSocketManagerOptions) {
+    this.apiKey = options.apiKey;
+    this.baseURL = options.baseURL ?? "wss://api.openai.com/v1/responses";
+    this.organization = options.organization;
+  }
+
+  /**
+   * Derive the WebSocket URL from a base HTTP or WebSocket URL.
+   * Converts `https://` to `wss://` and `http://` to `ws://` if needed,
+   * and ensures the path ends with `/responses`.
+   */
+  private getWebSocketURL(): string {
+    let url = this.baseURL;
+
+    if (url.startsWith("https://")) {
+      url = `wss://${url.slice(8)}`;
+    } else if (url.startsWith("http://")) {
+      url = `ws://${url.slice(7)}`;
+    }
+
+    if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
+      url = `wss://${url}`;
+    }
+
+    if (!url.endsWith("/responses")) {
+      if (url.endsWith("/")) {
+        url += "responses";
+      } else {
+        url += "/responses";
+      }
+    }
+
+    return url;
+  }
+
+  private async connect(): Promise<WebSocket> {
+    if (this.closed) {
+      throw new Error("WebSocket manager is closed");
+    }
+
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      return this.ws;
+    }
+
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      const url = this.getWebSocketURL();
+
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${this.apiKey}`,
+        "OpenAI-Beta": "responses.websocket=v1",
+      };
+
+      if (this.organization) {
+        headers["OpenAI-Organization"] = this.organization;
+      }
+
+      const ws = new WebSocket(url, { headers });
+
+      ws.on("open", () => {
+        this.ws = ws;
+        this.connectPromise = null;
+        resolve(ws);
+      });
+
+      ws.on("error", (err) => {
+        this.connectPromise = null;
+        this.ws = null;
+        reject(err);
+      });
+
+      ws.on("close", () => {
+        this.ws = null;
+        this.connectPromise = null;
+      });
+    });
+
+    return this.connectPromise;
+  }
+
+  /**
+   * Send a request over the WebSocket and return an async iterable of streaming events.
+   *
+   * Each streamed event is a parsed JSON object matching the Responses API streaming event schema.
+   */
+  async *stream(
+    request: WebSocketRequest,
+    signal?: AbortSignal
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): AsyncGenerator<any> {
+    const ws = await this.connect();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const eventQueue: any[] = [];
+    let resolveNext: (() => void) | null = null;
+    let done = false;
+    let error: Error | null = null;
+
+    const onMessage = (data: WebSocket.Data) => {
+      try {
+        const event = JSON.parse(data.toString());
+        eventQueue.push(event);
+        resolveNext?.();
+      } catch (e) {
+        // eslint-disable-next-line no-instanceof/no-instanceof
+        error = e instanceof Error ? e : new Error(String(e));
+        resolveNext?.();
+      }
+    };
+
+    const onError = (err: Error) => {
+      error = err;
+      done = true;
+      resolveNext?.();
+    };
+
+    const onClose = () => {
+      done = true;
+      resolveNext?.();
+    };
+
+    const onAbort = () => {
+      error = new Error("AbortError");
+      error.name = "AbortError";
+      done = true;
+      resolveNext?.();
+    };
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+    signal?.addEventListener("abort", onAbort);
+
+    const waitForNext = () =>
+      new Promise<void>((resolve) => {
+        resolveNext = resolve;
+      });
+
+    try {
+      ws.send(JSON.stringify(request));
+
+      while (!done || eventQueue.length > 0) {
+        if (eventQueue.length > 0) {
+          const event = eventQueue.shift()!;
+
+          if (event.type === "error") {
+            throw new Error(
+              event.error?.message ?? "Unknown WebSocket error from API"
+            );
+          }
+
+          yield event;
+
+          if (
+            event.type === "response.completed" ||
+            event.type === "response.failed" ||
+            event.type === "response.incomplete"
+          ) {
+            break;
+          }
+        } else if (!done) {
+          await waitForNext();
+          resolveNext = null;
+        }
+      }
+
+      if (error) {
+        throw error;
+      }
+    } finally {
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+      signal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  /**
+   * Send a request over the WebSocket and wait for the full response (non-streaming).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async invoke(request: WebSocketRequest, signal?: AbortSignal): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let result: any = null;
+    for await (const event of this.stream(
+      { ...request, stream: true },
+      signal
+    )) {
+      if (
+        event.type === "response.completed" ||
+        event.type === "response.failed" ||
+        event.type === "response.incomplete"
+      ) {
+        result = event.response;
+        break;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Close the WebSocket connection and prevent further usage.
+   */
+  close() {
+    this.closed = true;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connectPromise = null;
+  }
+
+  /**
+   * Whether the WebSocket connection is currently open.
+   */
+  get isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3125,6 +3125,9 @@ importers:
       openai:
         specifier: ^6.22.0
         version: 6.22.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0(bufferutil@4.1.0)
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
@@ -3153,6 +3156,9 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -23663,7 +23669,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.10.12
+      '@types/node': 25.3.0
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## Summary

- Add WebSocket transport support for the OpenAI Responses API via a new `useWebSocket` option on `ChatOpenAI`, enabling persistent connections that reduce latency for streaming and multi-turn conversations.
- Introduce `OpenAIWebSocketManager` utility class that handles connection lifecycle, streaming events, and non-streaming invocations over a single WebSocket.

Would have loved to just use native WebSocket primitive but we still support Node.js v20 and up which wouldn't allow us.

## Usage

```ts
import { ChatOpenAI } from '@langchain/openai';
import { HumanMessage } from '@langchain/core/messages';

const model = new ChatOpenAI({
  model: 'gpt-4o',
  useWebSocket: true,
});

// Non-streaming
const response = await model.invoke([new HumanMessage('Hello')]);

// Streaming
for await (const chunk of await model.stream([new HumanMessage('Count to 5')])) {
  console.log(chunk.content);
}

// Cleanup when done
model.closeWebSocket();
```