### PR TITLE
fix(core): throw clear error in BaseChatModel.invoke when _generate returns empty generations

### DIFF
--- a/.changeset/loud-cherries-vanish.md
+++ b/.changeset/loud-cherries-vanish.md
@@ -1,0 +1,6 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): throw clear error in BaseChatModel.invoke when _generate returns empty generations
+

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -284,7 +284,14 @@ export abstract class BaseChatModel<
       options,
       options?.callbacks
     );
-    const chatGeneration = result.generations[0][0] as ChatGeneration;
+    const chatGeneration = result.generations[0][0] as
+      | ChatGeneration
+      | undefined;
+    if (!chatGeneration) {
+      throw new Error(
+        "Chat model returned no generations. The underlying model may have filtered the response or returned an unexpected empty result."
+      );
+    }
     // TODO: Remove cast after figuring out inheritance
     return chatGeneration.message as OutputMessageType;
   }

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -8,6 +8,10 @@ import { getBufferString } from "../../messages/utils.js";
 import { AIMessage } from "../../messages/ai.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
 import { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
+import { BaseChatModel } from "../chat_models.js";
+import type { CallbackManagerForLLMRun } from "../../callbacks/manager.js";
+import type { BaseMessage } from "../../messages/index.js";
+import type { ChatResult } from "../../outputs.js";
 
 test("Test ChatModel accepts array shorthand for messages", async () => {
   const model = new FakeChatModel({});
@@ -446,4 +450,34 @@ test("Test ChatModel withStructuredOutput with Standard Schema", async () => {
     test: true,
     nested: { somethingelse: "somevalue" },
   });
+});
+
+// Regression test for https://github.com/langchain-ai/langchainjs/issues/9545
+// When a model's _generate returns an empty generations array, invoke() used to
+// throw a cryptic "Cannot read properties of undefined (reading 'message')" error.
+// It should now throw a clear, actionable error message.
+test("Test ChatModel.invoke throws clear error when _generate returns empty generations", async () => {
+  class EmptyGenerationsChatModel extends BaseChatModel {
+    _llmType() {
+      return "empty-generations-fake";
+    }
+
+    _combineLLMOutput() {
+      return {};
+    }
+
+    async _generate(
+      _messages: BaseMessage[],
+      _options: this["ParsedCallOptions"],
+      _runManager?: CallbackManagerForLLMRun
+    ): Promise<ChatResult> {
+      // Simulates a provider that returns no generations (e.g., filtered response)
+      return { generations: [] };
+    }
+  }
+
+  const model = new EmptyGenerationsChatModel({});
+  await expect(model.invoke("Hello")).rejects.toThrowError(
+    "Chat model returned no generations."
+  );
 });


### PR DESCRIPTION
Fixes #9545.

`BaseChatModel.invoke()` throws a descriptive error instead of a cryptic `TypeError` when the underlying `_generate` implementation returns an empty `generations` array.

---

## Root Cause

In `libs/langchain-core/src/language_models/chat_models.ts:287`, `invoke()` accesses `result.generations[0][0]` without any guard:

```typescript
const chatGeneration = result.generations[0][0] as ChatGeneration;
return chatGeneration.message as OutputMessageType;
```

When a provider's `_generate` returns `{ generations: [] }` (an empty array — e.g. because the API filtered the response or returned zero completions), `result.generations[0]` is `[]` and `result.generations[0][0]` is `undefined`. Calling `.message` on `undefined` then throws:

```
TypeError: Cannot read properties of undefined (reading 'message')
    at invoke (…/chat_models.js:84:48)
```

This matches exactly the stack traces reported in the issue.

---

## Solution

Added an explicit `undefined` check before accessing `.message`, and throw a clear, actionable error message:

```typescript
const chatGeneration = result.generations[0][0] as ChatGeneration | undefined;
if (!chatGeneration) {
  throw new Error(
    "Chat model returned no generations. The underlying model may have filtered " +
    "the response or returned an unexpected empty result."
  );
}
```

This is the minimal correct fix — it catches the exact failure point at the root cause rather than hiding it further up the stack.

---

## Testing

- Added `Test ChatModel.invoke throws clear error when _generate returns empty generations` in `libs/langchain-core/src/language_models/tests/chat_models.test.ts` that reproduces the exact scenario from the bug report: a model whose `_generate` returns `{ generations: [] }`.
- All 19 tests in `chat_models.test.ts` pass; all 1292 tests in `@langchain/core` pass.
- Run with: `pnpm --filter @langchain/core test`

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md