### PR TITLE
fix(openai): only use Responses API for OpenAI-specific built-in tools

### DIFF
--- a/libs/providers/langchain-openai/src/chat_models/index.ts
+++ b/libs/providers/langchain-openai/src/chat_models/index.ts
@@ -7,6 +7,7 @@ import { type OpenAICallOptions, type OpenAIChatInput } from "../types.js";
 import {
   _convertToOpenAITool,
   isBuiltInTool,
+  isOpenAIBuiltInTool,
   isCustomTool,
   isOpenAICustomTool,
 } from "../utils/tools.js";
@@ -627,7 +628,7 @@ export class ChatOpenAI<
   }
 
   protected _useResponsesApi(options: this["ParsedCallOptions"] | undefined) {
-    const usesBuiltInTools = options?.tools?.some(isBuiltInTool);
+    const usesBuiltInTools = options?.tools?.some(isOpenAIBuiltInTool);
     const hasResponsesOnlyKwargs =
       options?.previous_response_id != null ||
       options?.text != null ||

--- a/libs/providers/langchain-openai/src/utils/tools.ts
+++ b/libs/providers/langchain-openai/src/utils/tools.ts
@@ -232,6 +232,41 @@ export function formatToOpenAIToolChoice(
   }
 }
 
+/**
+ * OpenAI built-in tool types that require the Responses API.
+ * These are specific to OpenAI and not general tool types that other
+ * providers might use.
+ */
+const OPENAI_BUILTIN_TOOL_TYPES = new Set([
+  "code_interpreter",
+  "image_generation",
+  "file_search",
+  "web_search_preview",
+  "computer_use_preview",
+  "mcp",
+]);
+
+/**
+ * Checks if a tool is an OpenAI built-in tool that requires the Responses API.
+ * This is more specific than checking for any non-function tool type,
+ * as other providers may use custom tool types that work with the completions API.
+ */
+export function isOpenAIBuiltInTool(
+  tool: ChatOpenAIToolType
+): tool is ResponsesTool {
+  return (
+    "type" in tool &&
+    typeof tool.type === "string" &&
+    OPENAI_BUILTIN_TOOL_TYPES.has(tool.type)
+  );
+}
+
+/**
+ * @deprecated Use `isOpenAIBuiltInTool` instead. This function is too broad
+ * and catches provider-specific tool types that don't require the Responses API.
+ * Use `isOpenAIBuiltInTool` to check for OpenAI built-in tools that specifically
+ * require the Responses API.
+ */
 export function isBuiltInTool(tool: ChatOpenAIToolType): tool is ResponsesTool {
   return "type" in tool && tool.type !== "function";
 }


### PR DESCRIPTION
## Description

Fixes #10428

## Problem

`ChatOpenAI._useResponsesApi` was forcing the Responses API for any tool with a non-function type. This was too broad and caused issues with providers like Moonshot/Kimi that use custom tool types (e.g., `builtin_function`) which work with the standard completions API.

Users setting `useResponsesApi: false` still got redirected to the `/v1/responses` endpoint when using non-function tool types.

## Solution

Introduced `isOpenAIBuiltInTool()` which checks for specific OpenAI built-in tool types that actually require the Responses API:

| Tool Type | Requires Responses API |
|-----------|----------------------|
| `code_interpreter` | ✅ Yes |
| `image_generation` | ✅ Yes |
| `file_search` | ✅ Yes |
| `web_search_preview` | ✅ Yes |
| `computer_use_preview` | ✅ Yes |
| `mcp` | ✅ Yes |
| `builtin_function` (Moonshot) | ❌ No |
| Other custom types | ❌ No |

## Changes

- Added `OPENAI_BUILTIN_TOOL_TYPES` constant with known OpenAI built-in tool types
- Added `isOpenAIBuiltInTool()` function for precise checking
- Updated `_useResponsesApi()` to use `isOpenAIBuiltInTool()` instead of `isBuiltInTool()`
- Deprecated `isBuiltInTool()` (kept for backward compatibility)

## Example

Now works correctly with Moonshot/Kimi:
```typescript
const model = new ChatOpenAI({
  model: 'kimi-k2-turbo-preview',
  useResponsesApi: false, // Now respected!
  configuration: {
    baseURL: 'https://api.moonshot.cn/v1',
  },
});

const result = await model.invoke([...], {
  tools: [{ type: 'builtin_function', function: { name: '$web_search' } }],
});
// Now correctly uses /v1/chat/completions instead of /v1/responses
```

## Backward Compatibility

✅ No breaking changes - `isBuiltInTool()` is deprecated but still works