### PR TITLE
feat(aws): add bedrockApiKey, bedrockApiSecret, bedrockApiSessionToken to ChatBedrockConverse

### DIFF
--- a/.changeset/bedrock-api-key-credentials.md
+++ b/.changeset/bedrock-api-key-credentials.md
@@ -1,0 +1,9 @@
+---
+"@langchain/aws": patch
+---
+
+feat(aws): Add bedrockApiKey, bedrockApiSecret, and bedrockApiSessionToken to ChatBedrockConverse
+
+- New constructor fields allow passing AWS credentials directly instead of relying solely on the default credential provider chain
+- Falls back to BEDROCK_AWS_ACCESS_KEY_ID, BEDROCK_AWS_SECRET_ACCESS_KEY, and BEDROCK_AWS_SESSION_TOKEN environment variables
+- Explicit `credentials` field still takes highest priority

--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -83,6 +83,27 @@ export interface ChatBedrockConverseInput
   clientOptions?: BedrockRuntimeClientConfig;
 
   /**
+   * AWS access key ID. If provided along with `bedrockApiSecret`, these will be
+   * used to construct credentials for the Bedrock client. Falls back to the
+   * `BEDROCK_AWS_ACCESS_KEY_ID` environment variable.
+   */
+  bedrockApiKey?: string;
+
+  /**
+   * AWS secret access key. If provided along with `bedrockApiKey`, these will be
+   * used to construct credentials for the Bedrock client. Falls back to the
+   * `BEDROCK_AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  bedrockApiSecret?: string;
+
+  /**
+   * AWS session token. Optionally provided alongside `bedrockApiKey` and
+   * `bedrockApiSecret` for temporary credentials. Falls back to the
+   * `BEDROCK_AWS_SESSION_TOKEN` environment variable.
+   */
+  bedrockApiSessionToken?: string;
+
+  /**
    * Whether or not to stream responses
    */
   streaming?: boolean;
@@ -682,6 +703,9 @@ export class ChatBedrockConverse
   get lc_secrets(): { [key: string]: string } | undefined {
     return {
       apiKey: "API_KEY_NAME",
+      bedrockApiKey: "BEDROCK_AWS_ACCESS_KEY_ID",
+      bedrockApiSecret: "BEDROCK_AWS_SECRET_ACCESS_KEY",
+      bedrockApiSessionToken: "BEDROCK_AWS_SESSION_TOKEN",
     };
   }
 
@@ -718,6 +742,12 @@ export class ChatBedrockConverse
   performanceConfig?: PerformanceConfiguration;
 
   serviceTier?: ServiceTierType | undefined = undefined;
+
+  bedrockApiKey?: string;
+
+  bedrockApiSecret?: string;
+
+  bedrockApiSessionToken?: string;
 
   client: BedrockRuntimeClient;
 
@@ -756,9 +786,29 @@ export class ChatBedrockConverse
       ...rest
     } = fields;
 
-    const credentials =
-      rest?.credentials ??
-      defaultProvider({
+    const bedrockApiKey =
+      rest?.bedrockApiKey ??
+      getEnvironmentVariable("BEDROCK_AWS_ACCESS_KEY_ID");
+    const bedrockApiSecret =
+      rest?.bedrockApiSecret ??
+      getEnvironmentVariable("BEDROCK_AWS_SECRET_ACCESS_KEY");
+    const bedrockApiSessionToken =
+      rest?.bedrockApiSessionToken ??
+      getEnvironmentVariable("BEDROCK_AWS_SESSION_TOKEN");
+
+    let credentials: CredentialType;
+    if (rest?.credentials) {
+      credentials = rest.credentials;
+    } else if (bedrockApiKey && bedrockApiSecret) {
+      credentials = {
+        accessKeyId: bedrockApiKey,
+        secretAccessKey: bedrockApiSecret,
+        ...(bedrockApiSessionToken
+          ? { sessionToken: bedrockApiSessionToken }
+          : {}),
+      };
+    } else {
+      credentials = defaultProvider({
         profile,
         filepath,
         configFilepath,
@@ -769,6 +819,7 @@ export class ChatBedrockConverse
         webIdentityTokenFile,
         roleAssumerWithWebIdentity,
       });
+    }
 
     const region = rest?.region ?? getEnvironmentVariable("AWS_DEFAULT_REGION");
     if (!region) {
@@ -795,6 +846,9 @@ export class ChatBedrockConverse
     this.temperature = rest?.temperature;
     this.maxTokens = rest?.maxTokens;
     this.endpointHost = rest?.endpointHost;
+    this.bedrockApiKey = bedrockApiKey;
+    this.bedrockApiSecret = bedrockApiSecret;
+    this.bedrockApiSessionToken = bedrockApiSessionToken;
     this.topP = rest?.topP;
     this.additionalModelRequestFields = rest?.additionalModelRequestFields;
     this.streamUsage = rest?.streamUsage ?? this.streamUsage;

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1504,3 +1504,109 @@ describe("withStructuredOutput - StandardSchema", () => {
     }).rejects.toThrow("No tool calls found in the response.");
   });
 });
+
+describe("bedrockApiKey / bedrockApiSecret credentials", () => {
+  it("should accept bedrockApiKey and bedrockApiSecret in constructor", () => {
+    const model = new ChatBedrockConverse({
+      region: "us-east-1",
+      bedrockApiKey: "test-access-key-id",
+      bedrockApiSecret: "test-secret-access-key",
+    });
+    expect(model.bedrockApiKey).toBe("test-access-key-id");
+    expect(model.bedrockApiSecret).toBe("test-secret-access-key");
+    expect(model.bedrockApiSessionToken).toBeUndefined();
+    expect(model.region).toBe("us-east-1");
+  });
+
+  it("should accept bedrockApiSessionToken for temporary credentials", () => {
+    const model = new ChatBedrockConverse({
+      region: "us-east-1",
+      bedrockApiKey: "test-access-key-id",
+      bedrockApiSecret: "test-secret-access-key",
+      bedrockApiSessionToken: "test-session-token",
+    });
+    expect(model.bedrockApiKey).toBe("test-access-key-id");
+    expect(model.bedrockApiSecret).toBe("test-secret-access-key");
+    expect(model.bedrockApiSessionToken).toBe("test-session-token");
+  });
+
+  it("should read bedrockApiKey from BEDROCK_AWS_ACCESS_KEY_ID env var", () => {
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    try {
+      const model = new ChatBedrockConverse({
+        region: "us-east-1",
+      });
+      expect(model.bedrockApiKey).toBe("env-access-key");
+      expect(model.bedrockApiSecret).toBe("env-secret-key");
+    } finally {
+      delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+      delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+    }
+  });
+
+  it("should read bedrockApiSessionToken from BEDROCK_AWS_SESSION_TOKEN env var", () => {
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    process.env.BEDROCK_AWS_SESSION_TOKEN = "env-session-token";
+    try {
+      const model = new ChatBedrockConverse({
+        region: "us-east-1",
+      });
+      expect(model.bedrockApiSessionToken).toBe("env-session-token");
+    } finally {
+      delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+      delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+      delete process.env.BEDROCK_AWS_SESSION_TOKEN;
+    }
+  });
+
+  it("should prefer explicit credentials over bedrockApiKey/bedrockApiSecret", () => {
+    const model = new ChatBedrockConverse({
+      region: "us-east-1",
+      bedrockApiKey: "api-key-value",
+      bedrockApiSecret: "api-secret-value",
+      credentials: {
+        accessKeyId: "explicit-key",
+        secretAccessKey: "explicit-secret",
+      },
+    });
+    expect(model.bedrockApiKey).toBe("api-key-value");
+    expect(model.bedrockApiSecret).toBe("api-secret-value");
+    expect(model.region).toBe("us-east-1");
+  });
+
+  it("should use bedrockApiKey with string model shorthand", () => {
+    const model = new ChatBedrockConverse(
+      "anthropic.claude-3-haiku-20240307-v1:0",
+      {
+        region: "us-east-1",
+        bedrockApiKey: "test-key",
+        bedrockApiSecret: "test-secret",
+      }
+    );
+    expect(model.model).toBe("anthropic.claude-3-haiku-20240307-v1:0");
+    expect(model.bedrockApiKey).toBe("test-key");
+    expect(model.bedrockApiSecret).toBe("test-secret");
+  });
+
+  it("should include bedrockApiKey and bedrockApiSecret in lc_secrets", () => {
+    const model = new ChatBedrockConverse({
+      region: "us-east-1",
+      bedrockApiKey: "test-key",
+      bedrockApiSecret: "test-secret",
+    });
+    expect(model.lc_secrets).toHaveProperty(
+      "bedrockApiKey",
+      "BEDROCK_AWS_ACCESS_KEY_ID"
+    );
+    expect(model.lc_secrets).toHaveProperty(
+      "bedrockApiSecret",
+      "BEDROCK_AWS_SECRET_ACCESS_KEY"
+    );
+    expect(model.lc_secrets).toHaveProperty(
+      "bedrockApiSessionToken",
+      "BEDROCK_AWS_SESSION_TOKEN"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add `bedrockApiKey`, `bedrockApiSecret`, and `bedrockApiSessionToken` fields to `ChatBedrockConverse`, matching the Python `langchain-aws` `ChatBedrockConverse.bedrock_api_key` / `bedrock_api_secret` pattern.

This makes it easier to pass AWS credentials directly to the Bedrock client without constructing a credentials object manually, and automatically picks up the `BEDROCK_AWS_ACCESS_KEY_ID`, `BEDROCK_AWS_SECRET_ACCESS_KEY`, and `BEDROCK_AWS_SESSION_TOKEN` environment variables.

## Changes

### `@langchain/aws`

**`src/chat_models.ts`**
- Added `bedrockApiKey`, `bedrockApiSecret`, and `bedrockApiSessionToken` to `ChatBedrockConverseInput` interface and class fields
- Updated constructor credential resolution order: explicit `credentials` > `bedrockApiKey`/`bedrockApiSecret` > `defaultProvider()`
- Registered new fields in `lc_secrets` for proper serialization redaction

**`src/tests/chat_models.test.ts`**
- Added 7 unit tests covering constructor usage, env var fallback, priority over default provider, string model shorthand, and `lc_secrets` inclusion