### PR TITLE
fix(langchain-google): add withStructuredOutput overloads for type narrowing

### DIFF
--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -71,7 +71,26 @@ import {
   createFunctionCallingParser,
 } from "@langchain/core/language_models/structured_output";
 
+declare const __PKG_VERSION__: string;
+
 export type GooglePlatformType = "gai" | "gcp";
+
+type StructuredOutputSchema<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RunOutput extends Record<string, any>
+> =
+  | InteropZodType<RunOutput>
+  | SerializableSchema<RunOutput>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | Record<string, any>;
+
+type StructuredOutputWithRaw<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RunOutput extends Record<string, any>
+> = {
+  raw: BaseMessage;
+  parsed: RunOutput;
+};
 
 export function getPlatformType(
   platform: GooglePlatformType | undefined,
@@ -682,18 +701,35 @@ export abstract class BaseChatGoogle<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     RunOutput extends Record<string, any> = Record<string, any>
   >(
-    outputSchema:
-      | InteropZodType<RunOutput>
-      | SerializableSchema<RunOutput>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      | Record<string, any>,
+    outputSchema: StructuredOutputSchema<RunOutput>,
+    config?: StructuredOutputMethodOptions<false>
+  ): Runnable<BaseLanguageModelInput, RunOutput>;
+
+  withStructuredOutput<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    RunOutput extends Record<string, any> = Record<string, any>
+  >(
+    outputSchema: StructuredOutputSchema<RunOutput>,
+    config?: StructuredOutputMethodOptions<true>
+  ): Runnable<BaseLanguageModelInput, StructuredOutputWithRaw<RunOutput>>;
+
+  withStructuredOutput<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    RunOutput extends Record<string, any> = Record<string, any>
+  >(
+    outputSchema: StructuredOutputSchema<RunOutput>,
     config?: StructuredOutputMethodOptions<boolean>
   ):
     | Runnable<BaseLanguageModelInput, RunOutput>
-    | Runnable<
-        BaseLanguageModelInput,
-        { raw: BaseMessage; parsed: RunOutput }
-      > {
+    | Runnable<BaseLanguageModelInput, StructuredOutputWithRaw<RunOutput>>;
+
+  withStructuredOutput<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    RunOutput extends Record<string, any> = Record<string, any>
+  >(
+    outputSchema: StructuredOutputSchema<RunOutput>,
+    config?: StructuredOutputMethodOptions<boolean>
+  ) {
     let llm: Runnable<BaseMessage[], AIMessageChunk, CallOptions>;
     let outputParser: Runnable<BaseMessage, RunOutput>;
 

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test-d.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test-d.ts
@@ -1,0 +1,53 @@
+import { describe, it, expectTypeOf } from "vitest";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { type BaseMessage } from "@langchain/core/messages";
+import { ChatGoogle } from "../index.js";
+import { z } from "zod";
+
+describe("ChatGoogle withStructuredOutput type narrowing", () => {
+  const schema = z.object({
+    name: z.string(),
+    age: z.number(),
+  });
+  type Person = z.infer<typeof schema>;
+
+  const model = new ChatGoogle({
+    model: "gemini-2.5-flash",
+  });
+
+  it("narrows to parsed output when includeRaw is false", () => {
+    const structured = model.withStructuredOutput(schema, {
+      includeRaw: false,
+    });
+
+    type StructuredOutput = Awaited<ReturnType<typeof structured.invoke>>;
+    expectTypeOf<StructuredOutput>().toEqualTypeOf<Person>();
+  });
+
+  it("narrows to raw and parsed output when includeRaw is true", () => {
+    const structured = model.withStructuredOutput(schema, {
+      includeRaw: true,
+    });
+
+    type StructuredOutput = Awaited<ReturnType<typeof structured.invoke>>;
+    expectTypeOf<StructuredOutput>().toEqualTypeOf<{
+      raw: BaseMessage;
+      parsed: Person;
+    }>();
+  });
+
+  it("allows prompt.pipe() with parsed structured output", () => {
+    const prompt = ChatPromptTemplate.fromMessages([
+      ["system", "Extract structured data from the text."],
+      ["human", "{input}"],
+    ]);
+    const structured = model.withStructuredOutput(schema, {
+      includeRaw: false,
+    });
+
+    const chain = prompt.pipe(structured);
+
+    type ChainOutput = Awaited<ReturnType<typeof chain.invoke>>;
+    expectTypeOf<ChainOutput>().toEqualTypeOf<Person>();
+  });
+});

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -10,7 +10,11 @@ import {
 import * as fs from "node:fs";
 import { ApiClient } from "../../clients/index.js";
 import { GoogleRequestRecorder } from "../../utils/handler.js";
-import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import {
+  BaseCallbackHandler,
+  type HandleLLMNewTokenCallbackFields,
+  type NewTokenIndices,
+} from "@langchain/core/callbacks/base";
 import { ChatGoogle, ChatGoogleParams } from "../index.js";
 import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
 import { OutputParserException } from "@langchain/core/output_parsers";
@@ -844,11 +848,11 @@ describe("Google Mock", () => {
         {
           handleLLMNewToken(
             token: string,
-            _idx: unknown,
-            _runId: unknown,
-            _parentRunId: unknown,
-            _tags: unknown,
-            fields: { chunk?: unknown }
+            _idx: NewTokenIndices,
+            _runId: string,
+            _parentRunId?: string,
+            _tags?: string[],
+            fields?: HandleLLMNewTokenCallbackFields
           ) {
             newTokenCalls.push({ text: token, chunk: fields?.chunk });
           },
@@ -961,11 +965,11 @@ describe("Google Mock", () => {
         {
           handleLLMNewToken(
             token: string,
-            _idx: unknown,
-            _runId: unknown,
-            _parentRunId: unknown,
-            _tags: unknown,
-            fields: { chunk?: unknown }
+            _idx: NewTokenIndices,
+            _runId: string,
+            _parentRunId?: string,
+            _tags?: string[],
+            fields?: HandleLLMNewTokenCallbackFields
           ) {
             newTokenCalls.push({ text: token, chunk: fields?.chunk });
           },

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -133,8 +133,15 @@ describe("convertMessagesToGeminiContents", () => {
 
     const toolResponseContent = contents.find((c) => c.role === "function");
     expect(toolResponseContent).toBeDefined();
+    if (!toolResponseContent) {
+      throw new Error("Expected function response content");
+    }
+    expect(toolResponseContent.parts).toBeDefined();
+    if (!toolResponseContent.parts) {
+      throw new Error("Expected function response parts");
+    }
 
-    const functionResponsePart = toolResponseContent!.parts.find(
+    const functionResponsePart = toolResponseContent.parts.find(
       (p) => "functionResponse" in p && p.functionResponse
     );
     expect(functionResponsePart).toBeDefined();
@@ -170,8 +177,15 @@ describe("convertMessagesToGeminiContents", () => {
 
     const toolResponseContent = contents.find((c) => c.role === "function");
     expect(toolResponseContent).toBeDefined();
+    if (!toolResponseContent) {
+      throw new Error("Expected function response content");
+    }
+    expect(toolResponseContent.parts).toBeDefined();
+    if (!toolResponseContent.parts) {
+      throw new Error("Expected function response parts");
+    }
 
-    const functionResponsePart = toolResponseContent!.parts.find(
+    const functionResponsePart = toolResponseContent.parts.find(
       (p) => "functionResponse" in p && p.functionResponse
     );
     expect(functionResponsePart).toBeDefined();


### PR DESCRIPTION
BaseChatGoogle.withStructuredOutput() returned a union type Runnable<..., RunOutput> | Runnable<..., { raw: BaseMessage; parsed: RunOutput }> regardless of the includeRaw config option. This meant callers couldn't get proper type narrowing when passing includeRaw: true or includeRaw: false - the return type was always the full union, breaking .pipe() chains and requiring manual type assertions.
                                                                                                                                                                                                                                                                                                        This PR adds method overload signatures that narrow the return type based on the includeRaw literal type:
- includeRaw: false (or omitted) → Runnable<..., RunOutput>
- includeRaw: true → Runnable<..., { raw: BaseMessage; parsed: RunOutput }>

This matches the pattern already used by @langchain/core's BaseChatModel.withStructuredOutput().

Changes 
- libs/providers/langchain-google/src/chat_models/base.ts - added overload signatures for withStructuredOutput, converted the existing signature into the implementation signature with boolean config type
- libs/providers/langchain-google/src/chat_models/tests/index.test-d.ts - added type-level tests (using vitest expectTypeOf) verifying narrowing works for includeRaw: false, includeRaw: true, and prompt.pipe() chains

Fixes #10307