### PR TITLE
fix(community): always quote table names in PGVectorStore

### DIFF
--- a/libs/langchain-community/src/vectorstores/neon.ts
+++ b/libs/langchain-community/src/vectorstores/neon.ts
@@ -74,7 +74,7 @@ export class NeonPostgres extends VectorStore {
 
   get computedTableName() {
     return typeof this.schemaName !== "string"
-      ? `${this.tableName}`
+      ? `"${this.tableName}"`
       : `"${this.schemaName}"."${this.tableName}"`;
   }
 

--- a/libs/langchain-community/src/vectorstores/pgvector.ts
+++ b/libs/langchain-community/src/vectorstores/pgvector.ts
@@ -451,7 +451,7 @@ export class PGVectorStore extends VectorStore {
 
   get computedTableName() {
     return this.schemaName == null
-      ? `${this.tableName}`
+      ? `"${this.tableName}"`
       : `"${this.schemaName}"."${this.tableName}"`;
   }
 


### PR DESCRIPTION
### Summary

`PGVectorStore.computedTableName` only quotes the table name when a `schemaName` was provided. Without a schema, the table name is used unquoted, causing PostgreSQL to lowercase it per its default identifier handling. In order to use something like a PascalCase tableName, you must pass schema.

We could either apply this pull request or explicitly specify in the documentation that if your tableName needs a particular case, you'll need to quote it `{tableName: '"MyTable"'}` or specify schema: `{tableName: 'MyTable', schema: 'public'}`

This change unconditionally quotes the table name in `computedTableName`, making the behavior consistent regardless of whether a schema is provided.

### Breaking changes

- **Implicit lowercasing no longer applies.** If a user passes `tableName: "MyTable"` but the
  actual PostgreSQL table is `mytable`, their code will now fail because
  the quoted identifier `"MyTable"` no longer matches.

  ```ts
  // Before (worked because Postgres lowercased the unquoted identifier):
  PGVectorStore.initialize({ tableName: "MyTable", ... })
  // After (must match actual table name):
  PGVectorStore.initialize({ tableName: "mytable", ... })

  ```

- Pre-quoted table names will break. If you were manually quoting the table name (e.g. `tableName: '"MyTable"'`), it will now be double-quoted. Fix: pass the name without quotes.

  ```ts
  // Breaks:
  PGVectorStore.initialize({ tableName: '"MyTable"' });
  // Works:
  PGVectorStore.initialize({ tableName: "MyTable" });
  ```

  A simple solution we could do is to check if `tableName[0] === '"'` and NOT quote that. I'd need to add another unit test if we did that.

### Changes

- libs/langchain-community/src/vectorstores/pgvector.ts:

  Always quote table name and
  collection table name in computedTableName / computedCollectionTableName

### Testing

When I tried to run the unit tests I get a lot of failures. I think this is because I need to provide an API key or something, but I'm unfamiliar with the testing setup. If you need me to get these to all pass I can continue to churn on it.

```
Test Suites: 30 failed, 2 skipped, 37 passed, 67 of 69 total
Tests:       37 failed, 21 skipped, 277 passed, 335 total
Snapshots:   0 total
Time:        26.97 s
```

### Issue

I didn't find any issues (or even discussions) about this. I am happy to open one if you like.