### PR TITLE
fix(openai): guard string content in phase extraction

### DIFF
--- a/.changeset/fix-responses-string-content-phase.md
+++ b/.changeset/fix-responses-string-content-phase.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Fix `content.findIndex is not a function` error when `AIMessage` has string content in `convertMessagesToResponsesInput` phase extraction.

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1508,6 +1508,7 @@ export const convertMessagesToResponsesInput: Converter<
               });
             }) as ResponseInputMessageContentList,
             phase: iife(() => {
+              if (typeof content === "string") return undefined;
               const index = content.findIndex(
                 (item) => "phase" in item && typeof item.phase === "string"
               );

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -2425,6 +2425,25 @@ describe("phase parameter support", () => {
       expect(messageItem.phase).toBeUndefined();
     });
 
+    it("should handle AIMessage with string content without throwing", () => {
+      const aiMessage = new AIMessage({
+        content: "plain text response",
+      });
+
+      const result = convertMessagesToResponsesInput({
+        messages: [aiMessage],
+        zdrEnabled: false,
+        model: "gpt-4o",
+      });
+
+      const messageItem = result.find(
+        (item) => (item as any).type === "message"
+      ) as any;
+      expect(messageItem).toBeDefined();
+      expect(messageItem.content).toBe("plain text response");
+      expect(messageItem.phase).toBeUndefined();
+    });
+
     it("should preserve phase from extras through standard content path", () => {
       const aiMessage = new AIMessage({
         id: "msg_001",


### PR DESCRIPTION
## Summary
Fixes #10565

`convertMessagesToResponsesInput` crashes with `content.findIndex is not a function` when an `AIMessage` has string content (e.g. `new AIMessage('plain text')`). The `phase` extraction block added in #10509 assumes `content` is always an array, but the same function already handles string content in the content/flatMap block above — just the new phase block was missing the guard.

Fix: add `if (typeof content === "string") return undefined;` before `content.findIndex()`.

## AI Disclosure
This bug was identified through issue report analysis with AI assistance.