### PR TITLE
fix(core): handle reasoning blocks in OpenAI contentBlocks translator

### DIFF
--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -283,6 +283,30 @@ export function convertToV1FromResponses(
             text: String(text),
           };
         }
+      } else if (_isContentBlock(block, "reasoning")) {
+        // Handle reasoning block that may have either:
+        // - reasoning: string (already converted by provider)
+        // - summary: [{text: "..."}] (raw API format)
+        if (_isString(block.reasoning)) {
+          yield {
+            type: "reasoning",
+            reasoning: block.reasoning,
+          };
+        } else if (_isArray(block.summary)) {
+          const reasoningText = block.summary.reduce<string>(
+            (acc, item) => {
+              if (_isObject(item) && _isString(item.text)) {
+                return `${acc}${item.text}`;
+              }
+              return acc;
+            },
+            ""
+          );
+          yield {
+            type: "reasoning",
+            reasoning: reasoningText,
+          };
+        }
       }
     }
     for (const toolCall of message.tool_calls ?? []) {

--- a/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
@@ -153,6 +153,46 @@ describe("openaiTranslator", () => {
   });
 
   describe("Responses", () => {
+    it("should translate reasoning block in content array to v1 reasoning block", () => {
+      // This tests the case where reasoning is in the content array directly
+      // (as added by OpenAI provider's converter)
+      const message = new AIMessage({
+        content: [
+          { type: "reasoning", reasoning: "Let me think about this..." },
+          { type: "text", text: "The answer is 42." },
+        ],
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const expected: Array<ContentBlock.Standard> = [
+        { type: "reasoning", reasoning: "Let me think about this..." },
+        { type: "text", text: "The answer is 42." },
+      ];
+
+      expect(message.contentBlocks).toEqual(expected);
+    });
+
+    it("should translate reasoning block with summary array in content to v1 reasoning block", () => {
+      // This tests the case where reasoning block has summary array format
+      const message = new AIMessage({
+        content: [
+          {
+            type: "reasoning",
+            summary: [{ text: "First thought..." }, { text: " Second thought." }],
+          },
+          { type: "text", text: "Here is my response." },
+        ],
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const expected: Array<ContentBlock.Standard> = [
+        { type: "reasoning", reasoning: "First thought... Second thought." },
+        { type: "text", text: "Here is my response." },
+      ];
+
+      expect(message.contentBlocks).toEqual(expected);
+    });
+
     it("should translate responses message to v1 content blocks", () => {
       const message = new AIMessage({
         content: [


### PR DESCRIPTION
## Description

The `convertToV1FromResponses` function in `block_translators/openai.ts` was only processing text blocks in the content array loop, ignoring reasoning blocks. This caused the `contentBlocks` getter to drop reasoning content from OpenAI Responses API messages.

## Problem

When using models that return reasoning blocks (like OpenAI's reasoning models or models with `maxReasoningTokens` configured), the reasoning blocks in the content array were being silently dropped when accessing `message.contentBlocks`.

The OpenAI provider's converter (`converters/responses.ts`) correctly adds reasoning blocks to the content array:
```typescript
content.push({
  type: "reasoning",
  reasoning: reasoningText,
});
```

But the `convertToV1FromResponses` function only yielded text blocks in its content loop.

## Solution

Added handling for reasoning blocks in the content array loop, supporting both formats:
- `reasoning: string` format (already converted by provider)
- `summary: [{text: "..."}]` format (raw API format, for edge cases)

## Testing

Added two test cases:
1. Reasoning block with `reasoning` field (provider converted format)
2. Reasoning block with `summary` array (raw API format)

Fixes #10421