### PR TITLE
fix(google-common): preserve anthropic tool_use blocks in vertex claude formatting

### DIFF
--- a/.changeset/claude-vertex-anthropic-formatting-fix.md
+++ b/.changeset/claude-vertex-anthropic-formatting-fix.md
@@ -1,0 +1,9 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): preserve anthropic tool_use blocks and avoid duplicates in Claude Vertex formatting
+
+Improve Anthropic message conversion in the Vertex Claude path by preserving `tool_use` blocks from assistant content and deduplicating `tool_use` entries when they also appear in `tool_calls`.
+
+Add regression tests for Anthropic formatting with multi-turn/tool message flows.

--- a/libs/providers/langchain-google-common/src/utils/anthropic.ts
+++ b/libs/providers/langchain-google-common/src/utils/anthropic.ts
@@ -505,6 +505,17 @@ export function getAnthropicAPI(config?: AnthropicAPIConfig): GoogleAIAPI {
     };
   }
 
+  function toolUseContentToAnthropicContent(
+    content: Record<string, unknown>
+  ): AnthropicMessageContentToolUse {
+    return {
+      type: "tool_use",
+      id: content.id as string,
+      name: content.name as string,
+      input: content.input as Record<string, unknown>,
+    };
+  }
+
   function thinkingContentToAnthropicContent(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content: Record<string, any>
@@ -539,6 +550,8 @@ export function getAnthropicAPI(config?: AnthropicAPIConfig): GoogleAIAPI {
         return imageContentToAnthropicContent(
           content as MessageContentImageUrl
         );
+      case "tool_use":
+        return toolUseContentToAnthropicContent(content);
       case "thinking":
         return thinkingContentToAnthropicContent(
           content as Record<string, unknown>
@@ -548,6 +561,9 @@ export function getAnthropicAPI(config?: AnthropicAPIConfig): GoogleAIAPI {
           content as Record<string, unknown>
         );
       default:
+        if (type === "tool_call") {
+          return undefined;
+        }
         console.warn(`Unexpected content type: ${type}`, content);
         return undefined;
     }
@@ -831,9 +847,20 @@ export function getAnthropicAPI(config?: AnthropicAPIConfig): GoogleAIAPI {
   function aiMessageToAnthropicMessage(base: AIMessage): AnthropicMessage {
     const ret = baseRoleToAnthropicMessage(base, "assistant");
 
-    const toolContent = toolCallsToAnthropicContent(base.tool_calls);
+    const content = ret.content as AnthropicMessageContent[];
+    const existingToolUseIds = new Set(
+      content
+        .filter(
+          (block): block is AnthropicMessageContentToolUse =>
+            block.type === "tool_use"
+        )
+        .map((block) => block.id)
+    );
+
+    const toolContent = toolCallsToAnthropicContent(base.tool_calls).filter(
+      (block) => !existingToolUseIds.has(block.id)
+    );
     if (toolContent.length > 0) {
-      const content = ret.content as AnthropicMessageContent[];
       ret.content = [...content, ...toolContent];
     }
 


### PR DESCRIPTION
## Summary

Fixes Claude-on-Vertex multi-turn message formatting failures in `@langchain/google-common` by hardening Anthropic block conversion and tool call handling.

The root issue was loss or duplication of Anthropic `tool_use` content when assistant history is re-serialized on later turns. This could produce invalid requests in the Vertex Claude path after the first turn.

## Changes

### `@langchain/google-common`

- Updated Anthropic content conversion in `libs/providers/langchain-google-common/src/utils/anthropic.ts`:
  - Added explicit `tool_use` content conversion support via a dedicated helper.
  - Preserved assistant `tool_use` blocks in message content instead of dropping them.
  - Ignored legacy `tool_call` content blocks in this conversion path to avoid malformed output.
  - Deduplicated `tool_use` entries in assistant messages when the same call appears in both content blocks and `tool_calls`.

- Added/updated Anthropic formatting regression coverage in `libs/providers/langchain-google-common/src/tests/utils.test.ts` for:
  - Multi-turn assistant content that already contains `tool_use` plus `tool_calls` (no duplicates).
  - Tool message formatting to Anthropic `tool_result` blocks.
