### PR TITLE
feat(openai): add support for phase parameter on Responses API messages

### DIFF
--- a/.changeset/openai-phase-param.md
+++ b/.changeset/openai-phase-param.md
@@ -1,0 +1,11 @@
+---
+"@langchain/openai": minor
+"@langchain/core": patch
+---
+
+feat(openai): add support for phase parameter on Responses API messages
+
+- Extract `phase` from message output items and surface it on text content blocks
+- Support phase in streaming via `response.output_item.added` events
+- Round-trip phase through both raw provider and standard content paths
+- Move phase into `extras` dict in the core standard content translator

--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -268,10 +268,24 @@ export function convertToV1FromResponses(
         : message.content;
     for (const block of content) {
       if (_isContentBlock(block, "text")) {
-        const { text, annotations, ...rest } = block;
+        const {
+          text,
+          annotations,
+          phase,
+          extras: existingExtras,
+          ...rest
+        } = block;
+        const extras: Record<string, unknown> = _isObject(existingExtras)
+          ? { ...(existingExtras as Record<string, unknown>) }
+          : {};
+        if (_isString(phase)) {
+          extras.phase = phase;
+        }
+        const extrasSpread = Object.keys(extras).length > 0 ? { extras } : {};
         if (Array.isArray(annotations)) {
           yield {
             ...rest,
+            ...extrasSpread,
             type: "text",
             text: String(text),
             annotations: annotations.map(convertResponsesAnnotation),
@@ -279,6 +293,7 @@ export function convertToV1FromResponses(
         } else {
           yield {
             ...rest,
+            ...extrasSpread,
             type: "text",
             text: String(text),
           };

--- a/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
@@ -701,4 +701,71 @@ describe("openaiTranslator", () => {
       });
     });
   });
+
+  describe("phase parameter support", () => {
+    it("should move phase into extras on text content blocks in standard content", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "text",
+            text: "Let me check that for you.",
+            annotations: [],
+            phase: "commentary",
+          },
+        ],
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const blocks = message.contentBlocks;
+      const textBlock = blocks.find(
+        (b) => b.type === "text"
+      ) as ContentBlock.Text;
+      expect(textBlock).toBeDefined();
+      expect(textBlock.text).toBe("Let me check that for you.");
+      expect(textBlock.extras).toEqual({ phase: "commentary" });
+      // phase should not remain at top level in standard content
+      expect(textBlock.phase).toBeUndefined();
+    });
+
+    it("should move phase 'final_answer' into extras on text content blocks", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "text",
+            text: "The weather is sunny.",
+            annotations: [],
+            phase: "final_answer",
+          },
+        ],
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const blocks = message.contentBlocks;
+      const textBlock = blocks.find(
+        (b) => b.type === "text"
+      ) as ContentBlock.Text;
+      expect(textBlock).toBeDefined();
+      expect(textBlock.extras).toEqual({ phase: "final_answer" });
+    });
+
+    it("should not have extras when phase not present", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "text",
+            text: "Hello!",
+            annotations: [],
+          },
+        ],
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const blocks = message.contentBlocks;
+      const textBlock = blocks.find(
+        (b) => b.type === "text"
+      ) as ContentBlock.Text;
+      expect(textBlock).toBeDefined();
+      expect(textBlock.extras).toBeUndefined();
+    });
+  });
 });

--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "js-tiktoken": "^1.0.12",
-    "openai": "^6.27.0",
+    "openai": "^6.32.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -387,13 +387,15 @@ export const convertResponsesMessageToAIMessage: Converter<
             if ("parsed" in part && part.parsed != null) {
               additional_kwargs.parsed = part.parsed;
             }
-            return {
+            const block: ContentBlock = {
               type: "text",
               text: part.text,
               annotations: part.annotations.map(
                 convertOpenAIAnnotationToLangChain
               ),
-            } satisfies ContentBlock.Text;
+              ...(item.phase !== null ? { phase: item.phase } : {}),
+            };
+            return block;
           }
 
           if (part.type === "refusal") {
@@ -677,6 +679,15 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     event.item.type === "message"
   ) {
     id = event.item.id;
+    const phase = "phase" in event.item ? event.item.phase : undefined;
+    if (phase) {
+      content.push({
+        type: "text",
+        text: "",
+        phase,
+        index: 0,
+      } as ContentBlock.Text);
+    }
   } else if (
     event.type === "response.output_item.added" &&
     event.item.type === "function_call"
@@ -965,14 +976,16 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       currentMessage = undefined;
     }
 
-    const pushMessageContent: (
-      content: OpenAIClient.Responses.ResponseInputMessageContentList
-    ) => void = (content) => {
+    const pushMessageContent = (
+      content: OpenAIClient.Responses.ResponseInputMessageContentList,
+      phase?: OpenAIClient.Responses.EasyInputMessage["phase"]
+    ) => {
       if (!currentMessage) {
         currentMessage = {
           type: "message",
           role: messageRole,
           content: [],
+          ...(phase ? { phase } : {}),
         };
       }
       if (typeof currentMessage.content === "string") {
@@ -1141,7 +1154,20 @@ export const convertStandardContentMessageToResponsesInput: Converter<
 
     for (const block of message.contentBlocks) {
       if (block.type === "text") {
-        pushMessageContent([{ type: "input_text", text: block.text }]);
+        const phase = iife(() => {
+          if (
+            !(
+              "extras" in block &&
+              typeof block.extras === "object" &&
+              block.extras !== null &&
+              "phase" in block.extras
+            )
+          )
+            return undefined;
+          return block.extras
+            .phase as OpenAIClient.Responses.EasyInputMessage["phase"];
+        });
+        pushMessageContent([{ type: "input_text", text: block.text }], phase);
       } else if (block.type === "invalid_tool_call") {
         // no-op
       } else if (block.type === "reasoning") {
@@ -1452,7 +1478,7 @@ export const convertMessagesToResponsesInput: Converter<
         }
 
         if (typeof content === "string" || content.length > 0) {
-          input.push({
+          const messageItem: ResponsesInputItem = {
             type: "message",
             role: "assistant",
             ...(lcMsg.id && !zdrEnabled && lcMsg.id.startsWith("msg_")
@@ -1481,7 +1507,18 @@ export const convertMessagesToResponsesInput: Converter<
                 return [];
               });
             }) as ResponseInputMessageContentList,
-          });
+            phase: iife(() => {
+              const index = content.findIndex(
+                (item) => "phase" in item && typeof item.phase === "string"
+              );
+              if (index >= 0) {
+                return content[index]
+                  .phase as OpenAIClient.Responses.EasyInputMessage["phase"];
+              }
+              return undefined;
+            }),
+          };
+          input.push(messageItem);
         }
 
         const functionCallIds = additional_kwargs?.[_FUNCTION_CALL_IDS_MAP_KEY];

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -2208,3 +2208,323 @@ describe("convertResponsesDeltaToChatGenerationChunk - json_schema with tool cal
     });
   });
 });
+
+describe("phase parameter support", () => {
+  describe("convertResponsesMessageToAIMessage", () => {
+    it("should include phase on text content blocks when present on message output", () => {
+      const response = {
+        id: "resp_123",
+        model: "gpt-5.4",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_001",
+            role: "assistant",
+            phase: "commentary",
+            content: [
+              {
+                type: "output_text",
+                text: "Let me check that for you.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      };
+
+      const result = convertResponsesMessageToAIMessage(response as any);
+      expect(Array.isArray(result.content)).toBe(true);
+      const contentArray = result.content as Array<Record<string, unknown>>;
+      expect(contentArray).toHaveLength(1);
+      expect(contentArray[0].type).toBe("text");
+      expect(contentArray[0].phase).toBe("commentary");
+    });
+
+    it("should include phase 'final_answer' on text content blocks", () => {
+      const response = {
+        id: "resp_456",
+        model: "gpt-5.4",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_002",
+            role: "assistant",
+            phase: "final_answer",
+            content: [
+              {
+                type: "output_text",
+                text: "The weather is sunny.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      };
+
+      const result = convertResponsesMessageToAIMessage(response as any);
+      const contentArray = result.content as Array<Record<string, unknown>>;
+      expect(contentArray[0].phase).toBe("final_answer");
+    });
+
+    it("should not include phase on text content blocks when not present on message output", () => {
+      const response = {
+        id: "resp_789",
+        model: "gpt-4o",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_003",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Hello!",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      };
+
+      const result = convertResponsesMessageToAIMessage(response as any);
+      const contentArray = result.content as Array<Record<string, unknown>>;
+      expect(contentArray[0].phase).toBeUndefined();
+    });
+  });
+
+  describe("convertResponsesDeltaToChatGenerationChunk", () => {
+    it("should include phase on text content block when message item has phase", () => {
+      const event = {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "msg_001",
+          role: "assistant",
+          phase: "commentary",
+          content: [],
+          status: "in_progress",
+        },
+      } as any;
+
+      const chunk = convertResponsesDeltaToChatGenerationChunk(event);
+      expect(chunk).not.toBeNull();
+      const contentArray = chunk!.message.content as Array<
+        Record<string, unknown>
+      >;
+      expect(contentArray).toHaveLength(1);
+      expect(contentArray[0].type).toBe("text");
+      expect(contentArray[0].text).toBe("");
+      expect(contentArray[0].phase).toBe("commentary");
+    });
+
+    it("should not include phase content block when message item has no phase", () => {
+      const event = {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "msg_001",
+          role: "assistant",
+          content: [],
+          status: "in_progress",
+        },
+      } as any;
+
+      const chunk = convertResponsesDeltaToChatGenerationChunk(event);
+      expect(chunk).not.toBeNull();
+      const contentArray = chunk!.message.content as Array<
+        Record<string, unknown>
+      >;
+      // Should only have the id set, no content blocks with phase
+      expect(
+        contentArray.filter(
+          (block) => "phase" in block && block.phase !== undefined
+        )
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("convertMessagesToResponsesInput round-trip", () => {
+    it("should preserve phase when converting AIMessage back to responses input (responses/v1)", () => {
+      const aiMessage = new AIMessage({
+        id: "msg_001",
+        content: [
+          {
+            type: "text",
+            text: "Let me check that for you.",
+            phase: "commentary",
+          } as any,
+        ],
+        response_metadata: {
+          model_provider: "openai",
+        },
+      });
+
+      const result = convertMessagesToResponsesInput({
+        messages: [aiMessage],
+        zdrEnabled: false,
+        model: "gpt-5.4",
+      });
+
+      const messageItem = result.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.phase).toBe("commentary");
+    });
+
+    it("should not include phase when content blocks have no phase", () => {
+      const aiMessage = new AIMessage({
+        id: "msg_001",
+        content: [
+          {
+            type: "text",
+            text: "Hello!",
+          },
+        ],
+        response_metadata: {
+          model_provider: "openai",
+        },
+      });
+
+      const result = convertMessagesToResponsesInput({
+        messages: [aiMessage],
+        zdrEnabled: false,
+        model: "gpt-4o",
+      });
+
+      const messageItem = result.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.phase).toBeUndefined();
+    });
+
+    it("should preserve phase from extras through standard content path", () => {
+      const aiMessage = new AIMessage({
+        id: "msg_001",
+        content: [
+          {
+            type: "text",
+            text: "The answer is 42.",
+            extras: { phase: "final_answer" },
+          } as any,
+        ],
+        response_metadata: {
+          model_provider: "openai",
+          output_version: "v1",
+        },
+      });
+
+      const result = convertStandardContentMessageToResponsesInput(aiMessage);
+
+      const messageItem = result.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.phase).toBe("final_answer");
+    });
+  });
+
+  describe("full round-trip", () => {
+    it("should round-trip phase through response -> AIMessage -> input (raw provider path)", () => {
+      // Step 1: Simulate a response with phase
+      const response = {
+        id: "resp_123",
+        model: "gpt-5.4",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_001",
+            role: "assistant",
+            phase: "commentary",
+            content: [
+              {
+                type: "output_text",
+                text: "Let me check the weather.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      };
+
+      // Step 2: Convert response to AIMessage (phase on top-level content block)
+      const aiMessage = convertResponsesMessageToAIMessage(response as any);
+      const contentArray = aiMessage.content as Array<Record<string, unknown>>;
+      expect(contentArray[0].phase).toBe("commentary");
+
+      // Step 3: Convert AIMessage back to input via raw provider path
+      const input = convertMessagesToResponsesInput({
+        messages: [aiMessage],
+        zdrEnabled: false,
+        model: "gpt-5.4",
+      });
+
+      const messageItem = input.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.phase).toBe("commentary");
+    });
+
+    it("should round-trip phase through standard content path", () => {
+      // Standard content blocks have phase in extras
+      const aiMessage = new AIMessage({
+        id: "msg_001",
+        content: [
+          {
+            type: "text",
+            text: "The weather is sunny.",
+            extras: { phase: "final_answer" },
+          } as any,
+        ],
+        response_metadata: {
+          model_provider: "openai",
+          output_version: "v1",
+        },
+      });
+
+      const result = convertStandardContentMessageToResponsesInput(aiMessage);
+
+      const messageItem = result.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.phase).toBe("final_answer");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,31 +474,31 @@ importers:
         version: 0.27.3
       '@rolldown/binding-darwin-arm64':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-darwin-x64':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-linux-arm64-gnu':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-linux-arm64-musl':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-linux-x64-gnu':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-linux-x64-musl':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-win32-arm64-msvc':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@rolldown/binding-win32-ia32-msvc':
         specifier: '*'
         version: 1.0.0-beta.52
       '@rolldown/binding-win32-x64-msvc':
         specifier: '*'
-        version: 1.0.0-rc.10
+        version: 1.0.0-rc.11
       '@swc/core-win32-x64-msvc':
         specifier: '*'
         version: 1.15.11
@@ -2272,7 +2272,7 @@ importers:
         version: 1.0.21
       langsmith:
         specifier: '>=0.5.0 <1.0.0'
-        version: 0.5.9(@opentelemetry/api@1.9.0)(openai@6.27.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))
+        version: 0.5.9(@opentelemetry/api@1.9.0)(openai@6.32.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3281,8 +3281,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.21
       openai:
-        specifier: ^6.27.0
-        version: 6.27.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)
+        specifier: ^6.32.0
+        version: 6.32.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
@@ -7157,8 +7157,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -7175,8 +7175,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+    resolution: {integrity: sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -7217,8 +7217,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -7235,8 +7235,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -7265,8 +7265,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -7283,8 +7283,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -7323,8 +7323,8 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -7347,8 +7347,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -13065,6 +13065,18 @@ packages:
 
   openai@6.3.0:
     resolution: {integrity: sha512-E6vOGtZvdcb4yXQ5jXvDlUG599OhIkb/GjBLZXS+qk0HF+PJReIldEc9hM8Ft81vn+N6dRdFRb7BZNK8bbvXrw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.32.0:
+    resolution: {integrity: sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -20684,7 +20696,7 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.4':
@@ -20693,7 +20705,7 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.4':
@@ -20714,7 +20726,7 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.4':
@@ -20723,7 +20735,7 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.4':
@@ -20738,7 +20750,7 @@ snapshots:
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.4':
@@ -20747,7 +20759,7 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.4':
@@ -20772,7 +20784,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.4':
@@ -20784,7 +20796,7 @@ snapshots:
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.52':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.4':
@@ -26711,6 +26723,18 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       openai: 6.27.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)
 
+  langsmith@0.5.9(@opentelemetry/api@1.9.0)(openai@6.32.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 5.6.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      openai: 6.32.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)
+
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
@@ -27737,6 +27761,11 @@ snapshots:
       zod: 4.3.6
 
   openai@6.3.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.19.0(bufferutil@4.1.0)
+      zod: 4.3.6
+
+  openai@6.32.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.1.0)
       zod: 4.3.6


### PR DESCRIPTION
## Summary

Port of [langchain-ai/langchain#36161](https://github.com/langchain-ai/langchain/pull/36161). Adds support for the OpenAI Responses API `phase` parameter on message output items (e.g. `"commentary"`, `"final_answer"`), which indicates the phase of the model's response in agentic workflows.

## Changes

### `@langchain/openai`

**Non-streaming** (`convertResponsesMessageToAIMessage`): When a `message` output item includes a `phase` property, it is extracted and placed as a top-level property on the resulting text content block.

**Streaming** (`convertResponsesDeltaToChatGenerationChunk`): When a `response.output_item.added` event carries a message item with `phase`, an initial empty text content block is emitted with the `phase` value so downstream consumers see it from the first chunk.

**Input round-trip** (`convertMessagesToResponsesInput`): When converting AIMessages back to Responses API input, `phase` is read from the top-level content block property and set on the message-level input item.

**Standard content round-trip** (`convertStandardContentMessageToResponsesInput`): Reads `phase` from the `extras` dict on standard content blocks (where the core translator places it) and sets it on the message-level input item.

### `@langchain/core`

**Standard content translator** (`convertToV1FromResponses`): When converting raw provider text blocks to standard content format, the top-level `phase` property is moved into the `extras` dict following the existing convention used by `tool_search_call` and `tool_search_output` blocks.

### Bump `openai` SDK

`openai` dependency bumped from `^6.27.0` to `^6.32.0` to pick up the `phase` field on the `ResponseOutputMessage` type.
