### PR TITLE
fix(core): codeExecutionResult and executableCode content chunks are incorrectly transformed for Gemini API

### DIFF
--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -308,6 +308,8 @@ export abstract class BaseMessage<
     }
     this.additional_kwargs = fields.additional_kwargs;
     this.id = fields.id;
+    // contentBlocks is a computed getter and must not be serialized via lc_kwargs
+    delete this.lc_kwargs.contentBlocks;
   }
 
   /** Get text content of the message. */

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -66,6 +66,55 @@ describe("AIMessage", () => {
     ]);
   });
 
+  describe("toJSON with outputVersion v1", () => {
+    it("should not inline content in both 'content' and 'content_blocks' in toJSON output", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "text" as const,
+            text: "Here is a response with some content.",
+          },
+        ],
+        response_metadata: {
+          output_version: "v1",
+          model_provider: "google",
+        },
+      });
+
+      const serialized = message.toJSON();
+      expect(serialized.type).toBe("constructor");
+      const kwargs = (serialized as { kwargs: Record<string, unknown> }).kwargs;
+
+      // Bug: toJSON() produces both "content" and "content_blocks" keys in kwargs,
+      // duplicating the message content. The contentBlocks getter in lc_kwargs
+      // gets serialized as "content_blocks" (via lc_aliases) alongside "content".
+      expect(kwargs).not.toHaveProperty("content_blocks");
+    });
+
+    it("should not duplicate content when constructed with contentBlocks", () => {
+      const message = new AIMessage({
+        contentBlocks: [
+          {
+            type: "text" as const,
+            text: "This should only appear once.",
+          },
+          {
+            type: "tool_call" as const,
+            id: "call_1",
+            name: "search",
+            args: { q: "test" },
+          },
+        ],
+      });
+
+      const serialized = message.toJSON();
+      const kwargs = (serialized as { kwargs: Record<string, unknown> }).kwargs;
+
+      // Same bug: contentBlocks gets serialized as content_blocks alongside content
+      expect(kwargs).not.toHaveProperty("content_blocks");
+    });
+  });
+
   describe(".contentBlocks", () => {
     it("should have tool call content blocks from .tool_calls", () => {
       const message = new AIMessage({


### PR DESCRIPTION
## Summary

Fixes #10558.

- When `outputVersion: "v1"` is used, `toJSON()` serializes `contentBlocks` as a separate `content_blocks` key in `kwargs` alongside `content`, duplicating message content in the serialized output.
- The fix removes `contentBlocks` from `lc_kwargs` at the end of the `BaseMessage` constructor, since `contentBlocks` is a computed getter and should never be persisted in `lc_kwargs`.
- Added two regression tests verifying that `toJSON()` output does not contain `content_blocks` for messages constructed with either `content` + `output_version: "v1"` or the `contentBlocks` parameter.
