### PR TITLE
fix(core): apply castStandardMessageContent in streaming aggregation branch of _generateUncached

### DIFF
--- a/.changeset/fix-fix-castStandardMess.md.md
+++ b/.changeset/fix-fix-castStandardMess.md.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): apply castStandardMessageContent in streaming aggregation branch of _generateUncached

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -569,6 +569,9 @@ export abstract class BaseChatModel<
         if (aggregated === undefined) {
           throw new Error("Received empty response from chat model call.");
         }
+        if (outputVersion === "v1") {
+          aggregated.message = castStandardMessageContent(aggregated.message);
+        }
         generations.push([aggregated]);
         await runManagers?.[0].handleLLMEnd({
           generations,


### PR DESCRIPTION
## Summary

Fixes #10476. The `_generateUncached` method in `BaseChatModel` has three code paths that handle model output. Only two of them apply `castStandardMessageContent` when `outputVersion === "v1"`:

| Code path | Applies castStandardMessageContent? |
|-----------|------------------------------------|
| `_streamIterator` | ✅ Yes, per chunk |
| `_generateUncached` - non-streaming branch | ✅ Yes, per generation |
| `_generateUncached` - streaming aggregation branch | ❌ **No (fixed by this PR)** |

The third path is taken when a callback handler prefers streaming (`callbackHandlerPrefersStreaming` returns true). This is the default path when using `createAgent` from `langchain`, because LangGraph registers callback handlers that prefer streaming.

As a result, `output_version` is never set in the AIMessage's `response_metadata`, even when the user explicitly opts in via `LC_OUTPUT_VERSION=v1`.

## Changes

Added `castStandardMessageContent` call in the streaming aggregation branch of `_generateUncached`, right before the aggregated result is pushed to generations, matching the behavior of the other two code paths.

```typescript
if (outputVersion === "v1") {
  aggregated.message = castStandardMessageContent(aggregated.message);
}
```

## Test Plan

The existing test suite should cover this. Additionally, verifying that when `LC_OUTPUT_VERSION=v1` is set and using `createAgent`, the resulting AIMessage includes `output_version` in `response_metadata`.