### PR TITLE
fix(openai): preserve top-level Responses API ids

### DIFF
--- a/.changeset/calm-suits-talk.md
+++ b/.changeset/calm-suits-talk.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): preserve top-level responses api ids on AIMessage

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -336,7 +336,6 @@ export const convertResponsesMessageToAIMessage: Converter<
     throw error;
   }
 
-  let messageId: string | undefined;
   const content: MessageContent = [];
   const tool_calls: ToolCall[] = [];
   const invalid_tool_calls: InvalidToolCall[] = [];
@@ -380,7 +379,6 @@ export const convertResponsesMessageToAIMessage: Converter<
 
   for (const item of response.output) {
     if (item.type === "message") {
-      messageId = item.id;
       content.push(
         ...item.content.flatMap((part) => {
           if (part.type === "output_text") {
@@ -485,7 +483,7 @@ export const convertResponsesMessageToAIMessage: Converter<
   }
 
   return new AIMessage({
-    id: messageId,
+    id: response.id,
     content,
     tool_calls,
     invalid_tool_calls,

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -82,6 +82,34 @@ describe("convertResponsesUsageToUsageMetadata", () => {
 });
 
 describe("convertResponsesMessageToAIMessage", () => {
+  it("should use the top-level response id for AIMessage.id", () => {
+    const response = {
+      id: "resp_123",
+      model: "gpt-4o",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_123",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello!", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    expect(result.id).toBe("resp_123");
+    expect(result.response_metadata.id).toBe("resp_123");
+  });
+
   it("should elevate reasoning to content array", () => {
     const response = {
       id: "resp_123",


### PR DESCRIPTION
Fixes #10499.

## Summary
- preserve the top-level `response.id` when converting Responses API results to `AIMessage`
- add a regression test that distinguishes the response id from nested message item ids
- add the `@langchain/openai` patch changeset for the converter fix

## Testing
- `corepack pnpm --filter @langchain/openai exec vitest run src/converters/tests/responses.test.ts --typecheck.enabled false`
- `corepack pnpm --filter @langchain/openai exec vitest run src/chat_models/tests/responses.test.ts --typecheck.enabled false`
- `corepack pnpm --filter @langchain/openai exec vitest run --typecheck.enabled false`