### PR TITLE
fix(openai): emit handleLLMNewToken for usage chunk in Completions API streaming

### DIFF
--- a/.changeset/fix-completions-usage-metadata-callback.md
+++ b/.changeset/fix-completions-usage-metadata-callback.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): emit handleLLMNewToken callback for usage chunk in Completions API streaming
+
+The final usage chunk in `_streamResponseChunks` was only yielded via the async generator but did not call `runManager.handleLLMNewToken()`. This meant callback-based consumers (e.g. LangGraph's `StreamMessagesHandler`) never received the `usage_metadata` chunk. Added the missing `handleLLMNewToken` call to match the behavior of the main streaming loop.

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -425,6 +425,14 @@ export class ChatOpenAICompletions<
         text: "",
       });
       yield generationChunk;
+      await runManager?.handleLLMNewToken(
+        generationChunk.text ?? "",
+        { prompt: 0, completion: 0 },
+        undefined,
+        undefined,
+        undefined,
+        { chunk: generationChunk }
+      );
     }
     if (options.signal?.aborted) {
       throw new Error("AbortError");

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatOpenAICompletions } from "../completions.js";
 
 describe("ChatOpenAICompletions constructor", () => {
@@ -8,5 +10,104 @@ describe("ChatOpenAICompletions constructor", () => {
     });
     expect(model.model).toBe("gpt-4o-mini");
     expect(model.temperature).toBe(0.1);
+  });
+});
+
+describe("ChatOpenAICompletions streaming usage_metadata callback", () => {
+  it("should call handleLLMNewToken for the usage chunk", async () => {
+    const model = new ChatOpenAICompletions({
+      model: "gpt-4o-mini",
+      apiKey: "test-key",
+      streaming: true,
+      streamUsage: true,
+    });
+
+    // Mock completionWithRetry to return a fake async iterable
+    // that simulates: one content chunk, then a usage-only chunk
+    const fakeStream = (async function* () {
+      // Content chunk
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" as const, content: "Hello" },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: null,
+        model: "gpt-4o-mini",
+        service_tier: null,
+      };
+      // Final chunk with finish_reason
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { content: "" },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: "fp_abc123",
+        model: "gpt-4o-mini",
+        service_tier: null,
+      };
+      // Usage-only chunk (no choices)
+      yield {
+        choices: [],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+          prompt_tokens_details: null,
+          completion_tokens_details: null,
+        },
+        system_fingerprint: null,
+        model: "gpt-4o-mini",
+        service_tier: null,
+      };
+    })();
+
+    vi.spyOn(model, "completionWithRetry").mockResolvedValue(
+      fakeStream as ReturnType<typeof model.completionWithRetry>
+    );
+
+    // Create a mock runManager
+    const handleLLMNewToken = vi.fn();
+    const runManager = {
+      handleLLMNewToken,
+    } as unknown as CallbackManagerForLLMRun;
+
+    const chunks = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage("test")],
+      {},
+      runManager
+    )) {
+      chunks.push(chunk);
+    }
+
+    // Should have 3 chunks: content, finish, and usage
+    expect(chunks.length).toBe(3);
+
+    // The last chunk should have usage_metadata
+    const usageChunk = chunks[chunks.length - 1];
+    expect(usageChunk.message.usage_metadata).toBeDefined();
+    expect(usageChunk.message.usage_metadata?.input_tokens).toBe(10);
+    expect(usageChunk.message.usage_metadata?.output_tokens).toBe(5);
+    expect(usageChunk.message.usage_metadata?.total_tokens).toBe(15);
+
+    // handleLLMNewToken should have been called for EVERY chunk,
+    // including the usage chunk (this is the bug fix)
+    expect(handleLLMNewToken).toHaveBeenCalledTimes(3);
+
+    // Verify the last call includes the usage chunk
+    const lastCall = handleLLMNewToken.mock.calls[2];
+    const lastCallFields = lastCall[5]; // 6th argument is the fields object
+    expect(lastCallFields.chunk.message.usage_metadata).toBeDefined();
+    expect(lastCallFields.chunk.message.usage_metadata.input_tokens).toBe(10);
   });
 });


### PR DESCRIPTION
The final usage chunk in `_streamResponseChunks` (Completions API path) was only `yield`ed via the async generator but did not call `runManager.handleLLMNewToken()`. This meant callback-based consumers (e.g. LangGraph's `StreamMessagesHandler`) never received the `usage_metadata` chunk — it was silently dropped.

This is the Completions API equivalent of the Responses API bug fixed in #9733 / #9737. That fix added the missing `handleLLMNewToken` call in the Responses API path, but the same pattern in the Completions API path was missed.

### Changes

- **`completions.ts`**: Added the missing `await runManager?.handleLLMNewToken(...)` call after the usage chunk `yield` (one line, matching the pattern used in the main streaming loop)
- **`completions.test.ts`**: Added unit test that mocks a 3-chunk stream (content → finish → usage) and verifies `handleLLMNewToken` is called for all 3 chunks, including the usage chunk with `usage_metadata`

### Tests

- `pnpm --filter @langchain/openai test` — passes
- Test **fails without the fix** (`expected 3 calls, got 2`) and **passes with it**

Fixes #10142