### PR TITLE
fix(agents): continue after blocked tool calls

### DIFF
--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -935,6 +935,13 @@ export class ReactAgent<
         return AGENT_NODE_NAME;
       }
 
+      // afterModel middleware can inject ToolMessages (for example, when it blocks
+      // tool calls). Once every pending tool call has a corresponding ToolMessage,
+      // route back to the model so it can respond instead of exiting early.
+      if (ToolMessage.isInstance(lastMessage)) {
+        return AGENT_NODE_NAME;
+      }
+
       if (
         !AIMessage.isInstance(lastMessage) ||
         !lastMessage.tool_calls ||

--- a/libs/langchain/src/agents/middleware/tests/toolCallLimit.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/toolCallLimit.test.ts
@@ -676,7 +676,7 @@ describe("toolCallLimitMiddleware", () => {
       }
     });
 
-    it("should run remaining tools until limit is exceeded", async () => {
+    it("should return to the model when remaining tool calls are blocked", async () => {
       const middleware = toolCallLimitMiddleware({
         threadLimit: 3,
         runLimit: 2,
@@ -697,7 +697,7 @@ describe("toolCallLimitMiddleware", () => {
             content: "",
             tool_calls: [{ id: "4", name: "search", args: { query: "test3" } }],
           }),
-          new AIMessage("Should not reach here"),
+          new AIMessage("Final response after tool limit"),
         ],
       });
 
@@ -712,8 +712,16 @@ describe("toolCallLimitMiddleware", () => {
       });
 
       const lastMessage = result.messages[result.messages.length - 1];
-      expect(lastMessage.content).toContain(
-        "Tool call limit exceeded. Do not make additional tool calls."
+      expect(AIMessage.isInstance(lastMessage)).toBe(true);
+      expect(lastMessage.content).toBe("Final response after tool limit");
+
+      const blockedToolMessages = result.messages.filter(
+        (message): message is ToolMessage =>
+          ToolMessage.isInstance(message) && message.status === "error"
+      );
+      expect(blockedToolMessages).toHaveLength(2);
+      expect(blockedToolMessages[0].content).toContain(
+        "Tool call limit exceeded"
       );
       expect(searchToolMock).toHaveBeenCalledTimes(2);
       expect(calculatorToolMock).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
## Summary
- route back to the model when after-model middleware injects only `ToolMessage`s and there are no tool calls left to execute
- keep the existing pending-tool-call routing intact so allowed tool calls still run before we re-enter the model
- update the tool call limit regression to assert the agent produces a final AI response after blocked tool calls

Fixes #10090

## Validation
- `pnpm exec vitest run src/agents/middleware/tests/toolCallLimit.test.ts`
- `pnpm exec eslint src/agents/ReactAgent.ts src/agents/middleware/tests/toolCallLimit.test.ts`