### PR TITLE
feat(core): extend load() to accept objects and add dump() serializer

### DIFF
--- a/libs/langchain-core/src/load/index.ts
+++ b/libs/langchain-core/src/load/index.ts
@@ -63,7 +63,11 @@ import * as coreImportMap from "./import_map.js";
 import type { OptionalImportMap, SecretMap } from "./import_type.js";
 import { type SerializedFields, keyFromJson, mapKeys } from "./map_keys.js";
 import { getEnvironmentVariable } from "../utils/env.js";
-import { isEscapedObject, unescapeValue } from "./validation.js";
+import {
+  isEscapedObject,
+  unescapeValue,
+  serializeValue,
+} from "./validation.js";
 
 /**
  * Options for loading serialized LangChain objects.
@@ -418,10 +422,10 @@ async function reviver(this: ReviverContext, value: unknown): Promise<unknown> {
 }
 
 /**
- * Load a LangChain object from a JSON string.
+ * Load a LangChain object from a JSON string or a pre-parsed JavaScript object/array.
  *
  * **WARNING — insecure deserialization risk.** This function instantiates
- * classes and invokes constructors based on the contents of `text`. If `text`
+ * classes and invokes constructors based on the contents of `data`. If `data`
  * originates from an untrusted source, an attacker can craft a payload that
  * instantiates arbitrary allowed classes with attacker-controlled arguments,
  * potentially causing secret exfiltration, SSRF, or other side effects.
@@ -430,7 +434,8 @@ async function reviver(this: ReviverContext, value: unknown): Promise<unknown> {
  * fully trusted origin (e.g., your own database). **Never deserialize
  * user-supplied or network-received JSON without independent validation.**
  *
- * @param text - The JSON string to parse and load.
+ * @param data - A JSON string to parse, a pre-parsed JavaScript object/array,
+ *   or the return value of `dump()`.
  * @param options - Options for loading. See {@link LoadOptions} for security guidance.
  * @returns The loaded LangChain object.
  *
@@ -441,6 +446,10 @@ async function reviver(this: ReviverContext, value: unknown): Promise<unknown> {
  *
  * // Basic usage - secrets must be provided explicitly
  * const msg = await load<AIMessage>(jsonString);
+ *
+ * // With a pre-parsed object
+ * const row = await db.query("SELECT message FROM history WHERE id = $1", [id]);
+ * const msg = await load<AIMessage>(row.message); // row.message is already an object
  *
  * // With secrets from a map (preferred over secretsFromEnv)
  * const msg = await load<AIMessage>(jsonString, {
@@ -453,8 +462,11 @@ async function reviver(this: ReviverContext, value: unknown): Promise<unknown> {
  * });
  * ```
  */
-export async function load<T>(text: string, options?: LoadOptions): Promise<T> {
-  const json = JSON.parse(text);
+export async function load<T>(
+  data: string | Record<string, unknown> | unknown[],
+  options?: LoadOptions
+): Promise<T> {
+  const json = typeof data === "string" ? JSON.parse(data) : data;
 
   const context: ReviverContext = {
     optionalImportsMap: options?.optionalImportsMap ?? {},
@@ -469,3 +481,19 @@ export async function load<T>(text: string, options?: LoadOptions): Promise<T> {
 
   return reviver.call(context, json) as Promise<T>;
 }
+
+/**
+ * Return a plain JavaScript object representation of a LangChain object.
+ *
+ * Plain objects containing an `'lc'` key are automatically escaped to prevent
+ * confusion with the LC serialization format. The escape marker is removed
+ * during deserialization via `load()`.
+ *
+ * @param value - The object to serialize.
+ * @returns A plain object that can be passed to `JSON.stringify` or stored
+ *   directly in a database JSON column.
+ */
+export function dump(value: unknown): unknown {
+  return serializeValue(value);
+}
+

--- a/libs/langchain-core/src/load/tests/index.test.ts
+++ b/libs/langchain-core/src/load/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { load } from "../index.js";
+import { load, dump } from "../index.js";
 import { HumanMessage, AIMessage } from "../../messages/index.js";
 
 const SENTINEL_ENV_VAR = "TEST_SECRET_INJECTION_VAR";
@@ -682,5 +682,76 @@ describe("`load()`", () => {
         AIMessage
       );
     });
+  });
+
+  describe("Pre-parsed object input", () => {
+    it("accepts a pre-parsed object", async () => {
+      const msg = new HumanMessage("Hello from DB");
+      const parsedObj = JSON.parse(JSON.stringify(dump(msg))) as Record<
+        string,
+        unknown
+      >;
+      const restored = await load<HumanMessage>(parsedObj);
+      expect(restored).toBeInstanceOf(HumanMessage);
+      expect(restored.content).toBe("Hello from DB");
+    });
+
+    it("accepts a pre-parsed array of messages", async () => {
+      const messages = [new HumanMessage("Hi"), new AIMessage("Hello")];
+      const parsedArr = JSON.parse(JSON.stringify(dump(messages))) as unknown[];
+      const restored = await load<[HumanMessage, AIMessage]>(parsedArr);
+      expect(Array.isArray(restored)).toBe(true);
+      expect(restored[0]).toBeInstanceOf(HumanMessage);
+      expect(restored[1]).toBeInstanceOf(AIMessage);
+    });
+  });
+});
+
+describe("`dump()`", () => {
+  it("dump() returns a plain object from a Serializable", () => {
+    const msg = new HumanMessage("Hello");
+    const obj = dump(msg);
+    expect(typeof obj).toBe("object");
+    expect(obj).not.toBeInstanceOf(HumanMessage);
+    expect(() => JSON.stringify(obj)).not.toThrow();
+  });
+
+  it("dump()/load() round-trip preserves message content", async () => {
+    const msg = new HumanMessage("Round trip!");
+    const obj = dump(msg) as Record<string, unknown>;
+    const restored = await load<HumanMessage>(obj);
+    expect(restored).toBeInstanceOf(HumanMessage);
+    expect(restored.content).toBe("Round trip!");
+  });
+
+  it("stringify(dump())/load() round-trip preserves message content", async () => {
+    const msg = new AIMessage("AI response");
+    const str = JSON.stringify(dump(msg));
+    const restored = await load<AIMessage>(str);
+    expect(restored).toBeInstanceOf(AIMessage);
+    expect(restored.content).toBe("AI response");
+  });
+
+  it("dump() handles an array of messages", () => {
+    const messages = [new HumanMessage("Hi"), new AIMessage("Hello")];
+    const obj = dump(messages);
+    expect(Array.isArray(obj)).toBe(true);
+    expect(() => JSON.stringify(obj)).not.toThrow();
+  });
+
+  it("stringify(dump())/load() round-trip for array of messages", async () => {
+    const messages = [new HumanMessage("Hi"), new AIMessage("Hello")];
+    const str = JSON.stringify(dump(messages));
+    const restored = await load<[HumanMessage, AIMessage]>(str);
+    expect(Array.isArray(restored)).toBe(true);
+    expect(restored[0]).toBeInstanceOf(HumanMessage);
+    expect(restored[1]).toBeInstanceOf(AIMessage);
+  });
+
+  it("dump() on a primitive returns it as-is", () => {
+    expect(dump("hello")).toBe("hello");
+    expect(dump(42)).toBe(42);
+    expect(dump(null)).toBe(null);
+    expect(dump(true)).toBe(true);
   });
 });

--- a/libs/langchain/src/load/index.ts
+++ b/libs/langchain/src/load/index.ts
@@ -4,19 +4,19 @@ import * as importMap from "./import_map.js";
 import { OptionalImportMap } from "./import_type.js";
 
 /**
- * Load a LangChain module from a serialized text representation.
+ * Load a LangChain module from a serialized representation.
  * NOTE: This functionality is currently in beta.
  * Loaded classes may change independently of semver.
  *
  * **WARNING — insecure deserialization risk.** This function instantiates
- * classes and invokes constructors based on the contents of `text`. Never
+ * classes and invokes constructors based on the contents of `data`. Never
  * call this on untrusted or user-supplied input. Only deserialize data that
  * originates from a trusted source you control.
  *
  * See `@langchain/core/load` {@link LoadOptions} for detailed security
  * guidance on `secretsFromEnv`, `secretsMap`, and import maps.
  *
- * @param text Serialized text representation of the module.
+ * @param data Serialized JSON string, or a pre-parsed JavaScript object/array
  * @param secretsMap
  * @param optionalImportsMap
  * @param additionalImportsMap
@@ -24,7 +24,7 @@ import { OptionalImportMap } from "./import_type.js";
  * @returns A loaded instance of a LangChain module.
  */
 export async function load<T>(
-  text: string,
+  data: string | Record<string, unknown> | unknown[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   secretsMap: Record<string, any> = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,7 +33,7 @@ export async function load<T>(
   additionalImportsMap: Record<string, any> = {},
   secretsFromEnv?: boolean
 ): Promise<T> {
-  return coreLoad(text, {
+  return coreLoad(data, {
     secretsMap,
     optionalImportsMap,
     optionalImportEntrypoints,


### PR DESCRIPTION
## Summary
- Extend `load()` to accept pre-parsed JavaScript objects/arrays in addition to JSON strings, removing the need for redundant `JSON.stringify()` when database drivers auto-parse JSON columns
- Add `dump()` as the serialization complement of `load()`, mirroring Python LangChain's `dumpd()` — returns a plain object suitable for DB storage or `JSON.stringify`
- Update `langchain` wrapper's `load()` to match the new signature

Closes #10472

## Test plan
- [x] `load()` accepts pre-parsed objects (simulating DB auto-parse)
- [x] `load()` accepts pre-parsed arrays of messages
- [x] `load()` still accepts JSON strings (backwards compatible)
- [x] `dump()` returns a plain object from a Serializable
- [x] `dump()`/`load()` round-trip preserves message content
- [x] `JSON.stringify(dump())`/`load()` round-trip works
- [x] `dump()` handles arrays and primitives
- [x] All 45 existing + new tests pass with no type errors