### PR TITLE
fix(@langchain/google): deduplicate functionCall parts and preserve thoughtSignature in round-trip

### DIFF
--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -536,52 +536,27 @@ describe.each(coreModelInfo)(
     });
 
     test("function reply", async () => {
-      const tools: Gemini.Tool[] = [
-        {
-          functionDeclarations: [
-            {
-              name: "test",
-              description:
-                "Run a test with a specific name and get if it passed or failed",
-              parameters: {
-                type: "object",
-                properties: {
-                  testName: {
-                    type: "string",
-                    description: "The name of the test that should be run.",
-                  },
-                },
-                required: ["testName"],
-              },
-            },
-          ],
-        },
-      ];
+      const tools = [weatherTool];
       const llm = newChatGoogle().bindTools(tools);
-      const toolResult = {
-        testPassed: true,
-      };
-      const messages: BaseMessage[] = [
-        new HumanMessage("Run a test on the cobalt project."),
-        new AIMessage({
-          tool_calls: [
-            {
-              type: "tool_call",
-              id: "lc-tool-call-test-id",
-              name: "test",
-              args: {
-                testName: "cobalt",
-              },
-            },
-          ],
-        }),
-        new ToolMessage(JSON.stringify(toolResult), "lc-tool-call-test-id"),
+      const history: BaseMessage[] = [
+        new HumanMessage("What is the weather in New York?"),
       ];
-      const res = await llm.stream(messages);
+
+      const result1 = await llm.invoke(history);
+      history.push(result1);
+
+      const toolCalls = result1.tool_calls!;
+      expect(toolCalls.length).toBeGreaterThanOrEqual(1);
+
+      const toolMessage = await weatherTool.invoke(toolCalls[0]);
+      history.push(toolMessage);
+
+      const res = await llm.stream(history);
       const resArray: BaseMessageChunk[] = [];
       for await (const chunk of res) {
         resArray.push(chunk);
       }
+      expect(resArray.length).toBeGreaterThanOrEqual(1);
     });
 
     test("function - force tool", async () => {

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -441,11 +441,17 @@ function convertStandardContentMessageToGeminiContent(
   // Convert AIMessage tool_calls to functionCall parts
   if (AIMessage.isInstance(message) && message.tool_calls?.length) {
     for (const toolCall of message.tool_calls) {
+      const isGeneratedId = toolCall.id?.startsWith("lc-tool-call-");
+      const { thoughtSignature } = toolCall as typeof toolCall & {
+        thoughtSignature?: string;
+      };
       parts.push({
         functionCall: {
           name: toolCall.name,
           args: toolCall.args ?? {},
+          ...(!isGeneratedId && toolCall.id ? { id: toolCall.id } : {}),
         },
+        ...(thoughtSignature ? { thoughtSignature } : {}),
       } as Gemini.Part.FunctionCall);
     }
   }
@@ -736,15 +742,33 @@ function convertLegacyContentMessageToGeminiContent(
     }
   }
 
-  // Convert AIMessage tool_calls to functionCall parts
+  // Convert AIMessage tool_calls to functionCall parts, but skip when the
+  // content array already emitted functionCall blocks (avoids duplicates).
   if (AIMessage.isInstance(message) && message.tool_calls?.length) {
-    for (const toolCall of message.tool_calls) {
-      parts.push({
-        functionCall: {
-          name: toolCall.name,
-          args: toolCall.args ?? {},
-        },
-      } as Gemini.Part.FunctionCall);
+    const contentHasFunctionCalls =
+      Array.isArray(message.content) &&
+      message.content.some(
+        (item) =>
+          typeof item === "object" &&
+          item !== null &&
+          "type" in item &&
+          item.type === "functionCall"
+      );
+    if (!contentHasFunctionCalls) {
+      for (const toolCall of message.tool_calls) {
+        const isGeneratedId = toolCall.id?.startsWith("lc-tool-call-");
+        const { thoughtSignature } = toolCall as typeof toolCall & {
+          thoughtSignature?: string;
+        };
+        parts.push({
+          functionCall: {
+            name: toolCall.name,
+            args: toolCall.args ?? {},
+            ...(!isGeneratedId && toolCall.id ? { id: toolCall.id } : {}),
+          },
+          ...(thoughtSignature ? { thoughtSignature } : {}),
+        } as Gemini.Part.FunctionCall);
+      }
     }
   }
 

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -588,6 +588,164 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBeUndefined();
   });
 
+  test("no duplicate functionCall when content array already has functionCall blocks (legacy path)", () => {
+    const aiMsg = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            name: "get_weather",
+            args: { location: "New York" },
+            id: "server-id-1",
+          },
+          thoughtSignature: "fake-sig-abc",
+        },
+      ],
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { location: "New York" },
+          id: "server-id-1",
+          type: "tool_call" as const,
+        },
+      ],
+    });
+    const messages = [
+      new HumanMessage("What is the weather?"),
+      aiMsg,
+      new ToolMessage({
+        content: '{"temp": 21}',
+        tool_call_id: "server-id-1",
+        name: "get_weather",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const functionCallParts = modelContent!.parts!.filter(
+      (p) => "functionCall" in p && p.functionCall
+    );
+    expect(functionCallParts).toHaveLength(1);
+
+    const part = functionCallParts[0] as Gemini.Part.FunctionCall;
+    expect(part.thoughtSignature).toBe("fake-sig-abc");
+    expect(part.functionCall!.name).toBe("get_weather");
+  });
+
+  test("tool_calls with thoughtSignature and id are preserved in functionCall parts (legacy path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "native-id-42",
+          type: "tool_call" as const,
+        },
+      ],
+    });
+    // Gemini responses carry thoughtSignature as an extra property on tool calls
+    (aiMsg.tool_calls![0] as Record<string, unknown>).thoughtSignature =
+      "sig-xyz-123";
+
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: '{"temp": 15}',
+        tool_call_id: "native-id-42",
+        name: "get_weather",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const part = modelContent!.parts!.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(part).toBeDefined();
+    expect(part.thoughtSignature).toBe("sig-xyz-123");
+    expect(part.functionCall!.id).toBe("native-id-42");
+  });
+
+  test("tool_calls with thoughtSignature and id are preserved in functionCall parts (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "native-id-42",
+          type: "tool_call" as const,
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+    (aiMsg.tool_calls![0] as Record<string, unknown>).thoughtSignature =
+      "sig-xyz-123";
+
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: '{"temp": 15}',
+        tool_call_id: "native-id-42",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const part = modelContent!.parts!.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(part).toBeDefined();
+    expect(part.thoughtSignature).toBe("sig-xyz-123");
+    expect(part.functionCall!.id).toBe("native-id-42");
+  });
+
+  test("generated lc-tool-call IDs are omitted from functionCall.id (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "get_weather",
+            args: { city: "London" },
+            id: "lc-tool-call-abc123",
+            type: "tool_call" as const,
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: '{"temp": 15}',
+        tool_call_id: "lc-tool-call-abc123",
+        name: "get_weather",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const part = modelContent!.parts!.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(part).toBeDefined();
+    expect(part.functionCall!.id).toBeUndefined();
+  });
+
   test("v1 contentBlocks: text-plain block produces fileData part", () => {
     const messages = [
       new HumanMessage({


### PR DESCRIPTION
When Gemini returns a `functionCall` response, the converter stores it in two places on the `AIMessage`: the `content` array (as a typed content block with full metadata like `thoughtSignature`) and `tool_calls` (as a standard tool call). When converting that message back to Gemini format for the next request, both sources were iterated independently, producing a **duplicate `functionCall` part** — where the second copy was missing `thoughtSignature` and `id`.

This PR fixes the round-trip by:

- **Deduplicating** in the legacy converter: if the `content` array already emitted `functionCall` parts (which preserve all Gemini metadata), skip re-emitting from `tool_calls`.
- **Enriching** the `tool_calls` → `functionCall` conversion (both legacy and v1 paths) to carry `thoughtSignature` and native `id` through, for cases where `tool_calls` is the only source (e.g. manually constructed messages or the v1 path).
- **Fixing the "function reply" integration test** to use a real round-trip instead of a synthetic history that lacks a valid `thoughtSignature`.

closes https://github.com/langchain-ai/langchainjs/issues/10474
