### PR TITLE
chore: update dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 10
     groups:
       gh-actions-minor-and-patch:
@@ -22,9 +20,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 10
     groups:
       root-dev-minor-and-patch:
@@ -47,9 +43,7 @@ updates:
       - "/libs/langchain-textsplitters"
       - "/libs/langchain-mcp-adapters"
     schedule:
-      interval: weekly
-      day: monday
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "p-queue"
@@ -67,9 +61,7 @@ updates:
     directories:
       - "/libs/providers/*"
     schedule:
-      interval: weekly
-      day: monday
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 15
     groups:
       providers-minor-and-patch:
@@ -85,9 +77,7 @@ updates:
     directories:
       - "/internal/*"
     schedule:
-      interval: weekly
-      day: monday
-      time: "11:00"
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
       internal-minor-and-patch:


### PR DESCRIPTION
## Summary
- Switches all 5 dependabot update entries from `weekly` to `monthly` cadence
- Reduces PR noise while keeping dependencies reasonably current
- Security updates are unaffected (handled separately by GitHub)

## Test plan
- [x] CI Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)