### PR TITLE
fix(@langchain/google-genai): pass abort signal to fetch in non-streaming invoke

### DIFF
--- a/.changeset/google-genai-abort-signal.md
+++ b/.changeset/google-genai-abort-signal.md
@@ -1,0 +1,6 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(@langchain/google-genai): pass abort signal to fetch in non-streaming invoke
+- Added `options` as second argument to `completionWithRetry()` in `_generate`'s non-streaming branch, mirroring what `_streamResponseChunks` already does

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -892,10 +892,13 @@ export class ChatGoogleGenerativeAI
       return { generations, llmOutput: { estimatedTokenUsage: tokenUsage } };
     }
 
-    const res = await this.completionWithRetry({
-      ...parameters,
-      contents: actualPrompt,
-    });
+    const res = await this.completionWithRetry(
+      {
+        ...parameters,
+        contents: actualPrompt,
+      },
+      options
+    );
 
     let usageMetadata: UsageMetadata | undefined;
     if ("usageMetadata" in res.response) {

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -1162,3 +1162,30 @@ describe("withStructuredOutput - StandardSchema", () => {
     expect((result as any).parsed).toEqual({ name: "cobalt" });
   });
 });
+
+test("passes abort signal to completionWithRetry in non-streaming invoke", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    model: "gemini-2.0-flash",
+    apiKey: "testing",
+  });
+
+  const controller = new AbortController();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spy = vi.spyOn(model as any, "completionWithRetry").mockResolvedValue({
+    response: {
+      candidates: [
+        { content: { parts: [{ text: "Hello" }], role: "model" } },
+      ],
+    },
+  });
+
+  await model.invoke("Hello", { signal: controller.signal });
+
+  expect(spy).toHaveBeenCalledWith(
+    expect.any(Object),
+    expect.objectContaining({ signal: controller.signal })
+  );
+
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary

`ChatGoogleGenerativeAI.invoke()` ignores the `timeout` / `signal` option in the non-streaming code path. The `AbortSignal` created by `@langchain/core`'s `ensureConfig` is available inside `_generate` as `options.signal`, but is never forwarded to `completionWithRetry()`. The streaming path (`_streamResponseChunks`) already passes `signal` correctly — this PR fixes the asymmetry.

### Root cause

In `libs/providers/langchain-google-genai/src/chat_models.ts`, the non-streaming branch of `_generate` calls `completionWithRetry({ ...parameters, contents: actualPrompt })` without passing the second `options` argument. Since `completionWithRetry(request, options)` reads `options?.signal` to pass to both `callWithOptions` and `generateContent`, the signal is lost.

### Fix

- Added `options` as the second argument to `completionWithRetry()` in `_generate`'s non-streaming branch, mirroring what `_streamResponseChunks` already does
- Added a unit test that verifies the abort signal propagates through `completionWithRetry`

Same class of bug as #10471 which fixed `@langchain/google`.

Fixes #10470