### PR TITLE
fix(@langchain/google): preserve object ToolMessage contents in Gemini history

### DIFF
--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -352,6 +352,38 @@ function convertStandardVideoContentBlockToGeminiPart(
   return ret;
 }
 
+function isToolMessageLike(
+  message: BaseMessage | unknown
+): message is BaseMessage &
+  Pick<ToolMessage, "content" | "name" | "tool_call_id"> {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    (message as { type?: unknown }).type === "tool" &&
+    "tool_call_id" in message &&
+    typeof (message as { tool_call_id?: unknown }).tool_call_id === "string"
+  );
+}
+
+function appendToolCallsToGeminiParts(
+  message: BaseMessage,
+  parts: Gemini.Part[]
+): void {
+  if (!AIMessage.isInstance(message) || !message.tool_calls?.length) {
+    return;
+  }
+
+  for (const toolCall of message.tool_calls) {
+    parts.push({
+      functionCall: {
+        name: toolCall.name,
+        args: toolCall.args ?? {},
+      },
+    } as Gemini.Part.FunctionCall);
+  }
+}
+
 /**
  * Converts a single LangChain standard content block (v1 format)
  * into a Gemini.Part.
@@ -396,7 +428,7 @@ function convertStandardContentMessageToGeminiContent(
     role = "user";
   } else if (AIMessage.isInstance(message)) {
     role = "model";
-  } else if (ToolMessage.isInstance(message)) {
+  } else if (isToolMessageLike(message)) {
     // Tool messages in Gemini were represented as function responses, but now are "user"
     role = "user";
   } else if (ChatMessage.isInstance(message)) {
@@ -424,9 +456,10 @@ function convertStandardContentMessageToGeminiContent(
   const parts: Gemini.Part[] = [];
 
   // Process standard content blocks
-  const contentBlocks = Array.isArray(message.contentBlocks)
-    ? message.contentBlocks
-    : [];
+  const contentBlocks =
+    Array.isArray(message.content) && Array.isArray(message.contentBlocks)
+      ? message.contentBlocks
+      : [];
   contentBlocks.forEach((block: ContentBlock.Standard) => {
     const contentBlock =
       (message.additional_kwargs
@@ -439,19 +472,10 @@ function convertStandardContentMessageToGeminiContent(
   });
 
   // Convert AIMessage tool_calls to functionCall parts
-  if (AIMessage.isInstance(message) && message.tool_calls?.length) {
-    for (const toolCall of message.tool_calls) {
-      parts.push({
-        functionCall: {
-          name: toolCall.name,
-          args: toolCall.args ?? {},
-        },
-      } as Gemini.Part.FunctionCall);
-    }
-  }
+  appendToolCallsToGeminiParts(message, parts);
 
   // Handle tool messages as function responses
-  if (ToolMessage.isInstance(message) && message.tool_call_id) {
+  if (isToolMessageLike(message)) {
     const responseContent =
       typeof message.content === "string"
         ? message.content
@@ -673,7 +697,7 @@ function convertLegacyContentMessageToGeminiContent(
       return "user";
     } else if (AIMessage.isInstance(message)) {
       return "model";
-    } else if (ToolMessage.isInstance(message)) {
+    } else if (isToolMessageLike(message)) {
       // Tool messages in Gemini were represented as function responses, but now are "user"
       return "user";
     } else if (ChatMessage.isInstance(message)) {
@@ -736,8 +760,10 @@ function convertLegacyContentMessageToGeminiContent(
     }
   }
 
+  appendToolCallsToGeminiParts(message, parts);
+
   // Handle tool messages as function responses
-  if (ToolMessage.isInstance(message) && message.tool_call_id) {
+  if (isToolMessageLike(message)) {
     const responseContent =
       typeof message.content === "string"
         ? message.content

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -185,6 +185,48 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBe("get_weather");
   });
 
+  test("serializes object-valued ToolMessage content in the legacy path", () => {
+    const toolResult = {
+      status: "ok",
+      value: 42,
+      items: ["foo", "bar"],
+    };
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { input: "test" },
+            id: "call-123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: toolResult as never,
+        tool_call_id: "call-123",
+        name: "my_tool",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    expect(contents).toHaveLength(3);
+    expect(contents[1].role).toBe("model");
+    expect(contents[2].role).toBe("user");
+
+    const functionResponsePart = contents[2].parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    expect(functionResponsePart).toBeDefined();
+    expect(functionResponsePart.functionResponse!.name).toBe("my_tool");
+    expect(functionResponsePart.functionResponse!.response).toEqual({
+      result: JSON.stringify(toolResult),
+    });
+  });
+
   test("resolves functionResponse.name for multiple tool calls (legacy path)", () => {
     const messages = [
       new HumanMessage("hello"),
@@ -420,6 +462,52 @@ describe("convertMessagesToGeminiContents", () => {
     ) as Gemini.Part.FunctionResponse;
     expect(functionResponsePart).toBeDefined();
     expect(functionResponsePart.functionResponse!.name).toBe("get_weather");
+  });
+
+  test("serializes object-valued ToolMessage content in the v1 path", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "my_tool",
+          args: { input: "test" },
+          id: "call-123",
+          type: "tool_call",
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+
+    const toolResult = {
+      status: "ok",
+      value: 42,
+      items: ["foo", "bar"],
+    };
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: toolResult as never,
+        tool_call_id: "call-123",
+        name: "my_tool",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    expect(contents).toHaveLength(3);
+    expect(contents[1].role).toBe("model");
+    expect(contents[2].role).toBe("user");
+
+    const functionResponsePart = contents[2].parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    expect(functionResponsePart).toBeDefined();
+    expect(functionResponsePart.functionResponse!.name).toBe("my_tool");
+    expect(functionResponsePart.functionResponse!.response).toEqual({
+      result: JSON.stringify(toolResult),
+    });
   });
 
   test("Multiple tool calls name resolution (v1 path)", () => {


### PR DESCRIPTION
## Summary
- preserve object-valued `ToolMessage` payloads when converting chat history for Gemini, even when the tool output is a plain object
- restore legacy `AIMessage.tool_calls` -> Gemini `functionCall` conversion so tool conversations keep the expected model turn
- avoid reading `contentBlocks` for malformed v1 tool outputs before serializing them as `functionResponse` payloads

## Testing
- `corepack pnpm exec vitest run src/converters/tests/messages.test.ts`
- `corepack pnpm exec prettier --check src/converters/messages.ts src/converters/tests/messages.test.ts`
- `corepack pnpm exec eslint src/converters/messages.ts src/converters/tests/messages.test.ts`

Closes #10500.