### PR TITLE
fix(@langchain/openai): use response.id instead of nested item id for AIMessage.id

### DIFF
--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -336,7 +336,6 @@ export const convertResponsesMessageToAIMessage: Converter<
     throw error;
   }
 
-  let messageId: string | undefined;
   const content: MessageContent = [];
   const tool_calls: ToolCall[] = [];
   const invalid_tool_calls: InvalidToolCall[] = [];
@@ -380,7 +379,6 @@ export const convertResponsesMessageToAIMessage: Converter<
 
   for (const item of response.output) {
     if (item.type === "message") {
-      messageId = item.id;
       content.push(
         ...item.content.flatMap((part) => {
           if (part.type === "output_text") {
@@ -483,7 +481,7 @@ export const convertResponsesMessageToAIMessage: Converter<
   }
 
   return new AIMessage({
-    id: messageId,
+    id: response.id,
     content,
     tool_calls,
     invalid_tool_calls,

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -286,6 +286,60 @@ describe("convertResponsesMessageToAIMessage", () => {
     expect(storedOutput[0].name).toBe("get_weather");
     expect(storedOutput[0]).not.toHaveProperty("parsed_arguments");
   });
+
+  it("should set AIMessage.id to response.id, not a nested output item id", () => {
+    const response = {
+      id: "resp_top_level_id",
+      model: "gpt-4o",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_nested_item_id",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello!", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    // AIMessage.id must be the top-level response id, not the nested message item id
+    expect(result.id).toBe("resp_top_level_id");
+    expect(result.id).not.toBe("msg_nested_item_id");
+  });
+
+  it("should set AIMessage.id to response.id even with only tool call output", () => {
+    const response = {
+      id: "resp_tool_only",
+      model: "gpt-4o",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          id: "fc_nested_id",
+          call_id: "call_456",
+          name: "get_weather",
+          arguments: '{"city":"NYC"}',
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    // Even without a message output item, id should come from the response
+    expect(result.id).toBe("resp_tool_only");
+  });
 });
 
 describe("convertResponsesDeltaToChatGenerationChunk", () => {


### PR DESCRIPTION
## Summary

- `convertResponsesMessageToAIMessage` was setting `AIMessage.id` to a nested output item's `id` instead of the top-level `response.id`
- This caused wrong identifiers for deduplication/caching/tracing, and `undefined` id on tool-call-only responses
- Fix: remove `messageId` accumulator, use `response.id` directly (+1 / -3 lines)

Fixes #10499

## Changes

- `libs/providers/langchain-openai/src/converters/responses.ts`: remove `messageId` variable, set `id: response.id`
- `libs/providers/langchain-openai/src/converters/tests/responses.test.ts`: 2 regression tests — message-type output and tool-call-only response

## Test plan

- [x] All 66 tests in `responses.test.ts` pass
- [x] 228/228 tests pass across 25 test files
- [x] New test asserts `AIMessage.id === response.id` (not nested item id)
- [x] New test asserts `AIMessage.id` set correctly on tool-call-only responses