### PR TITLE
feat: add @langchain/iointelligence provider package

### DIFF
--- a/libs/providers/langchain-iointelligence/CHANGELOG.md
+++ b/libs/providers/langchain-iointelligence/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @langchain/iointelligence

--- a/libs/providers/langchain-iointelligence/LICENSE
+++ b/libs/providers/langchain-iointelligence/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) LangChain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/providers/langchain-iointelligence/README.md
+++ b/libs/providers/langchain-iointelligence/README.md
@@ -1,0 +1,79 @@
+# @langchain/iointelligence
+
+This package contains the LangChain.js integrations for IO Intelligence.
+
+## Installation
+
+```bash npm2yarn
+npm install @langchain/iointelligence @langchain/core
+```
+
+## Chat models
+
+This package adds support for IO Intelligence chat model inference via their OpenAI-compatible API.
+
+Set the necessary environment variable (or pass it in via the constructor):
+
+```bash
+export IO_INTELLIGENCE_API_KEY=
+```
+
+```typescript
+import { ChatIOIntelligence } from "@langchain/iointelligence";
+
+const model = new ChatIOIntelligence({
+  apiKey: process.env.IO_INTELLIGENCE_API_KEY, // Default value.
+  model: "meta-llama/Llama-3.3-70B-Instruct",
+});
+
+const res = await model.invoke([
+  {
+    role: "user",
+    content: "What is the capital of France?",
+  },
+]);
+```
+
+## Development
+
+To develop the `@langchain/iointelligence` package, you'll need to follow these instructions:
+
+### Install dependencies
+
+```bash
+pnpm install
+```
+
+### Build the package
+
+```bash
+pnpm build
+```
+
+Or from the repo root:
+
+```bash
+pnpm build --filter @langchain/iointelligence
+```
+
+### Run tests
+
+Test files should live within a `tests/` file in the `src/` folder. Unit tests should end in `.test.ts` and integration tests should
+end in `.int.test.ts`:
+
+```bash
+$ pnpm test
+$ pnpm test:int
+```
+
+### Lint & Format
+
+Run the linter & formatter to ensure your code is up to standard:
+
+```bash
+pnpm lint && pnpm format
+```
+
+### Adding new entrypoints
+
+If you add a new file to be exported, either import & re-export from `src/index.ts`, or add it to the `exports` field in the `package.json` file and run `pnpm build` to generate the new entrypoint.

--- a/libs/providers/langchain-iointelligence/docs/iointelligence.mdx
+++ b/libs/providers/langchain-iointelligence/docs/iointelligence.mdx
@@ -1,0 +1,122 @@
+---
+title: "ChatIOIntelligence integration"
+description: "Integrate with the ChatIOIntelligence chat model using LangChain JavaScript."
+---
+
+# ChatIOIntelligence
+
+[IO Intelligence](https://intelligence.io.solutions/) provides access to a wide range of open-source and proprietary models through an OpenAI-compatible API, powered by decentralized GPU infrastructure.
+
+This guide will help you getting started with `ChatIOIntelligence` [chat models](/oss/langchain/models). For detailed documentation of all `ChatIOIntelligence` features and configurations head to the [API reference](https://api.js.langchain.com/classes/_langchain_iointelligence.ChatIOIntelligence.html).
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | [PY support](https://python.langchain.com) | Package latest |
+| :--- | :--- | :---: | :---: | :---: |
+| `ChatIOIntelligence` | [`@langchain/iointelligence`](https://npmjs.com/@langchain/iointelligence) | ✅ | ❌ | ![NPM - Version](https://img.shields.io/npm/v/@langchain/iointelligence?style=flat-square&label=%20&) |
+
+### Model features
+
+| [Tool calling](/oss/javascript/docs/how_to/tool_calling) | [Structured output](/oss/javascript/docs/how_to/structured_output) | Image input | Audio input | Video input | [Token-level streaming](/oss/javascript/docs/how_to/chat_streaming) | [Token usage](/oss/javascript/docs/how_to/chat_token_usage_tracking) | [Logprobs](/oss/javascript/docs/how_to/logprobs) |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+
+## Setup
+
+To access IO Intelligence models you'll need to create an IO Intelligence account, get an API key, and install the `@langchain/iointelligence` integration package.
+
+### Credentials
+
+Head to [IO Intelligence](https://intelligence.io.solutions/) to sign up and generate an API key.
+
+```bash
+export IO_INTELLIGENCE_API_KEY="your-api-key"
+```
+
+If you want to get automated tracing of your model calls you can also set your [LangSmith](https://docs.smith.langchain.com/) API key by uncommenting below:
+
+```bash
+# export LANGSMITH_TRACING="true"
+# export LANGSMITH_API_KEY="your-api-key"
+```
+
+### Installation
+
+The LangChain ChatIOIntelligence integration lives in the `@langchain/iointelligence` package:
+
+<CodeGroup>
+
+```bash npm
+npm install @langchain/iointelligence @langchain/core
+```
+
+```bash yarn
+yarn add @langchain/iointelligence @langchain/core
+```
+
+```bash pnpm
+pnpm add @langchain/iointelligence @langchain/core
+```
+
+</CodeGroup>
+
+## Instantiation
+
+Now we can instantiate our model object and generate chat completions:
+
+```typescript
+import { ChatIOIntelligence } from "@langchain/iointelligence";
+
+const llm = new ChatIOIntelligence({
+  model: "meta-llama/Llama-3.3-70B-Instruct",
+  temperature: 0,
+  // other params...
+});
+```
+
+## Invocation
+
+```typescript
+const aiMsg = await llm.invoke([
+  {
+    role: "system",
+    content:
+      "You are a helpful assistant that translates English to French. Translate the user sentence.",
+  },
+  {
+    role: "user",
+    content: "I love programming.",
+  },
+]);
+aiMsg;
+```
+
+```txt
+AIMessage {
+  "content": "J'adore la programmation.",
+  "response_metadata": {
+    "tokenUsage": {
+      "completionTokens": 8,
+      "promptTokens": 31,
+      "totalTokens": 39
+    },
+    "finish_reason": "stop"
+  },
+  "tool_calls": [],
+  "invalid_tool_calls": []
+}
+```
+
+```typescript
+console.log(aiMsg.content);
+```
+
+```txt
+J'adore la programmation.
+```
+
+## API reference
+
+For detailed documentation of all ChatIOIntelligence features and configurations head to the [API reference](https://api.js.langchain.com/classes/_langchain_iointelligence.ChatIOIntelligence.html).

--- a/libs/providers/langchain-iointelligence/eslint.config.ts
+++ b/libs/providers/langchain-iointelligence/eslint.config.ts
@@ -1,0 +1,3 @@
+import { langchainConfig } from "@langchain/eslint";
+
+export default langchainConfig;

--- a/libs/providers/langchain-iointelligence/package.json
+++ b/libs/providers/langchain-iointelligence/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@langchain/iointelligence",
+  "version": "0.0.1",
+  "description": "IO Intelligence integration for LangChain.js",
+  "type": "module",
+  "author": "LangChain",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:langchain-ai/langchainjs.git"
+  },
+  "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/providers/langchain-iointelligence",
+  "scripts": {
+    "build": "turbo build:compile --filter @langchain/iointelligence --output-logs new-only",
+    "build:compile": "tsdown",
+    "lint:eslint": "eslint --cache src/",
+    "lint:dpdm": "dpdm --skip-dynamic-imports circular --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
+    "lint": "pnpm lint:eslint && pnpm lint:dpdm",
+    "lint:fix": "pnpm lint:eslint --fix && pnpm lint:dpdm",
+    "clean": "rm -rf .turbo dist/",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:int": "vitest run --mode int",
+    "test:standard:unit": "vitest run --mode standard-unit",
+    "test:standard:int": "vitest run --mode standard-int",
+    "test:standard": "pnpm test:standard:unit && pnpm test:standard:int",
+    "format": "prettier --write \"src\"",
+    "format:check": "prettier --check \"src\""
+  },
+  "dependencies": {
+    "@langchain/openai": "workspace:*"
+  },
+  "peerDependencies": {
+    "@langchain/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@langchain/core": "workspace:^",
+    "@langchain/eslint": "workspace:*",
+    "@langchain/standard-tests": "workspace:*",
+    "@langchain/tsconfig": "workspace:*",
+    "@tsconfig/recommended": "^1.0.3",
+    "@vitest/coverage-v8": "^3.2.4",
+    "dotenv": "^16.3.1",
+    "dpdm": "^3.14.0",
+    "eslint": "^9.34.0",
+    "prettier": "^3.5.0",
+    "typescript": "~5.8.3",
+    "vitest": "^3.2.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "input": "./src/index.ts",
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "module": "./dist/index.js"
+}

--- a/libs/providers/langchain-iointelligence/src/chat_models.ts
+++ b/libs/providers/langchain-iointelligence/src/chat_models.ts
@@ -1,0 +1,246 @@
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import {
+  ChatOpenAICallOptions,
+  ChatOpenAICompletions,
+  ChatOpenAIFields,
+} from "@langchain/openai";
+
+export interface ChatIOIntelligenceCallOptions
+  extends ChatOpenAICallOptions {
+  headers?: Record<string, string>;
+}
+
+export interface ChatIOIntelligenceInput extends ChatOpenAIFields {
+  /**
+   * The IO Intelligence API key to use for requests.
+   * @default process.env.IO_INTELLIGENCE_API_KEY
+   */
+  apiKey?: string;
+  /**
+   * The name of the model to use.
+   */
+  model?: string;
+  /**
+   * Up to 4 sequences where the API will stop generating further tokens. The
+   * returned text will not contain the stop sequence.
+   * Alias for `stopSequences`
+   */
+  stop?: Array<string>;
+  /**
+   * Up to 4 sequences where the API will stop generating further tokens. The
+   * returned text will not contain the stop sequence.
+   */
+  stopSequences?: Array<string>;
+  /**
+   * Whether or not to stream responses.
+   */
+  streaming?: boolean;
+  /**
+   * The temperature to use for sampling.
+   */
+  temperature?: number;
+  /**
+   * The maximum number of tokens that the model can process in a single response.
+   * This limits ensures computational efficiency and resource management.
+   */
+  maxTokens?: number;
+}
+
+/**
+ * IO Intelligence chat model integration.
+ *
+ * IO Intelligence provides an OpenAI-compatible API for accessing a wide
+ * range of open-source and proprietary models through decentralized GPU
+ * infrastructure.
+ *
+ * Setup:
+ * Install `@langchain/iointelligence` and set an environment variable named `IO_INTELLIGENCE_API_KEY`.
+ *
+ * ```bash
+ * npm install @langchain/iointelligence
+ * export IO_INTELLIGENCE_API_KEY="your-api-key"
+ * ```
+ *
+ * ## [Constructor args](https://api.js.langchain.com/classes/_langchain_iointelligence.ChatIOIntelligence.html#constructor)
+ *
+ * ## [Runtime args](https://api.js.langchain.com/interfaces/_langchain_iointelligence.ChatIOIntelligenceCallOptions.html)
+ *
+ * Runtime args can be passed as the second argument to any of the base runnable methods `.invoke`. `.stream`, `.batch`, etc.
+ * They can also be passed via `.withConfig`, or the second arg in `.bindTools`, like shown in the examples below:
+ *
+ * ```typescript
+ * // When calling `.withConfig`, call options should be passed via the first argument
+ * const llmWithArgsBound = llm.withConfig({
+ *   stop: ["\n"],
+ *   tools: [...],
+ * });
+ *
+ * // When calling `.bindTools`, call options should be passed via the second argument
+ * const llmWithTools = llm.bindTools(
+ *   [...],
+ *   {
+ *     tool_choice: "auto",
+ *   }
+ * );
+ * ```
+ *
+ * ## Examples
+ *
+ * <details open>
+ * <summary><strong>Instantiate</strong></summary>
+ *
+ * ```typescript
+ * import { ChatIOIntelligence } from '@langchain/iointelligence';
+ *
+ * const llm = new ChatIOIntelligence({
+ *   model: "meta-llama/Llama-3.3-70B-Instruct",
+ *   temperature: 0,
+ *   // other params...
+ * });
+ * ```
+ * </details>
+ *
+ * <br />
+ *
+ * <details>
+ * <summary><strong>Invoking</strong></summary>
+ *
+ * ```typescript
+ * const input = `Translate "I love programming" into French.`;
+ *
+ * // Models also accept a list of chat messages or a formatted prompt
+ * const result = await llm.invoke(input);
+ * console.log(result);
+ * ```
+ *
+ * ```txt
+ * AIMessage {
+ *   "content": "The French translation of \"I love programming\" is \"J'adore la programmation\".",
+ *   "response_metadata": {
+ *     "tokenUsage": {
+ *       "completionTokens": 18,
+ *       "promptTokens": 14,
+ *       "totalTokens": 32
+ *     },
+ *     "finish_reason": "stop"
+ *   },
+ *   "tool_calls": [],
+ *   "invalid_tool_calls": []
+ * }
+ * ```
+ * </details>
+ *
+ * <br />
+ *
+ * <details>
+ * <summary><strong>Streaming Chunks</strong></summary>
+ *
+ * ```typescript
+ * for await (const chunk of await llm.stream(input)) {
+ *   console.log(chunk);
+ * }
+ * ```
+ * </details>
+ *
+ * <br />
+ *
+ * <details>
+ * <summary><strong>Bind tools</strong></summary>
+ *
+ * ```typescript
+ * import { z } from 'zod';
+ *
+ * const GetWeather = {
+ *   name: "GetWeather",
+ *   description: "Get the current weather in a given location",
+ *   schema: z.object({
+ *     location: z.string().describe("The city and state, e.g. San Francisco, CA")
+ *   }),
+ * }
+ *
+ * const GetPopulation = {
+ *   name: "GetPopulation",
+ *   description: "Get the current population in a given location",
+ *   schema: z.object({
+ *     location: z.string().describe("The city and state, e.g. San Francisco, CA")
+ *   }),
+ * }
+ *
+ * const llmWithTools = llm.bindTools([GetWeather, GetPopulation]);
+ * const aiMsg = await llmWithTools.invoke(
+ *   "Which city is hotter today and which is bigger: LA or NY?"
+ * );
+ * console.log(aiMsg.tool_calls);
+ * ```
+ * </details>
+ *
+ * <br />
+ *
+ * <details>
+ * <summary><strong>Structured Output</strong></summary>
+ *
+ * ```typescript
+ * import { z } from 'zod';
+ *
+ * const Joke = z.object({
+ *   setup: z.string().describe("The setup of the joke"),
+ *   punchline: z.string().describe("The punchline to the joke"),
+ *   rating: z.number().optional().describe("How funny the joke is, from 1 to 10")
+ * }).describe('Joke to tell user.');
+ *
+ * const structuredLlm = llm.withStructuredOutput(Joke, { name: "Joke" });
+ * const jokeResult = await structuredLlm.invoke("Tell me a joke about cats");
+ * console.log(jokeResult);
+ * ```
+ * </details>
+ *
+ * <br />
+ */
+export class ChatIOIntelligence extends ChatOpenAICompletions<ChatIOIntelligenceCallOptions> {
+  static lc_name() {
+    return "ChatIOIntelligence";
+  }
+
+  _llmType() {
+    return "iointelligence";
+  }
+
+  get lc_secrets(): { [key: string]: string } | undefined {
+    return {
+      apiKey: "IO_INTELLIGENCE_API_KEY",
+    };
+  }
+
+  lc_serializable = true;
+
+  lc_namespace = ["langchain", "chat_models", "iointelligence"];
+
+  constructor(model: string, fields?: Omit<ChatIOIntelligenceInput, "model">);
+  constructor(fields?: Partial<ChatIOIntelligenceInput>);
+  constructor(
+    modelOrFields?: string | Partial<ChatIOIntelligenceInput>,
+    fieldsArg?: Omit<ChatIOIntelligenceInput, "model">
+  ) {
+    const fields =
+      typeof modelOrFields === "string"
+        ? { ...(fieldsArg ?? {}), model: modelOrFields }
+        : (modelOrFields ?? {});
+    const apiKey =
+      fields.apiKey || getEnvironmentVariable("IO_INTELLIGENCE_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        `IO Intelligence API key not found. Please set the IO_INTELLIGENCE_API_KEY environment variable or pass the key into "apiKey" field.`
+      );
+    }
+
+    super({
+      ...fields,
+      apiKey,
+      configuration: {
+        baseURL: "https://api.intelligence.io.solutions/api/v1",
+        ...fields.configuration,
+      },
+    });
+    this._addVersion("@langchain/iointelligence", __PKG_VERSION__);
+  }
+}

--- a/libs/providers/langchain-iointelligence/src/index.ts
+++ b/libs/providers/langchain-iointelligence/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./chat_models.js";

--- a/libs/providers/langchain-iointelligence/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-iointelligence/src/tests/chat_models.int.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "vitest";
+import { ChatIOIntelligence } from "../chat_models.js";
+
+test("invoke", async () => {
+  const llm = new ChatIOIntelligence({
+    model: "meta-llama/Llama-3.3-70B-Instruct",
+  });
+  const result = await llm.invoke("What is 2 + 2?");
+  expect(result.content.length).toBeGreaterThan(0);
+});
+
+test("stream", async () => {
+  const llm = new ChatIOIntelligence({
+    model: "meta-llama/Llama-3.3-70B-Instruct",
+  });
+  const stream = await llm.stream("What is 2 + 2?");
+  let tokens = "";
+  for await (const chunk of stream) {
+    tokens += chunk.content;
+  }
+  expect(tokens.length).toBeGreaterThan(0);
+});

--- a/libs/providers/langchain-iointelligence/src/tests/chat_models.standard.int.test.ts
+++ b/libs/providers/langchain-iointelligence/src/tests/chat_models.standard.int.test.ts
@@ -1,0 +1,39 @@
+import { ChatModelIntegrationTests } from "@langchain/standard-tests/vitest";
+import { AIMessageChunk } from "@langchain/core/messages";
+import {
+  ChatIOIntelligence,
+  ChatIOIntelligenceCallOptions,
+} from "../chat_models.js";
+
+class ChatIOIntelligenceStandardIntegrationTests extends ChatModelIntegrationTests<
+  ChatIOIntelligenceCallOptions,
+  AIMessageChunk
+> {
+  constructor() {
+    if (!process.env.IO_INTELLIGENCE_API_KEY) {
+      throw new Error(
+        "IO_INTELLIGENCE_API_KEY must be set to run standard integration tests."
+      );
+    }
+    super({
+      Cls: ChatIOIntelligence,
+      chatModelHasToolCalling: true,
+      chatModelHasStructuredOutput: true,
+      constructorArgs: {
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        maxRetries: 0,
+      },
+    });
+  }
+
+  supportedUsageMetadataDetails: {
+    invoke: Array<"audio_input" | "audio_output">;
+    stream: Array<"audio_input" | "audio_output">;
+  } = {
+    invoke: [],
+    stream: [],
+  };
+}
+
+const testClass = new ChatIOIntelligenceStandardIntegrationTests();
+testClass.runTests("ChatIOIntelligenceStandardIntegrationTests");

--- a/libs/providers/langchain-iointelligence/src/tests/chat_models.standard.test.ts
+++ b/libs/providers/langchain-iointelligence/src/tests/chat_models.standard.test.ts
@@ -1,0 +1,36 @@
+import { ChatModelUnitTests } from "@langchain/standard-tests/vitest";
+import { AIMessageChunk } from "@langchain/core/messages";
+import {
+  ChatIOIntelligence,
+  ChatIOIntelligenceCallOptions,
+} from "../chat_models.js";
+
+class ChatIOIntelligenceStandardUnitTests extends ChatModelUnitTests<
+  ChatIOIntelligenceCallOptions,
+  AIMessageChunk
+> {
+  constructor() {
+    super({
+      Cls: ChatIOIntelligence,
+      chatModelHasToolCalling: true,
+      chatModelHasStructuredOutput: true,
+      constructorArgs: {},
+    });
+    // This must be set so methods like `.bindTools` or `.withStructuredOutput`
+    // which we call after instantiating the model will work.
+    // (constructor will throw if API key is not set)
+    process.env.IO_INTELLIGENCE_API_KEY = "test";
+  }
+
+  testChatModelInitApiKey() {
+    // Unset the API key env var here so this test can properly check
+    // the API key class arg.
+    process.env.IO_INTELLIGENCE_API_KEY = "";
+    super.testChatModelInitApiKey();
+    // Re-set the API key env var here so other tests can run properly.
+    process.env.IO_INTELLIGENCE_API_KEY = "test";
+  }
+}
+
+const testClass = new ChatIOIntelligenceStandardUnitTests();
+testClass.runTests("ChatIOIntelligenceStandardUnitTests");

--- a/libs/providers/langchain-iointelligence/tsconfig.json
+++ b/libs/providers/langchain-iointelligence/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@langchain/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../../langchain-core" },
+    { "path": "../langchain-openai" }
+  ]
+}

--- a/libs/providers/langchain-iointelligence/tsdown.config.ts
+++ b/libs/providers/langchain-iointelligence/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { getBuildConfig, cjsCompatPlugin } from "@langchain/build";
+import pkg from "./package.json" with { type: "json" };
+
+export default getBuildConfig({
+  entry: ["./src/index.ts"],
+  define: { __PKG_VERSION__: JSON.stringify(pkg.version) },
+  plugins: [
+    cjsCompatPlugin({
+      files: ["dist/", "CHANGELOG.md", "README.md", "LICENSE"],
+    }),
+  ],
+});

--- a/libs/providers/langchain-iointelligence/vitest.config.ts
+++ b/libs/providers/langchain-iointelligence/vitest.config.ts
@@ -1,0 +1,73 @@
+import {
+  configDefaults,
+  defineConfig,
+  type UserConfigExport,
+} from "vitest/config";
+import pkg from "./package.json" with { type: "json" };
+const define = { __PKG_VERSION__: JSON.stringify(pkg.version) };
+
+export default defineConfig((env) => {
+  const common: UserConfigExport = {
+    test: {
+      environment: "node",
+      hideSkippedTests: true,
+      testTimeout: 30_000,
+      maxWorkers: 0.5,
+      exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
+      setupFiles: ["dotenv/config"],
+    },
+  };
+
+  if (env.mode === "standard-unit") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.standard.test.ts"],
+        name: "standard-unit",
+        environment: "node",
+      },
+    };
+  }
+
+  if (env.mode === "standard-int") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.standard.int.test.ts"],
+        name: "standard-int",
+        environment: "node",
+      },
+    };
+  }
+
+  if (env.mode === "int") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        globals: false,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.int.test.ts"],
+        name: "int",
+        environment: "node",
+      },
+    };
+  }
+
+  return {
+    define,
+    test: {
+      ...common.test,
+      environment: "node",
+      include: configDefaults.include,
+      typecheck: { enabled: true },
+    },
+  };
+});


### PR DESCRIPTION
## Description

Add [IO Intelligence](https://intelligence.io.solutions/) as a named LangChain chat model provider.

IO Intelligence provides an OpenAI-compatible API (base URL: `https://api.intelligence.io.solutions/api/v1`) for accessing open-source and proprietary models through decentralized GPU infrastructure.

The package extends `ChatOpenAICompletions` following the same pattern as `@langchain/deepseek` and `@langchain/xai`.

### What's included:
- `ChatIOIntelligence` chat model class (`src/chat_models.ts`)
- Standard unit tests (`src/tests/chat_models.standard.test.ts`)
- Standard integration tests (`src/tests/chat_models.standard.int.test.ts`)
- Custom integration tests (`src/tests/chat_models.int.test.ts`)
- Integration docs page (MDX) in `docs/` folder
- Full package configuration (package.json, tsconfig, tsdown, vitest, eslint)

### Usage:
```typescript
import { ChatIOIntelligence } from "@langchain/iointelligence";

const llm = new ChatIOIntelligence({
  model: "meta-llama/Llama-3.3-70B-Instruct",
  temperature: 0,
});

const result = await llm.invoke("Hello, world!");
```

### Environment variable:
```bash
export IO_INTELLIGENCE_API_KEY="your-api-key"
```

Twitter: @ionet_official