### PR TITLE
fix(openai): guard findIndex call for string content in phase extraction

### DIFF
--- a/.changeset/guard-findindex-string.md
+++ b/.changeset/guard-findindex-string.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): guard findIndex call for string content in phase extraction

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1321,6 +1321,27 @@ describe("convertMessagesToResponsesInput", () => {
     });
   });
 
+  describe("assistant message with string content", () => {
+    it("handles AIMessage with plain string content without throwing", () => {
+      const message = new AIMessage("plain text response");
+
+      const result = convertMessagesToResponsesInput({
+        messages: [message],
+        zdrEnabled: false,
+        model: "gpt-4o",
+      });
+
+      expect(result).toEqual([
+        {
+          type: "message",
+          role: "assistant",
+          content: "plain text response",
+          phase: undefined,
+        },
+      ]);
+    });
+  });
+
   describe("assistant reasoning conversion", () => {
     it("includes reasoning items in ZDR mode when encrypted content is present", () => {
       const message = new AIMessage({


### PR DESCRIPTION
## Problem

When an `AIMessage` has plain string content (e.g. `new AIMessage("text")`), `convertMessagesToResponsesInput` previously threw:

```
TypeError: content.findIndex is not a function
```

## Status

The code fix for this was already applied upstream (the `!Array.isArray(content)` guard at `responses.ts:1552`). This PR now only adds:

- **`.changeset/guard-findindex-string.md`** — Patch changeset entry
- **Regression test** — Verifies `AIMessage` with plain string content works without throwing

Closes #10565