### PR TITLE
fix(@langchain/google): preserve thought and thoughtSignature on text parts

### DIFF
--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -56,13 +56,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -129,13 +129,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -202,13 +202,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -714,7 +714,15 @@ function convertLegacyContentMessageToGeminiContent(
         parts.push({ text: item });
       } else if (typeof item === "object" && item !== null) {
         if (isMessageContentText(item)) {
-          parts.push({ text: item.text });
+          // Gemini thinking models include `thought` and `thoughtSignature`
+          // on text parts. These must be forwarded back to the API so it
+          // can distinguish thought parts from regular text.
+          const { thought, thoughtSignature } = item as unknown as Gemini.Part;
+          parts.push({
+            text: item.text,
+            ...(thought !== undefined ? { thought } : {}),
+            ...(thoughtSignature !== undefined ? { thoughtSignature } : {}),
+          });
         } else if (isDataContentBlock(item)) {
           parts.push(
             convertToProviderContentBlock(item, geminiContentBlockConverter)

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -472,6 +472,35 @@ describe("convertMessagesToGeminiContents", () => {
     expect(mergedParts[1].functionResponse!.name).toBe("get_time");
   });
 
+  test("preserves thought and thoughtSignature on text parts from thinking models (legacy path)", () => {
+    // Gemini thinking models produce [thought, functionCall] turns.
+    // Verify the converter preserves thought/thoughtSignature on text parts
+    // so the API can distinguish thoughts from regular text on the next call.
+    const messages = [
+      new HumanMessage("What's the weather in Paris?"),
+      new AIMessage({
+        content: [
+          {
+            type: "text",
+            text: "I need to check the weather.",
+            thought: true,
+            thoughtSignature: "dGhvdWdodC1zaWduYXR1cmUtMQ==",
+          },
+        ] as unknown as Array<Record<string, unknown>>,
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const part = modelContent!.parts[0] as Gemini.Part;
+    expect(part.text).toBe("I need to check the weather.");
+    expect(part.thought).toBe(true);
+    expect(part.thoughtSignature).toBe("dGhvdWdodC1zaWduYXR1cmUtMQ==");
+  });
+
   test("passes tool_call_id through as functionResponse.id (v1 standard path)", () => {
     const messages = [
       new HumanMessage("hello"),


### PR DESCRIPTION

Gemini thinking models (e.g. `gemini-2.5-pro`, `gemini-3-pro-preview`) return text parts with `thought: true` and `thoughtSignature` fields when performing function calling. The legacy message converter in `convertLegacyContentMessageToGeminiContent` was converting text content blocks as `{ text: item.text }`, stripping both fields. (The `functionCall` branch already preserves extra fields via `...etc` spread, so `thoughtSignature` on function call parts was not affected.)

This causes a 400 error on the next API call because a model turn containing a `functionCall` part may include `thought` parts but **not** regular `text` parts. With `thought` stripped, the API sees `[text, text, functionCall]` instead of `[thought, thought, functionCall]` and rejects the request.

Gemini 3 models additionally require `thoughtSignature` to be echoed back on all parts, per [Google's documentation](https://ai.google.dev/gemini-api/docs/thought-signatures):
> "When using Gemini 3 models, you must pass back thought signatures during function calling, otherwise you will get a validation error (4xx status code)."

### Fix

Preserve `thought` and `thoughtSignature` when converting text content blocks back to Gemini parts in the legacy (v0) path.

### Tests

- Verifies `thought` and `thoughtSignature` are preserved on text parts in a thinking model tool call scenario
- Verifies regular text parts (without thinking fields) are not affected

### Note

The diff includes unrelated Prettier formatting changes (ternary operator indentation) on lines that were already non-compliant with the repo's `.prettierrc`.

**Scope**: This fix applies to `@langchain/google` (`ChatGoogle`). The same issue exists in `@langchain/google-genai` (`ChatGoogleGenerativeAI`) — see #10103.

Related:
- #9624 — thought signature support for `ChatVertexAI` tool calling
- #10103 — same root cause in `@langchain/google-genai` (`_convertLangChainContentToPart` missing `type: "thinking"` handler)
- #10072 — prior fix for streaming non-text content blocks (merged in 0.1.3)