### PR TITLE
Add non-custodial wallet toolkit (agentwallet-langchain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ LangChain.js is written in TypeScript and can be used in:
 - [LangChain Forum](https://forum.langchain.com): Connect with the community and share all of your technical questions, ideas, and feedback.
 - [Chat LangChain](https://chat.langchain.com): Ask questions & chat with our documentation.
 
+## 🛠️ Community Tools & Integrations
+
+Third-party toolkits built on top of LangChain.js.
+
+| Toolkit | npm | Description |
+|---------|-----|-------------|
+| [agentwallet-langchain](https://www.npmjs.com/package/agentwallet-langchain) | `agentwallet-langchain` | Non-custodial wallet toolkit for AI agents. Tools: `AgentWalletBalanceTool`, `AgentWalletTransferTool`, `AgentWalletSwapTool`, `AgentWalletBridgeTool`, `AgentWalletX402Tool`. The `AgentWalletToolkit` bundles everything and works with LangGraph's `ToolNode`. |
+
 ## 💁 Contributing
 
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.


### PR DESCRIPTION
Built a wallet toolkit for LangChain.js that gives agents non-custodial wallets.

**What it does:**
- `AgentWalletBalanceTool` — check balances across EVM + Solana
- `AgentWalletTransferTool` — send tokens (native + ERC-20 / SPL)
- `AgentWalletSwapTool` — swap via Jupiter (Solana) and Uniswap V3 (EVM)
- `AgentWalletBridgeTool` — cross-chain bridging via CCTP V2 (17 chains)
- `AgentWalletX402Tool` — x402 micropayments for pay-per-request APIs
- `AgentWalletToolkit` — bundles all tools, works with LangGraph's `ToolNode`

**Why non-custodial matters:**
The agent holds its own private key. No Privy, no Coinbase CDP, no vendor lock-in. If the vendor goes down, the agent's wallet still works.

**npm:** [`agentwallet-langchain`](https://www.npmjs.com/package/agentwallet-langchain)
**License:** MIT

This PR adds a Community Tools & Integrations section to the README and lists `agentwallet-langchain` as the first entry.

Related: #10268