### PR TITLE
fix(google-cloud-sql-pg): re-throw non-string errors in PostgresLoader

### DIFF
--- a/.changeset/smooth-rings-wonder.md
+++ b/.changeset/smooth-rings-wonder.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-cloud-sql-pg": patch
+---
+
+fix(google-cloud-sql-pg): re-throw non-string errors in PostgresLoader

--- a/libs/providers/langchain-google-cloud-sql-pg/src/loader.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/loader.ts
@@ -188,8 +188,9 @@ export class PostgresLoader extends BaseDocumentLoader {
       result = await engine.pool.raw(queryStmt);
     } catch (error) {
       if (typeof error === "string") {
-        throw Error(error);
+        throw new Error(error);
       }
+      throw error;
     }
     const columnNames = result.fields.map(
       (field: { name: string }) => field.name
@@ -276,8 +277,9 @@ export class PostgresLoader extends BaseDocumentLoader {
       }
     } catch (error) {
       if (typeof error === "string") {
-        throw Error(error);
+        throw new Error(error);
       }
+      throw error;
     }
   }
 }

--- a/libs/providers/langchain-google-cloud-sql-pg/src/tests/loader.test.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/tests/loader.test.ts
@@ -1,0 +1,79 @@
+import { PostgresLoader, PostgresLoaderOptions } from "../loader.js";
+import PostgresEngine from "../engine.js";
+
+/**
+ * Unit tests for PostgresLoader error handling.
+ * These tests verify that non-string errors thrown by the database
+ * are properly propagated instead of being silently swallowed.
+ */
+
+function createMockEngine(rawFn: (...args: unknown[]) => unknown) {
+  return {
+    pool: {
+      raw: rawFn,
+    },
+  } as unknown as PostgresEngine;
+}
+
+describe("PostgresLoader error propagation", () => {
+  test("initialize() should re-throw non-string Error objects from pool.raw", async () => {
+    const dbError = new Error("connection refused");
+    const engine = createMockEngine(() => {
+      throw dbError;
+    });
+
+    const options: PostgresLoaderOptions = {
+      query: "SELECT * FROM some_table",
+    };
+
+    await expect(PostgresLoader.initialize(engine, options)).rejects.toThrow(
+      "connection refused"
+    );
+  });
+
+  test("initialize() should re-throw string errors from pool.raw", async () => {
+    const engine = createMockEngine(() => {
+      throw "string error message";
+    });
+
+    const options: PostgresLoaderOptions = {
+      query: "SELECT * FROM some_table",
+    };
+
+    await expect(PostgresLoader.initialize(engine, options)).rejects.toThrow(
+      "string error message"
+    );
+  });
+
+  test("lazyLoad() should re-throw non-string Error objects from pool.raw", async () => {
+    const dbError = new TypeError("query syntax error");
+    const engine = createMockEngine(() => {
+      throw dbError;
+    });
+
+    // Construct a loader directly to test lazyLoad without going through initialize
+    const loader = new PostgresLoader(engine, {
+      query: "SELECT * FROM some_table",
+      contentColumns: ["col1"],
+      metadataColumns: [],
+    });
+
+    const generator = loader.lazyLoad();
+    await expect(generator.next()).rejects.toThrow("query syntax error");
+  });
+
+  test("lazyLoad() should re-throw string errors from pool.raw", async () => {
+    const engine = createMockEngine(() => {
+      throw "a string error";
+    });
+
+    const loader = new PostgresLoader(engine, {
+      query: "SELECT * FROM some_table",
+      contentColumns: ["col1"],
+      metadataColumns: [],
+    });
+
+    const generator = loader.lazyLoad();
+    await expect(generator.next()).rejects.toThrow("a string error");
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/langchain-ai/langchainjs/issues/10463

`PostgresLoader` has two catch blocks (in `initialize()` and `lazyLoad()`) that only handle string-type errors. Non-string Error objects (the standard case in JS) are silently swallowed, causing confusing downstream failures.

## Changes

- Added `throw error` for non-string errors in both catch blocks in `loader.ts`
- Added unit tests verifying error propagation for both string and non-string errors

## Why this is the right fix

JavaScript errors are almost always Error objects, not strings. The current code only handles the rare string case and silently ignores the common case, which:
1. Makes `initialize()` crash with unhelpful `TypeError` on `result.fields.map()`
2. Makes `lazyLoad()` silently yield nothing on database errors

---
*This PR was developed with AI assistance.*