### PR TITLE
chore: upgrade People action Dockerfile from Python 3.9 to 3.12

### DIFF
--- a/.github/actions/people/Dockerfile
+++ b/.github/actions/people/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 RUN pip install httpx PyGithub "pydantic==2.0.2" pydantic-settings "pyyaml>=5.3.1,<6.0.0"
 


### PR DESCRIPTION
## Summary
- Upgrades `.github/actions/people/Dockerfile` from `python:3.9` to `python:3.12`
- Python 3.9 reached EOL in October 2025

## Test plan
- [x] CI Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)