### PR TITLE
fix(google-genai): merge consecutive ToolMessages into single turn for parallel function calling

### DIFF
--- a/libs/providers/langchain-google-genai/src/tests/common.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/common.test.ts
@@ -3,8 +3,9 @@ import {
   convertResponseContentToChatGenerationChunk,
   convertMessageContentToParts,
   mapGenerateContentResultToChatResult,
+  convertBaseMessagesToContent,
 } from "../utils/common.js";
-import { AIMessage } from "@langchain/core/messages";
+import { AIMessage, ToolMessage, HumanMessage } from "@langchain/core/messages";
 import type {
   EnhancedGenerateContentResponse,
   FinishReason,
@@ -374,5 +375,77 @@ describe("Round-trip thinking content handling", () => {
     expect(roundTrippedParts[1]).toEqual({
       text: "The final answer is 7.",
     });
+  });
+});
+
+// https://github.com/langchain-ai/langchainjs/issues/10342
+describe("Consecutive ToolMessage merging for parallel function calling", () => {
+  test("merges consecutive ToolMessages into a single user turn", () => {
+    const messages = [
+      new HumanMessage("What's the weather and time?"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "get_weather", args: { city: "NYC" } },
+          { id: "call_2", name: "get_time", args: { tz: "EST" } },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: "call_1",
+        content: '{"temp": 72}',
+      }),
+      new ToolMessage({
+        tool_call_id: "call_2",
+        content: '{"time": "3pm"}',
+      }),
+    ];
+
+    const result = convertBaseMessagesToContent(messages, true, false);
+
+    // Should produce 3 content entries: user, model, user (merged)
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("model");
+    expect(result[2].role).toBe("user");
+
+    // The third entry should have BOTH function responses merged
+    expect(result[2].parts).toHaveLength(2);
+    expect(result[2].parts[0]).toHaveProperty("functionResponse");
+    expect(result[2].parts[1]).toHaveProperty("functionResponse");
+  });
+
+  test("merges 3+ consecutive ToolMessages into a single user turn", () => {
+    const messages = [
+      new HumanMessage("Do three things"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "tool_a", args: {} },
+          { id: "call_2", name: "tool_b", args: {} },
+          { id: "call_3", name: "tool_c", args: {} },
+        ],
+      }),
+      new ToolMessage({ tool_call_id: "call_1", content: "result_a" }),
+      new ToolMessage({ tool_call_id: "call_2", content: "result_b" }),
+      new ToolMessage({ tool_call_id: "call_3", content: "result_c" }),
+    ];
+
+    const result = convertBaseMessagesToContent(messages, true, false);
+
+    expect(result).toHaveLength(3);
+    // All 3 tool responses merged into one user turn
+    expect(result[2].role).toBe("user");
+    expect(result[2].parts).toHaveLength(3);
+  });
+
+  test("still throws for consecutive non-function messages with same role", () => {
+    const messages = [
+      new HumanMessage("First"),
+      new HumanMessage("Second"),
+    ];
+
+    expect(() =>
+      convertBaseMessagesToContent(messages, true, false)
+    ).toThrow("Google Generative AI requires alternate messages between authors");
   });
 });

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -566,12 +566,27 @@ export function convertBaseMessagesToContent(
       }
       const role = convertAuthorToRole(author);
 
-      const prevContent = acc.content[acc.content.length];
+      const prevContent = acc.content[acc.content.length - 1];
       if (
         !acc.mergeWithPreviousContent &&
         prevContent &&
         prevContent.role === role
       ) {
+        if (role === "function") {
+          // Merge consecutive function/tool responses into a single user turn.
+          // Gemini requires all parallel function call responses in one content entry.
+          const parts = convertMessageContentToParts(
+            message,
+            isMultimodalModel,
+            messages.slice(0, index),
+            model
+          );
+          prevContent.parts.push(...parts);
+          return {
+            mergeWithPreviousContent: false,
+            content: acc.content,
+          };
+        }
         throw new Error(
           "Google Generative AI requires alternate messages between authors"
         );


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in `convertBaseMessagesToContent` that prevents consecutive `ToolMessage`s from being detected and merged. This causes the Gemini API to hang indefinitely when processing parallel function call results.

## Root Cause

`acc.content[acc.content.length]` is always `undefined` because arrays are 0-indexed. The duplicate-role check never fires, so consecutive `ToolMessage`s (which should be merged into a single user turn per Gemini API requirements) silently create separate content entries.

## Changes

1. **Fixed off-by-one**: `acc.content[acc.content.length]` → `acc.content[acc.content.length - 1]`
2. **Added merge logic**: When consecutive function-role messages are detected, their parts are merged into a single content entry instead of throwing an error

## Test Plan

Added unit tests verifying:
- Consecutive `ToolMessage`s are merged into a single user turn
- 3+ consecutive `ToolMessage`s are all merged
- Consecutive non-function messages with the same role still throw correctly

Fixes #10342