### PR TITLE
fix(google): avoid double-counting cached tokens in input_token_details.text

### DIFF
--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -1276,6 +1276,11 @@ export const convertGeminiGenerateContentResponseToUsageMetadata: Converter<
   addModalityCounts(usageMetadata?.promptTokensDetails, input_token_details);
   input_token_details.cache_read = usageMetadata?.cachedContentTokenCount ?? 0;
 
+  // Avoid double-counting: Gemini's text modality count includes cached tokens
+  if (input_token_details.text && input_token_details.cache_read) {
+    input_token_details.text = Math.max(0, input_token_details.text - input_token_details.cache_read);
+  }
+
   const output_token_details: OutputTokenDetails = {};
   addModalityCounts(
     usageMetadata?.candidatesTokensDetails,


### PR DESCRIPTION
## Problem

When using `@langchain/google` with Gemini models that support implicit caching, `input_token_details.text` includes **all** text tokens (including cached ones), while `input_token_details.cache_read` also counts the cached tokens. This causes LangSmith to double-count cached tokens when calculating costs.

LangSmith calculates cost as:
```
input_cost = (text × regular_price) + (cache_read × discounted_price)
```

Since `text` includes cached tokens, those tokens are charged at **both** the regular rate and the discounted cache rate.

## Root Cause

In `convertGeminiGenerateContentResponseToUsageMetadata`, Gemini's `promptTokensDetails[TEXT]` modality count equals the total text tokens (including cached). The code sets both `text` and `cache_read` without adjusting for the overlap.

## Fix

Subtract `cache_read` from `text` modality count so the values don't overlap, matching how cost is calculated in LangSmith.

Fixes #10339