### PR TITLE
fix(core): add JSDoc docstrings to fakeModel

### DIFF
--- a/libs/langchain-core/src/testing/fake_model_builder.ts
+++ b/libs/langchain-core/src/testing/fake_model_builder.ts
@@ -48,24 +48,10 @@ function nextToolCallId(): string {
  *
  * Queue responses with `.respond()` and `.respondWithTools()`, then
  * pass the instance directly wherever a chat model is expected.
- *
- * Each builder method queues a model response consumed in order per `invoke()`:
- *
- * `.respond(entry)` — enqueue a `BaseMessage`, `Error`, or factory function.
- *
- * `.respondWithTools(toolCalls[])` — enqueue an `AIMessage` with the given
- * tool calls. Content is derived from the input messages automatically.
- *
- * Both can be mixed freely in one chain. When all queued responses are
- * consumed, further invocations throw.
- *
- * Additional configuration:
- * - `.alwaysThrow(error)` — every call throws (overrides the queue)
- * - `.structuredResponse(value)` — value returned by `withStructuredOutput()`
- *
- * The model records all invocations in `.calls` / `.callCount`.
+ * Responses are consumed in first-in-first-out order — one per `invoke()` call.
+ * When all queued responses are consumed, further invocations throw.
  */
-class FakeBuiltModel extends BaseChatModel {
+export class FakeBuiltModel extends BaseChatModel {
   private queue: QueueEntry[] = [];
 
   private _alwaysThrowError: Error | undefined;
@@ -78,10 +64,18 @@ class FakeBuiltModel extends BaseChatModel {
 
   private _calls: FakeModelCall[] = [];
 
+  /**
+   * All invocations recorded by this model, in order.
+   * Each entry contains the `messages` array and `options` that were
+   * passed to `invoke()`.
+   */
   get calls(): FakeModelCall[] {
     return this._calls;
   }
 
+  /**
+   * The number of times this model has been invoked.
+   */
   get callCount(): number {
     return this._calls.length;
   }
@@ -98,6 +92,12 @@ class FakeBuiltModel extends BaseChatModel {
     return [];
   }
 
+  /**
+   * Enqueue a response that the model will return on its next invocation.
+   * @param entry A {@link BaseMessage} to return, an `Error` to throw, or
+   *   a factory `(messages) => BaseMessage | Error` for dynamic responses.
+   * @returns `this`, for chaining.
+   */
   respond(entry: BaseMessage | Error | ResponseFactory): this {
     if (typeof entry === "function") {
       this.queue.push({ kind: "factory", factory: entry });
@@ -109,6 +109,13 @@ class FakeBuiltModel extends BaseChatModel {
     return this;
   }
 
+  /**
+   * Enqueue an {@link AIMessage} that carries the given tool calls.
+   * Content is derived from the input messages at invocation time.
+   * @param toolCalls Array of tool calls. Each entry needs `name` and
+   *   `args`; `id` is optional and auto-generated when omitted.
+   * @returns `this`, for chaining.
+   */
   respondWithTools(
     toolCalls: Array<{ name: string; args: Record<string, any>; id?: string }>
   ): this {
@@ -124,16 +131,33 @@ class FakeBuiltModel extends BaseChatModel {
     return this;
   }
 
+  /**
+   * Make every invocation throw the given error, regardless of the queue.
+   * @param error The error to throw.
+   * @returns `this`, for chaining.
+   */
   alwaysThrow(error: Error): this {
     this._alwaysThrowError = error;
     return this;
   }
 
+  /**
+   * Set the value that {@link withStructuredOutput} will resolve to.
+   * @param value The structured object to return.
+   * @returns `this`, for chaining.
+   */
   structuredResponse(value: Record<string, any>): this {
     this._structuredResponseValue = value;
     return this;
   }
 
+  /**
+   * Bind tools to the model. Returns a new model that shares the same
+   * response queue and call history.
+   * @param tools The tools to bind, as {@link StructuredTool} instances or
+   *   plain {@link ToolSpec} objects.
+   * @returns A new RunnableBinding with the tools bound.
+   */
   bindTools(tools: (StructuredTool | ToolSpec)[]) {
     const merged = [...this._tools, ...tools];
     const next = new FakeBuiltModel();
@@ -147,6 +171,13 @@ class FakeBuiltModel extends BaseChatModel {
     return next.withConfig({} as BaseChatModelCallOptions);
   }
 
+  /**
+   * Returns a {@link Runnable} that produces the {@link structuredResponse}
+   * value. The schema argument is accepted for compatibility but ignored.
+   * @param _params Schema or params (ignored).
+   * @param _config Options (ignored).
+   * @returns A Runnable that resolves to the structured response value.
+   */
   withStructuredOutput<
     RunOutput extends Record<string, any> = Record<string, any>,
   >(
@@ -229,7 +260,27 @@ class FakeBuiltModel extends BaseChatModel {
 }
 
 /**
- * Creates a fake chat model for testing.
+ * Creates a new {@link FakeBuiltModel} for testing.
+ *
+ * Returns a chainable builder — queue responses, then pass the model
+ * anywhere a chat model is expected. Responses are consumed in FIFO
+ * order, one per `invoke()` call.
+ *
+ * ## API summary
+ *
+ * | Method | Description |
+ * | --- | --- |
+ * | `fakeModel()` | Creates a new fake chat model. Returns a chainable builder. |
+ * | `.respond(message)` | Queue an `AIMessage` (or any `BaseMessage`) to return on the next invocation. |
+ * | `.respond(error)` | Queue an `Error` to throw on the next invocation. |
+ * | `.respond(factory)` | Queue a function `(messages) => BaseMessage \| Error` for dynamic responses. |
+ * | `.respondWithTools(toolCalls)` | Shorthand for `.respond()` with tool calls. Each entry needs `name` and `args`; `id` is optional. |
+ * | `.alwaysThrow(error)` | Make every invocation throw this error, regardless of the queue. |
+ * | `.structuredResponse(value)` | Set the value returned by `.withStructuredOutput()`. |
+ * | `.bindTools(tools)` | Bind tools to the model. Returns a `RunnableBinding` that shares the response queue and call recording. |
+ * | `.withStructuredOutput(schema)` | Returns a runnable that produces the `.structuredResponse()` value. |
+ * | `.calls` | Array of `{ messages, options }` for every invocation (read-only). |
+ * | `.callCount` | Number of times the model has been invoked. |
  *
  * @example
  * ```typescript

--- a/libs/langchain-core/src/testing/index.ts
+++ b/libs/langchain-core/src/testing/index.ts
@@ -1,2 +1,2 @@
 export * from "./matchers.js";
-export { fakeModel } from "./fake_model_builder.js";
+export { fakeModel, FakeBuiltModel } from "./fake_model_builder.js";


### PR DESCRIPTION
## Summary

- Add JSDoc docstrings to all public methods and properties on `FakeBuiltModel` (`respond`, `respondWithTools`, `alwaysThrow`, `structuredResponse`, `bindTools`, `withStructuredOutput`, `calls`, `callCount`).
- Add an API summary table to the `fakeModel()` factory function docstring so the full builder API is discoverable from the entry point.
- Export `FakeBuiltModel` class so it appears in the API reference and can be used for type annotations.