### PR TITLE
fix(google): add missing parts filter for ToolMessage in standard converter

### DIFF
--- a/.changeset/fix-google-toolmessage-parts-filter.md
+++ b/.changeset/fix-google-toolmessage-parts-filter.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Filter non-`functionResponse` parts from ToolMessage conversion in the standard converter, matching the legacy converter behavior.

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -421,7 +421,7 @@ function convertStandardContentMessageToGeminiContent(
     role = "user";
   }
 
-  const parts: Gemini.Part[] = [];
+  let parts: Gemini.Part[] = [];
 
   // Process standard content blocks
   const contentBlocks = Array.isArray(message.contentBlocks)
@@ -473,6 +473,10 @@ function convertStandardContentMessageToGeminiContent(
         response: { result: responseContent },
       },
     });
+
+    // For tool messages, only keep functionResponse parts since the text content
+    // is already included in the functionResponse.response.result
+    parts = parts.filter((part) => "functionResponse" in part);
   }
 
   // Only return content if we have parts

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -474,8 +474,6 @@ function convertStandardContentMessageToGeminiContent(
       },
     });
 
-    // For tool messages, only keep functionResponse parts since the text content
-    // is already included in the functionResponse.response.result
     parts = parts.filter((part) => "functionResponse" in part);
   }
 

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -740,4 +740,29 @@ describe("convertMessagesToGeminiContents", () => {
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
   });
+
+  test("standard converter filters non-functionResponse parts for ToolMessage", () => {
+    const messages = [
+      new HumanMessage("search"),
+      new AIMessage({
+        content: [{ type: "text", text: "calling tool" }],
+        tool_calls: [{ id: "call_1", name: "search", args: { q: "test" } }],
+        response_metadata: { output_version: "v1" },
+      }),
+      new ToolMessage({
+        tool_call_id: "call_1",
+        content: "result data",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+    const functionContent = contents.find((c) =>
+      c.parts.some((p) => "functionResponse" in p)
+    )!;
+
+    expect(functionContent.parts).toHaveLength(1);
+    expect(
+      (functionContent.parts[0] as Record<string, unknown>).functionResponse
+    ).toBeDefined();
+  });
 });

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -741,9 +741,15 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBe("gs://bucket/report.pdf");
   });
 
-  test("standard converter filters non-functionResponse parts for ToolMessage", () => {
+  test("standard converter only sends functionResponse for ToolMessage (no duplicate text)", () => {
+    // When ToolMessage goes through the v1 standard converter, contentBlocks
+    // produces a text part AND the explicit handler adds a functionResponse
+    // part. Without filtering, both are sent to Gemini, duplicating content.
     const messages = [
-      new HumanMessage("search"),
+      new HumanMessage({
+        content: "search",
+        response_metadata: { output_version: "v1" },
+      }),
       new AIMessage({
         content: [{ type: "text", text: "calling tool" }],
         tool_calls: [{ id: "call_1", name: "search", args: { q: "test" } }],
@@ -752,6 +758,7 @@ describe("convertMessagesToGeminiContents", () => {
       new ToolMessage({
         tool_call_id: "call_1",
         content: "result data",
+        response_metadata: { output_version: "v1" },
       }),
     ];
 
@@ -764,5 +771,6 @@ describe("convertMessagesToGeminiContents", () => {
     expect(
       (functionContent.parts[0] as Record<string, unknown>).functionResponse
     ).toBeDefined();
+    expect(functionContent.parts.filter((p) => "text" in p)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #10459

- Add `parts.filter()` to keep only `functionResponse` parts for ToolMessages in the standard content converter
- This matches the existing behavior in the legacy converter (same file, L780)

Without this fix, ToolMessages send both text parts and functionResponse parts to the Gemini API, duplicating the content.

## AI Disclosure

This bug was identified through code review with AI assistance. The fix applies the same filter pattern already used in the legacy converter path.