### PR TITLE
fix: Add changeset for fake model docs

### DIFF
--- a/.changeset/quiet-birds-glow.md
+++ b/.changeset/quiet-birds-glow.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): add JSDoc docstrings to fakeModel builder API and export FakeBuiltModel


### PR DESCRIPTION
## Summary

- Add JSDoc docstrings to all public methods and properties on `FakeBuiltModel` (`respond`, `respondWithTools`, `alwaysThrow`, `structuredResponse`, `bindTools`, `withStructuredOutput`, `calls`, `callCount`).
- Add an API summary table to the `fakeModel()` factory function docstring so the full builder API is discoverable from the entry point.
- Export `FakeBuiltModel` class so it appears in the API reference and can be used for type annotations.