### PR TITLE
fix(langchain): export createAgent and middleware from browser entry point

### DIFF
--- a/.changeset/browser-export-agents-middleware.md
+++ b/.changeset/browser-export-agents-middleware.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): export createAgent and prebuilt middleware from browser entry point

--- a/libs/langchain/src/browser.ts
+++ b/libs/langchain/src/browser.ts
@@ -44,6 +44,16 @@ export {
 export { context } from "@langchain/core/utils/context";
 
 /**
+ * LangChain Agents
+ */
+export * from "./agents/index.js";
+
+/**
+ * `createAgent` pre-built middleware
+ */
+export * from "./agents/middleware/index.js";
+
+/**
  * LangChain Stores
  */
 export { InMemoryStore } from "@langchain/core/stores";


### PR DESCRIPTION
safe sequence is:
1. @langchain/langgraph releases a new version containing https://github.com/langchain-ai/langgraphjs/pull/2241
2. langchain bumps its @langchain/langgraph peer dependency minimum to that version

Export `createAgent` and all prebuilt middleware (`summarizationMiddleware`, `toolCallLimitMiddleware`, HITL, PII, model fallback, context editing, etc.) from the `langchain` browser entry point (`src/browser.ts`).

Currently, when bundling with Vite or Rollup targeting the browser, the `langchain` package resolves to `dist/browser.js` via the `"browser"` condition in `package.json` exports. This file does not export `createAgent` or any middleware, producing errors like `"createAgent" is not exported by "langchain/dist/browser.js"`.

The agents and middleware code has zero `node:*` imports in any runtime file - all dependencies (`@langchain/core`, `@langchain/langgraph`, `uuid`, `zod`) are browser-compatible. The only blocker was that `@langchain/langgraph`'s root export previously pulled in `node:async_hooks` transitively, but that was resolved in the companion PR langchain-ai/langgraphjs#2241 (merged), which added a `"browser"` condition to `@langchain/langgraph` pointing to its Node-free `web.js` entry.

**Changes:**
- `libs/langchain/src/browser.ts` - added `export * from "./agents/index.js"` and `export * from "./agents/middleware/index.js"`

**Note:** This PR depends on a released version of `@langchain/langgraph` that includes langchain-ai/langgraphjs#2241. Without that release, browser bundlers would still resolve `@langchain/langgraph` to its Node entry and hit `node:async_hooks`.

Fixes #10510

