### PR TITLE
fix(langchain): add "aws" alias to MODEL_PROVIDER_CONFIG for Bedrock hub prompt deserialization

### DIFF
--- a/.changeset/fix-bedrock-model-id-hub.md
+++ b/.changeset/fix-bedrock-model-id-hub.md
@@ -1,0 +1,6 @@
+---
+"langchain": patch
+"@langchain/classic": patch
+---
+
+fix(langchain): add "aws" alias to MODEL_PROVIDER_CONFIG so hub/node auto-detects ChatBedrockConverse from Python-serialized prompts

--- a/libs/langchain-classic/src/chat_models/universal.ts
+++ b/libs/langchain-classic/src/chat_models/universal.ts
@@ -98,6 +98,10 @@ export const MODEL_PROVIDER_CONFIG = {
     package: "@langchain/aws",
     className: "ChatBedrockConverse",
   },
+  aws: {
+    package: "@langchain/aws",
+    className: "ChatBedrockConverse",
+  },
   deepseek: {
     package: "@langchain/deepseek",
     className: "ChatDeepSeek",

--- a/libs/langchain-classic/src/hub/tests/inferModelProviderFromNamespace.test.ts
+++ b/libs/langchain-classic/src/hub/tests/inferModelProviderFromNamespace.test.ts
@@ -66,6 +66,16 @@ describe("inferModelProviderFromNamespace", () => {
         ])
       ).toBe("some-provider");
     });
+
+    it("extracts aws from langchain_aws", () => {
+      expect(
+        inferModelProviderFromNamespace([
+          "langchain_aws",
+          "chat_models",
+          "ChatBedrockConverse",
+        ])
+      ).toBe("aws");
+    });
   });
 
   describe("handles Google provider special cases", () => {

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -103,6 +103,10 @@ export const MODEL_PROVIDER_CONFIG = {
     package: "@langchain/aws",
     className: "ChatBedrockConverse",
   },
+  aws: {
+    package: "@langchain/aws",
+    className: "ChatBedrockConverse",
+  },
   deepseek: {
     package: "@langchain/deepseek",
     className: "ChatDeepSeek",

--- a/libs/langchain/src/hub/tests/inferModelProviderFromNamespace.test.ts
+++ b/libs/langchain/src/hub/tests/inferModelProviderFromNamespace.test.ts
@@ -66,6 +66,16 @@ describe("inferModelProviderFromNamespace", () => {
         ])
       ).toBe("some-provider");
     });
+
+    it("extracts aws from langchain_aws", () => {
+      expect(
+        inferModelProviderFromNamespace([
+          "langchain_aws",
+          "chat_models",
+          "ChatBedrockConverse",
+        ])
+      ).toBe("aws");
+    });
   });
 
   describe("handles Google provider special cases", () => {


### PR DESCRIPTION
## Summary

- Adds `"aws"` as an alias key in `MODEL_PROVIDER_CONFIG` (both `langchain` and `@langchain/classic`) so that `inferModelProviderFromNamespace` correctly resolves `ChatBedrockConverse` when pulling Python-serialized prompts from LangSmith Hub.

## Problem

When a Bedrock model prompt is saved in LangSmith (from Python), the serialized namespace is `["langchain_aws", "chat_models", "ChatBedrockConverse"]`. The `hub/node` `pull()` function uses `inferModelProviderFromNamespace` to extract the provider name, which strips `langchain_` and returns `"aws"`. However, `MODEL_PROVIDER_CONFIG` only had `"bedrock"` as its key — so the lookup failed, `getChatModelByClassName` returned `undefined`, and `load()` was called without the necessary import maps to resolve the class.

The `lc_aliases` (`model_id → model`, `region_name → region`) and the `load()` deserialization path already handle kwarg key mapping correctly. The missing piece was just the provider config lookup.

## Fix

Add `"aws"` entry to `MODEL_PROVIDER_CONFIG` pointing to the same `@langchain/aws` / `ChatBedrockConverse` config as `"bedrock"`.