### PR TITLE
fix(google): preserve thought/thoughtSignature in multi-turn conversations

### DIFF
--- a/.changeset/fix-google-reasoning-roundtrip.md
+++ b/.changeset/fix-google-reasoning-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Handle `type: "reasoning"` content blocks in standard and legacy converters, preventing thinking blocks from being silently dropped in multi-turn conversations.

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -56,13 +56,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -129,13 +129,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -202,13 +202,13 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
           typeof block.data === "string"
             ? block.data
             : typeof block.data === "object" && block.data !== null
-            ? // Convert Uint8Array to base64 string
-              btoa(
-                Array.from(block.data as Uint8Array)
-                  .map((byte) => String.fromCharCode(byte))
-                  .join("")
-              )
-            : String(block.data);
+              ? // Convert Uint8Array to base64 string
+                btoa(
+                  Array.from(block.data as Uint8Array)
+                    .map((byte) => String.fromCharCode(byte))
+                    .join("")
+                )
+              : String(block.data);
         return {
           inlineData: {
             mimeType: block.mime_type,
@@ -364,6 +364,15 @@ function convertStandardContentBlockToGeminiPart(
   switch (block.type) {
     case "text":
       return { text: block.text };
+    case "reasoning": {
+      const part: Record<string, unknown> = {
+        text: block.reasoning ?? "",
+        thought: true,
+      };
+      if ("thoughtSignature" in block)
+        part.thoughtSignature = block.thoughtSignature;
+      return part as Gemini.Part;
+    }
     case "image":
     case "audio":
     case "text-plain":
@@ -729,6 +738,15 @@ function convertLegacyContentMessageToGeminiContent(
           parts.push(messageContentImageUrl(item));
         } else if (isMessageContentMedia(item)) {
           parts.push(messageContentMedia(item));
+        } else if (item?.type === "reasoning") {
+          const rec = item as Record<string, unknown>;
+          const part: Record<string, unknown> = {
+            text: (rec.reasoning as string) ?? "",
+            thought: true,
+          };
+          if ("thoughtSignature" in rec)
+            part.thoughtSignature = rec.thoughtSignature;
+          parts.push(part as Gemini.Part);
         } else {
           parts.push(item as Gemini.Part);
         }

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -740,4 +740,54 @@ describe("convertMessagesToGeminiContents", () => {
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
   });
+
+  test("preserves reasoning blocks in standard converter (v1)", () => {
+    const messages = [
+      new HumanMessage("What is 2+2?"),
+      new AIMessage({
+        content: [
+          { type: "reasoning", reasoning: "Let me think about this..." },
+          { type: "text", text: "4" },
+        ],
+        response_metadata: { output_version: "v1" },
+      }),
+      new HumanMessage("And 3+3?"),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+    const modelContent = contents.find((c) => c.role === "model")!;
+
+    const thinkingPart = modelContent.parts[0] as Record<string, unknown>;
+    expect(thinkingPart.text).toBe("Let me think about this...");
+    expect(thinkingPart.thought).toBe(true);
+
+    const textPart = modelContent.parts[1] as Record<string, unknown>;
+    expect(textPart.text).toBe("4");
+    expect(textPart.thought).toBeUndefined();
+  });
+
+  test("preserves reasoning blocks with thoughtSignature in legacy converter", () => {
+    const messages = [
+      new HumanMessage("What is 2+2?"),
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning",
+            reasoning: "calculating...",
+            thoughtSignature: "sig-abc",
+          },
+          { type: "text", text: "4" },
+        ],
+      }),
+      new HumanMessage("Thanks"),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+    const modelContent = contents.find((c) => c.role === "model")!;
+
+    const thinkingPart = modelContent.parts[0] as Record<string, unknown>;
+    expect(thinkingPart.text).toBe("calculating...");
+    expect(thinkingPart.thought).toBe(true);
+    expect(thinkingPart.thoughtSignature).toBe("sig-abc");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #10461

- Preserve `thought` and `thoughtSignature` properties on text content blocks when converting back to Gemini Parts
- Applies to both the standard converter (`convertStandardContentBlockToGeminiPart`) and legacy converter paths
- Adds tests for thinking block round-trip in multi-turn conversations

This is the same bug that was fixed in `@langchain/google-genai` via #10415, applied to `@langchain/google`.

## AI Disclosure

This bug was identified through code review with AI assistance, by comparing the recent fix in `@langchain/google-genai` (#10415) with the `@langchain/google` converter code.