### PR TITLE
fix(community): expose basePath in VoyageEmbeddings constructor params

### DIFF
--- a/libs/community/langchain-community/src/embeddings/voyage.ts
+++ b/libs/community/langchain-community/src/embeddings/voyage.ts
@@ -16,6 +16,12 @@ export interface VoyageEmbeddingsParams extends EmbeddingsParams {
   batchSize?: number;
 
   /**
+   * Base URL for the Voyage AI API.
+   * @default "https://api.voyageai.com/v1"
+   */
+  basePath?: string;
+
+  /**
    * Input type for the embeddings request.
    */
   inputType?: string;
@@ -138,6 +144,7 @@ export class VoyageEmbeddings
     this.modelName = fieldsWithDefaults?.modelName ?? this.modelName;
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.apiKey = apiKey;
+    this.basePath = fieldsWithDefaults?.basePath ?? this.basePath;
     this.apiUrl = `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
     this.truncation = fieldsWithDefaults?.truncation;


### PR DESCRIPTION
## Problem

The `VoyageEmbeddings` class has a `basePath` property that defaults to `https://api.voyageai.com/v1`, but it is not exposed in `VoyageEmbeddingsParams`. This means:

1. `basePath` cannot be set via the constructor
2. Setting `basePath` after instantiation has no effect because `apiUrl` is already computed from the default

```typescript
const embeddings = new VoyageEmbeddings({
  apiKey: "key",
  basePath: "https://custom-endpoint.com/v1", // TS error + ignored
});
```

## Solution

- Add `basePath` to `VoyageEmbeddingsParams` interface
- Apply `basePath` from constructor fields before computing `apiUrl`

## Files Changed

- `libs/community/langchain-community/src/embeddings/voyage.ts`

Closes langchain-ai/langchainjs-community#20