### PR TITLE
fix(core): preserve v1 output for aggregated chat streams

### DIFF
--- a/.changeset/grumpy-coats-flow.md
+++ b/.changeset/grumpy-coats-flow.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Preserve `outputVersion: "v1"` message normalization when chat models aggregate streamed chunks for streaming-preferring callbacks.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -568,6 +568,11 @@ export abstract class BaseChatModel<
         if (aggregated === undefined) {
           throw new Error("Received empty response from chat model call.");
         }
+        if (outputVersion === "v1") {
+          aggregated.message = castStandardMessageContent(
+            aggregated.message
+          ) as AIMessageChunk;
+        }
         generations.push([aggregated]);
         await runManagers?.[0].handleLLMEnd({
           generations,

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -2,12 +2,23 @@ import { test, expect } from "vitest";
 import { z } from "zod/v3";
 import { z as z4 } from "zod/v4";
 import { zodToJsonSchema } from "../../utils/zod-to-json-schema/index.js";
-import { FakeChatModel, FakeListChatModel } from "../../utils/testing/index.js";
+import {
+  FakeChatModel,
+  FakeListChatModel,
+  FakeStreamingChatModel,
+} from "../../utils/testing/index.js";
 import { HumanMessage } from "../../messages/human.js";
 import { getBufferString } from "../../messages/utils.js";
-import { AIMessage } from "../../messages/ai.js";
+import { AIMessage, AIMessageChunk } from "../../messages/ai.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
 import { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
+import { BaseCallbackHandler } from "../../callbacks/base.js";
+
+class PreferStreamingCallbackHandler extends BaseCallbackHandler {
+  name = "prefer_streaming";
+
+  lc_prefer_streaming = true;
+}
 
 test("Test ChatModel accepts array shorthand for messages", async () => {
   const model = new FakeChatModel({});
@@ -385,6 +396,28 @@ test("Test ChatModel can stream back a custom event", async () => {
     }
   }
   expect(customEvent).toBeDefined();
+});
+
+test("Test ChatModel invoke applies outputVersion v1 when callbacks prefer streaming", async () => {
+  const model = new FakeStreamingChatModel({
+    outputVersion: "v1",
+    chunks: [
+      new AIMessageChunk({ content: "Hello" }),
+      new AIMessageChunk({ content: " there" }),
+    ],
+  });
+
+  const response = await model.invoke("Hello there!", {
+    callbacks: [new PreferStreamingCallbackHandler()],
+  });
+
+  expect(response.response_metadata.output_version).toBe("v1");
+  expect(response.content).toEqual([
+    {
+      type: "text",
+      text: "Hello there",
+    },
+  ]);
 });
 
 test(`Test ChatModel should not serialize a passed "cache" parameter`, async () => {


### PR DESCRIPTION
## Summary
- apply castStandardMessageContent to the aggregated message in the streaming-preferring _generateUncached() path
- add a focused @langchain/core regression covering outputVersion: "v1" with a streaming-preferring callback handler
- include the @langchain/core patch changeset for the user-facing fix

## Testing
- corepack pnpm --filter @langchain/core exec vitest run src/language_models/tests/chat_models.test.ts
- corepack pnpm --filter @langchain/core exec eslint src/language_models/chat_models.ts src/language_models/tests/chat_models.test.ts
- corepack pnpm exec prettier --check .changeset/grumpy-coats-flow.md libs/langchain-core/src/language_models/chat_models.ts libs/langchain-core/src/language_models/tests/chat_models.test.ts

Fixes #10476