### PR TITLE
fix(agents): propagate store and configurable to ToolNode middleware runtime

### DIFF
--- a/.changeset/config-propagation.md
+++ b/.changeset/config-propagation.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(agents): propagate store and configurable to ToolNode middleware runtime

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -298,6 +298,8 @@ export class ToolNode<
     const lgConfig = config as LangGraphRunnableConfig;
     const runtime = {
       context: lgConfig?.context,
+      store: lgConfig?.store,
+      configurable: lgConfig?.configurable,
       writer: lgConfig?.writer,
       interrupt: lgConfig?.interrupt,
       signal: lgConfig?.signal,

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -2975,4 +2975,78 @@ describe("middleware", () => {
       expect(val).toBeDefined();
     }
   });
+
+  it("should propagate store to wrapToolCall middleware runtime", async () => {
+    const store = new InMemoryStore();
+    let capturedStore: unknown;
+    let capturedConfigurable: unknown;
+
+    const testTool = tool(async () => "tool result", {
+      name: "test_tool",
+      description: "A test tool",
+      schema: z.object({}),
+    });
+
+    const middleware = createMiddleware({
+      name: "storeCheck",
+      wrapToolCall: async (request, handler) => {
+        capturedStore = request.runtime.store;
+        capturedConfigurable = request.runtime.configurable;
+        return handler(request);
+      },
+    });
+
+    const model = new FakeToolCallingModel({
+      toolCalls: [[{ name: "test_tool", args: {}, id: "1" }]],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [testTool],
+      store,
+      middleware: [middleware],
+    });
+
+    await agent.invoke({
+      messages: [new HumanMessage("call the tool")],
+    });
+
+    // Verify store is propagated to wrapToolCall (wrapped in AsyncBatchedStore)
+    expect(capturedStore).toBeDefined();
+    expect(capturedStore).not.toBeNull();
+    // Verify configurable is also propagated
+    expect(capturedConfigurable).toBeDefined();
+  });
+
+  it("should propagate store to wrapModelCall middleware runtime", async () => {
+    const store = new InMemoryStore();
+    let capturedStore: unknown;
+
+    const middleware = createMiddleware({
+      name: "storeCheck",
+      wrapModelCall: async (request, handler) => {
+        capturedStore = request.runtime.store;
+        return handler(request);
+      },
+    });
+
+    const model = new FakeToolCallingChatModel({
+      responses: [new AIMessage("hello")],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      store,
+      middleware: [middleware],
+    });
+
+    await agent.invoke({
+      messages: [new HumanMessage("hi")],
+    });
+
+    // Verify store is propagated to wrapModelCall (wrapped in AsyncBatchedStore)
+    expect(capturedStore).toBeDefined();
+    expect(capturedStore).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Propagates `store` and `configurable` from the LangGraph config to the middleware runtime in `ToolNode`, fixing an issue where `wrapToolCall` middleware could not access the LangGraph store or configurable values.

## Changes

### `langchain`

When `ToolNode` builds the runtime object passed to middleware's `wrapToolCall`, it was missing `store` and `configurable` from the `LangGraphRunnableConfig`. This meant middleware that needed to read from or write to the LangGraph store during tool execution had no way to access it.

This adds both `store` and `configurable` to the runtime object alongside the existing `context`, `writer`, `interrupt`, and `signal` fields.

Two tests are added to verify:
- `store` and `configurable` are available in `wrapToolCall` middleware runtime
- `store` is available in `wrapModelCall` middleware runtime
