### PR TITLE
fix(google-common): add Array.isArray guard in toolMessageToContent

### DIFF
--- a/.changeset/google-common-object-guard.md
+++ b/.changeset/google-common-object-guard.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): add Array.isArray guard in toolMessageToContent to prevent crash on plain object ToolMessage content

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -883,16 +883,18 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     const contentStr =
       typeof message.content === "string"
         ? message.content
-        : (message.content as ContentBlock[]).reduce(
-            (acc: string, content: ContentBlock) => {
-              if (content.type === "text") {
-                return acc + content.text;
-              } else {
-                return acc;
-              }
-            },
-            ""
-          );
+        : Array.isArray(message.content)
+          ? (message.content as ContentBlock[]).reduce(
+              (acc: string, content: ContentBlock) => {
+                if (content.type === "text") {
+                  return acc + content.text;
+                } else {
+                  return acc;
+                }
+              },
+              ""
+            )
+          : JSON.stringify(message.content);
     // Hacky :(
     const responseName =
       (isAIMessage(prevMessage) && !!prevMessage.tool_calls?.length


### PR DESCRIPTION
## Problem

`toolMessageToContent()` in `@langchain/google-common` calls `.reduce()` directly on
`message.content` assuming it is always a string or an array. When `content` is a plain
object (e.g. `{ status: "ok", value: 42 }`), `.reduce()` crashes because plain objects
don't have that method.

## Fix

Added an `Array.isArray()` check before calling `.reduce()`. When `content` is not a
string and not an array, it falls back to `JSON.stringify(message.content)`.

## Changed file

**`libs/providers/langchain-google-common/src/utils/gemini.ts`** — one ternary added
in `toolMessageToContent()` to guard the `.reduce()` call.

## Test Results
- `@langchain/google-common`: 277/277 passed ✅
