### PR TITLE
fix: bump tar override to >=7.5.11 to resolve CVE-2026-29786, CVE-2026-31802

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "@langchain/core": "workspace:^",
       "protobufjs": "^7.2.5",
       "form-data": "^4.0.4",
-      "tar": ">=7.5.4",
+      "tar": ">=7.5.11",
       "node-forge": ">=1.3.2"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@langchain/core': workspace:^
   protobufjs: ^7.2.5
   form-data: ^4.0.4
-  tar: '>=7.5.4'
+  tar: '>=7.5.11'
   node-forge: '>=1.3.2'
 
 importers:
@@ -14999,13 +14999,8 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
 
   tarn@3.0.2:
@@ -20095,7 +20090,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -24069,7 +24064,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.7
+      tar: 7.5.11
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -24370,7 +24365,7 @@ snapshots:
       closevector-common: 0.1.3
       closevector-hnswlib-node: 0.1.1
       jsonwebtoken: 9.0.3
-      tar: 7.5.7
+      tar: 7.5.11
       typescript: 5.9.3
     transitivePeerDependencies:
       - debug
@@ -24426,7 +24421,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.11
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -26108,7 +26103,7 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3
-      tar: 7.5.9
+      tar: 7.5.11
 
   giget@2.0.0:
     dependencies:
@@ -28103,7 +28098,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mitt@3.0.1: {}
 
@@ -28314,7 +28309,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.7
+      tar: 7.5.11
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -28530,7 +28525,7 @@ snapshots:
     dependencies:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
-      tar: 7.5.7
+      tar: 7.5.11
 
   onnxruntime-web@1.14.0:
     dependencies:
@@ -28906,7 +28901,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -30132,7 +30127,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 7.5.7
+      tar: 7.5.11
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -30418,15 +30413,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.7:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  tar@7.5.9:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Security Alert Patch

Resolves 2 Dependabot security alerts (high severity).

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | CVEs Resolved |
|---------|---------------|----------------|----------|---------------|
| `tar` | `>=7.5.4` | `>=7.5.11` | pnpm override bump | CVE-2026-29786, CVE-2026-31802 |

### CVE Details

- **CVE-2026-29786** ([GHSA-qffp-2rhf-9h96](https://github.com/advisories/GHSA-qffp-2rhf-9h96)): tar — Hardlink Path Traversal via Drive-Relative Linkpath (`<= 7.5.9`, fixed in `7.5.10`)
- **CVE-2026-31802** ([GHSA-9ppj-qmqm-q256](https://github.com/advisories/GHSA-9ppj-qmqm-q256)): tar — Symlink Path Traversal via Drive-Relative Linkpath (`<= 7.5.10`, fixed in `7.5.11`)

### Notes

`tar` is not a direct dependency of any published `@langchain/*` package. It is pulled in transitively by build/optional deps (`cmake-js`, `node-gyp`, `sqlite3`, `onnxruntime-node`, `closevector-node`, `giget`). The existing `pnpm.overrides` entry forces all resolutions to the patched version.

### Verification

- [x] Lockfile regenerated — all `tar@7.5.7` and `tar@7.5.9` resolutions replaced with `tar@7.5.11`
- [x] `pnpm install` succeeds