### PR TITLE
fix(google): correct mediaResolution type from object to string enum

### DIFF
--- a/libs/providers/langchain-google/src/chat_models/types.ts
+++ b/libs/providers/langchain-google/src/chat_models/types.ts
@@ -139,8 +139,9 @@ export interface ChatGoogleFields {
 
   /**
    * Media resolution for input media processing.
+   * Accepts a string value such as `"MEDIA_RESOLUTION_HIGH"`.
    */
-  mediaResolution?: Prettify<GeminiBase.MediaResolution>;
+  mediaResolution?: GeminiBase.GenerationConfig["mediaResolution"];
 
   /**
    * The number of reasoning tokens that the model should generate.


### PR DESCRIPTION
## Problem

The user-facing `mediaResolution` param in `BaseChatGoogleParams` is typed as `GeminiBase.MediaResolution` — an object with a `level` property:

```typescript
mediaResolution: { level: "MEDIA_RESOLUTION_HIGH" }
```

But the Gemini API `GenerationConfig.mediaResolution` expects a plain string. Passing the object causes:

```
Invalid value at 'generation_config' (media_resolution), Starting an object on a scalar field
```

Using the correct string value works at runtime but fails TypeScript type checking.

## Solution

Change the type from `GeminiBase.MediaResolution` (object) to `GenerationConfig["mediaResolution"]` (string union), which matches what the API actually expects.

## Files Changed

- `libs/providers/langchain-google/src/chat_models/types.ts`

Closes #10546