### PR TITLE
fix(mcp-adapters): preserve base headers and transport type in forked clients

### DIFF
--- a/.changeset/pink-maps-repair.md
+++ b/.changeset/pink-maps-repair.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mcp-adapters": patch
+---
+
+fix(mcp-adapters): preserve base headers and transport type in forked clients

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -321,7 +321,7 @@ const out = await t?.invoke({ a: 1, b: 2 });
 
 Notes:
 
-- **beforeToolCall** can return `{ args?, headers? }`. Headers are supported for HTTP/SSE. Stdio connections do not support custom headers.
+- **beforeToolCall** can return `{ args?, headers? }`. Headers are supported for HTTP/SSE. Stdio connections do not support custom headers. For HTTP/SSE, per-call headers are applied on top of any headers configured on the transport.
 - **afterToolCall** may return either a 2‑tuple `[content, artifact]`, a `ToolMessage`, a `Command` instance, or nothing (to keep the original result).
 
 ## Tool Configuration Options

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -39,8 +39,8 @@ const debugLog = getDebugLog("connection");
 
 export interface Client extends MCPClient {
   /**
-   * Fork the client with a new set of headers, it either returns a new client or the same client if the headers are the same
-   * @param headers - The headers to fork the client with
+   * Fork the client with additional or overridden headers. Existing headers are preserved unless overridden.
+   * @param headers - The headers to merge into the forked client configuration
    * @returns The forked client
    */
   fork: (headers: Record<string, string>) => Promise<Client>;
@@ -57,6 +57,7 @@ type ClientKeyObject = Omit<TransportOptions, "headers"> & {
 };
 
 export interface Connection {
+  type: "http" | "sse" | "stdio";
   transport:
     | StreamableHTTPClientTransport
     | SSEClientTransport
@@ -67,6 +68,28 @@ export interface Connection {
 }
 
 const transportTypes = ["http", "sse", "stdio"] as const;
+
+function mergeHeaders(
+  baseHeaders: Record<string, string> | undefined,
+  overrideHeaders: Record<string, string>
+): Record<string, string> {
+  const mergedHeaders = { ...(baseHeaders ?? {}) };
+
+  for (const [headerName, headerValue] of Object.entries(overrideHeaders)) {
+    for (const existingHeaderName of Object.keys(mergedHeaders)) {
+      if (
+        existingHeaderName !== headerName &&
+        existingHeaderName.toLowerCase() === headerName.toLowerCase()
+      ) {
+        delete mergedHeaders[existingHeaderName];
+      }
+    }
+
+    mergedHeaders[headerName] = headerValue;
+  }
+
+  return mergedHeaders;
+}
 
 type ConnectionManagerConfig = Pick<
   ResolvedClientConfig,
@@ -252,6 +275,7 @@ export class ConnectionManager {
     }) as Client;
 
     this.#connections.set(key, {
+      type,
       transport,
       client,
       transportOptions: options,
@@ -262,7 +286,7 @@ export class ConnectionManager {
   }
 
   /**
-   * Allows to fork a client with a new set of headers
+   * Allows to fork a client with merged headers
    */
   #forkClient(
     key: ClientKeyObject,
@@ -275,16 +299,25 @@ export class ConnectionManager {
       throw new Error("Transport not found");
     }
 
-    const type =
-      connection.transportOptions.type ?? connection.transportOptions.transport;
-    if (type === "stdio") {
+    if (connection.type === "stdio") {
       throw new Error("Forking stdio transport is not supported");
     }
 
-    return this.createClient(type as "http", key.serverName, {
-      ...connection.transportOptions,
-      headers,
-    } as ResolvedStreamableHTTPConnection);
+    const transportOptions = connection.transportOptions;
+    if ("command" in transportOptions) {
+      throw new Error("Forking stdio transport is not supported");
+    }
+
+    const forkedTransportOptions = {
+      ...transportOptions,
+      headers: mergeHeaders(transportOptions.headers, headers),
+    } as ResolvedStreamableHTTPConnection;
+
+    if (connection.type === "http") {
+      return this.createClient("http", key.serverName, forkedTransportOptions);
+    }
+
+    return this.createClient("sse", key.serverName, forkedTransportOptions);
   }
 
   /**

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -211,6 +211,137 @@ describe("ConnectionManager", () => {
       expect(mgr.getAllClients().length).toBe(2);
     });
 
+    test("forking HTTP client preserves existing headers", async () => {
+      const mgr = new ConnectionManager();
+      const base = await mgr.createClient("http", "svc", {
+        transport: "http",
+        url: "http://localhost:8000/mcp",
+        automaticSSEFallback: true,
+        headers: { Authorization: "Bearer token", A: "1" },
+      });
+
+      await (base as Client).fork({ "X-Check": "present" });
+
+      const [, options] = (StreamableHTTPClientTransport as Mock).mock.calls[1];
+      expect(options).toEqual(
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              Authorization: "Bearer token",
+              A: "1",
+              "X-Check": "present",
+            },
+          },
+        })
+      );
+    });
+
+    test("forking HTTP client overrides headers case-insensitively", async () => {
+      const mgr = new ConnectionManager();
+      const base = await mgr.createClient("http", "svc", {
+        transport: "http",
+        url: "http://localhost:8000/mcp",
+        automaticSSEFallback: true,
+        headers: {
+          Authorization: "Bearer token",
+          AUTHORIZATION: "Bearer stale",
+          "X-Base": "1",
+        },
+      });
+
+      await (base as Client).fork({ authorization: "Bearer override" });
+
+      const [, options] = (StreamableHTTPClientTransport as Mock).mock.calls[1];
+      expect(options).toEqual(
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              authorization: "Bearer override",
+              "X-Base": "1",
+            },
+          },
+        })
+      );
+    });
+
+    test("forking inferred HTTP client preserves streamable HTTP headers", async () => {
+      const mgr = new ConnectionManager();
+      const base = await mgr.createClient("http", "svc", {
+        url: "http://localhost:8000/mcp",
+        automaticSSEFallback: true,
+        headers: { Authorization: "Bearer token" },
+      });
+
+      await (base as Client).fork({ "X-Check": "present" });
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledTimes(2);
+      const [, options] = (StreamableHTTPClientTransport as Mock).mock.calls[1];
+      expect(options).toEqual(
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              Authorization: "Bearer token",
+              "X-Check": "present",
+            },
+          },
+        })
+      );
+    });
+
+    test("forking inferred SSE client preserves transport headers", async () => {
+      const mgr = new ConnectionManager();
+      const base = await mgr.createClient("sse", "svc", {
+        url: "http://localhost:8000/sse",
+        automaticSSEFallback: true,
+        headers: { Authorization: "Bearer token" },
+      });
+
+      await (base as Client).fork({ "X-Check": "present" });
+
+      expect(SSEClientTransport).toHaveBeenCalledTimes(2);
+      const [, options] = (SSEClientTransport as Mock).mock.calls[1];
+      expect(options).toEqual(
+        expect.objectContaining({
+          requestInit: {
+            headers: {
+              Authorization: "Bearer token",
+              "X-Check": "present",
+            },
+          },
+        })
+      );
+    });
+
+    test("forking HTTP client preserves auth provider", async () => {
+      const mgr = new ConnectionManager();
+      const authProvider = {
+        tokens: vi.fn().mockResolvedValue({ access_token: "abc" }),
+      } as never;
+
+      const base = await mgr.createClient("http", "svc", {
+        transport: "http",
+        url: "http://localhost:8000/mcp",
+        automaticSSEFallback: true,
+        headers: { Authorization: "Bearer token" },
+        authProvider,
+      });
+
+      await (base as Client).fork({ "X-Check": "present" });
+
+      const [, options] = (StreamableHTTPClientTransport as Mock).mock.calls[1];
+      expect(options).toEqual(
+        expect.objectContaining({
+          authProvider,
+          requestInit: {
+            headers: {
+              Authorization: "Bearer token",
+              "X-Check": "present",
+            },
+          },
+        })
+      );
+    });
+
     test("forking stdio client is not supported", async () => {
       const mgr = new ConnectionManager();
       const stdio = await mgr.createClient("stdio", "svc", {

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -25,12 +25,17 @@ class TestServers {
 
   async createHTTP(
     name: string,
-    opts?: { supportSSEFallback?: boolean; testHeaders?: boolean }
+    opts?: {
+      supportSSEFallback?: boolean;
+      testHeaders?: boolean;
+      requireAuth?: boolean;
+    }
   ): Promise<{ baseUrl: string }> {
     return new Promise((resolve, reject) => {
       const app = createDummyHttpServer(name, {
         supportSSEFallback: Boolean(opts?.supportSSEFallback),
         testHeaders: Boolean(opts?.testHeaders),
+        requireAuth: Boolean(opts?.requireAuth),
       });
       const httpServer = app.listen(0, "127.0.0.1", (err?: Error) => {
         if (err) return reject(err);
@@ -247,6 +252,110 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         await client.close();
       }
     });
+  });
+
+  test("beforeToolCall headers preserve static auth headers for HTTP", async () => {
+    const { baseUrl } = await servers.createHTTP("http-auth", {
+      requireAuth: true,
+      testHeaders: true,
+    });
+    const client = new MultiServerMCPClient({
+      mcpServers: {
+        http: {
+          transport: "http",
+          url: `${baseUrl}/mcp`,
+          automaticSSEFallback: true,
+          headers: { Authorization: "Bearer test-token" },
+        },
+      },
+      beforeToolCall: () => ({
+        headers: { "X-Check": "present" },
+      }),
+    });
+
+    try {
+      const tools = await client.getTools();
+      const checkHeadersTool = tools.find((tool) =>
+        tool.name.includes("check_headers")
+      );
+      const authResult = await checkHeadersTool!.invoke({
+        headerName: "Authorization",
+      });
+      const result = await checkHeadersTool!.invoke({ headerName: "X-Check" });
+      expect(authResult).toBe("Bearer test-token");
+      expect(result).toBe("present");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("beforeToolCall headers preserve static auth headers for SSE", async () => {
+    const { baseUrl } = await servers.createHTTP("sse-auth", {
+      requireAuth: true,
+      supportSSEFallback: true,
+      testHeaders: true,
+    });
+    const client = new MultiServerMCPClient({
+      mcpServers: {
+        sse: {
+          transport: "sse",
+          url: `${baseUrl}/sse`,
+          headers: { Authorization: "Bearer test-token" },
+        },
+      },
+      beforeToolCall: () => ({
+        headers: { "X-Check": "present" },
+      }),
+    });
+
+    try {
+      const tools = await client.getTools();
+      const checkHeadersTool = tools.find((tool) =>
+        tool.name.includes("check_headers")
+      );
+      const authResult = await checkHeadersTool!.invoke({
+        headerName: "Authorization",
+      });
+      const result = await checkHeadersTool!.invoke({ headerName: "X-Check" });
+      expect(authResult).toBe("Bearer test-token");
+      expect(result).toBe("present");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("beforeToolCall headers preserve static auth headers for inferred HTTP transports", async () => {
+    const { baseUrl } = await servers.createHTTP("http-implicit-auth", {
+      requireAuth: true,
+      testHeaders: true,
+    });
+    const client = new MultiServerMCPClient({
+      mcpServers: {
+        http: {
+          url: `${baseUrl}/mcp`,
+          automaticSSEFallback: true,
+          headers: { Authorization: "Bearer test-token" },
+        },
+      },
+      beforeToolCall: () => ({
+        headers: { "X-Check": "present" },
+      }),
+    });
+
+    try {
+      const tools = await client.getTools();
+      const checkHeadersTool = tools.find((tool) =>
+        tool.name.includes("check_headers")
+      );
+      const authResult = await checkHeadersTool!.invoke({
+        headerName: "Authorization",
+      });
+      const result = await checkHeadersTool!.invoke({ headerName: "X-Check" });
+      expect(authResult).toBe("Bearer test-token");
+      expect(result).toBe("present");
+    } finally {
+      await client.close();
+    }
   });
 
   test("onProgress and onLog hooks", async () => {


### PR DESCRIPTION
Forked MCP clients created from `beforeToolCall.headers` were rebuilding HTTP/SSE connections with only the per-call headers. That dropped base headers like `Authorization`, and inferred HTTP connections could also fail during fork with `Invalid transport type: undefined`.

### Changes

- preserve the original transport type for forks
- apply per-call headers as case-insensitive overrides on top of the base transport headers
- add coverage for HTTP/SSE forks, inferred HTTP forks, and `authProvider` preservation

This keeps `beforeToolCall.headers` behaving like per-call header overrides instead of replacing the base transport headers.

### Compatibility note

Omitted per-call headers no longer drop inherited base headers. If maintainers would rather preserve replacement semantics here, I can split this out and follow up with an explicit header-clearing mechanism.