### PR TITLE
fix(google): preserve object tool results in history

### DIFF
--- a/.changeset/curly-tigers-laugh.md
+++ b/.changeset/curly-tigers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+preserve object-valued tool results and legacy tool-call turns in ChatGoogle history conversion

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -25,6 +25,23 @@ import type { Gemini } from "../chat_models/types.js";
 import { iife } from "../utils/misc.js";
 import { InvalidInputError, ToolCallNotFoundError } from "../utils/errors.js";
 
+type ToolLikeMessage = BaseMessage & {
+  type: "tool";
+  tool_call_id: string;
+};
+
+function isToolLikeMessage(message: unknown): message is ToolLikeMessage {
+  return (
+    ToolMessage.isInstance(message) ||
+    (typeof message === "object" &&
+      message !== null &&
+      "type" in message &&
+      (message as { type?: unknown }).type === "tool" &&
+      "tool_call_id" in message &&
+      typeof (message as { tool_call_id?: unknown }).tool_call_id === "string")
+  );
+}
+
 /**
  * Standard content block converter for Google Gemini API.
  * Converts deprecated Data content blocks to Gemini Part format.
@@ -396,7 +413,7 @@ function convertStandardContentMessageToGeminiContent(
     role = "user";
   } else if (AIMessage.isInstance(message)) {
     role = "model";
-  } else if (ToolMessage.isInstance(message)) {
+  } else if (isToolLikeMessage(message)) {
     // Tool messages in Gemini were represented as function responses, but now are "user"
     role = "user";
   } else if (ChatMessage.isInstance(message)) {
@@ -424,9 +441,14 @@ function convertStandardContentMessageToGeminiContent(
   const parts: Gemini.Part[] = [];
 
   // Process standard content blocks
-  const contentBlocks = Array.isArray(message.contentBlocks)
-    ? message.contentBlocks
-    : [];
+  const contentBlocks =
+    isToolLikeMessage(message) &&
+    typeof message.content !== "string" &&
+    !Array.isArray(message.content)
+      ? []
+      : Array.isArray(message.contentBlocks)
+      ? message.contentBlocks
+      : [];
   contentBlocks.forEach((block: ContentBlock.Standard) => {
     const contentBlock =
       (message.additional_kwargs
@@ -451,7 +473,7 @@ function convertStandardContentMessageToGeminiContent(
   }
 
   // Handle tool messages as function responses
-  if (ToolMessage.isInstance(message) && message.tool_call_id) {
+  if (isToolLikeMessage(message) && message.tool_call_id) {
     const responseContent =
       typeof message.content === "string"
         ? message.content
@@ -673,7 +695,7 @@ function convertLegacyContentMessageToGeminiContent(
       return "user";
     } else if (AIMessage.isInstance(message)) {
       return "model";
-    } else if (ToolMessage.isInstance(message)) {
+    } else if (isToolLikeMessage(message)) {
       // Tool messages in Gemini were represented as function responses, but now are "user"
       return "user";
     } else if (ChatMessage.isInstance(message)) {
@@ -736,8 +758,19 @@ function convertLegacyContentMessageToGeminiContent(
     }
   }
 
+  if (AIMessage.isInstance(message) && message.tool_calls?.length) {
+    for (const toolCall of message.tool_calls) {
+      parts.push({
+        functionCall: {
+          name: toolCall.name,
+          args: toolCall.args ?? {},
+        },
+      } as Gemini.Part.FunctionCall);
+    }
+  }
+
   // Handle tool messages as function responses
-  if (ToolMessage.isInstance(message) && message.tool_call_id) {
+  if (isToolLikeMessage(message) && message.tool_call_id) {
     const responseContent =
       typeof message.content === "string"
         ? message.content

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -511,6 +511,99 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBe("tool-call-xyz");
   });
 
+  test("serializes object-valued ToolMessage content into functionResponse.result", () => {
+    const messages = [
+      new HumanMessage("What is the result of my_tool?"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { input: "test" },
+            id: "tool-call-123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: {
+          status: "ok",
+          value: 42,
+          items: ["foo", "bar"],
+        } as never,
+        tool_call_id: "tool-call-123",
+        name: "my_tool",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse | undefined;
+    expect(functionResponsePart).toBeDefined();
+    expect(functionResponsePart!.functionResponse!.name).toBe("my_tool");
+    expect(functionResponsePart!.functionResponse!.response).toEqual({
+      result: JSON.stringify({
+        status: "ok",
+        value: 42,
+        items: ["foo", "bar"],
+      }),
+    });
+  });
+
+  test("serializes object-valued ToolMessage content on the v1 path", () => {
+    const messages = [
+      new HumanMessage("What is the result of my_tool?"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { input: "test" },
+            id: "tool-call-123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: {
+          status: "ok",
+          value: 42,
+          items: ["foo", "bar"],
+        } as never,
+        tool_call_id: "tool-call-123",
+        name: "my_tool",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse | undefined;
+    expect(functionResponsePart).toBeDefined();
+    expect(functionResponsePart!.functionResponse!.name).toBe("my_tool");
+    expect(functionResponsePart!.functionResponse!.response).toEqual({
+      result: JSON.stringify({
+        status: "ok",
+        value: 42,
+        items: ["foo", "bar"],
+      }),
+    });
+  });
+
   test("omits generated tool_call_id from functionResponse.id (legacy path)", () => {
     const messages = [
       new HumanMessage("hello"),


### PR DESCRIPTION
## Summary
- preserve legacy `AIMessage.tool_calls` turns even when the assistant message content is empty
- treat object-valued tool messages as tool responses in both legacy and v1 Google history conversion paths
- add regression coverage for object-valued `ToolMessage` content and include a patch changeset for `@langchain/google`

Fixes #10500

## Testing
- `corepack pnpm --filter @langchain/google exec -- vitest run`
- `corepack pnpm --filter @langchain/google exec -- prettier --check src/converters/messages.ts src/converters/tests/messages.test.ts`
- `corepack pnpm --filter @langchain/google exec -- eslint src/converters/messages.ts src/converters/tests/messages.test.ts`
- `git diff --check`