### PR TITLE
fix(aws): handle $unknown reasoning_content blocks from GPT-OSS on Bedrock

### DIFF
--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -17,7 +17,10 @@ import {
 import { z } from "zod/v3";
 import { describe, expect, test, it, vi } from "vitest";
 import { convertToConverseMessages } from "../utils/message_inputs.js";
-import { handleConverseStreamContentBlockDelta } from "../utils/message_outputs.js";
+import {
+  handleConverseStreamContentBlockDelta,
+  convertConverseMessageToLangChainMessage,
+} from "../utils/message_outputs.js";
 import { ChatBedrockConverse } from "../chat_models.js";
 import { load } from "@langchain/core/load";
 
@@ -1608,5 +1611,76 @@ describe("bedrockApiKey / bedrockApiSecret credentials", () => {
       "bedrockApiSessionToken",
       "BEDROCK_AWS_SESSION_TOKEN"
     );
+  });
+});
+
+describe("convertConverseMessageToLangChainMessage - $unknown reasoning blocks (GPT-OSS)", () => {
+  const mockResponseMetadata = {
+    $metadata: { requestId: "test-request-id" },
+  };
+
+  it("should parse reasoning_content returned via $unknown wrapper (e.g. GPT-OSS on Bedrock)", () => {
+    // Simulate how the AWS SDK wraps unknown union members.
+    // GPT-OSS returns { type: "reasoning_content", reasoningText: { text: "..." } }
+    // but this type is not in the current SDK union, so it arrives as $unknown.
+    const message = {
+      role: "assistant" as const,
+      content: [
+        {
+          $unknown: [
+            "reasoning_content",
+            {
+              reasoningText: {
+                text: "The user asks how are you? I respond politely.",
+                signature: "",
+              },
+            },
+          ] as [string, unknown],
+        },
+        {
+          text: "I'm doing great, thank you!",
+        },
+      ],
+    };
+
+    const result = convertConverseMessageToLangChainMessage(
+      message,
+      mockResponseMetadata
+    );
+
+    expect(Array.isArray(result.content)).toBe(true);
+    const blocks = result.content as Array<Record<string, unknown>>;
+    const reasoningBlock = blocks.find((b) => b.type === "reasoning_content");
+    expect(reasoningBlock).toBeDefined();
+    expect(reasoningBlock?.reasoningText).toMatchObject({
+      text: "The user asks how are you? I respond politely.",
+    });
+
+    const textBlock = blocks.find((b) => b.type === "text");
+    expect(textBlock?.text).toBe("I'm doing great, thank you!");
+  });
+
+  it("should not produce non_standard blocks for reasoning_content from $unknown", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        {
+          $unknown: [
+            "reasoning_content",
+            { reasoningText: { text: "Thinking...", signature: "" } },
+          ] as [string, unknown],
+        },
+        { text: "Done." },
+      ],
+    };
+
+    const result = convertConverseMessageToLangChainMessage(
+      message,
+      mockResponseMetadata
+    );
+
+    const blocks = result.content as Array<Record<string, unknown>>;
+    const nonStandardBlock = blocks.find((b) => b.type === "non_standard");
+    expect(nonStandardBlock).toBeUndefined();
   });
 });

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -99,6 +99,35 @@ export function convertConverseMessageToLangChainMessage(
         });
       } else if ("video" in c) {
         content.push({ type: "video", video: c.video });
+      } else if ("$unknown" in c) {
+        // Handle content block types that are not yet in the AWS SDK's type
+        // union but may be returned by newer models (e.g. GPT-OSS on Bedrock).
+        // The SDK wraps them as { $unknown: ["type_name", value] }.
+        const [unknownType, unknownValue] = (c as { $unknown: [string, unknown] }).$unknown;
+        if (
+          unknownType === "reasoning_content" &&
+          unknownValue !== null &&
+          typeof unknownValue === "object"
+        ) {
+          const val = unknownValue as Record<string, unknown>;
+          const reasoningText = val.reasoningText as
+            | { text?: string; signature?: string }
+            | undefined;
+          const redactedContent = val.redactedContent;
+          if (reasoningText) {
+            content.push(
+              bedrockReasoningBlockToLangchainReasoningBlock({
+                reasoningText: reasoningText as Bedrock.ReasoningTextBlock,
+              })
+            );
+          } else if (redactedContent instanceof Uint8Array) {
+            content.push(
+              bedrockReasoningBlockToLangchainReasoningBlock({
+                redactedContent,
+              })
+            );
+          }
+        }
       }
     });
     return new AIMessage({


### PR DESCRIPTION
## Problem

When GPT-OSS models (e.g. `openai.gpt-oss-120b-1:0`) return a `reasoning_content` block via the Bedrock Converse API, the AWS SDK wraps it in a `$unknown` tagged union because the type is not part of the current SDK's typed `ContentBlock` union. Previously, none of the `if` branches in `convertConverseMessageToLangChainMessage` matched this shape, so the block was silently dropped. The caller saw:

```json
{ "type": "non_standard", "value": { "type": "reasoning_content", "reasoningText": { "text": "..." } } }
```

instead of the expected:

```json
{ "type": "reasoning_content", "reasoningText": { "text": "...", "signature": "..." } }
```

Fixes #9280

## What changed

**`libs/providers/langchain-aws/src/utils/message_outputs.ts`**

Added an `else if ("$unknown" in c)` branch at the end of the `forEach` in `convertConverseMessageToLangChainMessage`. When the unknown type name is `"reasoning_content"`, the value is routed through the existing `bedrockReasoningBlockToLangchainReasoningBlock` converter, producing the correct `reasoning_content` content block.

**`libs/providers/langchain-aws/src/tests/chat_models.test.ts`**

Added a `describe` block with two unit tests that construct messages containing a `$unknown` reasoning block (simulating GPT-OSS output) and assert:
1. The parsed message contains a proper `reasoning_content` block with the correct `reasoningText`.
2. No `non_standard` block appears in the output.

## How to test

```bash
cd libs/providers/langchain-aws
pnpm test
```

The two new unit tests cover the fix without requiring an AWS account. For an integration test, use `openai.gpt-oss-120b-1:0` on Bedrock and verify that `aiMsg.contentBlocks` contains a `reasoning_content` block instead of `non_standard`.