### PR TITLE
fix(core): align StructuredPrompt.pipe() with Python implementation

### DIFF
--- a/libs/langchain-core/src/prompts/structured.ts
+++ b/libs/langchain-core/src/prompts/structured.ts
@@ -1,5 +1,9 @@
 import { ChatPromptValueInterface } from "../prompt_values.js";
-import { RunnableLike, Runnable, RunnableBinding } from "../runnables/base.js";
+import {
+  RunnableLike,
+  Runnable,
+  RunnableSequence,
+} from "../runnables/base.js";
 import { RunnableConfig } from "../runnables/config.js";
 import { InputValues } from "../utils/types/index.js";
 import {
@@ -16,16 +20,6 @@ function isWithStructuredOutput(x: unknown): x is {
     x != null &&
     "withStructuredOutput" in x &&
     typeof x.withStructuredOutput === "function"
-  );
-}
-
-function isRunnableBinding(x: unknown): x is RunnableBinding<unknown, unknown> {
-  return (
-    typeof x === "object" &&
-    x != null &&
-    "lc_id" in x &&
-    Array.isArray(x.lc_id) &&
-    x.lc_id.join("/") === "langchain_core/runnables/RunnableBinding"
   );
 }
 
@@ -76,24 +70,27 @@ export class StructuredPrompt<
     coerceable: RunnableLike<ChatPromptValueInterface, NewRunOutput>
   ): Runnable<RunInput, Exclude<NewRunOutput, Error>, RunnableConfig> {
     if (isWithStructuredOutput(coerceable)) {
-      return super.pipe(coerceable.withStructuredOutput(this.schema));
+      return RunnableSequence.from([
+        this,
+        coerceable.withStructuredOutput(
+          this.schema,
+          ...(this.method ? [{ method: this.method }] : [])
+        ),
+      ]);
     }
 
-    if (
-      isRunnableBinding(coerceable) &&
-      isWithStructuredOutput(coerceable.bound)
-    ) {
-      return super.pipe(
-        new RunnableBinding({
-          bound: coerceable.bound.withStructuredOutput(
+    if (RunnableSequence.isRunnableSequence(coerceable)) {
+      const [first, ...rest] = coerceable.steps;
+      if (isWithStructuredOutput(first)) {
+        return RunnableSequence.from([
+          this,
+          first.withStructuredOutput(
             this.schema,
             ...(this.method ? [{ method: this.method }] : [])
           ),
-          kwargs: coerceable.kwargs ?? {},
-          config: coerceable.config,
-          configFactories: coerceable.configFactories,
-        })
-      );
+          ...rest,
+        ]);
+      }
     }
 
     throw new Error(

--- a/libs/langchain-core/src/prompts/tests/structured.test.ts
+++ b/libs/langchain-core/src/prompts/tests/structured.test.ts
@@ -14,6 +14,8 @@ import { StructuredPrompt } from "../structured.js";
 import { load } from "../../load/index.js";
 
 class FakeStructuredChatModel extends FakeListChatModel {
+  lastWithStructuredOutputOptions?: Record<string, any>;
+
   withStructuredOutput<
     RunOutput extends Record<string, any> = Record<string, any>,
   >(
@@ -53,6 +55,7 @@ class FakeStructuredChatModel extends FakeListChatModel {
         { raw: BaseMessage; parsed: RunOutput },
         RunnableConfig
       > {
+    this.lastWithStructuredOutputOptions = _config as Record<string, any>;
     if (!_config?.includeRaw) {
       if (typeof _params === "object") {
         const func = RunnableLambda.from(
@@ -97,10 +100,74 @@ test("Test format", async () => {
   const revivedChain = revived.pipe(model);
 
   await expect(revivedChain.invoke({})).resolves.toEqual(schema);
+});
 
-  const boundModel = model.withConfig({ runName: "boundModel" });
+test("Test method is passed to withStructuredOutput", async () => {
+  const schema = {
+    name: "yo",
+    description: "a structured output",
+    parameters: {
+      name: { type: "string" },
+      value: { type: "integer" },
+    },
+  };
+  const prompt = StructuredPrompt.fromMessagesAndSchema(
+    [["human", "I'm very structured, how about you?"]],
+    schema,
+    "jsonMode"
+  );
 
-  const chainWithBoundModel = prompt.pipe(boundModel);
+  const model = new FakeStructuredChatModel({ responses: [] });
 
-  await expect(chainWithBoundModel.invoke({})).resolves.toEqual(schema);
+  const chain = prompt.pipe(model);
+  await chain.invoke({});
+
+  expect(model.lastWithStructuredOutputOptions).toEqual({ method: "jsonMode" });
+});
+
+test("Test no method passes no extra args to withStructuredOutput", async () => {
+  const schema = {
+    name: "yo",
+    description: "a structured output",
+    parameters: {
+      name: { type: "string" },
+      value: { type: "integer" },
+    },
+  };
+  const prompt = StructuredPrompt.fromMessagesAndSchema(
+    [["human", "I'm very structured, how about you?"]],
+    schema
+  );
+
+  const model = new FakeStructuredChatModel({ responses: [] });
+
+  const chain = prompt.pipe(model);
+  await chain.invoke({});
+
+  expect(model.lastWithStructuredOutputOptions).toBeUndefined();
+});
+
+test("Test pipe with RunnableSequence collects steps after model", async () => {
+  const schema = {
+    name: "yo",
+    description: "a structured output",
+    parameters: {
+      name: { type: "string" },
+      value: { type: "integer" },
+    },
+  };
+  const prompt = StructuredPrompt.fromMessagesAndSchema(
+    [["human", "I'm very structured, how about you?"]],
+    schema
+  );
+
+  const model = new FakeStructuredChatModel({ responses: [] });
+  const postProcess = RunnableLambda.from(
+    (input: Record<string, any>) => ({ ...input, extra: true })
+  );
+
+  const chain = prompt.pipe(model.pipe(postProcess));
+
+  const result = await chain.invoke({});
+  expect(result).toEqual({ ...schema, extra: true });
 });


### PR DESCRIPTION
## Summary

Aligns `StructuredPrompt.pipe()` in JS with the [Python implementation](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/prompts/structured.py#L173-L181) to fix functional differences in how structured prompts are orchestrated.

## Changes

### `@langchain/core` — `prompts/structured.ts`

**`RunnableSequence` handling**: When a `RunnableSequence` is piped into a `StructuredPrompt` (e.g. `prompt.pipe(model.pipe(parser))`), the JS version previously threw because the sequence itself doesn't have `withStructuredOutput`. Now it decomposes the sequence — calls `withStructuredOutput` on the first step (the model) and passes the remaining steps through, mirroring how Python's `RunnableSequence` constructor flattens nested sequences.

**Direct `RunnableSequence.from()` construction**: Replaced `super.pipe()` delegation with direct `RunnableSequence.from([this, ...steps])` construction, matching Python's `RunnableSequence(self, others[0].with_structured_output(...), *others[1:])` pattern.

**`method` kwarg passthrough**: The direct `isWithStructuredOutput` path previously didn't forward `method` to `withStructuredOutput()`. Now both paths consistently pass it, matching Python's `**self.structured_output_kwargs`.

**Removed `RunnableBinding` special case**: Dropped `isRunnableBinding` helper and its special-case handling, which had no equivalent in the Python implementation.
