### PR TITLE
feat(aws): add video and audio content block support for ChatBedrockConverse input

### DIFF
--- a/.changeset/bedrock-video-audio-input.md
+++ b/.changeset/bedrock-video-audio-input.md
@@ -1,0 +1,9 @@
+---
+"@langchain/aws": minor
+---
+
+feat(aws): Add video and audio content block support for ChatBedrockConverse input messages
+
+- Convert standard multimodal video/audio blocks (base64, Uint8Array, data URL, S3 URI) to Bedrock's native format
+- Pass through native Bedrock video/audio blocks unchanged
+- Adds support for all Bedrock video formats (flv, mkv, mov, mp4, mpeg, mpg, three_gp, webm, wmv) and audio formats (aac, flac, m4a, mka, mkv, mp3, mp4, mpeg, mpga, ogg, opus, pcm, wav, webm, x-aac)

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -623,6 +623,188 @@ test("Streaming supports empty string chunks", async () => {
   expect(finalChunk.content).toBe("Hello world!");
 });
 
+describe("video content block conversion", () => {
+  test("converts multimodal video block with base64 data", () => {
+    const videoData = btoa("fake-video-bytes");
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: "text", text: "Describe this video" },
+          {
+            type: "video",
+            mimeType: "video/mp4",
+            data: videoData,
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(1);
+    const content = result.converseMessages[0].content!;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ text: "Describe this video" });
+    expect(content[1]).toHaveProperty("video");
+    expect(content[1].video?.format).toBe("mp4");
+    expect(content[1].video?.source?.bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test("converts multimodal video block with Uint8Array data", () => {
+    const videoBytes = new Uint8Array([1, 2, 3, 4]);
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "video",
+            mimeType: "video/webm",
+            data: videoBytes,
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("video");
+    expect(content[0].video?.format).toBe("webm");
+    expect(content[0].video?.source?.bytes).toBe(videoBytes);
+  });
+
+  test("passes through native Bedrock video block", () => {
+    const videoSource = {
+      bytes: new Uint8Array([1, 2, 3]),
+    };
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "video",
+            video: {
+              format: "mp4",
+              source: videoSource,
+            },
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("video");
+    expect(content[0].video?.format).toBe("mp4");
+    expect(content[0].video?.source).toBe(videoSource);
+  });
+
+  test("converts video block with S3 fileId", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "video",
+            mimeType: "video/mp4",
+            fileId: "s3://my-bucket/my-video.mp4",
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("video");
+    expect(content[0].video?.format).toBe("mp4");
+    expect(content[0].video?.source?.s3Location?.uri).toBe(
+      "s3://my-bucket/my-video.mp4"
+    );
+  });
+});
+
+describe("audio content block conversion", () => {
+  test("converts multimodal audio block with base64 data", () => {
+    const audioData = btoa("fake-audio-bytes");
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: "text", text: "Transcribe this audio" },
+          {
+            type: "audio",
+            mimeType: "audio/mp3",
+            data: audioData,
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(1);
+    const content = result.converseMessages[0].content!;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ text: "Transcribe this audio" });
+    expect(content[1]).toHaveProperty("audio");
+    expect(content[1].audio?.format).toBe("mp3");
+    expect(content[1].audio?.source?.bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test("converts multimodal audio block with Uint8Array data", () => {
+    const audioBytes = new Uint8Array([1, 2, 3, 4]);
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "audio",
+            mimeType: "audio/wav",
+            data: audioBytes,
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("audio");
+    expect(content[0].audio?.format).toBe("wav");
+    expect(content[0].audio?.source?.bytes).toBe(audioBytes);
+  });
+
+  test("passes through native Bedrock audio block", () => {
+    const audioSource = {
+      bytes: new Uint8Array([1, 2, 3]),
+    };
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "audio",
+            audio: {
+              format: "flac",
+              source: audioSource,
+            },
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("audio");
+    expect(content[0].audio?.format).toBe("flac");
+    expect(content[0].audio?.source).toBe(audioSource);
+  });
+
+  test("converts audio block with S3 fileId", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: "audio",
+            mimeType: "audio/mp3",
+            fileId: "s3://my-bucket/my-audio.mp3",
+          },
+        ],
+      }),
+    ]);
+
+    const content = result.converseMessages[0].content!;
+    expect(content[0]).toHaveProperty("audio");
+    expect(content[0].audio?.format).toBe("mp3");
+    expect(content[0].audio?.source?.s3Location?.uri).toBe(
+      "s3://my-bucket/my-audio.mp3"
+    );
+  });
+});
+
 describe("applicationInferenceProfile parameter", () => {
   const baseConstructorArgs = {
     region: "us-east-1",


### PR DESCRIPTION
## Summary

`ChatBedrockConverse` supported video and audio content blocks on the **output** side (parsing Bedrock responses), but not on the **input** side (converting user messages to Bedrock format). Passing a `{ type: "video", ... }` or `{ type: "audio", ... }` content block would throw an "Unsupported content block type" error.

This was reported as a bug in the Python `langchain-aws` package, and the same gap exists in the JS implementation.

## Changes

### `@langchain/aws`

**`src/utils/message_inputs.ts`**

Added video and audio input handling to `convertLangChainContentBlockToConverseContentBlock`:

- New `convertMultimodalVideoBlock` and `convertMultimodalAudioBlock` functions that convert standard multimodal content blocks to Bedrock's native `{ video: { format, source } }` / `{ audio: { format, source } }` format
- Shared `resolveMediaSource` helper that handles the different source types: base64 string, `Uint8Array`, base64 data URL, and S3 URI (`fileId`)
- Mime type → Bedrock format mapping for all supported video formats (flv, mkv, mov, mp4, mpeg, mpg, three_gp, webm, wmv) and audio formats (aac, flac, m4a, mka, mkv, mp3, mp4, mpeg, mpga, ogg, opus, pcm, wav, webm, x-aac)
- Native Bedrock video/audio blocks (already containing `block.video` / `block.audio`) are passed through unchanged
- Video and audio checks are placed **before** the `isDataContentBlock` check to avoid falling into the deprecated data content block path, which doesn't support these types

**`src/tests/chat_models.test.ts`**

8 new unit tests covering video (4) and audio (4) content block conversion: base64 data, `Uint8Array`, native Bedrock pass-through, and S3 `fileId` formats.
