### PR TITLE
fix(google): don't send empty toolConfig when no tool_choice is specified

### DIFF
--- a/.changeset/fix-google-tool-call-parsing.md
+++ b/.changeset/fix-google-tool-call-parsing.md
@@ -1,0 +1,12 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): don't send empty toolConfig when no tool_choice is specified
+
+When `bindTools()` was called without specifying `tool_choice`, an empty
+`toolConfig: { functionCallingConfig: {} }` was included in the API request.
+This caused the Gemini API to return tool invocations as text (Python code
+blocks) instead of structured `functionCall` parts. Now returns `undefined`
+when no `tool_choice` is set, omitting `toolConfig` from the request entirely
+and letting the API default to AUTO mode.

--- a/libs/providers/langchain-google/src/converters/tests/tools.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/tools.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { convertToolChoiceToGeminiConfig } from "../tools.js";
+
+describe("convertToolChoiceToGeminiConfig", () => {
+  test("returns undefined when toolChoice is undefined", () => {
+    const result = convertToolChoiceToGeminiConfig(undefined, true);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when hasTools is false", () => {
+    const result = convertToolChoiceToGeminiConfig("auto", false);
+    expect(result).toBeUndefined();
+  });
+
+  test('maps "auto" to AUTO mode', () => {
+    const result = convertToolChoiceToGeminiConfig("auto", true);
+    expect(result).toEqual({
+      functionCallingConfig: { mode: "AUTO" },
+    });
+  });
+
+  test('maps "any" to ANY mode', () => {
+    const result = convertToolChoiceToGeminiConfig("any", true);
+    expect(result).toEqual({
+      functionCallingConfig: { mode: "ANY" },
+    });
+  });
+
+  test('maps "required" to ANY mode', () => {
+    const result = convertToolChoiceToGeminiConfig("required", true);
+    expect(result).toEqual({
+      functionCallingConfig: { mode: "ANY" },
+    });
+  });
+
+  test('maps "none" to NONE mode', () => {
+    const result = convertToolChoiceToGeminiConfig("none", true);
+    expect(result).toEqual({
+      functionCallingConfig: { mode: "NONE" },
+    });
+  });
+
+  test("maps a function name string to ANY mode with allowedFunctionNames", () => {
+    const result = convertToolChoiceToGeminiConfig("my_function", true);
+    expect(result).toEqual({
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: ["my_function"],
+      },
+    });
+  });
+
+  test("maps object with mode to corresponding Gemini mode", () => {
+    const result = convertToolChoiceToGeminiConfig(
+      { mode: "auto" } as never,
+      true
+    );
+    expect(result).toEqual({
+      functionCallingConfig: { mode: "AUTO" },
+    });
+  });
+
+  test("maps object with function name to ANY with allowedFunctionNames", () => {
+    const result = convertToolChoiceToGeminiConfig(
+      { function: { name: "get_weather" } } as never,
+      true
+    );
+    expect(result).toEqual({
+      functionCallingConfig: {
+        allowedFunctionNames: ["get_weather"],
+      },
+    });
+  });
+});

--- a/libs/providers/langchain-google/src/converters/tools.ts
+++ b/libs/providers/langchain-google/src/converters/tools.ts
@@ -457,12 +457,10 @@ export function convertToolChoiceToGeminiConfig(
   toolChoice: ToolChoice | undefined,
   hasTools: boolean
 ): Gemini.Tools.ToolConfig | undefined {
-  // Only create config if tools are present
-  if (!hasTools) {
+  if (!hasTools || toolChoice === undefined) {
     return undefined;
   }
 
-  // Convert tool_choice to Gemini function calling config mode
   let mode: Gemini.Tools.FunctionCallingConfigMode | undefined;
   let allowedFunctionNames: string[] | undefined;
 
@@ -482,7 +480,6 @@ export function convertToolChoiceToGeminiConfig(
   } else if (toolChoiceMode === "none") {
     mode = "NONE";
   } else if (typeof toolChoiceMode === "string") {
-    // A function name, which is deprecated, but supported
     mode = "ANY";
     toolChoiceFunction = toolChoiceMode;
   }
@@ -495,7 +492,6 @@ export function convertToolChoiceToGeminiConfig(
     }
   }
 
-  // Build toolConfig: use explicit mode if provided, otherwise default to AUTO
   const functionCallingConfig: Gemini.Tools.FunctionCallingConfig = {};
   if (allowedFunctionNames?.length) {
     functionCallingConfig.allowedFunctionNames = allowedFunctionNames;


### PR DESCRIPTION
## Summary

Fixes #10173

When `ChatGoogle` from `@langchain/google` is used with `bindTools()` without specifying `tool_choice` (the common case), the Gemini API returns tool invocations as text containing Python code blocks instead of structured `functionCall` response parts. This means `tool_calls` is never populated on the response message.

## Changes

### `@langchain/google`

The root cause is in `convertToolChoiceToGeminiConfig` (`src/converters/tools.ts`). When no `tool_choice` is specified, the function was returning `{ functionCallingConfig: {} }` — an empty but present config object. This gets sent as `toolConfig: { functionCallingConfig: {} }` in the request body, which causes the Gemini API to treat tools as informational rather than callable.

The working `ChatVertexAI` package (via `@langchain/google-common`) returns `undefined` when no `tool_choice` is set, omitting `toolConfig` from the request entirely and letting the API default to its AUTO function calling mode.

The fix aligns `@langchain/google` with this behavior: when `tool_choice` is `undefined`, return `undefined` so no `toolConfig` is included in the request.

Added `src/converters/tests/tools.test.ts` with tests covering all `convertToolChoiceToGeminiConfig` code paths.
