### PR TITLE
fix(google-genai): filter empty parts from streaming/non-streaming responses

### DIFF
--- a/libs/providers/langchain-google-genai/src/tests/common.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/common.test.ts
@@ -127,6 +127,67 @@ describe("Thinking content handling", () => {
     expect(typeof result.generations[0].message.content).toBe("string");
     expect(result.generations[0].message.content).toBe("Regular response");
   });
+
+  test("should filter out empty parts from response", () => {
+    const mockResponse = createMockResponse([
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: { name: "get_weather", args: { city: "NYC" } },
+            },
+            {} as GoogleGenerativeAIPart,
+          ] as GoogleGenerativeAIPart[],
+        },
+        finishReason: "STOP" as FinishReason,
+        index: 0,
+        safetyRatings: [],
+      },
+    ]);
+
+    const result = mapGenerateContentResultToChatResult(mockResponse);
+    const content = result.generations[0].message.content;
+
+    expect(Array.isArray(content)).toBe(true);
+    if (!Array.isArray(content)) return;
+    // Empty {} part should be filtered out, leaving only the functionCall
+    expect(content.length).toBe(1);
+    expect(content[0]).toHaveProperty("type", "functionCall");
+  });
+
+  test("should filter out empty parts while keeping valid parts", () => {
+    const mockResponse = createMockResponse([
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              text: "Let me think...",
+              thought: true,
+            },
+            {} as GoogleGenerativeAIPart,
+            {
+              text: "Here is the answer.",
+            },
+            {} as GoogleGenerativeAIPart,
+          ] as GoogleGenerativeAIPart[],
+        },
+        finishReason: "STOP" as FinishReason,
+        index: 0,
+        safetyRatings: [],
+      },
+    ]);
+
+    const result = mapGenerateContentResultToChatResult(mockResponse);
+    const content = result.generations[0].message.content;
+
+    expect(Array.isArray(content)).toBe(true);
+    if (!Array.isArray(content)) return;
+    expect(content.length).toBe(2);
+    expect((content[0] as ThinkingBlock).type).toBe("thinking");
+    expect((content[1] as TextBlock).type).toBe("text");
+  });
 });
 
 describe("Streaming thinking content handling", () => {
@@ -267,5 +328,75 @@ describe("Streaming thinking content handling", () => {
     // Should NOT be a concatenated string like "Thinking...Answer"
     expect(typeof content).not.toBe("string");
     expect(Array.isArray(content)).toBe(true);
+  });
+
+  test("should filter out empty parts from streaming response", () => {
+    const mockResponse = createMockResponse([
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: { name: "get_weather", args: { city: "NYC" } },
+            },
+            {} as GoogleGenerativeAIPart,
+          ] as GoogleGenerativeAIPart[],
+        },
+        finishReason: "STOP" as FinishReason,
+        index: 0,
+        safetyRatings: [],
+      },
+    ]);
+
+    const result = convertResponseContentToChatGenerationChunk(mockResponse, {
+      index: 0,
+    });
+
+    expect(result).not.toBeNull();
+    const content = result!.message.content;
+
+    expect(Array.isArray(content)).toBe(true);
+    if (!Array.isArray(content)) return;
+    // Empty {} part should be filtered out
+    expect(content.length).toBe(1);
+    expect(content[0]).toHaveProperty("type", "functionCall");
+  });
+
+  test("should filter empty parts while keeping valid parts in streaming", () => {
+    const mockResponse = createMockResponse([
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              text: "Thinking...",
+              thought: true,
+            },
+            {} as GoogleGenerativeAIPart,
+            {
+              text: "The result is 42.",
+            },
+            {} as GoogleGenerativeAIPart,
+          ] as GoogleGenerativeAIPart[],
+        },
+        finishReason: "STOP" as FinishReason,
+        index: 0,
+        safetyRatings: [],
+      },
+    ]);
+
+    const result = convertResponseContentToChatGenerationChunk(mockResponse, {
+      index: 0,
+    });
+
+    expect(result).not.toBeNull();
+    const content = result!.message.content;
+
+    expect(Array.isArray(content)).toBe(true);
+    if (!Array.isArray(content)) return;
+    expect(content.length).toBe(2);
+    expect((content[0] as ThinkingBlock).type).toBe("thinking");
+    expect((content[1] as TextBlock).type).toBe("text");
+    expect((content[1] as TextBlock).text).toBe("The result is 42.");
   });
 });

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -562,51 +562,59 @@ export function mapGenerateContentResultToChatResult(
   ) {
     content = parts[0].text;
   } else if (Array.isArray(parts) && parts.length > 0) {
-    content = parts.map((p) => {
-      if (p.thought && "text" in p && p.text) {
-        return {
-          type: "thinking",
-          thinking: p.text,
-          ...(p.thoughtSignature ? { signature: p.thoughtSignature } : {}),
-        };
-      } else if ("text" in p) {
-        return {
-          type: "text",
-          text: p.text,
-        };
-      } else if ("inlineData" in p) {
-        return {
-          type: "inlineData",
-          inlineData: p.inlineData,
-        };
-      } else if ("functionCall" in p) {
-        return {
-          type: "functionCall",
-          functionCall: p.functionCall,
-        };
-      } else if ("functionResponse" in p) {
-        return {
-          type: "functionResponse",
-          functionResponse: p.functionResponse,
-        };
-      } else if ("fileData" in p) {
-        return {
-          type: "fileData",
-          fileData: p.fileData,
-        };
-      } else if ("executableCode" in p) {
-        return {
-          type: "executableCode",
-          executableCode: p.executableCode,
-        };
-      } else if ("codeExecutionResult" in p) {
-        return {
-          type: "codeExecutionResult",
-          codeExecutionResult: p.codeExecutionResult,
-        };
-      }
-      return p;
-    });
+    content = parts
+      .map((p) => {
+        if (p.thought && "text" in p && p.text) {
+          return {
+            type: "thinking",
+            thinking: p.text,
+            ...(p.thoughtSignature ? { signature: p.thoughtSignature } : {}),
+          };
+        } else if ("text" in p) {
+          return {
+            type: "text",
+            text: p.text,
+          };
+        } else if ("inlineData" in p) {
+          return {
+            type: "inlineData",
+            inlineData: p.inlineData,
+          };
+        } else if ("functionCall" in p) {
+          return {
+            type: "functionCall",
+            functionCall: p.functionCall,
+          };
+        } else if ("functionResponse" in p) {
+          return {
+            type: "functionResponse",
+            functionResponse: p.functionResponse,
+          };
+        } else if ("fileData" in p) {
+          return {
+            type: "fileData",
+            fileData: p.fileData,
+          };
+        } else if ("executableCode" in p) {
+          return {
+            type: "executableCode",
+            executableCode: p.executableCode,
+          };
+        } else if ("codeExecutionResult" in p) {
+          return {
+            type: "codeExecutionResult",
+            codeExecutionResult: p.codeExecutionResult,
+          };
+        }
+        // Skip empty or unrecognized parts (e.g., empty {} from streaming
+        // finish-marker chunks). These cause "Unknown content {}" errors
+        // when the message is later re-serialized via _convertLangChainContentToPart.
+        if (Object.keys(p).length === 0) {
+          return undefined;
+        }
+        return p;
+      })
+      .filter((p): p is NonNullable<typeof p> => p !== undefined);
   } else {
     // no content returned - likely due to abnormal stop reason, e.g. malformed function call
     content = [];
@@ -702,51 +710,59 @@ export function convertResponseContentToChatGenerationChunk(
   ) {
     content = streamParts.map((p) => p.text).join("");
   } else if (Array.isArray(streamParts)) {
-    content = streamParts.map((p) => {
-      if (p.thought && "text" in p && p.text) {
-        return {
-          type: "thinking",
-          thinking: p.text,
-          ...(p.thoughtSignature ? { signature: p.thoughtSignature } : {}),
-        };
-      } else if ("text" in p) {
-        return {
-          type: "text",
-          text: p.text,
-        };
-      } else if ("inlineData" in p) {
-        return {
-          type: "inlineData",
-          inlineData: p.inlineData,
-        };
-      } else if ("functionCall" in p) {
-        return {
-          type: "functionCall",
-          functionCall: p.functionCall,
-        };
-      } else if ("functionResponse" in p) {
-        return {
-          type: "functionResponse",
-          functionResponse: p.functionResponse,
-        };
-      } else if ("fileData" in p) {
-        return {
-          type: "fileData",
-          fileData: p.fileData,
-        };
-      } else if ("executableCode" in p) {
-        return {
-          type: "executableCode",
-          executableCode: p.executableCode,
-        };
-      } else if ("codeExecutionResult" in p) {
-        return {
-          type: "codeExecutionResult",
-          codeExecutionResult: p.codeExecutionResult,
-        };
-      }
-      return p;
-    });
+    content = streamParts
+      .map((p) => {
+        if (p.thought && "text" in p && p.text) {
+          return {
+            type: "thinking",
+            thinking: p.text,
+            ...(p.thoughtSignature ? { signature: p.thoughtSignature } : {}),
+          };
+        } else if ("text" in p) {
+          return {
+            type: "text",
+            text: p.text,
+          };
+        } else if ("inlineData" in p) {
+          return {
+            type: "inlineData",
+            inlineData: p.inlineData,
+          };
+        } else if ("functionCall" in p) {
+          return {
+            type: "functionCall",
+            functionCall: p.functionCall,
+          };
+        } else if ("functionResponse" in p) {
+          return {
+            type: "functionResponse",
+            functionResponse: p.functionResponse,
+          };
+        } else if ("fileData" in p) {
+          return {
+            type: "fileData",
+            fileData: p.fileData,
+          };
+        } else if ("executableCode" in p) {
+          return {
+            type: "executableCode",
+            executableCode: p.executableCode,
+          };
+        } else if ("codeExecutionResult" in p) {
+          return {
+            type: "codeExecutionResult",
+            codeExecutionResult: p.codeExecutionResult,
+          };
+        }
+        // Skip empty or unrecognized parts (e.g., empty {} from streaming
+        // finish-marker chunks). These cause "Unknown content {}" errors
+        // when the message is later re-serialized via _convertLangChainContentToPart.
+        if (Object.keys(p).length === 0) {
+          return undefined;
+        }
+        return p;
+      })
+      .filter((p): p is NonNullable<typeof p> => p !== undefined);
   } else {
     // no content returned - likely due to abnormal stop reason, e.g. malformed function call
     content = [];


### PR DESCRIPTION
## Bug

When using `ChatGoogleGenerativeAI` with streaming mode and tool calls (especially with Gemini models that have thinking enabled), the Google API may return empty `{}` parts as finish-marker chunks in streaming responses. These empty objects pass through the fallback `return p;` in both `mapGenerateContentResultToChatResult` (non-streaming) and `convertResponseContentToChatGenerationChunk` (streaming), causing them to accumulate in `AIMessageChunk.content` arrays.

When the conversation history containing these empty parts is later sent back to the API, `_convertLangChainContentToPart` throws **"Unknown content {}"** because it cannot map empty objects to any valid Google API part type.

### Reproduction

1. Create a `ChatGoogleGenerativeAI` instance with thinking enabled
2. Use streaming mode (`.stream()`) in a multi-turn agent loop with tool calls
3. The accumulated `AIMessageChunk` from the first turn will contain empty `{}` objects in its `.content` array
4. When this message is included in the history for the next LLM call, it throws `Error: Unknown content {}`

### Root Cause

In `libs/providers/langchain-google-genai/src/utils/common.ts`, both `mapGenerateContentResultToChatResult` and `convertResponseContentToChatGenerationChunk` have a parts-mapping block that ends with a bare `return p;` fallback. When the API returns an empty part `{}` (which matches none of the `if/else if` conditions like `"text" in p`, `"functionCall" in p`, etc.), it passes through as-is into the content array.

## Fix

- Added a check before the final `return p;` to filter out empty objects (`Object.keys(p).length === 0`)
- Used `.filter()` with a type guard to remove `undefined` entries from the mapped array
- Applied the fix to both the non-streaming (`mapGenerateContentResultToChatResult`) and streaming (`convertResponseContentToChatGenerationChunk`) code paths
- Added unit tests covering empty parts filtering in both modes

## Test Plan

- [x] Added unit tests for `mapGenerateContentResultToChatResult` with empty `{}` parts
- [x] Added unit tests for `convertResponseContentToChatGenerationChunk` with empty `{}` parts
- [x] Verified empty parts are filtered while valid parts (text, thinking, functionCall) are preserved
- [x] Verified against real Gemini API (GPUGeek Google-format endpoint) with streaming + tool calls + thinking enabled


Made with [Cursor](https://cursor.com)