### PR TITLE
fix(core, langchain): bump uuid ^10 to ^11 to fix Metro bundler error

### DIFF
--- a/.changeset/fix-metro-uuid-v1.md
+++ b/.changeset/fix-metro-uuid-v1.md
@@ -1,0 +1,8 @@
+---
+"@langchain/core": patch
+"langchain": patch
+---
+
+fix(core, langchain): bump uuid dependency from ^10.0.0 to ^11.0.0 to fix Metro bundler error
+
+The `uuid` v10 package has ambiguous `exports` in its `package.json` which causes Metro (used by Expo/React Native) to resolve the wrong entry point, resulting in `Cannot read properties of undefined (reading 'v1')`. The `uuid` v11 package fixes its exports map to work correctly with Metro's package exports resolution.

--- a/libs/langchain-core/package.json
+++ b/libs/langchain-core/package.json
@@ -38,7 +38,7 @@
     "langsmith": ">=0.5.0 <1.0.0",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.0",
     "zod": "^3.25.76 || ^4"
   },
   "devDependencies": {

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -82,7 +82,7 @@
     "@langchain/langgraph": "^1.1.2",
     "@langchain/langgraph-checkpoint": "^1.0.0",
     "langsmith": ">=0.5.0 <1.0.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.0",
     "zod": "^3.25.76 || ^4"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,8 +685,8 @@ importers:
         specifier: '>=0.5.0 <1.0.0'
         version: 0.5.6(@opentelemetry/api@1.9.0)(openai@6.22.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
@@ -1658,8 +1658,8 @@ importers:
         specifier: ^6.6.2
         version: 6.6.2
       uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6


### PR DESCRIPTION
## Summary

Fixes #10158

Bumps the `uuid` dependency from `^10.0.0` to `^11.0.0` in `@langchain/core` and `langchain` to fix a Metro bundler crash when importing langchain in Expo/React Native projects.

## Changes

The `uuid` v10 package has an ambiguous `exports` field in its `package.json` that causes newer versions of Metro (which enable package exports resolution by default) to resolve the wrong entry point (`wrapper.mjs`). This results in:

```
TypeError: Cannot read properties of undefined (reading 'v1')
```

The `uuid` v11 release fixes its exports map to correctly support Metro's resolution algorithm while maintaining both ESM and CJS support. This is the same fix that was applied in [aws-amplify/amplify-js#14408](https://github.com/aws-amplify/amplify-js/issues/14408).

### Affected packages
- `@langchain/core`: `uuid` `^10.0.0` → `^11.0.0`
- `langchain`: `uuid` `^10.0.0` → `^11.0.0`
