### PR TITLE
fix(google): strip type from executableCode/codeExecutionResult in multi-turn

### DIFF
--- a/.changeset/fix-google-code-execution-roundtrip.md
+++ b/.changeset/fix-google-code-execution-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Strip `type` field from `executableCode` and `codeExecutionResult` content blocks when converting back to Gemini API format, preventing 400 errors in multi-turn conversations.

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -628,6 +628,36 @@ describe.each(coreModelInfo)(
       expect(result2.content).toMatch(/21/);
     });
 
+    test("code execution multi-turn", async () => {
+      const llm = newChatGoogle({
+        tools: [{ codeExecution: {} }],
+      });
+
+      // First turn: ask for code execution
+      const result1 = await llm.invoke(
+        "Calculate the sum of 1 to 10 using Python code."
+      );
+      expect(AIMessage.isInstance(result1)).toBe(true);
+
+      // Result should contain executableCode and/or codeExecutionResult blocks
+      const hasCodeBlocks = result1.contentBlocks.some(
+        (b: any) =>
+          b.type === "executableCode" || b.type === "codeExecutionResult"
+      );
+      expect(hasCodeBlocks).toBe(true);
+
+      // Second turn: use the AI response in a follow-up
+      const history: BaseMessage[] = [
+        new HumanMessage("Calculate the sum of 1 to 10 using Python code."),
+        result1,
+        new HumanMessage("Now calculate 1 to 100 using the same approach."),
+      ];
+      const result2 = await llm.invoke(history);
+      expect(AIMessage.isInstance(result2)).toBe(true);
+      expect(typeof result2.text).toBe("string");
+      expect(result2.text.length).toBeGreaterThan(0);
+    });
+
     test("function reply", async () => {
       const tools: Gemini.Tool[] = [
         {

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -371,6 +371,14 @@ function convertStandardContentBlockToGeminiPart(
       return convertStandardDataContentBlockToGeminiPart(block);
     case "video":
       return convertStandardVideoContentBlockToGeminiPart(block);
+    case "executableCode": {
+      const { type, ...rest } = block as unknown as Record<string, unknown>;
+      return rest as Gemini.Part;
+    }
+    case "codeExecutionResult": {
+      const { type, ...rest } = block as unknown as Record<string, unknown>;
+      return rest as Gemini.Part;
+    }
     default:
       return null;
   }
@@ -729,6 +737,12 @@ function convertLegacyContentMessageToGeminiContent(
           parts.push(messageContentImageUrl(item));
         } else if (isMessageContentMedia(item)) {
           parts.push(messageContentMedia(item));
+        } else if (
+          item?.type === "executableCode" ||
+          item?.type === "codeExecutionResult"
+        ) {
+          const { type, ...rest } = item;
+          parts.push(rest as Gemini.Part);
         } else {
           parts.push(item as Gemini.Part);
         }

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -740,4 +740,38 @@ describe("convertMessagesToGeminiContents", () => {
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
   });
+
+  test("strips type field from executableCode and codeExecutionResult blocks in multi-turn", () => {
+    const messages = [
+      new HumanMessage("render a chart"),
+      new AIMessage({
+        content: [
+          { type: "text", text: "Here is the code:" },
+          {
+            type: "executableCode",
+            executableCode: { language: "PYTHON", code: "print('hi')" },
+          },
+          {
+            type: "codeExecutionResult",
+            codeExecutionResult: { outcome: "OUTCOME_OK", output: "hi\n" },
+          },
+        ],
+        response_metadata: { model_provider: "google" },
+      }),
+      new HumanMessage("looks good"),
+    ];
+
+    const result = convertMessagesToGeminiContents(messages);
+    const modelContent = result.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts.length).toBe(3);
+
+    const codePart = modelContent!.parts[1] as Record<string, unknown>;
+    expect(codePart.executableCode).toBeDefined();
+    expect(codePart.type).toBeUndefined();
+
+    const resultPart = modelContent!.parts[2] as Record<string, unknown>;
+    expect(resultPart.codeExecutionResult).toBeDefined();
+    expect(resultPart.type).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #10567

`executableCode` and `codeExecutionResult` content blocks retain the `type` field (added internally by the block translator) when converted back to Gemini API format, causing a 400 error (`Unknown name "type"`) in multi-turn conversations.

The `functionCall` case in the same converter already strips `type` correctly (L722-727) — this applies the same pattern to these two block types. Also added handling in the standard converter path where they were silently dropped.

## AI Disclosure
This bug was identified through issue report analysis with AI assistance.