### PR TITLE
chore: bump simple-git to fix CVE-2026-28292

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15132,8 +15132,8 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  simple-git@3.32.2:
-    resolution: {integrity: sha512-n/jhNmvYh8dwyfR6idSfpXrFazuyd57jwNMzgjGnKZV/1lTh0HKvPq20v4AQ62rP+l19bWjjXPTCdGHMt0AdrQ==}
+  simple-git@3.33.0:
+    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
 
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
@@ -30179,7 +30179,7 @@ snapshots:
       pretty-ms: 9.3.0
       proper-lockfile: 4.1.2
       semver: 7.7.4
-      simple-git: 3.32.2
+      simple-git: 3.33.0
       slice-ansi: 8.0.0
       stdout-update: 4.0.1
       strip-ansi: 7.1.2
@@ -31841,7 +31841,7 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@3.32.2:
+  simple-git@3.33.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1


### PR DESCRIPTION
## Summary

Bumps `simple-git` from 3.32.2 to 3.33.0 in the lockfile to resolve [CVE-2026-28292](https://github.com/advisories/GHSA-r275-fr43-pm7q).

## Changes

The vulnerability is a case-sensitivity bypass in `simple-git`'s `blockUnsafeOperationsPlugin`. The regex that blocks `-c protocol.allow=always` is case-sensitive, but git treats config keys case-insensitively — passing `-c PROTOCOL.ALLOW=always` bypasses the check and enables arbitrary command execution via the `ext::` protocol.

In this repo, `simple-git` is a transitive dependency of `node-llama-cpp` (an optional peer dependency of `@langchain/community`). The practical exploit risk is low since the vulnerable code path requires user-controlled arguments passed to git operations, which `node-llama-cpp` doesn't expose. Nonetheless, this patch resolves the critical CVE in the lockfile.

`node-llama-cpp@3.17.1` already declares `"simple-git": "^3.32.2"`, so the semver range covers the fix — only the lockfile needed updating. No `package.json` changes required.
