### PR TITLE
docs: fix typos, add Ollama setup instructions, update outdated references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Integrations are a core component of LangChain. LangChain provides standard inte
 - **Interoperability**: LangChain components expose a standard interface, allowing developers to easily swap them for each other. If you implement a LangChain integration, any developer using a different component will easily be able to swap yours in.
 - **Best Practices**: Through their standard interface, LangChain components encourage and facilitate best practices (streaming, async, etc.) that improve developer experience and application performance.
 
-See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://js.langchain.com/docs/how_to/#custom) in our docs.
+See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/langchain/how_to/#custom) in our docs.
 
 #### Integration Packages
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ LangChain is a framework for building LLM-powered applications. It helps you cha
 
 **Documentation**: To learn more about LangChain, check out [the docs](https://docs.langchain.com/oss/javascript/langchain/overview).
 
-If you're looking for more advanced customization or agent orchestration, check out [LangGraph.js](https://docs.langchain.com/oss/javascript/langgraph/overview). our framework for building agents and controllable workflows.
+If you're looking for more advanced customization or agent orchestration, check out [LangGraph.js](https://docs.langchain.com/oss/javascript/langgraph/overview), our framework for building agents and controllable workflows.
 
 > [!NOTE]
 > Looking for the Python version? Check out [LangChain](https://github.com/langchain-ai/langchain).
 
-To help you ship LangChain apps to production faster, check out [LangSmith](https://smith.langchain.com).
-[LangSmith](https://smith.langchain.com) is a unified developer platform for building, testing, and monitoring LLM applications.
+To help you ship LangChain apps to production faster, check out [LangSmith](https://smith.langchain.com), a unified developer platform for building, testing, and monitoring LLM applications.
 
 ## ⚡️ Quick Install
 

--- a/libs/providers/langchain-google-common/README.md
+++ b/libs/providers/langchain-google-common/README.md
@@ -42,14 +42,10 @@ When using tools or functions with Gemini models, the following Zod schema featu
 
 For detailed examples and workarounds, see the Tool Schema Limitations section in the @langchain/google-vertexai or @langchain/google-genai package documentation.
 
-## TODO
+## Planned Features
 
-Tasks and services still to be implemented:
+Tasks and services that may be implemented in the future:
 
-- PaLM Vertex AI support and backwards compatibility
-- PaLM MakerSuite support and backwards compatibility
-- Semantic Retrieval / AQA model
-- PaLM embeddings
 - Gemini embeddings
 - Multimodal embeddings
 - Vertex AI Search
@@ -59,5 +55,4 @@ Tasks and services still to be implemented:
   - Google managed models
     - Claude
 - AI Studio Tuned Models
-- MakerSuite / Google Drive Hub
 - Google Cloud Vector Store

--- a/libs/providers/langchain-ollama/README.md
+++ b/libs/providers/langchain-ollama/README.md
@@ -8,7 +8,15 @@ This package contains the LangChain.js integrations for Ollama via the `ollama` 
 npm install @langchain/ollama @langchain/core
 ```
 
-TODO: add setup instructions for Ollama locally
+## Setup
+
+To use this package, you need to have Ollama running locally:
+
+1. Download and install Ollama from [ollama.com](https://ollama.com/)
+2. Pull a model: `ollama pull llama3`
+3. Ensure the Ollama server is running (it starts automatically after installation)
+
+By default, the package connects to `http://localhost:11434`. You can customize this by setting the `baseUrl` option when instantiating the model.
 
 ## Chat Models
 


### PR DESCRIPTION
## Summary

This PR addresses several documentation issues across the repository.

### Changes

1. **README.md**: Fixed punctuation typo (period should be comma before "our framework for building agents")
2. **README.md**: Consolidated duplicate LangSmith description into a single sentence
3. **@langchain/ollama README**: Replaced `TODO: add setup instructions for Ollama locally` with actual setup instructions (download link, model pull command, default URL)
4. **@langchain/google-common README**: Removed deprecated PaLM and MakerSuite references from the TODO list (PaLM API was deprecated by Google in favor of Gemini), renamed section from "TODO" to "Planned Features"
5. **CONTRIBUTING.md**: Updated outdated `js.langchain.com` URL to `docs.langchain.com` (old URL returns 308 Permanent Redirect)

### Why

- TODO placeholders in published package READMEs create a poor first impression for developers evaluating integrations
- Outdated references to deprecated services (PaLM, MakerSuite) can confuse users
- Broken/redirecting URLs in contributor docs add unnecessary friction
