### PR TITLE
ci: add minimum workflow permissions to all workflow files

### DIFF
--- a/.github/workflows/benchmark-tests.yml
+++ b/.github/workflows/benchmark-tests.yml
@@ -13,6 +13,9 @@ on:
   #     - "libs/langchain-core/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
       - "!.github/workflows/ci.yml"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "36 12 * * 2"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,9 @@ on:
       - "libs/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,6 +10,9 @@ on:
         default: "dev"
         type: string
 
+permissions:
+  contents: read
+
 env:
   CI: true
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,6 +13,9 @@ on:
       - "libs/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,9 @@ on:
       - ".github/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,9 @@ name: Node.js Integration Tests
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -7,6 +7,9 @@ on:
     branches: [jacob/people]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   langchain-people:
     if: github.repository_owner == 'langchain-ai'

--- a/.github/workflows/platform-compatibility.yml
+++ b/.github/workflows/platform-compatibility.yml
@@ -10,6 +10,9 @@ on:
       - "libs/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ name: 🦋 Changesets Release
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CI: true
 

--- a/.github/workflows/standard-tests.yml
+++ b/.github/workflows/standard-tests.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 13 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   standard-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-exports.yml
+++ b/.github/workflows/test-exports.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/test-exports.yml"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/unit-tests-integrations.yml
+++ b/.github/workflows/unit-tests-integrations.yml
@@ -11,6 +11,9 @@ on:
       - "libs/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/unit-tests-langchain-core.yml
+++ b/.github/workflows/unit-tests-langchain-core.yml
@@ -12,6 +12,9 @@ on:
       - "libs/langchain-core/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #

--- a/.github/workflows/unit-tests-langchain.yml
+++ b/.github/workflows/unit-tests-langchain.yml
@@ -14,6 +14,9 @@ on:
       - "libs/langchain-classic/**"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #


### PR DESCRIPTION
## Summary
- Adds explicit top-level `permissions: contents: read` to 16 workflow files that were missing a permissions block
- Follows the principle of least privilege by restricting `GITHUB_TOKEN` scope instead of inheriting broad repository/org defaults
- Jobs that need elevated permissions (e.g. `security-events: write`, `contents: write`) already declare their own job-level permissions

## Test plan
- [x] CI Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)