### PR TITLE
fix(community): surface Voyage AI API errors in VoyageEmbeddings (fixes #10031)

### DIFF
--- a/.changeset/five-fans-tan.md
+++ b/.changeset/five-fans-tan.md
@@ -1,0 +1,6 @@
+---
+"@langchain/community": patch
+---
+
+fix(community): surface Voyage AI API errors in VoyageEmbeddings (fixes #10031)
+

--- a/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -70,3 +70,76 @@ test("embedDocuments succeeds on a valid 200 response", async () => {
 
   expect(result).toEqual([fakeEmbedding]);
 });
+
+test("embedDocuments falls back to JSON.stringify for unknown error payload shape", async () => {
+  // Neither `detail` nor `error.message` are present: the thrown error should
+  // still surface the raw payload instead of crashing or producing an opaque
+  // "undefined" message.
+  const unknownPayload = { unexpected: "shape", code: 42 };
+  global.fetch = makeFetchMock(unknownPayload, 500);
+
+  const embeddings = new VoyageEmbeddings({ apiKey: FAKE_API_KEY });
+
+  await expect(embeddings.embedDocuments(["Hello"])).rejects.toThrow(
+    `Voyage AI API error (HTTP 500): ${JSON.stringify(unknownPayload)}`
+  );
+});
+
+test("embedDocuments does not retry on 4xx errors (STATUS_NO_RETRY)", async () => {
+  // 401 is in AsyncCaller's STATUS_NO_RETRY list. With `.status` attached to
+  // the thrown error, defaultFailedAttemptHandler must rethrow immediately so
+  // fetch is called exactly once.
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    json: async () => ({ detail: "Provided API key is invalid." }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+  global.fetch = fetchMock;
+
+  const embeddings = new VoyageEmbeddings({
+    apiKey: FAKE_API_KEY,
+    // Give retries plenty of room — the point is that *none* should happen.
+    maxRetries: 5,
+  });
+
+  await expect(embeddings.embedDocuments(["Hello"])).rejects.toThrow(
+    "Voyage AI API error (HTTP 401)"
+  );
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("embedDocuments does retry on 5xx errors", async () => {
+  // 500 is NOT in STATUS_NO_RETRY, so the AsyncCaller should retry.
+  // First call fails, second succeeds.
+  const fakeEmbedding = [0.4, 0.5, 0.6];
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Temporary server error" }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ embedding: fakeEmbedding }],
+        model: "voyage-01",
+        usage: { total_tokens: 3 },
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  global.fetch = fetchMock;
+
+  const embeddings = new VoyageEmbeddings({
+    apiKey: FAKE_API_KEY,
+    maxRetries: 2,
+  });
+
+  const result = await embeddings.embedDocuments(["Hello"]);
+
+  expect(result).toEqual([fakeEmbedding]);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});

--- a/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/community/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -1,0 +1,72 @@
+import { test, vi, expect, beforeEach, afterEach } from "vitest";
+import { VoyageEmbeddings } from "../voyage.js";
+
+const FAKE_API_KEY = "voyage-test-key";
+
+function makeFetchMock(
+  body: unknown,
+  status = 200
+): typeof global.fetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("embedDocuments surfaces Voyage API error with detail field (issue #10031)", async () => {
+  global.fetch = makeFetchMock({ detail: "Provided API key is invalid." }, 401);
+
+  const embeddings = new VoyageEmbeddings({ apiKey: FAKE_API_KEY });
+
+  await expect(embeddings.embedDocuments(["Hello"])).rejects.toThrow(
+    "Voyage AI API error (HTTP 401): Provided API key is invalid."
+  );
+});
+
+test("embedQuery surfaces Voyage API error with detail field", async () => {
+  global.fetch = makeFetchMock({ detail: "Provided API key is invalid." }, 401);
+
+  const embeddings = new VoyageEmbeddings({ apiKey: FAKE_API_KEY });
+
+  await expect(embeddings.embedQuery("Hello")).rejects.toThrow(
+    "Voyage AI API error (HTTP 401): Provided API key is invalid."
+  );
+});
+
+test("embedDocuments surfaces generic Voyage API error via error.message field", async () => {
+  // 400 is in AsyncCaller's STATUS_NO_RETRY list, so it won't be retried.
+  global.fetch = makeFetchMock(
+    { error: { message: "Input exceeds maximum token length" } },
+    400
+  );
+
+  const embeddings = new VoyageEmbeddings({ apiKey: FAKE_API_KEY });
+
+  await expect(embeddings.embedDocuments(["Hello"])).rejects.toThrow(
+    "Voyage AI API error (HTTP 400): Input exceeds maximum token length"
+  );
+});
+
+test("embedDocuments succeeds on a valid 200 response", async () => {
+  const fakeEmbedding = [0.1, 0.2, 0.3];
+  global.fetch = makeFetchMock({
+    data: [{ embedding: fakeEmbedding }],
+    model: "voyage-01",
+    usage: { total_tokens: 3 },
+  });
+
+  const embeddings = new VoyageEmbeddings({ apiKey: FAKE_API_KEY });
+  const result = await embeddings.embedDocuments(["Hello"]);
+
+  expect(result).toEqual([fakeEmbedding]);
+});

--- a/libs/community/langchain-community/src/embeddings/voyage.ts
+++ b/libs/community/langchain-community/src/embeddings/voyage.ts
@@ -219,6 +219,24 @@ export class VoyageEmbeddings
       });
 
       const json = await response.json();
+
+      if (!response.ok) {
+        const message =
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (json as any)?.detail ??
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (json as any)?.error?.message ??
+          JSON.stringify(json);
+        const err = new Error(
+          `Voyage AI API error (HTTP ${response.status}): ${message}`
+        );
+        // Attach status so AsyncCaller's defaultFailedAttemptHandler can
+        // skip retries for non-transient HTTP errors (4xx).
+        (err as NodeJS.ErrnoException & { status: number }).status =
+          response.status;
+        throw err;
+      }
+
       return json;
     };
 


### PR DESCRIPTION
## Summary

Fixes #10031.

`VoyageEmbeddings.embeddingWithRetry` called `response.json()` and returned the result without ever checking `response.ok`. When the Voyage AI API returned an error (e.g. an invalid API key, HTTP 401), the response body is `{ detail: "Provided API key is invalid." }` — a plain object with no `.data` field. Callers such as `embedDocuments` then tried to destructure `{ data: batchResponse }` from that object, received `undefined`, and crashed with an opaque `TypeError: Cannot read properties of undefined` rather than the actual API error.

---

## Root Cause

In `embeddingWithRetry` ([voyage.ts L221](libs/community/langchain-community/src/embeddings/voyage.ts#L221)):

```ts
const json = await response.json();
return json;  // ← returned regardless of HTTP status
```

`embedDocuments` then does:

```ts
const { data: batchResponse } = batchResponses[i];
embeddings.push(batchResponse[j].embedding); // ← TypeError when batchResponse is undefined
```

---

## Solution

After parsing the JSON, check `!response.ok`. If the response is an error, extract the human-readable message from `json.detail` (Voyage AI's standard error field) or `json.error.message` (fallback), and throw an `Error` with the HTTP status attached as `.status`. Attaching `.status` is required so `AsyncCaller.defaultFailedAttemptHandler` recognises the error as non-retriable for 4xx codes that are in its `STATUS_NO_RETRY` list (400–409), preventing needless retries on e.g. auth failures.

The change is confined to `embeddingWithRetry` and does not touch `embedDocuments`, `embedQuery`, or any public interface.

---

## Testing

Added `libs/community/langchain-community/src/embeddings/tests/voyage.test.ts` (unit tests, no real API key needed):

- `embedDocuments surfaces Voyage API error with detail field` — mocks a 401 with `{ detail: "..." }`, asserts the thrown error contains the message
- `embedQuery surfaces Voyage API error with detail field` — same for the query path
- `embedDocuments surfaces generic Voyage API error via error.message field` — mocks a 400 with `{ error: { message: "..." } }`, asserts fallback extraction
- `embedDocuments succeeds on a valid 200 response` — regression: normal happy path still works

All 4 tests pass. Existing integration tests (`voyage.int.test.ts`) are unaffected.

---

## Checklist

- [x] Fixes the root cause (HTTP status is now checked before the response is used)
- [x] New tests reproduce the exact failing scenario from the issue
- [x] Existing integration tests unchanged
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md

> **AI disclosure**: This PR was created with the assistance of Claude Code (Anthropic's AI coding assistant).