### PR TITLE
fix(anthropic): omit undefined sampling params from API requests

### DIFF
--- a/.changeset/fix-anthropic-sampling-params.md
+++ b/.changeset/fix-anthropic-sampling-params.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+Fix temperature/topK/topP handling: guard all three so undefined values are not
+set on the request object, and fix broken topK/topP validation when thinking is
+enabled.

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1215,8 +1215,11 @@ export class ChatAnthropicMessages<
     };
 
     if (this.thinking.type === "enabled" || this.thinking.type === "adaptive") {
-      if (this.topP !== undefined && this.topK !== -1) {
+      if (this.topK !== undefined) {
         throw new Error("topK is not supported when thinking is enabled");
+      }
+      if (this.topP !== undefined) {
+        throw new Error("topP is not supported when thinking is enabled");
       }
       if (this.temperature !== undefined && this.temperature !== 1) {
         throw new Error(
@@ -1225,8 +1228,12 @@ export class ChatAnthropicMessages<
       }
     } else {
       // Only set temperature, top_k, and top_p if thinking is disabled
-      output.temperature = this.temperature;
-      output.top_k = this.topK;
+      if (this.temperature !== undefined) {
+        output.temperature = this.temperature;
+      }
+      if (this.topK !== undefined) {
+        output.top_k = this.topK;
+      }
       if (this.topP !== undefined) {
         output.top_p = this.topP;
       }

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -330,6 +330,87 @@ test("invocationParams returns empty array when tools is empty array", () => {
   expect(params.tools).toEqual([]);
 });
 
+test("invocationParams omits temperature/top_k/top_p keys when not set", () => {
+  const model = new ChatAnthropic({
+    model: "claude-haiku-4-5-20251001",
+    apiKey: "testing",
+  });
+
+  const params = model.invocationParams({});
+
+  expect("temperature" in params).toBe(false);
+  expect("top_k" in params).toBe(false);
+  expect("top_p" in params).toBe(false);
+});
+
+test("invocationParams includes temperature/top_k/top_p when explicitly set", () => {
+  const model = new ChatAnthropic({
+    model: "claude-haiku-4-5-20251001",
+    apiKey: "testing",
+    temperature: 0,
+    topK: 10,
+    topP: 0.9,
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.temperature).toBe(0);
+  expect(params.top_k).toBe(10);
+  expect(params.top_p).toBe(0.9);
+});
+
+test("thinking enabled throws on topK even without topP", () => {
+  const model = new ChatAnthropic({
+    model: "claude-sonnet-4-6-20250514",
+    apiKey: "testing",
+    topK: 5,
+    thinking: { type: "enabled", budget_tokens: 1000 },
+  });
+
+  expect(() => model.invocationParams({})).toThrow(
+    "topK is not supported when thinking is enabled"
+  );
+});
+
+test("thinking enabled throws on topP", () => {
+  const model = new ChatAnthropic({
+    model: "claude-sonnet-4-6-20250514",
+    apiKey: "testing",
+    topP: 0.9,
+    thinking: { type: "enabled", budget_tokens: 1000 },
+  });
+
+  expect(() => model.invocationParams({})).toThrow(
+    "topP is not supported when thinking is enabled"
+  );
+});
+
+test("adaptive thinking throws on topK", () => {
+  const model = new ChatAnthropic({
+    model: "claude-opus-4-6",
+    apiKey: "testing",
+    topK: 5,
+    thinking: { type: "adaptive" },
+  });
+
+  expect(() => model.invocationParams({})).toThrow(
+    "topK is not supported when thinking is enabled"
+  );
+});
+
+test("adaptive thinking throws on topP", () => {
+  const model = new ChatAnthropic({
+    model: "claude-opus-4-6",
+    apiKey: "testing",
+    topP: 0.9,
+    thinking: { type: "adaptive" },
+  });
+
+  expect(() => model.invocationParams({})).toThrow(
+    "topP is not supported when thinking is enabled"
+  );
+});
+
 test("Can properly format messages with container_upload blocks", async () => {
   const messageHistory = [
     new HumanMessage({


### PR DESCRIPTION
Related to #9258

`ChatAnthropic` sends `temperature: undefined` and `top_k: undefined` on the request object when those params aren't explicitly set, which causes "temperature and top_p cannot both be specified" errors on Claude 4.5+ models.

A prior fix (commit `e9c41f0ab`) guarded `topP` but left `temperature` and `topK` unconditional. The thinking-enabled validation was also broken - the `topP` check was AND-gated with `topK`, so setting only `topK: 5` with thinking enabled would not throw.

**Changes:**

- Guard all three sampling param assignments (`temperature`, `topK`, `topP`) with `!== undefined` checks so they're only present on the request when explicitly set
- Split the broken `topP !== undefined && topK !== -1` validation into separate checks for `topK` and `topP` when thinking is enabled/adaptive
- Added 6 unit tests covering: key omission when unset, explicit value passthrough (including `temperature: 0`), and thinking-mode validation for both `topK` and `topP` independently

---

# API Alignment Analysis

Verification that PR changes align with the [Anthropic Messages API docs](https://platform.claude.com/docs/en/api/messages) and [Extended Thinking docs](https://platform.claude.com/docs/en/docs/build-with-claude/extended-thinking).

Docs fetched: 2026-03-15.

---

## 1. `temperature` - guard with `!== undefined`

**Docs:**

> Amount of randomness injected into the response.
>
> Defaults to `1.0`. Ranges from `0.0` to `1.0`. Use `temperature` closer to `0.0` for analytical / multiple choice, and closer to `1.0` for creative and generative tasks.

The parameter is **optional**. Previously the code assigned `output.temperature = this.temperature` unconditionally, which set the key to `undefined` when the user did not provide a value. Now we only set it when explicitly provided.

**Aligned.** Optional param is only sent when set.

---

## 2. `top_p` - guard with `!== undefined` (already existed)

**Docs:**

> Use nucleus sampling.
>
> In nucleus sampling, we compute the cumulative distribution over all the options for each subsequent token in decreasing probability order and cut it off once it reaches a particular probability specified by `top_p`. You should either alter `temperature` or `top_p`, but not both.
>
> Recommended for advanced use cases only. You usually only need to use `temperature`.

The parameter is **optional**. The `top_p` guard already existed before this PR; no change was needed.

Note: the docs say *"You should either alter temperature or top_p, but not both"* - using "should", not "must". We intentionally do **not** add client-side mutual-exclusivity validation to avoid breaking users who rely on the current (permissive) API behavior.

**Aligned.** Soft recommendation respected without over-constraining.

---

## 3. `top_k` - guard with `!== undefined`

**Docs:**

> Only sample from the top K options for each subsequent token.
>
> Used to remove "long tail" low probability responses.
>
> Recommended for advanced use cases only. You usually only need to use `temperature`.

The parameter is **optional**. Previously the code assigned `output.top_k = this.topK` unconditionally. Now we only set it when explicitly provided.

**Aligned.** Optional param is only sent when set.

---

## 4. Thinking-mode validation - separate `topK` and `topP` checks

**Docs (Extended Thinking page):**

The official docs list the following restrictions when extended thinking is enabled:

> - `tool_choice` only supports `{"type": "auto"}` or `{"type": "none"}`
> - `budget_tokens` must be set to a value less than `max_tokens`
> - You cannot toggle thinking in the middle of an assistant turn

The docs **do not explicitly document** that `temperature`, `top_p`, or `top_k` are restricted when thinking is enabled. However, the API **enforces this at runtime** - sending `top_k` or `top_p` with thinking enabled returns an error, and `temperature` must be `1` (the default).

The previous code already had client-side checks for this, but they were buggy:

- `topK` check used `this.topK !== -1` (dead code - `topK` defaults to `undefined`, not `-1`)
- `topP` check was AND-gated with `topK` (`this.topP !== undefined && this.topK !== -1`), so setting only `topK` with thinking enabled would not throw

We fixed these to be independent checks:

```typescript
if (this.topK !== undefined) {
  throw new Error("topK is not supported when thinking is enabled");
}
if (this.topP !== undefined) {
  throw new Error("topP is not supported when thinking is enabled");
}
```

The `temperature !== 1` exception is preserved - the API accepts `temperature: 1` with thinking since `1.0` is the default value.

**Aligned.** Fixes pre-existing validation to match actual API runtime behavior.

---

## 5. Model-specific differences

**Docs ([Models overview](https://platform.claude.com/docs/en/docs/about-claude/models)) and [Adaptive Thinking](https://platform.claude.com/docs/en/docs/build-with-claude/adaptive-thinking):**

### Sampling parameters (`temperature`, `top_p`, `top_k`)

The Messages API docs describe these parameters uniformly - **no model-specific differences** are documented. The same optional semantics, defaults, and ranges apply to all Claude models.

### Thinking mode support varies by model

> Adaptive thinking is supported on the following models:
>
> - Claude Opus 4.6 (`claude-opus-4-6`)
> - Claude Sonnet 4.6 (`claude-sonnet-4-6`)

> `thinking.type: "enabled"` and `budget_tokens` are **deprecated** on Opus 4.6 and Sonnet 4.6 and will be removed in a future model release. Use `thinking.type: "adaptive"` with the `effort` parameter instead.

> Older models (Sonnet 4.5, Opus 4.5, etc.) do not support adaptive thinking and require `thinking.type: "enabled"` with `budget_tokens`.

Extended thinking (`type: "enabled"`) is supported on: Opus 4.6, Sonnet 4.6, Haiku 4.5, Sonnet 4.5, Opus 4.5, Opus 4.1, Sonnet 4, Opus 4. **Not** on Claude 3 Haiku.

| Mode | Opus 4.6 | Sonnet 4.6 | Haiku 4.5 | Older models |
|------|----------|------------|-----------|--------------|
| Adaptive (`type: "adaptive"`) | Yes | Yes | No | No |
| Manual (`type: "enabled"`) | Deprecated | Deprecated | Yes | Yes |

### Impact on this PR

Our validation checks `this.thinking.type` - it is **not model-gated**, which is correct. The sampling param restrictions when thinking is enabled apply uniformly regardless of model. No model-specific branching is needed.

---

## Summary

| Parameter | Docs say | Our behavior | Status |
|-----------|----------|--------------|--------|
| `temperature` | Optional | Only sent when explicitly set | Aligned |
| `top_p` | Optional, soft exclusivity with `temperature` | Only sent when explicitly set; no mutual-exclusivity error | Aligned |
| `top_k` | Optional | Only sent when explicitly set | Aligned |
| Thinking + `top_k` | Undocumented but API-enforced | Client-side error (pre-existing, now fixed) | Aligned |
| Thinking + `top_p` | Undocumented but API-enforced | Client-side error (pre-existing, now fixed) | Aligned |
| Thinking + `temperature` | Undocumented but API-enforced | Error unless value is `1` (pre-existing) | Aligned |
