### PR TITLE
fix(google): fail fast for Claude models on Vertex AI

### DIFF
--- a/.changeset/chatgoogle-claude-vertex-guard.md
+++ b/.changeset/chatgoogle-claude-vertex-guard.md
@@ -1,0 +1,7 @@
+---
+"@langchain/google": patch
+---
+
+fix(@langchain/google): fail fast for Claude models on Vertex with actionable guidance
+
+`ChatGoogle` now throws a clear `ConfigurationError` when a Claude model is used on Vertex AI, and points users to `@langchain/anthropic` with the Vertex SDK path. Added unit and integration tests to keep this behavior deterministic.

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -87,6 +87,10 @@ export function getPlatformType(
   }
 }
 
+function isClaudeModelName(modelName: string): boolean {
+  return /(^|[/:_-])claude([/:_-]|$)/i.test(modelName);
+}
+
 export interface BaseChatGoogleParams
   extends BaseChatModelParams,
     ChatGoogleFields {
@@ -245,6 +249,18 @@ export abstract class BaseChatGoogle<
     return "google";
   }
 
+  protected assertModelSupportedForVertex(): void {
+    if (this.platform !== "gcp") {
+      return;
+    }
+
+    if (isClaudeModelName(this.model)) {
+      throw new ConfigurationError(
+        "Claude models on Vertex AI are not supported by ChatGoogle in @langchain/google. Use @langchain/anthropic with @anthropic-ai/vertex-sdk (via ChatAnthropic createClient) for Claude on Vertex AI."
+      );
+    }
+  }
+
   protected get urlMethod(): string {
     return this.streaming ? "streamGenerateContent?alt=sse" : "generateContent";
   }
@@ -288,6 +304,7 @@ export abstract class BaseChatGoogle<
   }
 
   protected async buildUrlVertex(urlMethod?: string): Promise<string> {
+    this.assertModelSupportedForVertex();
     if (this.isVertexExpress) {
       return this.buildUrlVertexExpress(urlMethod);
     } else {

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -346,6 +346,20 @@ function propSum(o: Record<string, number>): number {
     .reduce((acc, val) => acc + val);
 }
 
+describe("Claude on Vertex AI support", () => {
+  test("throws actionable error before request for ChatGoogle", async () => {
+    const model = new ChatGoogle({
+      model: "claude-sonnet-4@20250514",
+      platformType: "gcp",
+      apiKey: "test-api-key",
+    });
+
+    await expect(model.invoke("Hello")).rejects.toThrow(
+      "Claude models on Vertex AI are not supported by ChatGoogle in @langchain/google."
+    );
+  });
+});
+
 const weatherTool = tool(
   (_) => ({
     temp: 21,

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -432,6 +432,39 @@ describe("Google Mock", () => {
     });
   });
 
+  test("throws actionable error for Claude models on Vertex AI", async () => {
+    const apiClient = new MockApiClient({
+      fileName: "gemini-chat-001.json",
+    });
+    const model = new ChatGoogle({
+      model: "claude-sonnet-4@20250514",
+      platformType: "gcp",
+      apiClient,
+    });
+
+    await expect(model.invoke("Hello")).rejects.toThrow(
+      "Claude models on Vertex AI are not supported by ChatGoogle in @langchain/google."
+    );
+    expect(apiClient.request).toBeUndefined();
+  });
+
+  test("continues to use google publisher urls for Gemini models on Vertex AI", async () => {
+    const apiClient = new MockApiClient({
+      fileName: "gemini-chat-001.json",
+    });
+    const model = new ChatGoogle({
+      model: "gemini-2.5-flash",
+      platformType: "gcp",
+      apiClient,
+    });
+
+    await model.invoke("Hello");
+
+    expect(apiClient.request.url).toContain(
+      "/publishers/google/models/gemini-2.5-flash:generateContent"
+    );
+  });
+
   type TestReasoning = {
     model: string;
     maxReasoningTokens?: number;

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
@@ -124,7 +124,6 @@ describe("ChatOpenRouter constructor", () => {
   });
 });
 
-
 describe("attribution headers", () => {
   function extractHeaders(model: ChatOpenRouter): Record<string, string> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

This PR addresses confusing Claude-on-Vertex behavior in `@langchain/google` by failing fast with actionable guidance.

Users currently see docs mention Claude on Vertex AI and may try `ChatGoogle` directly. Internally, `ChatGoogle` is Gemini-oriented (`generateContent` flow), so Claude model usage fails in a non-obvious way. This change makes the behavior explicit.

## Changes

- Add Claude model detection guard for Vertex (`platformType: "gcp"`) in `BaseChatGoogle`.
- Throw a clear `ConfigurationError` with migration guidance to:
  - `@langchain/anthropic`
  - `@anthropic-ai/vertex-sdk` via `ChatAnthropic.createClient`
- Add unit tests:
  - Claude + Vertex throws actionable error
  - Gemini + Vertex behavior remains unchanged (URL regression check)
- Add integration test:
  - deterministic fail-fast assertion for Claude + Vertex in int mode
- Add changeset:
  - patch release note for `@langchain/google`

## Testing

- `pnpm --filter @langchain/google test src/chat_models/tests/index.test.ts`
- `pnpm vitest run --mode int src/chat_models/tests/index.int.test.ts -t "throws actionable error before request for ChatGoogle"`

## Notes

- Running full `pnpm --filter @langchain/google test` in this environment also surfaced two existing converter tests failing in `src/converters/tests/messages.test.ts` (legacy-path assertions), unrelated to this change.

Fixes #10596