### PR TITLE
fix(@langchain/google): preserve originalTextContentBlock metadata when reconstructing Gemini API request body

### DIFF
--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -361,19 +361,66 @@ function convertStandardVideoContentBlockToGeminiPart(
 function convertStandardContentBlockToGeminiPart(
   block: ContentBlock.Standard
 ): Gemini.Part | null {
+  let part: Gemini.Part | null = null;
+
   switch (block.type) {
     case "text":
-      return { text: block.text };
+      part = { text: block.text };
+      break;
     case "image":
     case "audio":
     case "text-plain":
     case "file":
-      return convertStandardDataContentBlockToGeminiPart(block);
+      part = convertStandardDataContentBlockToGeminiPart(block);
+      break;
     case "video":
-      return convertStandardVideoContentBlockToGeminiPart(block);
+      part = convertStandardVideoContentBlockToGeminiPart(block);
+      break;
+    case "reasoning": {
+      const reasoning = "reasoning" in block ? (block.reasoning as string) : "";
+      part = { text: reasoning, thought: true };
+      break;
+    }
+    case "non_standard": {
+      const value =
+        "value" in block ? (block.value as Record<string, unknown>) : undefined;
+      if (value) {
+        if ("executableCode" in value && value.executableCode) {
+          part = { executableCode: value.executableCode } as Gemini.Part;
+        } else if (
+          "codeExecutionResult" in value &&
+          value.codeExecutionResult
+        ) {
+          part = {
+            codeExecutionResult: value.codeExecutionResult,
+          } as Gemini.Part;
+        } else if ("functionResponse" in value && value.functionResponse) {
+          part = { functionResponse: value.functionResponse } as Gemini.Part;
+        } else if ("functionCall" in value && value.functionCall) {
+          part = { functionCall: value.functionCall } as Gemini.Part;
+        }
+      }
+      break;
+    }
     default:
       return null;
   }
+
+  // Propagate Gemini-specific metadata from the standard block to the part
+  if (part) {
+    const blockRecord = block as Record<string, unknown>;
+    if (blockRecord.thoughtSignature !== undefined) {
+      part.thoughtSignature = blockRecord.thoughtSignature as string;
+    }
+    if (blockRecord.partMetadata !== undefined) {
+      part.partMetadata = blockRecord.partMetadata as Record<string, unknown>;
+    }
+    if (blockRecord.thought !== undefined && block.type !== "reasoning") {
+      part.thought = blockRecord.thought as boolean;
+    }
+  }
+
+  return part;
 }
 
 /**
@@ -428,11 +475,8 @@ function convertStandardContentMessageToGeminiContent(
     ? message.contentBlocks
     : [];
   contentBlocks.forEach((block: ContentBlock.Standard) => {
-    const contentBlock =
-      (message.additional_kwargs
-        .originalTextContentBlock as ContentBlock.Standard) || block;
     const part: Gemini.Part | null =
-      convertStandardContentBlockToGeminiPart(contentBlock);
+      convertStandardContentBlockToGeminiPart(block);
     if (part) {
       parts.push(part);
     }
@@ -705,7 +749,19 @@ function convertLegacyContentMessageToGeminiContent(
   if (typeof message.content === "string") {
     // Simple string content
     if (message.content.trim()) {
-      parts.push({ text: message.content });
+      const originalBlock = message.additional_kwargs
+        ?.originalTextContentBlock as Record<string, unknown> | undefined;
+      const part: Gemini.Part = { text: message.content };
+      if (originalBlock?.thoughtSignature !== undefined) {
+        part.thoughtSignature = originalBlock.thoughtSignature as string;
+      }
+      if (originalBlock?.partMetadata !== undefined) {
+        part.partMetadata = originalBlock.partMetadata as Record<
+          string,
+          unknown
+        >;
+      }
+      parts.push(part);
     }
   } else if (Array.isArray(message.content)) {
     // Array of content blocks (legacy format)

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { Gemini } from "../../chat_models/types.js";
 import {
   convertGeminiPartsToToolCalls,
@@ -739,5 +744,214 @@ describe("convertMessagesToGeminiContents", () => {
     expect(
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
+  });
+
+  test("v0 legacy path: preserves thoughtSignature from originalTextContentBlock for string content", () => {
+    const aiMsg = new AIMessage({
+      content: "Hello thinking world",
+      additional_kwargs: {
+        originalTextContentBlock: {
+          type: "text",
+          text: "Hello thinking world",
+          thoughtSignature: "sig-abc123",
+        },
+      },
+      response_metadata: { model_provider: "google" },
+    });
+    const messages = [new HumanMessage("hello"), aiMsg];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(1);
+    expect(modelContent!.parts[0].text).toBe("Hello thinking world");
+    expect(modelContent!.parts[0].thoughtSignature).toBe("sig-abc123");
+  });
+
+  test("v0 legacy path: preserves partMetadata from originalTextContentBlock for string content", () => {
+    const aiMsg = new AIMessage({
+      content: "Hello with metadata",
+      additional_kwargs: {
+        originalTextContentBlock: {
+          type: "text",
+          text: "Hello with metadata",
+          partMetadata: { custom: "data" },
+        },
+      },
+      response_metadata: { model_provider: "google" },
+    });
+    const messages = [new HumanMessage("hello"), aiMsg];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts[0].text).toBe("Hello with metadata");
+    expect(modelContent!.parts[0].partMetadata).toEqual({ custom: "data" });
+  });
+
+  test("v1 standard path: converts non_standard executableCode blocks to Gemini parts", () => {
+    const messages = [
+      new HumanMessage("run code"),
+      new AIMessage({
+        content: [
+          { type: "text" as const, text: "Here is the code:" },
+          {
+            type: "non_standard" as const,
+            value: {
+              type: "executableCode",
+              executableCode: {
+                language: "PYTHON",
+                code: 'print("hello")',
+              },
+            },
+          },
+          {
+            type: "non_standard" as const,
+            value: {
+              type: "codeExecutionResult",
+              codeExecutionResult: {
+                outcome: "OUTCOME_OK",
+                output: "hello",
+              },
+            },
+          },
+          { type: "text" as const, text: "Done!" },
+        ],
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(4);
+
+    expect(modelContent!.parts[0].text).toBe("Here is the code:");
+    expect(
+      (modelContent!.parts[1] as Gemini.Part).executableCode
+    ).toBeDefined();
+    expect((modelContent!.parts[1] as Gemini.Part).executableCode!.code).toBe(
+      'print("hello")'
+    );
+    expect(
+      (modelContent!.parts[2] as Gemini.Part).codeExecutionResult
+    ).toBeDefined();
+    expect(
+      (modelContent!.parts[2] as Gemini.Part).codeExecutionResult!.outcome
+    ).toBe("OUTCOME_OK");
+    expect(modelContent!.parts[3].text).toBe("Done!");
+  });
+
+  test("v1 standard path: converts reasoning blocks to thought parts", () => {
+    const messages = [
+      new HumanMessage("think about this"),
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning" as const,
+            reasoning: "Let me think about this...",
+            thought: true,
+          },
+          { type: "text" as const, text: "Here is my answer." },
+        ],
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(2);
+
+    expect(modelContent!.parts[0].text).toBe("Let me think about this...");
+    expect(modelContent!.parts[0].thought).toBe(true);
+    expect(modelContent!.parts[1].text).toBe("Here is my answer.");
+    expect(modelContent!.parts[1].thought).toBeUndefined();
+  });
+
+  test("v1 standard path: propagates thoughtSignature on text blocks", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: [
+          {
+            type: "text" as const,
+            text: "Response with signature",
+            thoughtSignature: "sig-xyz789",
+          },
+        ],
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(1);
+    expect(modelContent!.parts[0].text).toBe("Response with signature");
+    expect(modelContent!.parts[0].thoughtSignature).toBe("sig-xyz789");
+  });
+
+  test("v1 standard path: round-trips streamed AIMessageChunk with originalTextContentBlock through Google translator", () => {
+    // Simulates a streamed v0 message chunk with originalTextContentBlock being
+    // fed back to ChatGoogle — the contentBlocks getter goes through the
+    // ChatGoogleTranslator which uses originalTextContentBlock for single-text messages
+    const chunk = new AIMessageChunk({
+      content: "Streamed text",
+      additional_kwargs: {
+        originalTextContentBlock: {
+          type: "text",
+          text: "Streamed text",
+          thoughtSignature: "sig-stream-001",
+        },
+      },
+      response_metadata: { model_provider: "google" },
+    });
+    const messages = [new HumanMessage("hello"), chunk];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(1);
+    expect(modelContent!.parts[0].text).toBe("Streamed text");
+    expect(modelContent!.parts[0].thoughtSignature).toBe("sig-stream-001");
+  });
+
+  test("v1 standard path: non_standard blocks with thoughtSignature preserved", () => {
+    const messages = [
+      new HumanMessage("run code"),
+      new AIMessage({
+        content: [
+          {
+            type: "non_standard" as const,
+            value: {
+              type: "executableCode",
+              executableCode: {
+                language: "PYTHON",
+                code: 'print("hi")',
+              },
+            },
+            thoughtSignature: "sig-code-001",
+          },
+        ],
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toHaveLength(1);
+    expect(
+      (modelContent!.parts[0] as Gemini.Part).executableCode
+    ).toBeDefined();
+    expect(modelContent!.parts[0].thoughtSignature).toBe("sig-code-001");
   });
 });


### PR DESCRIPTION
# Description

Fix the outbound conversion pipeline in `@langchain/google` to properly use metadata from `originalTextContentBlock` (`thoughtSignature`, `partMetadata`) when converting `AIMessage`/`AIMessageChunk` back to Gemini API parts.

Fixes #10562

## Problem

When an `AIMessageChunk` from `ChatGoogle.stream()` is fed back as conversation history to a subsequent `ChatGoogle.invoke()` call, the `originalTextContentBlock` metadata (specifically `thoughtSignature` and `partMetadata`) is **ignored** during the Gemini API request body reconstruction. This causes:

1. **v1 standard path**: `convertStandardContentBlockToGeminiPart()` returned `null` for `non_standard` blocks (wrapping `executableCode`, `codeExecutionResult`, etc.) and `reasoning` blocks — losing Google-specific content types entirely
2. **v1 standard path**: The `originalTextContentBlock || block` fallback incorrectly substituted `originalTextContentBlock` for **every** content block in the iteration, instead of relying on `contentBlocks` (which already incorporates it via `ChatGoogleTranslator`)
3. **v1 standard path**: `thoughtSignature`, `thought`, and `partMetadata` were not propagated from standard content blocks to Gemini parts
4. **v0 legacy path**: When content was a string, `thoughtSignature` and `partMetadata` from `originalTextContentBlock` were silently dropped

## Changes

### `libs/providers/langchain-google/src/converters/messages.ts`
- **`convertStandardContentBlockToGeminiPart` (v1 path)**: Added handling for `non_standard` blocks (`executableCode`, `codeExecutionResult`, `functionResponse`, `functionCall`) and `reasoning` blocks; added metadata propagation for `thoughtSignature`, `partMetadata`, and `thought` from standard content blocks to Gemini parts
- **`convertStandardContentMessageToGeminiContent` (v1 path)**: Removed incorrect `originalTextContentBlock || block` fallback — `contentBlocks` already handles `originalTextContentBlock` via the `ChatGoogleTranslator`
- **`convertLegacyContentMessageToGeminiContent` (v0 path)**: When converting string content, use `originalTextContentBlock` to propagate `thoughtSignature` and `partMetadata` to the Gemini text part

### `libs/providers/langchain-google/src/converters/tests/messages.test.ts`
- Added 7 new test cases covering:
  - v0 legacy path: preserves `thoughtSignature` and `partMetadata` from `originalTextContentBlock` for string content
  - v1 standard path: converts `non_standard` `executableCode`/`codeExecutionResult` blocks to Gemini parts
  - v1 standard path: converts `reasoning` blocks to thought parts
  - v1 standard path: propagates `thoughtSignature` on text blocks
  - v1 standard path: round-trips streamed `AIMessageChunk` with `originalTextContentBlock` through Google translator
  - v1 standard path: `non_standard` blocks with `thoughtSignature` preserved

## Testing

- All 7 new tests pass
- All existing tests continue to pass (2 pre-existing failures in the test suite are unrelated)
- Lint passes (`pnpm lint`)
- Format passes (`pnpm format`)