### PR TITLE
fix: StateSchema type incompatibility when used with createAgent

### DIFF
--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -76,10 +76,10 @@
     "yaml": "^2.8.1"
   },
   "peerDependencies": {
-    "@langchain/core": "workspace:^"
+    "@langchain/core": "workspace:^",
+    "@langchain/langgraph": "^1.1.2"
   },
   "dependencies": {
-    "@langchain/langgraph": "^1.1.2",
     "@langchain/langgraph-checkpoint": "^1.0.0",
     "langsmith": ">=0.5.0 <1.0.0",
     "uuid": "^11.1.0",


### PR DESCRIPTION
### Problem

Users passing a `StateSchema` from `@langchain/langgraph` into `createAgent` from `langchain` get a TypeScript error:

```
Property '[STATE_SCHEMA_SYMBOL]' is missing in type 'StateSchema<...>' but required in type 'StateSchema<any>'
```

This happens because `@langchain/langgraph` was listed as a regular dependency of `langchain`. Package managers can install two separate copies on disk — one for the user's project and one nested inside `langchain`. The `StateSchema` class uses a `unique symbol` internally for branding, and TypeScript gives each copy its own distinct symbol type, making the two `StateSchema` types incompatible.

### Solution

Move `@langchain/langgraph` from `dependencies` to `peerDependencies`, matching the existing pattern for `@langchain/core`. This ensures a single shared installation so TypeScript sees one symbol declaration and treats all `StateSchema` references as the same type.

Users on npm v7+ will have the peer dependency auto-installed. Users who already import from `@langchain/langgraph` (which is everyone affected by this bug) already have it in their `package.json`.