### PR TITLE
fix(exa): replace deprecated method usage in docs, tests, and example

### DIFF
--- a/.changeset/fix-exa-deprecated-methods.md
+++ b/.changeset/fix-exa-deprecated-methods.md
@@ -1,0 +1,5 @@
+---
+"@langchain/exa": patch
+---
+
+fix: replace deprecated getRelevantDocuments with invoke in docstring and test, update example to use createOpenAIToolsAgent

--- a/examples/src/langchain-classic/tools/exa_agent.ts
+++ b/examples/src/langchain-classic/tools/exa_agent.ts
@@ -6,7 +6,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import Exa from "exa-js";
 import {
   AgentExecutor,
-  createOpenAIFunctionsAgent,
+  createOpenAIToolsAgent,
 } from "@langchain/classic/agents";
 import { createRetrieverTool } from "@langchain/classic/tools/retriever";
 import { ExaRetriever } from "@langchain/exa";
@@ -28,7 +28,7 @@ const searchTool = createRetrieverTool(exaRetriever, {
 });
 
 const tools = [searchTool];
-const llm = new ChatOpenAI({ model: "gpt-4", temperature: 0 });
+const llm = new ChatOpenAI({ model: "gpt-4o", temperature: 0 });
 const prompt = ChatPromptTemplate.fromMessages([
   [
     "system",
@@ -38,7 +38,7 @@ const prompt = ChatPromptTemplate.fromMessages([
   new MessagesPlaceholder("agent_scratchpad"),
 ]);
 const agentExecutor = new AgentExecutor({
-  agent: await createOpenAIFunctionsAgent({
+  agent: await createOpenAIToolsAgent({
     llm,
     tools,
     prompt,

--- a/libs/providers/langchain-exa/src/retrievers.ts
+++ b/libs/providers/langchain-exa/src/retrievers.ts
@@ -37,7 +37,7 @@ export function _getMetadata<T extends ContentsOptions = { text: true }>(
  *     process.env.EXA_BASE_URL,
  *   ),
  * });
- * const docs = await retriever.getRelevantDocuments("hello");
+ * const docs = await retriever.invoke("hello");
  * ```
  */
 export class ExaRetriever<

--- a/libs/providers/langchain-exa/src/tests/retrievers.int.test.ts
+++ b/libs/providers/langchain-exa/src/tests/retrievers.int.test.ts
@@ -7,7 +7,7 @@ test("ExaRetriever can retrieve some data", async () => {
     client: new Exa(),
   });
 
-  const results = await exaRetriever.getRelevantDocuments(
+  const results = await exaRetriever.invoke(
     "What does the AI company LangChain do?"
   );
 


### PR DESCRIPTION
  ## Summary

  - Replace deprecated `getRelevantDocuments` with `invoke` in `ExaRetriever` docstring and integration test
  - Update `exa_agent.ts` example to use `createOpenAIToolsAgent` (replacing deprecated `createOpenAIFunctionsAgent`) and `gpt-4o` (replacing `gpt-4`)

  ## Test plan

  - [x] Unit tests pass (`pnpm test`)
  - [x] Build succeeds with no publint/attw issues
  
  
  ----
  
  Twitter/X: [@WilliamEspegren](https://x.com/WilliamEspegren)