### PR TITLE
feat(mongodb): add mongodb automated embedding support

### DIFF
--- a/.changeset/bold-pans-shine.md
+++ b/.changeset/bold-pans-shine.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mongodb": minor
+---
+
+Add MongoDB auto-embed support

--- a/libs/providers/langchain-mongodb/src/tests/cache.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/cache.int.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@jest/globals";
+import { test, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { MongoClient, Collection } from "mongodb";
 import { Generation } from "@langchain/core/outputs";
 import { MongoDBCache, MongoDBAtlasSemanticCache } from "../cache.js";

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -1,6 +1,7 @@
 import { Collection } from "mongodb";
 import { Readable } from "stream";
 import { setInterval } from "timers/promises";
+import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
@@ -23,7 +24,36 @@ export async function waitForIndexToBeQueryable(
 ): Promise<void> {
   return Readable.from(setInterval(5000, undefined, { ref: false }))
     .map(() => collection.listSearchIndexes().toArray())
-    .find((indexes: { name: string; queryable?: boolean }[]) =>
-      indexes.some((index) => index.name === indexName && index.queryable)
-    );
+    .find((indexes: { name: string; status: string; }[]) => {
+      const found = indexes.some((index) => index.name === indexName && index.status === "READY");
+      return found;
+    });
+}
+
+/**
+ * Wait for documents to be indexed and searchable after insertion.
+ * Polls the vector store with a test query until search succeeds,
+ * indicating that auto-embeddings are complete.
+ */
+export async function waitForDocumentsIndexed(
+  vectorStore: MongoDBAtlasVectorSearch,
+  testQuery: string,
+  maxWaitTime = 60000
+): Promise<void> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitTime) {
+    const result = await vectorStore.similaritySearch(testQuery, 1);
+    if (result.length > 0) {
+      return; // Search succeeded, documents are indexed
+    } else {
+      // Documents not yet indexed, retry after a short delay
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    }
+  }
+
+  throw new Error(
+    `Documents not indexed after ${maxWaitTime}ms for query: "${testQuery}". ` +
+    `Auto-embedding may have failed or the timeout is too short.`
+  );
 }

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -24,8 +24,10 @@ export async function waitForIndexToBeQueryable(
 ): Promise<void> {
   return Readable.from(setInterval(5000, undefined, { ref: false }))
     .map(() => collection.listSearchIndexes().toArray())
-    .find((indexes: { name: string; status: string; }[]) => {
-      const found = indexes.some((index) => index.name === indexName && index.status === "READY");
+    .find((indexes: { name: string; status: string }[]) => {
+      const found = indexes.some(
+        (index) => index.name === indexName && index.status === "READY"
+      );
       return found;
     });
 }
@@ -48,12 +50,12 @@ export async function waitForDocumentsIndexed(
       return; // Search succeeded, documents are indexed
     } else {
       // Documents not yet indexed, retry after a short delay
-      await new Promise(resolve => setTimeout(resolve, 5000));
+      await new Promise((resolve) => setTimeout(resolve, 5000));
     }
   }
 
   throw new Error(
     `Documents not indexed after ${maxWaitTime}ms for query: "${testQuery}". ` +
-    `Auto-embedding may have failed or the timeout is too short.`
+      `Auto-embedding may have failed or the timeout is too short.`
   );
 }

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -44,6 +44,14 @@ beforeAll(async () => {
 
   const namespace = "langchain_test_db.langchain_test";
   const [dbName, collectionName] = namespace.split(".");
+
+  // Drop and recreate collection to ensure clean state and no lingering indexes
+  try {
+    await client.db(dbName).dropCollection(collectionName);
+  } catch {
+    // Collection may not exist, which is fine
+  }
+
   collection = await client.db(dbName).createCollection(collectionName);
 
   await collection.createSearchIndex({

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
@@ -141,28 +141,50 @@ describe.skipIf(skipAutoEmbedTests)("Auto Embedding Tests with data", () => {
     expect(results).toMatchObject([
       { pageContent: "What is a sandwich?", metadata: { c: 1 } },
     ]);
+  });
 
-    // // we can pre filter the search
-    // const preFilter = {
-    //   e: { $lte: 1 },
-    // };
+  test("MongoDBAtlasVectorSearch similaritySearchWithScore", async () => {
+    const vectorStore = new MongoDBAtlasVectorSearch({ collection });
 
-    // const filteredResults = await vectorStore.similaritySearch(
-    //   "That fence is purple",
-    //   1,
-    //   preFilter
-    // );
+    expect(vectorStore).toBeDefined();
 
-    // expect(filteredResults).toEqual([]);
+    // check if the database is empty
+    await collection.deleteMany({});
 
-    // const retriever = vectorStore.asRetriever({
-    //   filter: {
-    //     preFilter,
-    //   },
-    // });
+    await vectorStore.addDocuments([
+      {
+        pageContent: "Dogs are tough.",
+        metadata: { a: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "Cats have fluff.",
+        metadata: { b: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "What is a sandwich?",
+        metadata: { c: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "That fence is purple.",
+        metadata: { d: 1, e: 2, created_at: new Date().toISOString() },
+      },
+    ]);
 
-    // const docs = await retriever.getRelevantDocuments("That fence is purple");
-    // expect(docs).toEqual([]);
+    await waitForDocumentsIndexed(vectorStore, "Sandwich");
+
+    const results = await vectorStore.similaritySearchWithScore(
+      "Sandwich",
+      1
+    );
+
+    expect(results.length).toEqual(1);
+    expect(results[0]).toHaveLength(2);
+    expect(results[0][0]).toMatchObject({
+      pageContent: "What is a sandwich?",
+      metadata: { c: 1 },
+    });
+    expect(typeof results[0][1]).toBe("number");
+    expect(results[0][1]).toBeGreaterThan(0);
   });
 
   // Maximal Marginal Relevance is not yet supported with auto-embedding.

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
@@ -172,10 +172,7 @@ describe.skipIf(skipAutoEmbedTests)("Auto Embedding Tests with data", () => {
 
     await waitForDocumentsIndexed(vectorStore, "Sandwich");
 
-    const results = await vectorStore.similaritySearchWithScore(
-      "Sandwich",
-      1
-    );
+    const results = await vectorStore.similaritySearchWithScore("Sandwich", 1);
 
     expect(results.length).toEqual(1);
     expect(results[0]).toHaveLength(2);

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
@@ -1,0 +1,650 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  vi,
+  test,
+} from "vitest";
+import { Collection, MongoClient } from "mongodb";
+import { Document } from "@langchain/core/documents";
+import { Document as BSONDocument } from "bson";
+import semver from "semver";
+
+import { MongoDBAtlasVectorSearch } from "../vectorstores.js";
+import {
+  uri,
+  waitForIndexToBeQueryable,
+  waitForDocumentsIndexed,
+} from "./utils.js";
+
+/**
+ * The following json can be used to create an index in atlas for Cohere embeddings.
+ * Use "langchain.test" for the namespace and "default" for the index name.
+
+{
+  "mappings": {
+    "fields": {
+      "e": { "type": "number" },
+      "embedding": {
+        "dimensions": 1536,
+        "similarity": "euclidean",
+        "type": "knnVector"
+      }
+    }
+  }
+}
+*/
+
+const tempClient = new MongoClient(uri());
+await tempClient.connect();
+const admin = tempClient.db().admin();
+const serverStatus = await admin.serverStatus();
+const version = serverStatus.version || "unknown";
+const runAutoEmbedTests = semver.gte(version, "8.2.0");
+const skipAutoEmbedTests = !runAutoEmbedTests;
+await tempClient.close();
+
+describe.skipIf(skipAutoEmbedTests)("Auto Embedding Tests with data", () => {
+  const defaultEmbeddingModel = "voyage-4";
+
+  let client: MongoClient;
+  let collection: Collection;
+  beforeAll(async () => {
+    client = new MongoClient(uri(), { monitorCommands: true });
+    await client.connect();
+
+    const namespace = "langchain_test_db.langchain_auto_embed_test";
+    const [dbName, collectionName] = namespace.split(".");
+    const db = client.db(dbName);
+
+    // Drop and recreate collection to ensure clean state and no lingering indexes
+    try {
+      await db.dropCollection(collectionName);
+    } catch {
+      // Collection may not exist, which is fine
+    }
+
+    collection = await db.createCollection(collectionName);
+
+    // Create search index with autoEmbed for auto-embedding
+    // This is the correct format for MongoDB's vectorSearch with auto-embedding
+    await collection.createSearchIndex({
+      name: "default",
+      type: "vectorSearch",
+      definition: {
+        fields: [
+          {
+            type: "autoEmbed",
+            modality: "text",
+            path: "text",
+            model: defaultEmbeddingModel,
+          },
+        ],
+      },
+    });
+
+    await waitForIndexToBeQueryable(collection, "default");
+  });
+
+  beforeEach(async () => {
+    await collection.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("MongoDBStore sets client metadata", () => {
+    const spy = vi.spyOn(client!, "appendMetadata");
+    new MongoDBAtlasVectorSearch({ collection });
+    expect(spy).toHaveBeenCalledWith({ name: "langchainjs_vector" });
+    vi.clearAllMocks();
+  });
+
+  test("MongoDBAtlasVectorSearch with external ids", async () => {
+    const vectorStore = new MongoDBAtlasVectorSearch({ collection });
+
+    expect(vectorStore).toBeDefined();
+
+    // check if the database is empty
+    await collection.deleteMany({});
+
+    await vectorStore.addDocuments([
+      {
+        pageContent: "Dogs are tough.",
+        metadata: { a: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "Cats have fluff.",
+        metadata: { b: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "What is a sandwich?",
+        metadata: { c: 1, created_at: new Date().toISOString() },
+      },
+      {
+        pageContent: "That fence is purple.",
+        metadata: { d: 1, e: 2, created_at: new Date().toISOString() },
+      },
+    ]);
+
+    await waitForDocumentsIndexed(vectorStore, "Sandwich");
+
+    const results: Document[] = await vectorStore.similaritySearch(
+      "Sandwich",
+      1
+    );
+
+    expect(results.length).toEqual(1);
+    expect(results).toMatchObject([
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+    ]);
+
+    // // we can pre filter the search
+    // const preFilter = {
+    //   e: { $lte: 1 },
+    // };
+
+    // const filteredResults = await vectorStore.similaritySearch(
+    //   "That fence is purple",
+    //   1,
+    //   preFilter
+    // );
+
+    // expect(filteredResults).toEqual([]);
+
+    // const retriever = vectorStore.asRetriever({
+    //   filter: {
+    //     preFilter,
+    //   },
+    // });
+
+    // const docs = await retriever.getRelevantDocuments("That fence is purple");
+    // expect(docs).toEqual([]);
+  });
+
+  // Maximal Marginal Relevance is not yet supported with auto-embedding.
+  test.skip("MongoDBAtlasVectorSearch with Maximal Marginal Relevance", async () => {
+    const texts = ["foo", "foo", "foy"];
+    // Auto-embed mode: no embeddings needed, collection only
+    const vectorStore = await MongoDBAtlasVectorSearch.fromTexts(
+      texts,
+      {},
+      {
+        collection,
+        indexName: "default",
+      }
+    );
+
+    await waitForDocumentsIndexed(vectorStore, "foy");
+
+    const output = await vectorStore.maxMarginalRelevanceSearch("foo", {
+      k: 10,
+      fetchK: 20,
+      lambda: 0.1,
+    });
+
+    expect(output).toHaveLength(texts.length);
+
+    const actual = output.map((doc) => doc.pageContent);
+    const expected = ["foo", "foy", "foo"];
+    expect(actual).toEqual(expected);
+
+    const standardRetriever = await vectorStore.asRetriever();
+
+    const standardRetrieverOutput =
+      await standardRetriever._getRelevantDocuments("foo");
+    expect(output).toHaveLength(texts.length);
+
+    const standardRetrieverActual = standardRetrieverOutput.map(
+      (doc) => doc.pageContent
+    );
+    const standardRetrieverExpected = ["foo", "foo", "foy"];
+    expect(standardRetrieverActual).toEqual(standardRetrieverExpected);
+
+    const retriever = await vectorStore.asRetriever({
+      searchType: "mmr",
+      searchKwargs: {
+        fetchK: 20,
+        lambda: 0.1,
+      },
+    });
+
+    const retrieverOutput = await retriever._getRelevantDocuments("foo");
+    expect(output).toHaveLength(texts.length);
+
+    const retrieverActual = retrieverOutput.map((doc) => doc.pageContent);
+    const retrieverExpected = ["foo", "foy", "foo"];
+    expect(retrieverActual).toEqual(retrieverExpected);
+
+    const similarity = await vectorStore.similaritySearchWithScore("foo", 1);
+    expect(similarity.length).toBe(1);
+  });
+
+  test("MongoDBAtlasVectorSearch upsert", async () => {
+    const vectorStore = new MongoDBAtlasVectorSearch({ collection });
+
+    expect(vectorStore).toBeDefined();
+
+    // check if the database is empty
+    await collection.deleteMany({});
+
+    const ids = await vectorStore.addDocuments([
+      { pageContent: "Dogs are tough.", metadata: { a: 1 } },
+      { pageContent: "Cats have fluff.", metadata: { b: 1 } },
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+      { pageContent: "That fence is purple.", metadata: { d: 1, e: 2 } },
+    ]);
+
+    await waitForDocumentsIndexed(vectorStore, "Sandwich");
+
+    const results: Document[] = await vectorStore.similaritySearch(
+      "Sandwich",
+      1
+    );
+
+    expect(results.length).toEqual(1);
+    expect(results).toMatchObject([
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+    ]);
+
+    await vectorStore.addDocuments(
+      [{ pageContent: "upserted", metadata: {} }],
+      {
+        ids: [ids[2]],
+      }
+    );
+
+    const results2: Document[] = await vectorStore.similaritySearch(
+      "Sandwich",
+      1
+    );
+
+    expect(results2.length).toEqual(1);
+    expect(results2[0].pageContent).not.toContain("sandwich");
+  });
+
+  describe("MongoDBAtlasVectorSearch Constructor", () => {
+    test("initializes with minimal configuration", () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({
+        collection,
+      });
+      expect(vectorStore).toBeDefined();
+    });
+
+    test("initializes with custom index name", () => {
+      const customIndexName = "custom_index";
+      const vectorStore = new MongoDBAtlasVectorSearch({
+        collection,
+        indexName: customIndexName,
+      });
+      expect(vectorStore).toBeDefined();
+      // @ts-expect-error: Testing private property
+      expect(vectorStore.indexName).toEqual(customIndexName);
+    });
+
+    test("initializes with custom field names", () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({
+        collection,
+        textKey: "content",
+        embeddingKey: "vector",
+        primaryKey: "docId",
+      });
+      expect(vectorStore).toBeDefined();
+
+      // @ts-expect-error: Testing private properties
+      const { textKey, embeddingKey, primaryKey } = vectorStore;
+      expect(textKey).toEqual("content");
+      expect(embeddingKey).toEqual("vector");
+      expect(primaryKey).toEqual("docId");
+    });
+
+    test("initializes AsyncCaller with custom parameters", () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({
+        collection,
+        maxConcurrency: 5,
+        maxRetries: 3,
+      });
+      expect(vectorStore).toBeDefined();
+
+      const {
+        // @ts-expect-error: Testing private property
+        caller: { maxConcurrency, maxRetries },
+      } = vectorStore;
+      expect(maxConcurrency).toEqual(5);
+      expect(maxRetries).toEqual(3);
+    });
+  });
+
+  describe("addDocuments method", () => {
+    let vectorStore: MongoDBAtlasVectorSearch;
+    const documents = [
+      new Document({ pageContent: "test 1" }),
+      new Document({ pageContent: "test 2" }),
+    ];
+    beforeEach(async () => {
+      vectorStore = new MongoDBAtlasVectorSearch({ collection });
+    });
+    test("correctly embeds and stores documents", async () => {
+      await vectorStore.addDocuments(documents);
+
+      const results = await collection
+        .find({}, { projection: { _id: 0, text: 1 }, sort: { text: 1 } })
+        .toArray();
+
+      expect(results).toEqual([
+        {
+          text: "test 1",
+        },
+        {
+          text: "test 2",
+        },
+      ]);
+    });
+
+    test("custom _ids can be provided", async () => {
+      await vectorStore.addDocuments(documents, { ids: ["id1", "id2"] });
+
+      const results = await collection
+        .find({}, { projection: { text: 1 } })
+        .toArray();
+
+      expect(results).toMatchObject([
+        {
+          _id: "id1",
+          text: "test 1",
+        },
+        {
+          _id: "id2",
+          text: "test 2",
+        },
+      ]);
+    });
+
+    test("documents are updated if they already exist", async () => {
+      const ids = ["id1", "id2"];
+      await vectorStore.addDocuments(documents, { ids });
+
+      const updatedDocuments = [
+        new Document({
+          pageContent: "updated 1",
+        }),
+        new Document({
+          pageContent: "updated 2",
+        }),
+      ];
+
+      await vectorStore.addDocuments(updatedDocuments, { ids });
+
+      // assert that no new documents were added
+      expect(await collection.countDocuments({})).toBe(2);
+
+      const results = await collection
+        .find({}, { projection: { text: 1 } })
+        .toArray();
+      expect(results).toEqual([
+        { text: "updated 1", _id: "id1" },
+        { text: "updated 2", _id: "id2" },
+      ]);
+    });
+  });
+
+  describe("delete method", () => {
+    beforeEach(async () => {
+      const documents: BSONDocument[] = [
+        { _id: "id1", text: "doc1" },
+        { _id: "id2", text: "doc2" },
+        { _id: "id3", text: "doc3" },
+        { _id: "id4", text: "doc4" },
+        { _id: "id5", text: "doc5" },
+      ];
+      await collection.insertMany(documents);
+    });
+
+    test("removes documents by ids", async () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({ collection });
+
+      await vectorStore.delete({ ids: ["id1", "id3"] });
+
+      const remaining = await collection
+        .find({})
+        .map(({ _id }) => _id)
+        .toArray();
+      expect(remaining.length).toBe(3);
+      expect(remaining).toEqual(["id2", "id4", "id5"]);
+    });
+
+    test("handles large number of ids by chunking", async () => {
+      // no need to use real embeddings for this test
+      // since we're only testing the delete functionality
+      // and not the embedding process.
+      const embeddings = {
+        embedDocuments: vi
+          .fn<() => Promise<number[][]>>()
+          .mockResolvedValue(Array(100).fill(Array(1536).fill(0.1))),
+        embedQuery: vi
+          .fn<() => Promise<number[][]>>()
+          .mockResolvedValue(Array(1536).fill(0.1)),
+      };
+
+      let deletes = 0;
+      client.on("commandStarted", (event) => {
+        if (event.commandName === "delete") {
+          deletes += 1;
+        }
+      });
+
+      // @ts-expect-error: Mock embeddings
+      const vectorStore = new MongoDBAtlasVectorSearch(embeddings, {
+        collection,
+      });
+      const ids = Array.from({ length: 100 }, (_, i) => `id${i}`);
+      await vectorStore.addDocuments(
+        ids.map((id) => new Document({ pageContent: id.toString() })),
+        { ids }
+      );
+
+      await vectorStore.delete({ ids });
+
+      expect(deletes).toEqual(100 / 50); // 100 docs / chunk size
+    });
+
+    test("ignores non-existent ids", async () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({ collection });
+
+      await vectorStore.delete({
+        ids: ["nonexistent1", "nonexistent2", "id1"],
+      });
+
+      const remaining = await collection
+        .find({})
+        .map(({ _id }) => _id)
+        .toArray();
+      expect(remaining).toEqual(["id2", "id3", "id4", "id5"]);
+    });
+  });
+
+  describe("Static Methods", () => {
+    describe("fromTexts", () => {
+      const texts = ["text1", "text2", "text3"];
+
+      test("populates a vector store from strings with a metadata object", async () => {
+        const metadata = { source: "test" };
+        const vectorStore = await MongoDBAtlasVectorSearch.fromTexts(
+          texts,
+          metadata,
+          { collection }
+        );
+
+        expect(vectorStore).toBeInstanceOf(MongoDBAtlasVectorSearch);
+
+        const results = await collection
+          .find({}, { projection: { text: 1, source: 1, _id: 0 } })
+          .toArray();
+        expect(results).toEqual([
+          { text: "text1", source: "test" },
+          { text: "text2", source: "test" },
+          { text: "text3", source: "test" },
+        ]);
+      });
+
+      test("populates a vector store from strings with an array of metadata objects", async () => {
+        const vectorStore = await MongoDBAtlasVectorSearch.fromTexts(
+          texts,
+          [{ source: "test1" }, { source: "test2" }, { source: "test3" }],
+          { collection }
+        );
+
+        expect(vectorStore).toBeInstanceOf(MongoDBAtlasVectorSearch);
+
+        const results = await collection
+          .find({}, { projection: { text: 1, source: 1, _id: 0 } })
+          .toArray();
+        expect(results).toEqual([
+          { text: "text1", source: "test1" },
+          { text: "text2", source: "test2" },
+          { text: "text3", source: "test3" },
+        ]);
+      });
+    });
+
+    describe("fromDocuments", () => {
+      test("returns an instance of MongoDBAtlasVectorSearch", async () => {
+        const documents = [
+          new Document({
+            pageContent: "doc1",
+            metadata: { source: "source1" },
+          }),
+        ];
+        const store = await MongoDBAtlasVectorSearch.fromDocuments(documents, {
+          collection,
+        });
+        expect(store).toBeInstanceOf(MongoDBAtlasVectorSearch);
+      });
+
+      test("embeds and inserts the provided documents", async () => {
+        const documents = [
+          new Document({
+            pageContent: "doc1",
+            metadata: { source: "source1" },
+          }),
+          new Document({
+            pageContent: "doc2",
+            metadata: { source: "source2" },
+          }),
+        ];
+
+        await MongoDBAtlasVectorSearch.fromDocuments(documents, {
+          collection,
+        });
+
+        const results = await collection
+          .find({}, { projection: { _id: 0, text: 1 } })
+          .toArray();
+        expect(results.length).toBe(2);
+
+        expect(results).toEqual([{ text: "doc1" }, { text: "doc2" }]);
+      });
+
+      test("uses custom ids if provided", async () => {
+        const documents = [
+          new Document({
+            pageContent: "doc1",
+            metadata: { source: "source1" },
+          }),
+          new Document({
+            pageContent: "doc2",
+            metadata: { source: "source2" },
+          }),
+        ];
+
+        await MongoDBAtlasVectorSearch.fromDocuments(documents, {
+          collection,
+          ids: ["custom1", "custom2"],
+        });
+
+        const results = await collection
+          .find({}, { projection: { _id: 1, text: 1 } })
+          .toArray();
+        expect(results.length).toBe(2);
+
+        expect(results).toEqual([
+          { text: "doc1", _id: "custom1" },
+          { text: "doc2", _id: "custom2" },
+        ]);
+      });
+
+      test("upserts documents if they already exist", async () => {
+        await MongoDBAtlasVectorSearch.fromDocuments(
+          [
+            new Document({ pageContent: "doc1" }),
+            new Document({ pageContent: "doc2" }),
+          ],
+          { collection, ids: ["id1", "id2"] }
+        );
+
+        await MongoDBAtlasVectorSearch.fromDocuments(
+          [
+            new Document({ pageContent: "updated 1" }),
+            new Document({ pageContent: "updated 2" }),
+          ],
+          { collection, ids: ["id1", "id2"] }
+        );
+
+        expect(await collection.countDocuments({})).toBe(2);
+
+        const results = await collection
+          .find({}, { projection: { text: 1, _id: 0 } })
+          .toArray();
+
+        expect(results).toEqual([{ text: "updated 1" }, { text: "updated 2" }]);
+      });
+    });
+  });
+});
+
+describe("Auto Embedding Tests without data", () => {
+  let client: MongoClient;
+  let collection: Collection;
+  let vectorStore: MongoDBAtlasVectorSearch;
+
+  beforeAll(async () => {
+    client = new MongoClient(uri(), { monitorCommands: true });
+    await client.connect();
+
+    const namespace = "langchain_test_db.langchain_auto_embed_test";
+    const [dbName, collectionName] = namespace.split(".");
+    const db = client.db(dbName);
+
+    // Drop and recreate collection to ensure clean state and no lingering indexes
+    try {
+      await db.dropCollection(collectionName);
+    } catch {
+      // Collection may not exist, which is fine
+    }
+
+    collection = await db.createCollection(collectionName);
+    vectorStore = new MongoDBAtlasVectorSearch({
+      collection,
+    });
+  });
+
+  test("addVectors method throws error when auto embedding is enabled", async () => {
+    await expect(vectorStore.addVectors([], [], {})).rejects.toThrow(
+      "Cannot add vectors directly when using auto-embedding mode."
+    );
+  });
+
+  test("similaritySearchVectorWithScore method throws error when auto embedding is enabled", async () => {
+    const vectorStore = new MongoDBAtlasVectorSearch({
+      collection,
+    });
+    await expect(
+      vectorStore.similaritySearchVectorWithScore([], 2)
+    ).rejects.toThrow(
+      "Cannot perform similarity search with vectors directly when using auto-embedding mode."
+    );
+  });
+});

--- a/libs/providers/langchain-mongodb/src/vectorstores.ts
+++ b/libs/providers/langchain-mongodb/src/vectorstores.ts
@@ -11,7 +11,6 @@ import {
   AsyncCaller,
   AsyncCallerParams,
 } from "@langchain/core/utils/async_caller";
-import { Callbacks } from "@langchain/core/callbacks/manager";
 
 /**
  * Stub embeddings for auto-embedding mode.
@@ -298,15 +297,13 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
    * @param query - Text query for finding similar documents.
    * @param k - Number of similar results to return. Defaults to 4.
    * @param filter - Optional filter based on `FilterType`.
-   * @param _callbacks - Optional callbacks for monitoring search progress
    * @returns A promise resolving to an array of tuples, each containing a
    *          document and its similarity score.
    */
   async similaritySearchWithScore(
     query: string,
     k = 4,
-    filter: this["FilterType"] | undefined = undefined,
-    _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
+    filter: this["FilterType"] | undefined = undefined
   ): Promise<[Document, number][]> {
     if (this.useAutoEmbedding) {
       // Auto-embed mode: use text-based $vectorSearch query
@@ -325,14 +322,12 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
    * @param query - Text query for finding similar documents.
    * @param k - Number of similar results to return. Defaults to 4.
    * @param filter - Optional filter based on `FilterType`.
-   * @param _callbacks - Optional callbacks for monitoring search progress
    * @returns A promise resolving to an array of `DocumentInterface` instances representing similar documents.
    */
   async similaritySearch(
     query: string,
     k = 4,
-    filter: this["FilterType"] | undefined = undefined,
-    _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
+    filter: this["FilterType"] | undefined = undefined
   ): Promise<DocumentInterface[]> {
     const resultsWithScore = await this.similaritySearchWithScore(query, k ?? 4, filter);
     return resultsWithScore.map(([doc]) => doc);

--- a/libs/providers/langchain-mongodb/src/vectorstores.ts
+++ b/libs/providers/langchain-mongodb/src/vectorstores.ts
@@ -93,9 +93,7 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
    * (embeddings, args) - embeddings are provided by the user
    * (args) - the server handles embeddings
    */
-  constructor(
-    args: MongoDBAtlasVectorSearchLibArgs
-  );
+  constructor(args: MongoDBAtlasVectorSearchLibArgs);
   constructor(
     embeddings: EmbeddingsInterface,
     args: MongoDBAtlasVectorSearchLibArgs
@@ -146,7 +144,9 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     options?: { ids?: string[] }
   ) {
     if (this.useAutoEmbedding) {
-      throw new Error("Cannot add vectors directly when using auto-embedding mode.");
+      throw new Error(
+        "Cannot add vectors directly when using auto-embedding mode."
+      );
     }
     const docs = vectors.map((embedding, idx) => ({
       [this.textKey]: documents[idx].pageContent,
@@ -239,24 +239,26 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     filter?: MongoDBAtlasFilter
   ): Promise<[Document, number][]> {
     if (this.useAutoEmbedding) {
-      throw new Error("Cannot perform similarity search with vectors directly when using auto-embedding mode.");
+      throw new Error(
+        "Cannot perform similarity search with vectors directly when using auto-embedding mode."
+      );
     }
 
     const postFilterPipeline = filter?.postFilterPipeline ?? [];
     const preFilter: MongoDBDocument | undefined =
       filter?.preFilter ||
-        filter?.postFilterPipeline ||
-        filter?.includeEmbeddings
+      filter?.postFilterPipeline ||
+      filter?.includeEmbeddings
         ? filter.preFilter
         : filter;
     const removeEmbeddingsPipeline = !filter?.includeEmbeddings
       ? [
-        {
-          $project: {
-            [this.embeddingKey]: 0,
+          {
+            $project: {
+              [this.embeddingKey]: 0,
+            },
           },
-        },
-      ]
+        ]
       : [];
 
     const pipeline: MongoDBDocument[] = [
@@ -329,7 +331,11 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     k = 4,
     filter: this["FilterType"] | undefined = undefined
   ): Promise<DocumentInterface[]> {
-    const resultsWithScore = await this.similaritySearchWithScore(query, k ?? 4, filter);
+    const resultsWithScore = await this.similaritySearchWithScore(
+      query,
+      k ?? 4,
+      filter
+    );
     return resultsWithScore.map(([doc]) => doc);
   }
 
@@ -341,18 +347,18 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     const postFilterPipeline = filter?.postFilterPipeline ?? [];
     const preFilter: MongoDBDocument | undefined =
       filter?.preFilter ||
-        filter?.postFilterPipeline ||
-        filter?.includeEmbeddings
+      filter?.postFilterPipeline ||
+      filter?.includeEmbeddings
         ? filter.preFilter
         : filter;
     const removeEmbeddingsPipeline = !filter?.includeEmbeddings
       ? [
-        {
-          $project: {
-            [this.embeddingKey]: 0,
+          {
+            $project: {
+              [this.embeddingKey]: 0,
+            },
           },
-        },
-      ]
+        ]
       : [];
 
     const pipeline: MongoDBDocument[] = [
@@ -406,7 +412,9 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>
   ): Promise<Document[]> {
     if (this.useAutoEmbedding) {
-      throw new Error("Cannot perform MMR search with vectors directly when using auto-embedding mode.");
+      throw new Error(
+        "Cannot perform MMR search with vectors directly when using auto-embedding mode."
+      );
     }
 
     const { k, fetchK = 20, lambda = 0.5, filter } = options;
@@ -493,7 +501,9 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
   static async fromTexts(
     texts: string[],
     metadatas: object[] | object,
-    embeddingsOrDbConfig: EmbeddingsInterface | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
+    embeddingsOrDbConfig:
+      | EmbeddingsInterface
+      | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
     dbConfig?: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
   ): Promise<MongoDBAtlasVectorSearch> {
     const docs: Document[] = [];
@@ -509,10 +519,19 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     // Detect which calling convention is being used
     if (dbConfig !== undefined) {
       // `fromTexts(texts, metadatas, embeddings, dbConfig)` embeddings provided by the user
-      return this.fromDocuments(docs, embeddingsOrDbConfig as EmbeddingsInterface, dbConfig);
+      return this.fromDocuments(
+        docs,
+        embeddingsOrDbConfig as EmbeddingsInterface,
+        dbConfig
+      );
     } else {
       // `fromTexts(texts, metadatas, dbConfig)` the server handles embeddings
-      return this.fromDocuments(docs, embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & { ids?: string[] });
+      return this.fromDocuments(
+        docs,
+        embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & {
+          ids?: string[];
+        }
+      );
     }
   }
 
@@ -541,7 +560,9 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
   ): Promise<MongoDBAtlasVectorSearch>;
   static async fromDocuments(
     docs: Document[],
-    embeddingsOrDbConfig: EmbeddingsInterface | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
+    embeddingsOrDbConfig:
+      | EmbeddingsInterface
+      | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
     dbConfig?: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
   ): Promise<MongoDBAtlasVectorSearch> {
     let embeddings: EmbeddingsInterface;
@@ -556,7 +577,10 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       instance = new this(embeddings, finalDbConfig);
     } else {
       // `fromDocuments(docs, dbConfig)` the server handles embeddings
-      finalDbConfig = embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & { ids?: string[] };
+      finalDbConfig =
+        embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & {
+          ids?: string[];
+        };
       instance = new this(finalDbConfig);
     }
 

--- a/libs/providers/langchain-mongodb/src/vectorstores.ts
+++ b/libs/providers/langchain-mongodb/src/vectorstores.ts
@@ -5,12 +5,31 @@ import {
 } from "@langchain/core/vectorstores";
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { chunkArray } from "@langchain/core/utils/chunk_array";
-import { Document } from "@langchain/core/documents";
+import { Document, DocumentInterface } from "@langchain/core/documents";
 import { maximalMarginalRelevance } from "@langchain/core/utils/math";
 import {
   AsyncCaller,
   AsyncCallerParams,
 } from "@langchain/core/utils/async_caller";
+import { Callbacks } from "@langchain/core/callbacks/manager";
+
+/**
+ * Stub embeddings for auto-embedding mode.
+ * Throws if any embedding method is called, since the server handles embeddings.
+ */
+class AutoEmbeddingStub implements EmbeddingsInterface {
+  async embedDocuments(_texts: string[]): Promise<number[][]> {
+    throw new Error(
+      "Embeddings not available when using auto-embedding mode. The MongoDB Atlas server handles all embedding generation."
+    );
+  }
+
+  async embedQuery(_text: string): Promise<number[]> {
+    throw new Error(
+      "Embeddings not available when using auto-embedding mode. The MongoDB Atlas server handles all embedding generation."
+    );
+  }
+}
 
 /**
  * Type that defines the arguments required to initialize the
@@ -64,21 +83,52 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
 
   private caller: AsyncCaller;
 
+  private readonly useAutoEmbedding: boolean;
+
   _vectorstoreType(): string {
     return "mongodb_atlas";
   }
 
+  /**
+   * Constructor with function overloads for backward compatibility.
+   * (embeddings, args) - embeddings are provided by the user
+   * (args) - the server handles embeddings
+   */
+  constructor(
+    args: MongoDBAtlasVectorSearchLibArgs
+  );
   constructor(
     embeddings: EmbeddingsInterface,
     args: MongoDBAtlasVectorSearchLibArgs
+  );
+  constructor(
+    embeddingsOrDbConfig: EmbeddingsInterface | MongoDBAtlasVectorSearchLibArgs,
+    args?: MongoDBAtlasVectorSearchLibArgs
   ) {
-    super(embeddings, args);
-    this.collection = args.collection;
-    this.indexName = args.indexName ?? "default";
-    this.textKey = args.textKey ?? "text";
-    this.embeddingKey = args.embeddingKey ?? "embedding";
-    this.primaryKey = args.primaryKey ?? "_id";
-    this.caller = new AsyncCaller(args);
+    let embeddings: EmbeddingsInterface;
+    let libArgs: MongoDBAtlasVectorSearchLibArgs;
+    let useAutoEmbedding = false;
+
+    if (args !== undefined) {
+      // (embeddings, args) - embeddings are provided by the user
+      embeddings = embeddingsOrDbConfig as EmbeddingsInterface;
+      libArgs = args;
+    } else {
+      // (args) - the server handles embeddings
+      libArgs = embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs;
+      // Set embeddings to a stub that throws if embedding methods are called, since the server handles embeddings in this mode
+      embeddings = new AutoEmbeddingStub();
+      useAutoEmbedding = true;
+    }
+
+    super(embeddings, libArgs);
+    this.collection = libArgs.collection;
+    this.indexName = libArgs.indexName ?? "default";
+    this.textKey = libArgs.textKey ?? "text";
+    this.embeddingKey = libArgs.embeddingKey ?? "embedding";
+    this.primaryKey = libArgs.primaryKey ?? "_id";
+    this.caller = new AsyncCaller(libArgs);
+    this.useAutoEmbedding = useAutoEmbedding;
     this.collection.db.client.appendMetadata({
       name: "langchainjs_vector",
     });
@@ -96,6 +146,9 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     documents: Document[],
     options?: { ids?: string[] }
   ) {
+    if (this.useAutoEmbedding) {
+      throw new Error("Cannot add vectors directly when using auto-embedding mode.");
+    }
     const docs = vectors.map((embedding, idx) => ({
       [this.textKey]: documents[idx].pageContent,
       [this.embeddingKey]: embedding,
@@ -124,19 +177,52 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
   }
 
   /**
-   * Method to add documents to the MongoDB collection. It first converts
-   * the documents to vectors using the embeddings and then calls the
-   * addVectors method.
+   * Method to add documents to the MongoDB collection.
+   *
+   * In manual embedding mode: converts documents to vectors using embeddings, then inserts.
+   * In auto-embed mode: inserts documents with text only; MongoDB server handles embedding.
+   *
    * @param documents Documents to be added.
    * @returns Promise that resolves when the documents have been added.
    */
   async addDocuments(documents: Document[], options?: { ids?: string[] }) {
-    const texts = documents.map(({ pageContent }) => pageContent);
-    return this.addVectors(
-      await this.embeddings.embedDocuments(texts),
-      documents,
-      options
-    );
+    if (this.useAutoEmbedding) {
+      // Auto-embed mode: insert documents WITHOUT vectors
+      // MongoDB auto-embedding index will read textKey and generate embeddings
+      const docs = documents.map((document) => ({
+        [this.textKey]: document.pageContent,
+        ...document.metadata,
+      }));
+
+      if (options?.ids === undefined) {
+        await this.collection.insertMany(docs);
+      } else {
+        if (options.ids.length !== documents.length) {
+          throw new Error(
+            `If provided, "options.ids" must be an array with the same length as "documents".`
+          );
+        }
+        const { ids } = options;
+        for (let i = 0; i < docs.length; i += 1) {
+          await this.caller.call(async () => {
+            await this.collection.updateOne(
+              { [this.primaryKey]: ids[i] },
+              { $set: { [this.primaryKey]: ids[i], ...docs[i] } },
+              { upsert: true }
+            );
+          });
+        }
+      }
+      return options?.ids ?? docs.map((doc) => doc[this.primaryKey]);
+    } else {
+      // Manual embedding mode: embed documents client-side then insert with vectors
+      const texts = documents.map(({ pageContent }) => pageContent);
+      return this.addVectors(
+        await this.embeddings.embedDocuments(texts),
+        documents,
+        options
+      );
+    }
   }
 
   /**
@@ -153,21 +239,25 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     k: number,
     filter?: MongoDBAtlasFilter
   ): Promise<[Document, number][]> {
+    if (this.useAutoEmbedding) {
+      throw new Error("Cannot perform similarity search with vectors directly when using auto-embedding mode.");
+    }
+
     const postFilterPipeline = filter?.postFilterPipeline ?? [];
     const preFilter: MongoDBDocument | undefined =
       filter?.preFilter ||
-      filter?.postFilterPipeline ||
-      filter?.includeEmbeddings
+        filter?.postFilterPipeline ||
+        filter?.includeEmbeddings
         ? filter.preFilter
         : filter;
     const removeEmbeddingsPipeline = !filter?.includeEmbeddings
       ? [
-          {
-            $project: {
-              [this.embeddingKey]: 0,
-            },
+        {
+          $project: {
+            [this.embeddingKey]: 0,
           },
-        ]
+        },
+      ]
       : [];
 
     const pipeline: MongoDBDocument[] = [
@@ -201,17 +291,118 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
   }
 
   /**
+   * Performs similarity search using text-based queries (auto-embedding mode) or vector queries (manual embedding mode).
+   * In auto-embed mode, the text query is sent to MongoDB which handles embedding server-side.
+   * In manual embedding mode, the text is embedded client-side and passed as a vector.
+   *
+   * @param query - Text query for finding similar documents.
+   * @param k - Number of similar results to return. Defaults to 4.
+   * @param filter - Optional filter based on `FilterType`.
+   * @param _callbacks - Optional callbacks for monitoring search progress
+   * @returns A promise resolving to an array of tuples, each containing a
+   *          document and its similarity score.
+   */
+  async similaritySearchWithScore(
+    query: string,
+    k = 4,
+    filter: this["FilterType"] | undefined = undefined,
+    _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
+  ): Promise<[Document, number][]> {
+    if (this.useAutoEmbedding) {
+      // Auto-embed mode: use text-based $vectorSearch query
+      return this.textBasedSearchWithScore(query, k, filter);
+    }
+
+    // Manual embedding mode: embed query client-side
+    const queryEmbedding = await this.embeddings.embedQuery(query);
+    return this.similaritySearchVectorWithScore(queryEmbedding, k, filter);
+  }
+
+  /**
+   * Searches for documents similar to a text query by embedding the query and
+   * performing a similarity search on the resulting vector.
+   *
+   * @param query - Text query for finding similar documents.
+   * @param k - Number of similar results to return. Defaults to 4.
+   * @param filter - Optional filter based on `FilterType`.
+   * @param _callbacks - Optional callbacks for monitoring search progress
+   * @returns A promise resolving to an array of `DocumentInterface` instances representing similar documents.
+   */
+  async similaritySearch(
+    query: string,
+    k = 4,
+    filter: this["FilterType"] | undefined = undefined,
+    _callbacks: Callbacks | undefined = undefined // implement passing to embedQuery later
+  ): Promise<DocumentInterface[]> {
+    const resultsWithScore = await this.similaritySearchWithScore(query, k ?? 4, filter);
+    return resultsWithScore.map(([doc]) => doc);
+  }
+
+  private async textBasedSearchWithScore(
+    query: string,
+    k: number,
+    filter?: MongoDBAtlasFilter
+  ): Promise<[Document, number][]> {
+    const postFilterPipeline = filter?.postFilterPipeline ?? [];
+    const preFilter: MongoDBDocument | undefined =
+      filter?.preFilter ||
+        filter?.postFilterPipeline ||
+        filter?.includeEmbeddings
+        ? filter.preFilter
+        : filter;
+    const removeEmbeddingsPipeline = !filter?.includeEmbeddings
+      ? [
+        {
+          $project: {
+            [this.embeddingKey]: 0,
+          },
+        },
+      ]
+      : [];
+
+    const pipeline: MongoDBDocument[] = [
+      {
+        $vectorSearch: {
+          // Use text query with model for server-side embedding
+          query: { text: query },
+          index: this.indexName,
+          path: this.textKey, // Search on the text field, not the embedding field
+          limit: k,
+          numCandidates: 10 * k,
+          ...(preFilter && { filter: preFilter }),
+        },
+      },
+      {
+        $set: {
+          score: { $meta: "vectorSearchScore" },
+        },
+      },
+      ...removeEmbeddingsPipeline,
+      ...postFilterPipeline,
+    ];
+
+    const results = this.collection
+      .aggregate(pipeline)
+      .map<[Document, number]>((result) => {
+        const { score, [this.textKey]: text, ...metadata } = result;
+        return [new Document({ pageContent: text, metadata }), score];
+      });
+
+    return results.toArray();
+  }
+
+  /**
    * Return documents selected using the maximal marginal relevance.
    * Maximal marginal relevance optimizes for similarity to the query AND diversity
    * among selected documents.
-   *
+   * Not supported in auto-embedding mode.
    * @param {string} query - Text to look up documents similar to.
    * @param {number} options.k - Number of documents to return.
-   * @param {number} options.fetchK=20- Number of documents to fetch before passing to the MMR algorithm.
+   * @param {number} options.fetchK=20 - Number of documents to fetch before passing to the MMR algorithm (manual embedding mode only).
    * @param {number} options.lambda=0.5 - Number between 0 and 1 that determines the degree of diversity among the results,
    *                 where 0 corresponds to maximum diversity and 1 to minimum diversity.
    * @param {MongoDBAtlasFilter} options.filter - Optional Atlas Search operator to pre-filter on document fields
-   *                                      or post-filter following the knnBeta search.
+   *                                      or post-filter following the search.
    *
    * @returns {Promise<Document[]>} - List of documents selected by maximal marginal relevance.
    */
@@ -219,6 +410,10 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     query: string,
     options: MaxMarginalRelevanceSearchOptions<this["FilterType"]>
   ): Promise<Document[]> {
+    if (this.useAutoEmbedding) {
+      throw new Error("Cannot perform MMR search with vectors directly when using auto-embedding mode.");
+    }
+
     const { k, fetchK = 20, lambda = 0.5, filter } = options;
 
     const queryEmbedding = await this.embeddings.embedQuery(query);
@@ -278,6 +473,11 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
    * Static method to create an instance of MongoDBAtlasVectorSearch from a
    * list of texts. It first converts the texts to vectors and then adds
    * them to the MongoDB collection.
+   *
+   * Supports two calling conventions for backward compatibility:
+   * - `fromTexts(texts, metadatas, embeddings, dbConfig)` embeddings are provided by the user
+   * - `fromTexts(texts, metadatas, dbConfig)` the server handles embeddings
+   *
    * @param texts List of texts to be converted to vectors.
    * @param metadatas Metadata for the texts.
    * @param embeddings Embeddings to be used for conversion.
@@ -289,6 +489,17 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     metadatas: object[] | object,
     embeddings: EmbeddingsInterface,
     dbConfig: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
+  ): Promise<MongoDBAtlasVectorSearch>;
+  static async fromTexts(
+    texts: string[],
+    metadatas: object[] | object,
+    dbConfig: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
+  ): Promise<MongoDBAtlasVectorSearch>;
+  static async fromTexts(
+    texts: string[],
+    metadatas: object[] | object,
+    embeddingsOrDbConfig: EmbeddingsInterface | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
+    dbConfig?: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
   ): Promise<MongoDBAtlasVectorSearch> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -299,15 +510,28 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       });
       docs.push(newDoc);
     }
-    return this.fromDocuments(docs, embeddings, dbConfig);
+
+    // Detect which calling convention is being used
+    if (dbConfig !== undefined) {
+      // `fromTexts(texts, metadatas, embeddings, dbConfig)` embeddings provided by the user
+      return this.fromDocuments(docs, embeddingsOrDbConfig as EmbeddingsInterface, dbConfig);
+    } else {
+      // `fromTexts(texts, metadatas, dbConfig)` the server handles embeddings
+      return this.fromDocuments(docs, embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & { ids?: string[] });
+    }
   }
 
   /**
    * Static method to create an instance of MongoDBAtlasVectorSearch from a
    * list of documents. It first converts the documents to vectors and then
    * adds them to the MongoDB collection.
+   *
+   * Supports three calling conventions for backward compatibility:
+   * - `fromDocuments(docs, embeddings, dbConfig)` embeddings are provided by the user
+   * - `fromDocuments(docs, dbConfig)` the server handles embeddings
+   *
    * @param docs List of documents to be converted to vectors.
-   * @param embeddings Embeddings to be used for conversion.
+   * @param embeddingsOrDbConfig Embeddings to be used for conversion or the database configuration.
    * @param dbConfig Database configuration for MongoDB Atlas.
    * @returns Promise that resolves to a new instance of MongoDBAtlasVectorSearch.
    */
@@ -315,9 +539,33 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     docs: Document[],
     embeddings: EmbeddingsInterface,
     dbConfig: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
+  ): Promise<MongoDBAtlasVectorSearch>;
+  static async fromDocuments(
+    docs: Document[],
+    dbConfig: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
+  ): Promise<MongoDBAtlasVectorSearch>;
+  static async fromDocuments(
+    docs: Document[],
+    embeddingsOrDbConfig: EmbeddingsInterface | (MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }),
+    dbConfig?: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] }
   ): Promise<MongoDBAtlasVectorSearch> {
-    const instance = new this(embeddings, dbConfig);
-    await instance.addDocuments(docs, { ids: dbConfig.ids });
+    let embeddings: EmbeddingsInterface;
+    let finalDbConfig: MongoDBAtlasVectorSearchLibArgs & { ids?: string[] };
+
+    let instance;
+    // Detect which calling convention is being used
+    if (dbConfig !== undefined) {
+      // `fromDocuments(docs, embeddings, dbConfig)` embeddings provided by the user
+      embeddings = embeddingsOrDbConfig as EmbeddingsInterface;
+      finalDbConfig = dbConfig;
+      instance = new this(embeddings, finalDbConfig);
+    } else {
+      // `fromDocuments(docs, dbConfig)` the server handles embeddings
+      finalDbConfig = embeddingsOrDbConfig as MongoDBAtlasVectorSearchLibArgs & { ids?: string[] };
+      instance = new this(finalDbConfig);
+    }
+
+    await instance.addDocuments(docs, { ids: finalDbConfig.ids });
     return instance;
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This PR adds MongoDB Automated Embedding support.

Issue: https://jira.mongodb.org/browse/NODE-7503
[This MongoDB Automated Embedding tutorial](https://www.mongodb.com/docs/atlas/atlas-vector-search/crud-embeddings/create-embeddings-automatic/?interface=driver&language=nodejs) explains how auto embedding works and how it can be used by the MongoDB Node Driver. This same approach was used to allow `MongoDBAtlasVectorSearch` to utilize Automated Embedding. Automated Embedding is supported in MongoDB 8.2 and higher.