### PR TITLE
fix(core): preserve v1 streamed invoke output

### DIFF
--- a/.changeset/bright-snails-hear.md
+++ b/.changeset/bright-snails-hear.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve v1 message content when invoke aggregates streamed chat chunks

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -568,6 +568,11 @@ export abstract class BaseChatModel<
         if (aggregated === undefined) {
           throw new Error("Received empty response from chat model call.");
         }
+        if (outputVersion === "v1") {
+          aggregated.message = castStandardMessageContent(
+            aggregated.message
+          ) as AIMessageChunk;
+        }
         generations.push([aggregated]);
         await runManagers?.[0].handleLLMEnd({
           generations,

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -122,6 +122,25 @@ test("Test ChatModel uses callbacks with a cache", async () => {
   expect(response2.content).toEqual(acc);
 });
 
+test("Test ChatModel preserves v1 output in streaming aggregation", async () => {
+  const model = new FakeListChatModel({
+    responses: ["Hello there!"],
+  });
+  const preferStreamingCallback =
+    new (class extends RunCollectorCallbackHandler {
+      lc_prefer_streaming = true;
+    })();
+
+  const response = await model.invoke("Hello there!", {
+    callbacks: [preferStreamingCallback],
+    outputVersion: "v1",
+  });
+
+  expect(response.response_metadata.output_version).toBe("v1");
+  expect(Array.isArray(response.content)).toBe(true);
+  expect(response.content).toEqual(response.contentBlocks);
+});
+
 test("Test ChatModel legacy params withStructuredOutput", async () => {
   const model = new FakeListChatModel({
     responses: [`{ "test": true, "nested": { "somethingelse": "somevalue" } }`],

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -2,12 +2,23 @@ import { test, expect } from "vitest";
 import { z } from "zod/v3";
 import { z as z4 } from "zod/v4";
 import { zodToJsonSchema } from "../../utils/zod-to-json-schema/index.js";
-import { FakeChatModel, FakeListChatModel } from "../../utils/testing/index.js";
+import {
+  FakeChatModel,
+  FakeListChatModel,
+  FakeStreamingChatModel,
+} from "../../utils/testing/index.js";
 import { HumanMessage } from "../../messages/human.js";
 import { getBufferString } from "../../messages/utils.js";
-import { AIMessage } from "../../messages/ai.js";
+import { AIMessage, AIMessageChunk } from "../../messages/ai.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
 import { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
+import { BaseCallbackHandler } from "../../callbacks/base.js";
+
+class PreferStreamingCallbackHandler extends BaseCallbackHandler {
+  name = "prefer_streaming";
+
+  lc_prefer_streaming = true;
+}
 
 test("Test ChatModel accepts array shorthand for messages", async () => {
   const model = new FakeChatModel({});
@@ -123,22 +134,25 @@ test("Test ChatModel uses callbacks with a cache", async () => {
 });
 
 test("Test ChatModel preserves v1 output in streaming aggregation", async () => {
-  const model = new FakeListChatModel({
-    responses: ["Hello there!"],
+  const model = new FakeStreamingChatModel({
+    outputVersion: "v1",
+    chunks: [
+      new AIMessageChunk({ content: "Hello" }),
+      new AIMessageChunk({ content: " there" }),
+    ],
   });
-  const preferStreamingCallback =
-    new (class extends RunCollectorCallbackHandler {
-      lc_prefer_streaming = true;
-    })();
 
   const response = await model.invoke("Hello there!", {
-    callbacks: [preferStreamingCallback],
-    outputVersion: "v1",
+    callbacks: [new PreferStreamingCallbackHandler()],
   });
 
   expect(response.response_metadata.output_version).toBe("v1");
-  expect(Array.isArray(response.content)).toBe(true);
-  expect(response.content).toEqual(response.contentBlocks);
+  expect(response.content).toEqual([
+    {
+      type: "text",
+      text: "Hello there",
+    },
+  ]);
 });
 
 test("Test ChatModel legacy params withStructuredOutput", async () => {


### PR DESCRIPTION
## Summary
- preserve outputVersion: "v1" normalization when BaseChatModel.invoke() is forced through the streaming aggregation path
- add a regression for invoke() with a callback handler that prefers streaming so the aggregated message keeps esponse_metadata.output_version
- add the @langchain/core patch changeset for the user-facing bug fix

## Testing
- corepack pnpm --dir libs/langchain-core exec vitest run src/language_models/tests/chat_models.test.ts
- corepack pnpm --filter @langchain/core test -- src/language_models/tests/chat_models.test.ts
- corepack pnpm exec prettier --check libs/langchain-core/src/language_models/chat_models.ts libs/langchain-core/src/language_models/tests/chat_models.test.ts
- corepack pnpm --filter @langchain/core lint:eslint -- src/language_models/chat_models.ts src/language_models/tests/chat_models.test.ts

Fixes #10476.