### PR TITLE
fix(core): extract text content from message blocks in output parser

### DIFF
--- a/libs/langchain-core/src/output_parsers/base.ts
+++ b/libs/langchain-core/src/output_parsers/base.ts
@@ -56,7 +56,14 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
   }
 
   protected _baseMessageContentToString(content: ContentBlock[]): string {
-    return JSON.stringify(content);
+    return content
+      .map((part) => {
+        if (part.type === "text") {
+          return part.text;
+        }
+        return "";
+      })
+      .join("");
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #10437

When models like Gemini with reasoning tokens (`maxReasoningTokens`) return content as an array of blocks (e.g., `[{type: "reasoning", ...}, {type: "text", text: "..."}]`), the `_baseMessageContentToString` method was using `JSON.stringify()` which converted the entire array to a JSON string. This caused structured output parsing to fail with:

```
OutputParserException: Failed to parse. Text: "[{\"type\":\"reasoning\",\"reasoning\":\"...\"},{\"type\":\"text\",\"text\":\"{\\\"answer\\\": \\\"4\\\"}\"}]"
```

## Solution

The fix extracts only text-type blocks and joins them, filtering out non-text blocks like reasoning, image_url, etc. This matches the behavior of:
- `BaseMessage.text` getter
- Google's `generationToString` method

## Before (bug)
```typescript
protected _baseMessageContentToString(content: ContentBlock[]): string {
  return JSON.stringify(content);
}
// Input:  [{type: "reasoning", reasoning: "..."}, {type: "text", text: '{"answer": "4"}'}]
// Output: '[{"type":"reasoning",...},{"type":"text","text":"{\\"answer\\": \\"4\\"}"}]'
// Result: Parser fails - cannot parse this as the expected JSON schema
```

## After (fix)
```typescript
protected _baseMessageContentToString(content: ContentBlock[]): string {
  return content
    .map((part) => {
      if (part.type === "text") {
        return part.text;
      }
      return "";
    })
    .join("");
}
// Input:  [{type: "reasoning", reasoning: "..."}, {type: "text", text: '{"answer": "4"}'}]
// Output: '{"answer": "4"}'
// Result: Parser successfully parses the JSON
```

## Testing

Tested with various content block combinations:
- Single text block ✅
- Reasoning + text blocks (the bug case) ✅
- Multiple text blocks ✅
- Mixed content (image + text) ✅
- Empty array ✅
- Only non-text blocks ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)