### PR TITLE
fix(google): normalize ChatGoogle callback token usage

### DIFF
--- a/.changeset/contributor-03-chatgoogle-token-usage.md
+++ b/.changeset/contributor-03-chatgoogle-token-usage.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Fix `ChatGoogle` so non-streaming results expose standard camelCase `llmOutput.tokenUsage` fields in callbacks and response metadata.

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -476,6 +476,14 @@ export abstract class BaseChatGoogle<
 
     const usageMetadata =
       convertGeminiGenerateContentResponseToUsageMetadata(data);
+    const tokenUsage =
+      usageMetadata !== undefined
+        ? {
+            promptTokens: usageMetadata.input_tokens,
+            completionTokens: usageMetadata.output_tokens,
+            totalTokens: usageMetadata.total_tokens,
+          }
+        : undefined;
     message.usage_metadata = usageMetadata;
 
     return {
@@ -493,7 +501,7 @@ export abstract class BaseChatGoogle<
         },
       ],
       llmOutput: {
-        tokenUsage: usageMetadata,
+        tokenUsage,
         model: data.modelVersion,
         responseId: data.responseId,
         usageMetadata,

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -315,6 +315,39 @@ describe("Google Mock", () => {
     );
   });
 
+  test("handleLLMEnd exposes camelCase llmOutput tokenUsage", async () => {
+    let tokenUsage:
+      | {
+          promptTokens?: number;
+          completionTokens?: number;
+          totalTokens?: number;
+        }
+      | undefined;
+
+    const llm = new ChatGoogle({
+      model: "gemini-2.5-flash",
+      apiClient: new MockApiClient({
+        fileName: "gemini-chat-001.json",
+      }),
+      callbacks: [
+        {
+          handleLLMEnd(output) {
+            tokenUsage = output.llmOutput?.tokenUsage;
+          },
+        },
+      ],
+    });
+
+    const result = await llm.invoke("What is 1+1?");
+
+    expect(tokenUsage).toEqual({
+      promptTokens: 9,
+      completionTokens: 36,
+      totalTokens: 45,
+    });
+    expect(result.response_metadata.tokenUsage).toEqual(tokenUsage);
+  });
+
   test("passes abort signal to fetch in non-streaming invoke", async () => {
     const apiClient = new MockApiClient({
       fileName: "gemini-chat-001.json",


### PR DESCRIPTION
Fixes #10518.

## Summary
- normalize non-streaming `ChatGoogle` `llmOutput.tokenUsage` to the standard camelCase LangChain shape
- preserve the provider-specific `usageMetadata` payload alongside the normalized token usage
- add a focused regression covering `handleLLMEnd` and the returned message `response_metadata`

## Validation
- `pnpm exec vitest run src/chat_models/tests/index.test.ts`
- `pnpm exec prettier --check src/chat_models/base.ts src/chat_models/tests/index.test.ts ../../../.changeset/contributor-03-chatgoogle-token-usage.md`
- `pnpm exec eslint src/chat_models/base.ts src/chat_models/tests/index.test.ts`