### PR TITLE
fix: bump basic-ftp to 5.2.0 to resolve CVE-2026-27699

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10038,10 +10038,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.1.0:
-    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
+  basic-ftp@5.2.0:
+    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -22100,8 +22099,8 @@ snapshots:
   '@mistralai/mistralai@1.15.1(bufferutil@4.1.0)':
     dependencies:
       ws: 8.19.0(bufferutil@4.1.0)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -25602,7 +25601,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  basic-ftp@5.1.0: {}
+  basic-ftp@5.2.0: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -27918,7 +27917,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.1.0
+      basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## CVE Fix: CVE-2026-27699

**Package:** `basic-ftp`
**Vulnerable versions:** < 5.2.0
**Fixed version:** 5.2.0
**Severity:** Critical (CVSS 9.1)
**CVE:** https://nvd.nist.gov/vuln/detail/CVE-2026-27699
**Advisory:** https://github.com/patrickjuchli/basic-ftp/security/advisories/GHSA-5rq4-664w-9x2c

### Summary

Path traversal vulnerability in `basic-ftp`'s `downloadToDir()` method allows a malicious FTP server to write files outside the intended download directory.

### Fix

Lockfile-only update. The existing `^5.0.2` range in `get-uri` already allows 5.2.0 — this just re-resolves the transitive dependency in the lockfile from 5.1.0 → 5.2.0.

### Dependency chain

`puppeteer` / `apify-client` / `release-it` → `proxy-agent` → `pac-proxy-agent` → `get-uri` → `basic-ftp`

All paths are dev-only (devDependencies/peerDependencies).