### PR TITLE
Feature/mongodb voyage endpoint

### DIFF
--- a/.changeset/funky-hoops-fold.md
+++ b/.changeset/funky-hoops-fold.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": minor
+---
+
+expose `basePath` in VoyageEmbeddings constructor to support custom API endpoints

--- a/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -22,26 +22,7 @@ describe("VoyageEmbeddings", () => {
       basePath: "https://ai.mongodb.com/v1",
     });
 
-    await embeddings.embedQuery("Hello world");
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "https://ai.mongodb.com/v1/embeddings"
-    );
-  });
-
-  test("uses apiUrl provided in constructor", async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
-      json: async () => ({
-        data: [{ embedding: [0.1, 0.2, 0.3] }],
-      }),
-    } as Response);
-    global.fetch = fetchMock;
-
-    const embeddings = new VoyageEmbeddings({
-      apiKey: "test-key",
-      apiUrl: "https://ai.mongodb.com/v1/embeddings",
-    });
+    expect(embeddings.apiUrl).toBe("https://ai.mongodb.com/v1/embeddings");
 
     await embeddings.embedQuery("Hello world");
 

--- a/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { VoyageEmbeddings } from "../voyage.js";
+
+describe("VoyageEmbeddings", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test("uses basePath provided in constructor", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      json: async () => ({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    const embeddings = new VoyageEmbeddings({
+      apiKey: "test-key",
+      basePath: "https://ai.mongodb.com/v1",
+    });
+
+    await embeddings.embedQuery("Hello world");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ai.mongodb.com/v1/embeddings",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+
+  test("uses apiUrl provided in constructor", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      json: async () => ({
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    const embeddings = new VoyageEmbeddings({
+      apiKey: "test-key",
+      apiUrl: "https://ai.mongodb.com/v1/embeddings",
+    });
+
+    await embeddings.embedQuery("Hello world");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ai.mongodb.com/v1/embeddings",
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+});

--- a/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { VoyageEmbeddings } from "../voyage.js";
 
 describe("VoyageEmbeddings", () => {
@@ -6,11 +6,11 @@ describe("VoyageEmbeddings", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   test("uses basePath provided in constructor", async () => {
-    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
       json: async () => ({
         data: [{ embedding: [0.1, 0.2, 0.3] }],
       }),
@@ -24,16 +24,14 @@ describe("VoyageEmbeddings", () => {
 
     await embeddings.embedQuery("Hello world");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://ai.mongodb.com/v1/embeddings",
-      expect.objectContaining({
-        method: "POST",
-      })
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://ai.mongodb.com/v1/embeddings"
     );
   });
 
   test("uses apiUrl provided in constructor", async () => {
-    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
       json: async () => ({
         data: [{ embedding: [0.1, 0.2, 0.3] }],
       }),
@@ -47,11 +45,9 @@ describe("VoyageEmbeddings", () => {
 
     await embeddings.embedQuery("Hello world");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://ai.mongodb.com/v1/embeddings",
-      expect.objectContaining({
-        method: "POST",
-      })
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://ai.mongodb.com/v1/embeddings"
     );
   });
 });

--- a/libs/community/langchain-community/src/embeddings/voyage.ts
+++ b/libs/community/langchain-community/src/embeddings/voyage.ts
@@ -13,19 +13,10 @@ export interface VoyageEmbeddingsParams extends EmbeddingsParams {
    * Base URL for Voyage API requests.
    * If your API key was created on the MongoDB Atlas UI, this should be 'https://ai.mongodb.com/v1'.
    * If your API key was created on the Voyage AI Dashboard, this should be 'https://api.voyageai.com/v1'.
-   * The default is 'https://api.voyageai.com/v1'.
+   * @default "https://api.voyageai.com/v1"
    * @see https://www.mongodb.com/docs/voyageai/management/api-keys/?client-curl-default=curl#create-an-api-key
    */
   basePath?: string;
-
-  /**
-   * Full embeddings endpoint URL.
-   * If your API key was created on the MongoDB Atlas UI, this should be 'https://ai.mongodb.com/v1/embeddings'.
-   * If your API key was created on the Voyage AI Dashboard, this should be 'https://api.voyageai.com/v1/embeddings'.
-   * The default is 'https://api.voyageai.com/v1/embeddings'.
-   * @see https://www.mongodb.com/docs/voyageai/management/api-keys/?client-curl-default=curl#create-an-api-key
-   */
-  apiUrl?: string;
 
   /**
    * The maximum number of documents to embed in a single request. This is
@@ -115,6 +106,7 @@ export class VoyageEmbeddings
 
   private apiKey: string;
 
+  /** Do not modify directly. Pass in the basePath option to the constructor. */
   basePath?: string = "https://api.voyageai.com/v1";
 
   apiUrl: string;
@@ -141,7 +133,6 @@ export class VoyageEmbeddings
       apiKey?: string;
       inputType?: string;
       basePath?: string;
-      apiUrl?: string;
     }
   ) {
     const fieldsWithDefaults = { ...fields };
@@ -159,7 +150,7 @@ export class VoyageEmbeddings
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.apiKey = apiKey;
     this.basePath = fieldsWithDefaults?.basePath ?? this.basePath;
-    this.apiUrl = fieldsWithDefaults?.apiUrl ?? `${this.basePath}/embeddings`;
+    this.apiUrl = `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
     this.truncation = fieldsWithDefaults?.truncation;
     this.outputDimension = fieldsWithDefaults?.outputDimension;

--- a/libs/community/langchain-community/src/embeddings/voyage.ts
+++ b/libs/community/langchain-community/src/embeddings/voyage.ts
@@ -10,6 +10,24 @@ export interface VoyageEmbeddingsParams extends EmbeddingsParams {
   modelName: string;
 
   /**
+   * Base URL for Voyage API requests.
+   * If your API key was created on the MongoDB Atlas UI, this should be 'https://ai.mongodb.com/v1'.
+   * If your API key was created on the Voyage AI Dashboard, this should be 'https://api.voyageai.com/v1'.
+   * The default is 'https://api.voyageai.com/v1'.
+   * @see https://www.mongodb.com/docs/voyageai/management/api-keys/?client-curl-default=curl#create-an-api-key
+   */
+  basePath?: string;
+
+  /**
+   * Full embeddings endpoint URL.
+   * If your API key was created on the MongoDB Atlas UI, this should be 'https://ai.mongodb.com/v1/embeddings'.
+   * If your API key was created on the Voyage AI Dashboard, this should be 'https://api.voyageai.com/v1/embeddings'.
+   * The default is 'https://api.voyageai.com/v1/embeddings'.
+   * @see https://www.mongodb.com/docs/voyageai/management/api-keys/?client-curl-default=curl#create-an-api-key
+   */
+  apiUrl?: string;
+
+  /**
    * The maximum number of documents to embed in a single request. This is
    * limited by the Voyage AI API to a maximum of 8.
    */
@@ -122,6 +140,8 @@ export class VoyageEmbeddings
       verbose?: boolean;
       apiKey?: string;
       inputType?: string;
+      basePath?: string;
+      apiUrl?: string;
     }
   ) {
     const fieldsWithDefaults = { ...fields };
@@ -138,7 +158,8 @@ export class VoyageEmbeddings
     this.modelName = fieldsWithDefaults?.modelName ?? this.modelName;
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.apiKey = apiKey;
-    this.apiUrl = `${this.basePath}/embeddings`;
+    this.basePath = fieldsWithDefaults?.basePath ?? this.basePath;
+    this.apiUrl = fieldsWithDefaults?.apiUrl ?? `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
     this.truncation = fieldsWithDefaults?.truncation;
     this.outputDimension = fieldsWithDefaults?.outputDimension;


### PR DESCRIPTION
Expose `basePath` in VoyageEmbeddings constructor

Fixes the issue where `basePath` exists as a class property but cannot be configured during instantiation. This creates confusion as users might try to modify `basePath` after construction, which has no effect since `apiUrl` is only constructed once in the constructor.

Changes:
- Add `basePath` to the constructor parameter types

Fixes langchain-ai/langchainjs-community#20 
