### PR TITLE
feat(baseten): Add @langchain/baseten provider package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,6 +67,12 @@ pkg:@langchain/aws:
           - libs/providers/langchain-aws/**
           - libs/providers/langchain-aws/**/*
 
+pkg:@langchain/baseten:
+  - changed-files:
+      - any-glob-to-any-file:
+          - libs/providers/langchain-baseten/**
+          - libs/providers/langchain-baseten/**/*
+
 pkg:@langchain/cloudflare:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -54,6 +54,7 @@ jobs:
             docs
             anthropic
             aws
+            baseten
             cloudflare
             cohere
             deepseek

--- a/.github/workflows/unit-tests-integrations.yml
+++ b/.github/workflows/unit-tests-integrations.yml
@@ -45,7 +45,7 @@ jobs:
     needs: get-changed-files
     runs-on: ubuntu-latest
     env:
-      PACKAGES: "anthropic,aws,cloudflare,core,deepseek,fireworks,google-cloud-sql-pg,google-common,google-gauth,google-genai,google-vertexai,google-vertexai-web,google-webauth,groq,ibm,mcp-adapters,mistralai,mongodb,neo4j,ollama,openai,perplexity,redis,standard-tests,textsplitters,together-ai,xai"
+      PACKAGES: "anthropic,aws,baseten,cloudflare,core,deepseek,fireworks,google-cloud-sql-pg,google-common,google-gauth,google-genai,google-vertexai,google-vertexai-web,google-webauth,groq,ibm,mcp-adapters,mistralai,mongodb,neo4j,ollama,openai,perplexity,redis,standard-tests,textsplitters,together-ai,xai"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       matrix_length: ${{ steps.set-matrix.outputs.matrix_length }}

--- a/libs/providers/langchain-baseten/CHANGELOG.md
+++ b/libs/providers/langchain-baseten/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @langchain/baseten
+
+## 0.0.1
+
+Initial release of the standalone Baseten provider package for LangChain.js.

--- a/libs/providers/langchain-baseten/CHANGELOG.md
+++ b/libs/providers/langchain-baseten/CHANGELOG.md
@@ -1,5 +1,5 @@
 # @langchain/baseten
 
-## 0.0.1
+## 0.1.0
 
 Initial release of the standalone Baseten provider package for LangChain.js.

--- a/libs/providers/langchain-baseten/LICENSE
+++ b/libs/providers/langchain-baseten/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) LangChain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/providers/langchain-baseten/README.md
+++ b/libs/providers/langchain-baseten/README.md
@@ -1,0 +1,77 @@
+# @langchain/baseten
+
+This package contains the LangChain.js integration for Baseten.
+
+## Installation
+
+```bash npm2yarn
+npm install @langchain/baseten @langchain/core
+```
+
+This package depends on [`@langchain/core`](https://npmjs.com/package/@langchain/core/).
+If you use it together with other LangChain packages, make sure they all resolve
+to the same `@langchain/core` version.
+
+## Chat Models
+
+Use `ChatBaseten` for chat-completions style models exposed by Baseten's
+OpenAI-compatible APIs.
+
+```bash
+export BASETEN_API_KEY="your-api-key"
+```
+
+```typescript
+import { ChatBaseten } from "@langchain/baseten";
+
+const model = new ChatBaseten({
+  model: "deepseek-ai/DeepSeek-V3.1",
+  temperature: 0,
+});
+
+const response = await model.invoke("Tell me a short joke.");
+console.log(response.content);
+```
+
+For dedicated/self-deployed Baseten models, pass `modelUrl`:
+
+```typescript
+import { ChatBaseten } from "@langchain/baseten";
+
+const model = new ChatBaseten({
+  modelUrl:
+    "https://model-abc123.api.baseten.co/environments/production/predict",
+});
+```
+
+## Development
+
+Install dependencies from the monorepo root:
+
+```bash
+pnpm install
+```
+
+Build this package:
+
+```bash
+pnpm --filter @langchain/baseten build
+```
+
+Run unit tests:
+
+```bash
+pnpm --filter @langchain/baseten test
+```
+
+Run integration tests:
+
+```bash
+pnpm --filter @langchain/baseten test:int
+```
+
+Run standard tests:
+
+```bash
+pnpm --filter @langchain/baseten test:standard
+```

--- a/libs/providers/langchain-baseten/package.json
+++ b/libs/providers/langchain-baseten/package.json
@@ -39,7 +39,8 @@
     "dotenv": "^17.4.0",
     "dpdm": "^3.14.0",
     "typescript": "~5.8.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "zod": "^3.25.76 || ^4"
   },
   "publishConfig": {
     "access": "public"

--- a/libs/providers/langchain-baseten/package.json
+++ b/libs/providers/langchain-baseten/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@langchain/baseten",
+  "version": "0.0.1",
+  "description": "Baseten integration for LangChain.js",
+  "type": "module",
+  "author": "LangChain",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:langchain-ai/langchainjs.git"
+  },
+  "homepage": "https://github.com/langchain-ai/langchainjs/tree/main/libs/providers/langchain-baseten",
+  "scripts": {
+    "build": "turbo build:compile --filter @langchain/baseten --output-logs new-only",
+    "build:compile": "tsdown",
+    "clean": "rm -rf .turbo dist/",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:int": "vitest run --mode int",
+    "test:standard:unit": "vitest run --mode standard-unit",
+    "test:standard:int": "vitest run --mode standard-int",
+    "test:standard": "pnpm test:standard:unit && pnpm test:standard:int"
+  },
+  "dependencies": {
+    "@langchain/openai": "workspace:*"
+  },
+  "peerDependencies": {
+    "@langchain/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@langchain/core": "workspace:^",
+    "@langchain/standard-tests": "workspace:*",
+    "@langchain/tsconfig": "workspace:*",
+    "@tsconfig/recommended": "^1.0.3",
+    "@vitest/coverage-v8": "^3.2.4",
+    "dotenv": "^17.4.0",
+    "dpdm": "^3.14.0",
+    "typescript": "~5.8.3",
+    "vitest": "^4.1.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "input": "./src/index.ts",
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "module": "./dist/index.js"
+}

--- a/libs/providers/langchain-baseten/src/chat_models.ts
+++ b/libs/providers/langchain-baseten/src/chat_models.ts
@@ -12,12 +12,15 @@ import { ChatOpenAI } from "@langchain/openai";
 import type { LangSmithParams } from "@langchain/core/language_models/chat_models";
 import type { BaseMessage } from "@langchain/core/messages";
 import { AIMessageChunk } from "@langchain/core/messages";
-import type { ToolCallChunk } from "@langchain/core/messages/tool";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import { DEFAULT_BASE_URL, DEFAULT_API_KEY_ENV_VAR } from "./const.js";
 import { normalizeModelUrl } from "./converters/params.js";
+import {
+  normalizeToolCallChunks,
+  chunkHasContent,
+} from "./converters/chat_models.js";
 import type { BasetenChatInput } from "./types.js";
 
 function resolveApiKey(fields?: BasetenChatInput): string {
@@ -33,56 +36,6 @@ function resolveApiKey(fields?: BasetenChatInput): string {
       `option or set the ${DEFAULT_API_KEY_ENV_VAR} environment variable.\n\n` +
       `  Get your API key at https://app.baseten.co/settings/api-keys`
   );
-}
-
-/**
- * Fix TensorRT-LLM tool-call streaming quirks:
- * - Fold same-index deltas within a single SSE event into one entry
- * - Clear `id` on continuation deltas (no `name`) so `concat()` merges by index
- *
- * See: Python `langchain-baseten._normalize_tool_call_chunks`
- */
-export function normalizeToolCallChunks(
-  chunks: ToolCallChunk[]
-): ToolCallChunk[] {
-  if (chunks.length <= 1 && (!chunks[0] || chunks[0].name)) return chunks;
-
-  const byIndex = new Map<number, ToolCallChunk>();
-
-  for (const tc of chunks) {
-    if (tc.index == null) continue;
-    const existing = byIndex.get(tc.index);
-    if (!existing) {
-      byIndex.set(tc.index, { ...tc });
-    } else {
-      byIndex.set(tc.index, {
-        ...existing,
-        name: existing.name ?? tc.name,
-        args: (existing.args ?? "") + (tc.args ?? ""),
-        id: existing.id ?? tc.id,
-      });
-    }
-  }
-
-  const result: ToolCallChunk[] = [];
-  for (const tc of byIndex.values()) {
-    if (!tc.name && tc.id != null) {
-      result.push({ ...tc, id: undefined });
-    } else {
-      result.push(tc);
-    }
-  }
-
-  return result;
-}
-
-function chunkHasContent(message: AIMessageChunk): boolean {
-  if (typeof message.content === "string" && message.content.length > 0)
-    return true;
-  if (Array.isArray(message.content) && message.content.length > 0) return true;
-  if (message.tool_call_chunks && message.tool_call_chunks.length > 0)
-    return true;
-  return false;
 }
 
 function inferModelNameFromUrl(url: string): string {

--- a/libs/providers/langchain-baseten/src/chat_models.ts
+++ b/libs/providers/langchain-baseten/src/chat_models.ts
@@ -16,12 +16,9 @@ import type { ToolCallChunk } from "@langchain/core/messages/tool";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
-import {
-  DEFAULT_BASE_URL,
-  DEFAULT_API_KEY_ENV_VAR,
-  normalizeModelUrl,
-  type BasetenChatInput,
-} from "./types.js";
+import { DEFAULT_BASE_URL, DEFAULT_API_KEY_ENV_VAR } from "./const.js";
+import { normalizeModelUrl } from "./converters/params.js";
+import type { BasetenChatInput } from "./types.js";
 
 function resolveApiKey(fields?: BasetenChatInput): string {
   if (fields?.basetenApiKey) return fields.basetenApiKey;

--- a/libs/providers/langchain-baseten/src/chat_models.ts
+++ b/libs/providers/langchain-baseten/src/chat_models.ts
@@ -1,0 +1,233 @@
+/**
+ * ChatBaseten — Baseten LLM provider for LangChain.
+ *
+ * Extends ChatOpenAI to target Baseten's OpenAI-compatible inference API.
+ * Includes streaming fixes for TensorRT-LLM serving quirks ported from
+ * the Python `langchain-baseten` package.
+ *
+ * @packageDocumentation
+ */
+
+import { ChatOpenAI } from "@langchain/openai";
+import type { LangSmithParams } from "@langchain/core/language_models/chat_models";
+import type { BaseMessage } from "@langchain/core/messages";
+import { AIMessageChunk } from "@langchain/core/messages";
+import type { ToolCallChunk } from "@langchain/core/messages/tool";
+import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_API_KEY_ENV_VAR,
+  normalizeModelUrl,
+  type BasetenChatInput,
+} from "./types.js";
+
+function resolveApiKey(fields?: BasetenChatInput): string {
+  if (fields?.basetenApiKey) return fields.basetenApiKey;
+  if (typeof fields?.apiKey === "string") return fields.apiKey;
+  if (typeof fields?.openAIApiKey === "string") return fields.openAIApiKey;
+
+  const envKey = getEnvironmentVariable(DEFAULT_API_KEY_ENV_VAR);
+  if (envKey) return envKey;
+
+  throw new Error(
+    `Baseten API key not found. Provide it via the "basetenApiKey" constructor ` +
+      `option or set the ${DEFAULT_API_KEY_ENV_VAR} environment variable.\n\n` +
+      `  Get your API key at https://app.baseten.co/settings/api-keys`
+  );
+}
+
+/**
+ * Fix TensorRT-LLM tool-call streaming quirks:
+ * - Fold same-index deltas within a single SSE event into one entry
+ * - Clear `id` on continuation deltas (no `name`) so `concat()` merges by index
+ *
+ * See: Python `langchain-baseten._normalize_tool_call_chunks`
+ */
+export function normalizeToolCallChunks(
+  chunks: ToolCallChunk[]
+): ToolCallChunk[] {
+  if (chunks.length <= 1 && (!chunks[0] || chunks[0].name)) return chunks;
+
+  const byIndex = new Map<number, ToolCallChunk>();
+
+  for (const tc of chunks) {
+    if (tc.index == null) continue;
+    const existing = byIndex.get(tc.index);
+    if (!existing) {
+      byIndex.set(tc.index, { ...tc });
+    } else {
+      byIndex.set(tc.index, {
+        ...existing,
+        name: existing.name ?? tc.name,
+        args: (existing.args ?? "") + (tc.args ?? ""),
+        id: existing.id ?? tc.id,
+      });
+    }
+  }
+
+  const result: ToolCallChunk[] = [];
+  for (const tc of byIndex.values()) {
+    if (!tc.name && tc.id != null) {
+      result.push({ ...tc, id: undefined });
+    } else {
+      result.push(tc);
+    }
+  }
+
+  return result;
+}
+
+function chunkHasContent(message: AIMessageChunk): boolean {
+  if (typeof message.content === "string" && message.content.length > 0)
+    return true;
+  if (Array.isArray(message.content) && message.content.length > 0)
+    return true;
+  if (message.tool_call_chunks && message.tool_call_chunks.length > 0)
+    return true;
+  return false;
+}
+
+function inferModelNameFromUrl(url: string): string {
+  const match = /model-([a-zA-Z0-9]+)/.exec(url);
+  return match ? `model-${match[1]}` : "baseten-model";
+}
+
+/**
+ * Baseten chat model for LangChain.
+ *
+ * Wraps {@link ChatOpenAI} pointed at `https://inference.baseten.co/v1`.
+ * Streaming, tool calling, structured output, and token tracking are
+ * all inherited from ChatOpenAI.
+ *
+ * @example
+ * ```typescript
+ * import { ChatBaseten } from "@langchain/baseten";
+ *
+ * const model = new ChatBaseten({
+ *   model: "deepseek-ai/DeepSeek-V3.1",
+ * });
+ *
+ * const result = await model.invoke("What is the capital of France?");
+ * ```
+ *
+ * @example
+ * ```typescript
+ * import { ChatBaseten } from "@langchain/baseten";
+ * import { HumanMessage } from "@langchain/core/messages";
+ *
+ * const model = new ChatBaseten({
+ *   model: "deepseek-ai/DeepSeek-V3.1",
+ *   temperature: 0.7,
+ * });
+ *
+ * const result = await model.invoke([
+ *   new HumanMessage("Tell me a joke"),
+ * ]);
+ * ```
+ */
+export class ChatBaseten extends ChatOpenAI {
+  static lc_name() {
+    return "ChatBaseten";
+  }
+
+  constructor(fields?: BasetenChatInput) {
+    const apiKey = resolveApiKey(fields);
+
+    let baseURL: string;
+    let model: string;
+
+    if (fields?.modelUrl) {
+      baseURL = normalizeModelUrl(fields.modelUrl);
+      model = fields.model ?? inferModelNameFromUrl(fields.modelUrl);
+    } else {
+      baseURL = fields?.baseURL ?? DEFAULT_BASE_URL;
+      model = fields?.model ?? "";
+    }
+
+    const {
+      basetenApiKey: _basetenApiKey,
+      baseURL: _baseURL,
+      modelUrl: _modelUrl,
+      configuration,
+      ...rest
+    } = fields ?? {};
+
+    super({
+      ...rest,
+      model,
+      apiKey,
+      streamUsage: rest.streamUsage ?? true,
+      configuration: {
+        ...configuration,
+        baseURL,
+      },
+    });
+  }
+
+  override getName(): string {
+    return "ChatBaseten";
+  }
+
+  override getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {
+    const params = super.getLsParams(options);
+    return {
+      ...params,
+      ls_provider: "baseten",
+    };
+  }
+
+  override async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const result = await super._generate(messages, options, runManager);
+    for (const generation of result.generations) {
+      generation.message.response_metadata = {
+        ...generation.message.response_metadata,
+        model_provider: "baseten",
+      };
+    }
+    return result;
+  }
+
+  // Reasoning content (`additional_kwargs.reasoning_content`) is handled by
+  // the parent ChatOpenAI via its completions converters — no override needed.
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    for await (const chunk of super._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      const message = chunk.message;
+
+      if (AIMessageChunk.isInstance(message)) {
+        if (message.tool_call_chunks && message.tool_call_chunks.length > 0) {
+          message.tool_call_chunks = normalizeToolCallChunks(
+            message.tool_call_chunks
+          );
+        }
+
+        // Baseten sends cumulative usage on every content chunk; strip it so
+        // LangChain only counts the final usage-only chunk.
+        if (message.usage_metadata && chunkHasContent(message)) {
+          message.usage_metadata = undefined;
+        }
+
+        message.response_metadata = {
+          ...message.response_metadata,
+          model_provider: "baseten",
+        };
+      }
+
+      yield chunk;
+    }
+  }
+}

--- a/libs/providers/langchain-baseten/src/chat_models.ts
+++ b/libs/providers/langchain-baseten/src/chat_models.ts
@@ -82,8 +82,7 @@ export function normalizeToolCallChunks(
 function chunkHasContent(message: AIMessageChunk): boolean {
   if (typeof message.content === "string" && message.content.length > 0)
     return true;
-  if (Array.isArray(message.content) && message.content.length > 0)
-    return true;
+  if (Array.isArray(message.content) && message.content.length > 0) return true;
   if (message.tool_call_chunks && message.tool_call_chunks.length > 0)
     return true;
   return false;

--- a/libs/providers/langchain-baseten/src/const.ts
+++ b/libs/providers/langchain-baseten/src/const.ts
@@ -1,0 +1,13 @@
+/**
+ * Default base URL for Baseten's managed inference API.
+ * Supports all open-source models hosted on Baseten's Model APIs.
+ *
+ * For self-deployed models, override with the model-specific URL:
+ * `https://model-{model_id}.api.baseten.co/v1`
+ */
+export const DEFAULT_BASE_URL = "https://inference.baseten.co/v1";
+
+/**
+ * Default environment variable name for the Baseten API key.
+ */
+export const DEFAULT_API_KEY_ENV_VAR = "BASETEN_API_KEY";

--- a/libs/providers/langchain-baseten/src/converters/chat_models.ts
+++ b/libs/providers/langchain-baseten/src/converters/chat_models.ts
@@ -1,0 +1,52 @@
+import { AIMessageChunk } from "@langchain/core/messages";
+import type { ToolCallChunk } from "@langchain/core/messages/tool";
+
+/**
+ * Fix TensorRT-LLM tool-call streaming quirks:
+ * - Fold same-index deltas within a single SSE event into one entry
+ * - Clear `id` on continuation deltas (no `name`) so `concat()` merges by index
+ *
+ * See: Python `langchain-baseten._normalize_tool_call_chunks`
+ */
+export function normalizeToolCallChunks(
+  chunks: ToolCallChunk[]
+): ToolCallChunk[] {
+  if (chunks.length <= 1 && (!chunks[0] || chunks[0].name)) return chunks;
+
+  const byIndex = new Map<number, ToolCallChunk>();
+
+  for (const tc of chunks) {
+    if (tc.index == null) continue;
+    const existing = byIndex.get(tc.index);
+    if (!existing) {
+      byIndex.set(tc.index, { ...tc });
+    } else {
+      byIndex.set(tc.index, {
+        ...existing,
+        name: existing.name ?? tc.name,
+        args: (existing.args ?? "") + (tc.args ?? ""),
+        id: existing.id ?? tc.id,
+      });
+    }
+  }
+
+  const result: ToolCallChunk[] = [];
+  for (const tc of byIndex.values()) {
+    if (!tc.name && tc.id != null) {
+      result.push({ ...tc, id: undefined });
+    } else {
+      result.push(tc);
+    }
+  }
+
+  return result;
+}
+
+export function chunkHasContent(message: AIMessageChunk): boolean {
+  if (typeof message.content === "string" && message.content.length > 0)
+    return true;
+  if (Array.isArray(message.content) && message.content.length > 0) return true;
+  if (message.tool_call_chunks && message.tool_call_chunks.length > 0)
+    return true;
+  return false;
+}

--- a/libs/providers/langchain-baseten/src/converters/params.ts
+++ b/libs/providers/langchain-baseten/src/converters/params.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize a dedicated model URL to OpenAI-compatible `/sync/v1` format.
+ *
+ * Baseten dedicated model endpoints come in several forms:
+ * - `.../predict` -> converted to `.../sync/v1`
+ * - `.../sync` -> appended with `/v1`
+ * - anything else -> ensures trailing `/v1`
+ *
+ * See: Python `langchain-baseten._normalize_model_url`
+ */
+export function normalizeModelUrl(url: string): string {
+  if (url.endsWith("/predict")) {
+    return `${url.slice(0, -"/predict".length)}/sync/v1`;
+  }
+  if (url.endsWith("/sync")) {
+    return `${url}/v1`;
+  }
+  if (!url.endsWith("/v1")) {
+    let trimmed = url;
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.slice(0, -1);
+    }
+    return `${trimmed}/v1`;
+  }
+  return url;
+}

--- a/libs/providers/langchain-baseten/src/index.ts
+++ b/libs/providers/langchain-baseten/src/index.ts
@@ -1,0 +1,3 @@
+export { ChatBaseten, normalizeToolCallChunks } from "./chat_models.js";
+export { normalizeModelUrl } from "./types.js";
+export type { BasetenChatInput } from "./types.js";

--- a/libs/providers/langchain-baseten/src/index.ts
+++ b/libs/providers/langchain-baseten/src/index.ts
@@ -1,3 +1,3 @@
 export { ChatBaseten, normalizeToolCallChunks } from "./chat_models.js";
-export { normalizeModelUrl } from "./types.js";
+export { normalizeModelUrl } from "./converters/params.js";
 export type { BasetenChatInput } from "./types.js";

--- a/libs/providers/langchain-baseten/src/index.ts
+++ b/libs/providers/langchain-baseten/src/index.ts
@@ -1,3 +1,4 @@
-export { ChatBaseten, normalizeToolCallChunks } from "./chat_models.js";
+export { ChatBaseten } from "./chat_models.js";
+export { normalizeToolCallChunks } from "./converters/chat_models.js";
 export { normalizeModelUrl } from "./converters/params.js";
 export type { BasetenChatInput } from "./types.js";

--- a/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
@@ -1,12 +1,30 @@
-import { describe, it, expect } from "vitest";
-import { HumanMessage } from "@langchain/core/messages";
+import { describe, it, expect, test } from "vitest";
+import {
+  HumanMessage,
+  AIMessage,
+  AIMessageChunk,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { concat } from "@langchain/core/utils/stream";
+import { z } from "zod/v3";
 import { ChatBaseten } from "../chat_models.js";
 
 const BASETEN_MODEL = "deepseek-ai/DeepSeek-V3.1";
 
+function makeModel(overrides?: Record<string, unknown>) {
+  return new ChatBaseten({
+    model: BASETEN_MODEL,
+    maxTokens: 200,
+    ...overrides,
+  });
+}
+
+// ─── Basic invoke ────────────────────────────────────────────────────
+
 describe("ChatBaseten Integration Tests", () => {
   it("should invoke ChatBaseten directly", { timeout: 60_000 }, async () => {
-    const model = new ChatBaseten({ model: BASETEN_MODEL });
+    const model = makeModel();
 
     const result = await model.invoke([
       new HumanMessage("What is 2 + 2? Answer with just the number."),
@@ -21,19 +39,113 @@ describe("ChatBaseten Integration Tests", () => {
     "should stream responses from ChatBaseten",
     { timeout: 60_000 },
     async () => {
-      const model = new ChatBaseten({ model: BASETEN_MODEL });
+      const model = makeModel();
 
-      const chunks: string[] = [];
+      const chunks: AIMessageChunk[] = [];
       for await (const chunk of await model.stream(
         "Say the word 'hello' and nothing else."
       )) {
-        if (typeof chunk.content === "string") {
-          chunks.push(chunk.content);
-        }
+        chunks.push(chunk);
       }
 
-      const fullResponse = chunks.join("");
-      expect(fullResponse.toLowerCase()).toContain("hello");
+      expect(chunks.length).toBeGreaterThan(1);
+
+      let combined = chunks[0];
+      for (let i = 1; i < chunks.length; i++) {
+        combined = concat(combined, chunks[i]);
+      }
+      expect(typeof combined.content).toBe("string");
+      expect((combined.content as string).toLowerCase()).toContain("hello");
+    }
+  );
+
+  it(
+    "invoke returns usage metadata",
+    { timeout: 60_000 },
+    async () => {
+      const model = makeModel();
+      const res = await model.invoke([new HumanMessage("Say hi")]);
+
+      expect(res.usage_metadata).toBeDefined();
+      expect(res.usage_metadata!.input_tokens).toBeGreaterThan(0);
+      expect(res.usage_metadata!.output_tokens).toBeGreaterThan(0);
+    }
+  );
+
+  it(
+    "stream supports abort signal",
+    { timeout: 60_000 },
+    async () => {
+      const model = makeModel({ maxTokens: 500 });
+      await expect(async () => {
+        const stream = await model.stream(
+          "Write a very long story about a robot.",
+          { signal: AbortSignal.timeout(500) }
+        );
+        for await (const _chunk of stream) {
+          // consume
+        }
+      }).rejects.toThrow();
     }
   );
 });
+
+// ─── Tool calling ────────────────────────────────────────────────────
+
+describe("tool calling", () => {
+  const weatherTool = tool(
+    async (input: { location: string }) =>
+      `The weather in ${input.location} is sunny, 72°F.`,
+    {
+      name: "get_weather",
+      description: "Get the current weather for a location.",
+      schema: z.object({
+        location: z.string().describe("City name"),
+      }),
+    }
+  );
+
+  test(
+    "model calls a bound tool",
+    { timeout: 60_000 },
+    async () => {
+      const model = makeModel().bindTools([weatherTool]);
+      const res = await model.invoke("What's the weather in San Francisco?");
+
+      expect(res.tool_calls).toBeDefined();
+      expect(res.tool_calls!.length).toBeGreaterThanOrEqual(1);
+      expect(res.tool_calls![0].name).toBe("get_weather");
+      expect(res.tool_calls![0].args).toHaveProperty("location");
+    }
+  );
+
+  test(
+    "full tool calling round-trip",
+    { timeout: 60_000 },
+    async () => {
+      const model = makeModel().bindTools([weatherTool]);
+      const aiMsg = await model.invoke("What's the weather in Paris?");
+
+      expect(aiMsg.tool_calls!.length).toBeGreaterThanOrEqual(1);
+      const toolCall = aiMsg.tool_calls![0];
+
+      const toolResult = await weatherTool.invoke(toolCall.args);
+
+      const finalRes = await model.invoke([
+        new HumanMessage("What's the weather in Paris?"),
+        new AIMessage({
+          content: aiMsg.content,
+          tool_calls: aiMsg.tool_calls,
+        }),
+        new ToolMessage({
+          tool_call_id: toolCall.id!,
+          content: toolResult,
+        }),
+      ]);
+
+      expect(typeof finalRes.content).toBe("string");
+      expect((finalRes.content as string).length).toBeGreaterThan(0);
+    }
+  );
+});
+

--- a/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
@@ -5,21 +5,17 @@ import { ChatBaseten } from "../chat_models.js";
 const BASETEN_MODEL = "deepseek-ai/DeepSeek-V3.1";
 
 describe("ChatBaseten Integration Tests", () => {
-  it(
-    "should invoke ChatBaseten directly",
-    { timeout: 60_000 },
-    async () => {
-      const model = new ChatBaseten({ model: BASETEN_MODEL });
+  it("should invoke ChatBaseten directly", { timeout: 60_000 }, async () => {
+    const model = new ChatBaseten({ model: BASETEN_MODEL });
 
-      const result = await model.invoke([
-        new HumanMessage("What is 2 + 2? Answer with just the number."),
-      ]);
+    const result = await model.invoke([
+      new HumanMessage("What is 2 + 2? Answer with just the number."),
+    ]);
 
-      expect(result.content).toBeTruthy();
-      expect(typeof result.content).toBe("string");
-      expect(result.content).toContain("4");
-    }
-  );
+    expect(result.content).toBeTruthy();
+    expect(typeof result.content).toBe("string");
+    expect(result.content).toContain("4");
+  });
 
   it(
     "should stream responses from ChatBaseten",

--- a/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { ChatBaseten } from "../chat_models.js";
+
+const BASETEN_MODEL = "deepseek-ai/DeepSeek-V3.1";
+
+describe("ChatBaseten Integration Tests", () => {
+  it(
+    "should invoke ChatBaseten directly",
+    { timeout: 60_000 },
+    async () => {
+      const model = new ChatBaseten({ model: BASETEN_MODEL });
+
+      const result = await model.invoke([
+        new HumanMessage("What is 2 + 2? Answer with just the number."),
+      ]);
+
+      expect(result.content).toBeTruthy();
+      expect(typeof result.content).toBe("string");
+      expect(result.content).toContain("4");
+    }
+  );
+
+  it(
+    "should stream responses from ChatBaseten",
+    { timeout: 60_000 },
+    async () => {
+      const model = new ChatBaseten({ model: BASETEN_MODEL });
+
+      const chunks: string[] = [];
+      for await (const chunk of await model.stream(
+        "Say the word 'hello' and nothing else."
+      )) {
+        if (typeof chunk.content === "string") {
+          chunks.push(chunk.content);
+        }
+      }
+
+      const fullResponse = chunks.join("");
+      expect(fullResponse.toLowerCase()).toContain("hello");
+    }
+  );
+});

--- a/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.int.test.ts
@@ -59,35 +59,27 @@ describe("ChatBaseten Integration Tests", () => {
     }
   );
 
-  it(
-    "invoke returns usage metadata",
-    { timeout: 60_000 },
-    async () => {
-      const model = makeModel();
-      const res = await model.invoke([new HumanMessage("Say hi")]);
+  it("invoke returns usage metadata", { timeout: 60_000 }, async () => {
+    const model = makeModel();
+    const res = await model.invoke([new HumanMessage("Say hi")]);
 
-      expect(res.usage_metadata).toBeDefined();
-      expect(res.usage_metadata!.input_tokens).toBeGreaterThan(0);
-      expect(res.usage_metadata!.output_tokens).toBeGreaterThan(0);
-    }
-  );
+    expect(res.usage_metadata).toBeDefined();
+    expect(res.usage_metadata!.input_tokens).toBeGreaterThan(0);
+    expect(res.usage_metadata!.output_tokens).toBeGreaterThan(0);
+  });
 
-  it(
-    "stream supports abort signal",
-    { timeout: 60_000 },
-    async () => {
-      const model = makeModel({ maxTokens: 500 });
-      await expect(async () => {
-        const stream = await model.stream(
-          "Write a very long story about a robot.",
-          { signal: AbortSignal.timeout(500) }
-        );
-        for await (const _chunk of stream) {
-          // consume
-        }
-      }).rejects.toThrow();
-    }
-  );
+  it("stream supports abort signal", { timeout: 60_000 }, async () => {
+    const model = makeModel({ maxTokens: 500 });
+    await expect(async () => {
+      const stream = await model.stream(
+        "Write a very long story about a robot.",
+        { signal: AbortSignal.timeout(500) }
+      );
+      for await (const _chunk of stream) {
+        // consume
+      }
+    }).rejects.toThrow();
+  });
 });
 
 // ─── Tool calling ────────────────────────────────────────────────────
@@ -105,47 +97,38 @@ describe("tool calling", () => {
     }
   );
 
-  test(
-    "model calls a bound tool",
-    { timeout: 60_000 },
-    async () => {
-      const model = makeModel().bindTools([weatherTool]);
-      const res = await model.invoke("What's the weather in San Francisco?");
+  test("model calls a bound tool", { timeout: 60_000 }, async () => {
+    const model = makeModel().bindTools([weatherTool]);
+    const res = await model.invoke("What's the weather in San Francisco?");
 
-      expect(res.tool_calls).toBeDefined();
-      expect(res.tool_calls!.length).toBeGreaterThanOrEqual(1);
-      expect(res.tool_calls![0].name).toBe("get_weather");
-      expect(res.tool_calls![0].args).toHaveProperty("location");
-    }
-  );
+    expect(res.tool_calls).toBeDefined();
+    expect(res.tool_calls!.length).toBeGreaterThanOrEqual(1);
+    expect(res.tool_calls![0].name).toBe("get_weather");
+    expect(res.tool_calls![0].args).toHaveProperty("location");
+  });
 
-  test(
-    "full tool calling round-trip",
-    { timeout: 60_000 },
-    async () => {
-      const model = makeModel().bindTools([weatherTool]);
-      const aiMsg = await model.invoke("What's the weather in Paris?");
+  test("full tool calling round-trip", { timeout: 60_000 }, async () => {
+    const model = makeModel().bindTools([weatherTool]);
+    const aiMsg = await model.invoke("What's the weather in Paris?");
 
-      expect(aiMsg.tool_calls!.length).toBeGreaterThanOrEqual(1);
-      const toolCall = aiMsg.tool_calls![0];
+    expect(aiMsg.tool_calls!.length).toBeGreaterThanOrEqual(1);
+    const toolCall = aiMsg.tool_calls![0];
 
-      const toolResult = await weatherTool.invoke(toolCall.args);
+    const toolResult = await weatherTool.invoke(toolCall.args);
 
-      const finalRes = await model.invoke([
-        new HumanMessage("What's the weather in Paris?"),
-        new AIMessage({
-          content: aiMsg.content,
-          tool_calls: aiMsg.tool_calls,
-        }),
-        new ToolMessage({
-          tool_call_id: toolCall.id!,
-          content: toolResult,
-        }),
-      ]);
+    const finalRes = await model.invoke([
+      new HumanMessage("What's the weather in Paris?"),
+      new AIMessage({
+        content: aiMsg.content,
+        tool_calls: aiMsg.tool_calls,
+      }),
+      new ToolMessage({
+        tool_call_id: toolCall.id!,
+        content: toolResult,
+      }),
+    ]);
 
-      expect(typeof finalRes.content).toBe("string");
-      expect((finalRes.content as string).length).toBeGreaterThan(0);
-    }
-  );
+    expect(typeof finalRes.content).toBe("string");
+    expect((finalRes.content as string).length).toBeGreaterThan(0);
+  });
 });
-

--- a/libs/providers/langchain-baseten/src/tests/chat_models.standard.int.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.standard.int.test.ts
@@ -1,0 +1,109 @@
+import { ChatModelIntegrationTests } from "@langchain/standard-tests/vitest";
+import { AIMessageChunk } from "@langchain/core/messages";
+import { z } from "zod/v3";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import type { ChatOpenAICallOptions } from "@langchain/openai";
+
+import { ChatBaseten } from "../chat_models.js";
+
+const adderSchema = z
+  .object({
+    a: z.number().int().describe("The first integer to add."),
+    b: z.number().int().describe("The second integer to add."),
+  })
+  .describe("Add two integers");
+
+const MATH_ADDITION_PROMPT = ChatPromptTemplate.fromMessages([
+  [
+    "system",
+    "You are bad at math and must ALWAYS call the {toolName} function.",
+  ],
+  ["human", "What is the sum of 1836281973 and 19973286?"],
+]);
+
+class ChatBasetenStandardIntegrationTests extends ChatModelIntegrationTests<
+  ChatOpenAICallOptions,
+  AIMessageChunk
+> {
+  constructor() {
+    if (!process.env.BASETEN_API_KEY) {
+      throw new Error(
+        "BASETEN_API_KEY must be set to run standard integration tests."
+      );
+    }
+    super({
+      Cls: ChatBaseten,
+      chatModelHasToolCalling: true,
+      chatModelHasStructuredOutput: true,
+      supportsParallelToolCalls: true,
+      constructorArgs: {
+        model: "deepseek-ai/DeepSeek-V3.1",
+      },
+    });
+  }
+
+  async testInvokeMoreComplexTools() {
+    this.skipTestMessage(
+      "testInvokeMoreComplexTools",
+      "ChatBaseten",
+      "Baseten models do not support tool schemas with unknown/any parameters."
+    );
+  }
+
+  async testUsageMetadata() {
+    this.skipTestMessage(
+      "testUsageMetadata",
+      "ChatBaseten",
+      "Baseten does not guarantee a `model` field in response_metadata."
+    );
+  }
+
+  async testWithStructuredOutput() {
+    const model = new this.Cls(this.constructorArgs);
+    if (!model.withStructuredOutput) {
+      throw new Error(
+        "withStructuredOutput undefined. Cannot test structured output."
+      );
+    }
+
+    const modelWithTools = model.withStructuredOutput(adderSchema, {
+      name: "math_addition",
+    });
+
+    const result = await MATH_ADDITION_PROMPT.pipe(modelWithTools).invoke({
+      toolName: "math_addition",
+    });
+
+    this.expect(result.a).toBeDefined();
+    this.expect(typeof result.a).toBe("number");
+    this.expect(result.b).toBeDefined();
+    this.expect(typeof result.b).toBe("number");
+  }
+
+  async testWithStructuredOutputIncludeRaw() {
+    const model = new this.Cls(this.constructorArgs);
+    if (!model.withStructuredOutput) {
+      throw new Error(
+        "withStructuredOutput undefined. Cannot test structured output."
+      );
+    }
+
+    const modelWithTools = model.withStructuredOutput(adderSchema, {
+      includeRaw: true,
+      name: "math_addition",
+    });
+
+    const result = await MATH_ADDITION_PROMPT.pipe(modelWithTools).invoke({
+      toolName: "math_addition",
+    });
+
+    this.expect(result.raw).toBeInstanceOf(this.invokeResponseType);
+    this.expect(result.parsed.a).toBeDefined();
+    this.expect(typeof result.parsed.a).toBe("number");
+    this.expect(result.parsed.b).toBeDefined();
+    this.expect(typeof result.parsed.b).toBe("number");
+  }
+}
+
+const testClass = new ChatBasetenStandardIntegrationTests();
+testClass.runTests("ChatBasetenStandardIntegrationTests");

--- a/libs/providers/langchain-baseten/src/tests/chat_models.standard.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.standard.test.ts
@@ -1,0 +1,29 @@
+import { ChatModelUnitTests } from "@langchain/standard-tests/vitest";
+import { AIMessageChunk } from "@langchain/core/messages";
+import type { ChatOpenAICallOptions } from "@langchain/openai";
+
+import { ChatBaseten } from "../chat_models.js";
+
+class ChatBasetenStandardUnitTests extends ChatModelUnitTests<
+  ChatOpenAICallOptions,
+  AIMessageChunk
+> {
+  constructor() {
+    super({
+      Cls: ChatBaseten,
+      chatModelHasToolCalling: true,
+      chatModelHasStructuredOutput: true,
+      constructorArgs: { model: "deepseek-ai/DeepSeek-V3.1" },
+    });
+    process.env.BASETEN_API_KEY = "test";
+  }
+
+  testChatModelInitApiKey() {
+    process.env.BASETEN_API_KEY = "";
+    super.testChatModelInitApiKey();
+    process.env.BASETEN_API_KEY = "test";
+  }
+}
+
+const testClass = new ChatBasetenStandardUnitTests();
+testClass.runTests("ChatBasetenStandardUnitTests");

--- a/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
@@ -232,9 +232,7 @@ describe("ChatBaseten", () => {
         basetenApiKey: TEST_API_KEY,
       });
 
-      const params = model.getLsParams(
-        {} as ChatBaseten["ParsedCallOptions"]
-      );
+      const params = model.getLsParams({} as ChatBaseten["ParsedCallOptions"]);
 
       expect(params.ls_provider).toBe("baseten");
       expect(params.ls_model_name).toBe(TEST_MODEL);

--- a/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
@@ -193,9 +193,9 @@ describe("ChatBaseten", () => {
     });
 
     it("throws a descriptive error when no API key is available", () => {
-      expect(
-        () => new ChatBaseten({ model: TEST_MODEL })
-      ).toThrowError(/Baseten API key not found/);
+      expect(() => new ChatBaseten({ model: TEST_MODEL })).toThrowError(
+        /Baseten API key not found/
+      );
     });
   });
 
@@ -241,9 +241,7 @@ describe("ChatBaseten", () => {
       msg.additional_kwargs = { reasoning_content: "Let me think..." };
 
       const fakeResult = {
-        generations: [
-          { text: "Answer", message: msg, generationInfo: {} },
-        ],
+        generations: [{ text: "Answer", message: msg, generationInfo: {} }],
         llmOutput: {},
       };
 
@@ -598,14 +596,14 @@ describe("normalizeModelUrl", () => {
   });
 
   it("appends /v1 to bare URL without trailing slash", () => {
-    expect(
-      normalizeModelUrl("https://model-abc123.api.baseten.co")
-    ).toBe("https://model-abc123.api.baseten.co/v1");
+    expect(normalizeModelUrl("https://model-abc123.api.baseten.co")).toBe(
+      "https://model-abc123.api.baseten.co/v1"
+    );
   });
 
   it("strips trailing slash before appending /v1", () => {
-    expect(
-      normalizeModelUrl("https://model-abc123.api.baseten.co/")
-    ).toBe("https://model-abc123.api.baseten.co/v1");
+    expect(normalizeModelUrl("https://model-abc123.api.baseten.co/")).toBe(
+      "https://model-abc123.api.baseten.co/v1"
+    );
   });
 });

--- a/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
@@ -12,6 +12,15 @@ import type { ToolCallChunk } from "@langchain/core/messages/tool";
 const TEST_API_KEY = "test-baseten-api-key";
 const TEST_MODEL = "deepseek-ai/DeepSeek-V3.1";
 
+interface ClientConfig {
+  baseURL: string;
+  defaultHeaders?: Record<string, string>;
+}
+
+function getClientConfig(model: ChatBaseten): ClientConfig {
+  return (model as unknown as { clientConfig: ClientConfig }).clientConfig;
+}
+
 describe("ChatBaseten", () => {
   let originalEnv: string | undefined;
 
@@ -35,7 +44,7 @@ describe("ChatBaseten", () => {
         basetenApiKey: TEST_API_KEY,
       });
 
-      expect((model as any).clientConfig.baseURL).toBe(DEFAULT_BASE_URL);
+      expect(getClientConfig(model).baseURL).toBe(DEFAULT_BASE_URL);
     });
 
     it("allows overriding base URL for self-deployed models", () => {
@@ -46,7 +55,7 @@ describe("ChatBaseten", () => {
         baseURL: customURL,
       });
 
-      expect((model as any).clientConfig.baseURL).toBe(customURL);
+      expect(getClientConfig(model).baseURL).toBe(customURL);
     });
 
     it("sets the model name correctly", () => {
@@ -79,8 +88,8 @@ describe("ChatBaseten", () => {
         },
       });
 
-      expect((model as any).clientConfig.baseURL).toBe(DEFAULT_BASE_URL);
-      expect((model as any).clientConfig.defaultHeaders).toEqual({
+      expect(getClientConfig(model).baseURL).toBe(DEFAULT_BASE_URL);
+      expect(getClientConfig(model).defaultHeaders).toEqual({
         "X-Custom": "value",
       });
     });
@@ -112,7 +121,7 @@ describe("ChatBaseten", () => {
         basetenApiKey: TEST_API_KEY,
       });
 
-      expect((model as any).clientConfig.baseURL).toBe(
+      expect(getClientConfig(model).baseURL).toBe(
         "https://model-abc123.api.baseten.co/environments/production/sync/v1"
       );
     });
@@ -147,7 +156,7 @@ describe("ChatBaseten", () => {
         basetenApiKey: TEST_API_KEY,
       });
 
-      expect((model as any).clientConfig.baseURL).toBe(
+      expect(getClientConfig(model).baseURL).toBe(
         "https://model-abc123.api.baseten.co/environments/production/sync/v1"
       );
     });
@@ -223,7 +232,9 @@ describe("ChatBaseten", () => {
         basetenApiKey: TEST_API_KEY,
       });
 
-      const params = model.getLsParams({} as any);
+      const params = model.getLsParams(
+        {} as ChatBaseten["ParsedCallOptions"]
+      );
 
       expect(params.ls_provider).toBe("baseten");
       expect(params.ls_model_name).toBe(TEST_MODEL);
@@ -249,7 +260,10 @@ describe("ChatBaseten", () => {
         .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
         .mockResolvedValueOnce(fakeResult);
 
-      const result = await model._generate([], {} as any);
+      const result = await model._generate(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      );
 
       expect(
         result.generations[0].message.additional_kwargs.reasoning_content
@@ -283,7 +297,10 @@ describe("ChatBaseten", () => {
         );
 
       const chunks: ChatGenerationChunk[] = [];
-      for await (const c of model._streamResponseChunks([], {} as any)) {
+      for await (const c of model._streamResponseChunks(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      )) {
         chunks.push(c);
       }
 
@@ -318,7 +335,10 @@ describe("ChatBaseten", () => {
         .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
         .mockResolvedValueOnce(fakeResult);
 
-      const result = await model._generate([], {} as any);
+      const result = await model._generate(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      );
 
       expect(result.generations[0].message.response_metadata).toEqual(
         expect.objectContaining({ model_provider: "baseten" })
@@ -345,7 +365,10 @@ describe("ChatBaseten", () => {
         .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
         .mockResolvedValueOnce(fakeResult);
 
-      const result = await model._generate([], {} as any);
+      const result = await model._generate(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      );
       const meta = result.generations[0].message.response_metadata;
 
       expect(meta).toEqual({
@@ -362,8 +385,8 @@ describe("ChatBaseten", () => {
       content: string,
       overrides?: {
         tool_call_chunks?: ToolCallChunk[];
-        usage_metadata?: any;
-        response_metadata?: Record<string, any>;
+        usage_metadata?: Record<string, number>;
+        response_metadata?: Record<string, unknown>;
       }
     ): ChatGenerationChunk {
       const msg = new AIMessageChunk({
@@ -397,7 +420,10 @@ describe("ChatBaseten", () => {
         .mockReturnValueOnce(fakeStream([makeChunk("hello")]));
 
       const chunks: ChatGenerationChunk[] = [];
-      for await (const c of model._streamResponseChunks([], {} as any)) {
+      for await (const c of model._streamResponseChunks(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      )) {
         chunks.push(c);
       }
 
@@ -438,7 +464,10 @@ describe("ChatBaseten", () => {
         .mockReturnValueOnce(fakeStream([contentChunk, usageOnlyChunk]));
 
       const chunks: ChatGenerationChunk[] = [];
-      for await (const c of model._streamResponseChunks([], {} as any)) {
+      for await (const c of model._streamResponseChunks(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      )) {
         chunks.push(c);
       }
 
@@ -474,7 +503,10 @@ describe("ChatBaseten", () => {
         .mockReturnValueOnce(fakeStream([chunk]));
 
       const chunks: ChatGenerationChunk[] = [];
-      for await (const c of model._streamResponseChunks([], {} as any)) {
+      for await (const c of model._streamResponseChunks(
+        [],
+        {} as ChatBaseten["ParsedCallOptions"]
+      )) {
         chunks.push(c);
       }
 

--- a/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
@@ -1,0 +1,611 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  ChatBaseten,
+  normalizeToolCallChunks,
+  normalizeModelUrl,
+} from "../index.js";
+import { DEFAULT_BASE_URL, DEFAULT_API_KEY_ENV_VAR } from "../types.js";
+import { AIMessageChunk } from "@langchain/core/messages";
+import { ChatGenerationChunk } from "@langchain/core/outputs";
+import type { ToolCallChunk } from "@langchain/core/messages/tool";
+
+const TEST_API_KEY = "test-baseten-api-key";
+const TEST_MODEL = "deepseek-ai/DeepSeek-V3.1";
+
+describe("ChatBaseten", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env[DEFAULT_API_KEY_ENV_VAR];
+    delete process.env[DEFAULT_API_KEY_ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env[DEFAULT_API_KEY_ENV_VAR] = originalEnv;
+    } else {
+      delete process.env[DEFAULT_API_KEY_ENV_VAR];
+    }
+  });
+
+  describe("constructor", () => {
+    it("sets default base URL to Baseten inference endpoint", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect((model as any).clientConfig.baseURL).toBe(DEFAULT_BASE_URL);
+    });
+
+    it("allows overriding base URL for self-deployed models", () => {
+      const customURL = "https://model-abc123.api.baseten.co/v1";
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+        baseURL: customURL,
+      });
+
+      expect((model as any).clientConfig.baseURL).toBe(customURL);
+    });
+
+    it("sets the model name correctly", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.model).toBe(TEST_MODEL);
+    });
+
+    it("passes through additional ChatOpenAI options", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+        temperature: 0.5,
+        maxTokens: 1024,
+      });
+
+      expect(model.temperature).toBe(0.5);
+      expect(model.maxTokens).toBe(1024);
+    });
+
+    it("preserves additional configuration options alongside baseURL", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+        configuration: {
+          defaultHeaders: { "X-Custom": "value" },
+        },
+      });
+
+      expect((model as any).clientConfig.baseURL).toBe(DEFAULT_BASE_URL);
+      expect((model as any).clientConfig.defaultHeaders).toEqual({
+        "X-Custom": "value",
+      });
+    });
+
+    it("enables streamUsage by default", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.streamUsage).toBe(true);
+    });
+
+    it("allows disabling streamUsage explicitly", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+        streamUsage: false,
+      });
+
+      expect(model.streamUsage).toBe(false);
+    });
+
+    it("normalizes modelUrl and uses it as baseURL", () => {
+      const model = new ChatBaseten({
+        model: "custom-model",
+        modelUrl:
+          "https://model-abc123.api.baseten.co/environments/production/predict",
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect((model as any).clientConfig.baseURL).toBe(
+        "https://model-abc123.api.baseten.co/environments/production/sync/v1"
+      );
+    });
+
+    it("infers model name from modelUrl when model is omitted", () => {
+      const model = new ChatBaseten({
+        modelUrl:
+          "https://model-xyz789.api.baseten.co/environments/production/sync/v1",
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.model).toBe("model-xyz789");
+    });
+
+    it("prefers explicit model over URL-inferred name", () => {
+      const model = new ChatBaseten({
+        model: "my-org/my-model",
+        modelUrl:
+          "https://model-abc123.api.baseten.co/environments/production/sync/v1",
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.model).toBe("my-org/my-model");
+    });
+
+    it("modelUrl overrides baseURL", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        modelUrl:
+          "https://model-abc123.api.baseten.co/environments/production/sync",
+        baseURL: "https://should-be-ignored.com/v1",
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect((model as any).clientConfig.baseURL).toBe(
+        "https://model-abc123.api.baseten.co/environments/production/sync/v1"
+      );
+    });
+  });
+
+  describe("API key resolution", () => {
+    it("uses basetenApiKey when provided explicitly", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.apiKey).toBe(TEST_API_KEY);
+    });
+
+    it("uses apiKey field as fallback", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        apiKey: "fallback-key",
+      });
+
+      expect(model.apiKey).toBe("fallback-key");
+    });
+
+    it("falls back to BASETEN_API_KEY environment variable", () => {
+      process.env[DEFAULT_API_KEY_ENV_VAR] = "env-api-key";
+
+      const model = new ChatBaseten({ model: TEST_MODEL });
+
+      expect(model.apiKey).toBe("env-api-key");
+    });
+
+    it("prefers basetenApiKey over apiKey and env var", () => {
+      process.env[DEFAULT_API_KEY_ENV_VAR] = "env-key";
+
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: "explicit-key",
+        apiKey: "generic-key",
+      });
+
+      expect(model.apiKey).toBe("explicit-key");
+    });
+
+    it("throws a descriptive error when no API key is available", () => {
+      expect(
+        () => new ChatBaseten({ model: TEST_MODEL })
+      ).toThrowError(/Baseten API key not found/);
+    });
+  });
+
+  describe("getName", () => {
+    it("returns 'ChatBaseten'", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      expect(model.getName()).toBe("ChatBaseten");
+    });
+  });
+
+  describe("lc_name", () => {
+    it("returns 'ChatBaseten' for serialization", () => {
+      expect(ChatBaseten.lc_name()).toBe("ChatBaseten");
+    });
+  });
+
+  describe("getLsParams", () => {
+    it("returns baseten as the LangSmith provider", () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const params = model.getLsParams({} as any);
+
+      expect(params.ls_provider).toBe("baseten");
+      expect(params.ls_model_name).toBe(TEST_MODEL);
+    });
+  });
+
+  describe("reasoning content", () => {
+    it("preserves reasoning_content in additional_kwargs from _generate", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const msg = new AIMessageChunk({ content: "Answer" });
+      msg.additional_kwargs = { reasoning_content: "Let me think..." };
+
+      const fakeResult = {
+        generations: [
+          { text: "Answer", message: msg, generationInfo: {} },
+        ],
+        llmOutput: {},
+      };
+
+      const superGenerate = vi
+        .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
+        .mockResolvedValueOnce(fakeResult);
+
+      const result = await model._generate([], {} as any);
+
+      expect(
+        result.generations[0].message.additional_kwargs.reasoning_content
+      ).toBe("Let me think...");
+
+      superGenerate.mockRestore();
+    });
+
+    it("preserves reasoning_content in additional_kwargs from stream chunks", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const msg = new AIMessageChunk({ content: "Hello" });
+      msg.additional_kwargs = { reasoning_content: "step 1" };
+      const chunk = new ChatGenerationChunk({
+        text: "Hello",
+        message: msg,
+      });
+
+      const superStream = vi
+        .spyOn(
+          Object.getPrototypeOf(ChatBaseten.prototype),
+          "_streamResponseChunks"
+        )
+        .mockReturnValueOnce(
+          (async function* () {
+            yield chunk;
+          })()
+        );
+
+      const chunks: ChatGenerationChunk[] = [];
+      for await (const c of model._streamResponseChunks([], {} as any)) {
+        chunks.push(c);
+      }
+
+      expect(
+        (chunks[0].message as AIMessageChunk).additional_kwargs
+          .reasoning_content
+      ).toBe("step 1");
+
+      superStream.mockRestore();
+    });
+  });
+
+  describe("_generate", () => {
+    it("adds model_provider to response metadata", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const fakeResult = {
+        generations: [
+          {
+            text: "Hello!",
+            message: new AIMessageChunk({ content: "Hello!" }),
+            generationInfo: {},
+          },
+        ],
+        llmOutput: {},
+      };
+
+      const superGenerate = vi
+        .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
+        .mockResolvedValueOnce(fakeResult);
+
+      const result = await model._generate([], {} as any);
+
+      expect(result.generations[0].message.response_metadata).toEqual(
+        expect.objectContaining({ model_provider: "baseten" })
+      );
+
+      superGenerate.mockRestore();
+    });
+
+    it("preserves existing response metadata", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const msg = new AIMessageChunk({ content: "Hi" });
+      msg.response_metadata = { finish_reason: "stop" };
+
+      const fakeResult = {
+        generations: [{ text: "Hi", message: msg, generationInfo: {} }],
+        llmOutput: {},
+      };
+
+      const superGenerate = vi
+        .spyOn(Object.getPrototypeOf(ChatBaseten.prototype), "_generate")
+        .mockResolvedValueOnce(fakeResult);
+
+      const result = await model._generate([], {} as any);
+      const meta = result.generations[0].message.response_metadata;
+
+      expect(meta).toEqual({
+        finish_reason: "stop",
+        model_provider: "baseten",
+      });
+
+      superGenerate.mockRestore();
+    });
+  });
+
+  describe("_streamResponseChunks", () => {
+    function makeChunk(
+      content: string,
+      overrides?: {
+        tool_call_chunks?: ToolCallChunk[];
+        usage_metadata?: any;
+        response_metadata?: Record<string, any>;
+      }
+    ): ChatGenerationChunk {
+      const msg = new AIMessageChunk({
+        content,
+        tool_call_chunks: overrides?.tool_call_chunks,
+        usage_metadata: overrides?.usage_metadata,
+      });
+      if (overrides?.response_metadata) {
+        msg.response_metadata = overrides.response_metadata;
+      }
+      return new ChatGenerationChunk({ text: content, message: msg });
+    }
+
+    async function* fakeStream(
+      chunks: ChatGenerationChunk[]
+    ): AsyncGenerator<ChatGenerationChunk> {
+      for (const c of chunks) yield c;
+    }
+
+    it("tags every chunk with model_provider: baseten", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const superStream = vi
+        .spyOn(
+          Object.getPrototypeOf(ChatBaseten.prototype),
+          "_streamResponseChunks"
+        )
+        .mockReturnValueOnce(fakeStream([makeChunk("hello")]));
+
+      const chunks: ChatGenerationChunk[] = [];
+      for await (const c of model._streamResponseChunks([], {} as any)) {
+        chunks.push(c);
+      }
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].message.response_metadata).toEqual(
+        expect.objectContaining({ model_provider: "baseten" })
+      );
+
+      superStream.mockRestore();
+    });
+
+    it("strips usage_metadata from content chunks", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const contentChunk = makeChunk("hi", {
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+        },
+      });
+      const usageOnlyChunk = makeChunk("", {
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      });
+
+      const superStream = vi
+        .spyOn(
+          Object.getPrototypeOf(ChatBaseten.prototype),
+          "_streamResponseChunks"
+        )
+        .mockReturnValueOnce(fakeStream([contentChunk, usageOnlyChunk]));
+
+      const chunks: ChatGenerationChunk[] = [];
+      for await (const c of model._streamResponseChunks([], {} as any)) {
+        chunks.push(c);
+      }
+
+      expect(chunks).toHaveLength(2);
+      expect(
+        (chunks[0].message as AIMessageChunk).usage_metadata
+      ).toBeUndefined();
+      expect(
+        (chunks[1].message as AIMessageChunk).usage_metadata
+      ).toBeDefined();
+
+      superStream.mockRestore();
+    });
+
+    it("normalizes tool_call_chunks in stream", async () => {
+      const model = new ChatBaseten({
+        model: TEST_MODEL,
+        basetenApiKey: TEST_API_KEY,
+      });
+
+      const chunk = makeChunk("", {
+        tool_call_chunks: [
+          { name: "get_weather", args: '{"loc', id: "call_1", index: 0 },
+          { name: undefined, args: 'ation":', id: "call_2", index: 0 },
+        ],
+      });
+
+      const superStream = vi
+        .spyOn(
+          Object.getPrototypeOf(ChatBaseten.prototype),
+          "_streamResponseChunks"
+        )
+        .mockReturnValueOnce(fakeStream([chunk]));
+
+      const chunks: ChatGenerationChunk[] = [];
+      for await (const c of model._streamResponseChunks([], {} as any)) {
+        chunks.push(c);
+      }
+
+      const msg = chunks[0].message as AIMessageChunk;
+      expect(msg.tool_call_chunks).toHaveLength(1);
+      expect(msg.tool_call_chunks![0]).toMatchObject({
+        name: "get_weather",
+        args: '{"location":',
+        index: 0,
+      });
+
+      superStream.mockRestore();
+    });
+  });
+});
+
+describe("normalizeToolCallChunks", () => {
+  it("returns single chunk with name unchanged", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: "search", args: '{"q":"hi"}', id: "c1", index: 0 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toEqual(chunks);
+  });
+
+  it("consolidates same-index entries", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: "search", args: '{"q":', id: "c1", index: 0 },
+      { name: undefined, args: '"hi"}', id: "c2", index: 0 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "search",
+      args: '{"q":"hi"}',
+      id: "c1",
+      index: 0,
+    });
+  });
+
+  it("nulls out id on continuation chunks (no name)", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: undefined, args: '"rest"}', id: "c99", index: 0 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBeUndefined();
+    expect(result[0].args).toBe('"rest"}');
+  });
+
+  it("keeps separate entries for different indices", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: "search", args: '{"a":1}', id: "c1", index: 0 },
+      { name: "fetch", args: '{"b":2}', id: "c2", index: 1 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("search");
+    expect(result[1].name).toBe("fetch");
+  });
+
+  it("handles empty array", () => {
+    expect(normalizeToolCallChunks([])).toEqual([]);
+  });
+
+  it("preserves first non-null id when merging", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: "fn", args: "{", id: undefined, index: 0 },
+      { name: undefined, args: "}", id: "c5", index: 0 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("c5");
+    expect(result[0].name).toBe("fn");
+  });
+
+  it("merges three same-index deltas", () => {
+    const chunks: ToolCallChunk[] = [
+      { name: "tool", args: '{"a":', id: "c1", index: 0 },
+      { name: undefined, args: '"b",', id: "c2", index: 0 },
+      { name: undefined, args: '"c":1}', id: "c3", index: 0 },
+    ];
+    const result = normalizeToolCallChunks(chunks);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "tool",
+      args: '{"a":"b","c":1}',
+      id: "c1",
+      index: 0,
+    });
+  });
+});
+
+describe("normalizeModelUrl", () => {
+  it("converts /predict to /sync/v1", () => {
+    expect(
+      normalizeModelUrl(
+        "https://model-abc123.api.baseten.co/environments/production/predict"
+      )
+    ).toBe(
+      "https://model-abc123.api.baseten.co/environments/production/sync/v1"
+    );
+  });
+
+  it("appends /v1 to /sync", () => {
+    expect(
+      normalizeModelUrl(
+        "https://model-abc123.api.baseten.co/environments/production/sync"
+      )
+    ).toBe(
+      "https://model-abc123.api.baseten.co/environments/production/sync/v1"
+    );
+  });
+
+  it("leaves /sync/v1 unchanged", () => {
+    const url =
+      "https://model-abc123.api.baseten.co/environments/production/sync/v1";
+    expect(normalizeModelUrl(url)).toBe(url);
+  });
+
+  it("appends /v1 to bare URL without trailing slash", () => {
+    expect(
+      normalizeModelUrl("https://model-abc123.api.baseten.co")
+    ).toBe("https://model-abc123.api.baseten.co/v1");
+  });
+
+  it("strips trailing slash before appending /v1", () => {
+    expect(
+      normalizeModelUrl("https://model-abc123.api.baseten.co/")
+    ).toBe("https://model-abc123.api.baseten.co/v1");
+  });
+});

--- a/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-baseten/src/tests/chat_models.test.ts
@@ -4,7 +4,7 @@ import {
   normalizeToolCallChunks,
   normalizeModelUrl,
 } from "../index.js";
-import { DEFAULT_BASE_URL, DEFAULT_API_KEY_ENV_VAR } from "../types.js";
+import { DEFAULT_BASE_URL, DEFAULT_API_KEY_ENV_VAR } from "../const.js";
 import { AIMessageChunk } from "@langchain/core/messages";
 import { ChatGenerationChunk } from "@langchain/core/outputs";
 import type { ToolCallChunk } from "@langchain/core/messages/tool";

--- a/libs/providers/langchain-baseten/src/types.ts
+++ b/libs/providers/langchain-baseten/src/types.ts
@@ -1,0 +1,101 @@
+import type { ChatOpenAIFields } from "@langchain/openai";
+
+/**
+ * Default base URL for Baseten's managed inference API.
+ * Supports all open-source models hosted on Baseten's Model APIs.
+ *
+ * For self-deployed models, override with the model-specific URL:
+ * `https://model-{model_id}.api.baseten.co/v1`
+ */
+export const DEFAULT_BASE_URL = "https://inference.baseten.co/v1";
+
+/**
+ * Default environment variable name for the Baseten API key.
+ */
+export const DEFAULT_API_KEY_ENV_VAR = "BASETEN_API_KEY";
+
+/**
+ * Normalize a dedicated model URL to OpenAI-compatible `/sync/v1` format.
+ *
+ * Baseten dedicated model endpoints come in several forms:
+ * - `.../predict` -> converted to `.../sync/v1`
+ * - `.../sync` -> appended with `/v1`
+ * - anything else -> ensures trailing `/v1`
+ *
+ * See: Python `langchain-baseten._normalize_model_url`
+ */
+export function normalizeModelUrl(url: string): string {
+  if (url.endsWith("/predict")) {
+    return url.replace(/\/predict$/, "/sync/v1");
+  }
+  if (url.endsWith("/sync")) {
+    return `${url}/v1`;
+  }
+  if (!url.endsWith("/v1")) {
+    return `${url.replace(/\/+$/, "")}/v1`;
+  }
+  return url;
+}
+
+/**
+ * Input fields for constructing a `ChatBaseten` instance.
+ *
+ * Extends `ChatOpenAIFields` since Baseten exposes an OpenAI-compatible API.
+ * The API key defaults to the `BASETEN_API_KEY` environment variable and
+ * the base URL defaults to Baseten's managed inference endpoint.
+ *
+ * @example
+ * ```typescript
+ * const input: BasetenChatInput = {
+ *   model: "deepseek-ai/DeepSeek-V3.1",
+ *   // apiKey defaults to process.env.BASETEN_API_KEY
+ * };
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Self-deployed model via dedicated URL
+ * const input: BasetenChatInput = {
+ *   modelUrl: "https://model-abc123.api.baseten.co/environments/production/predict",
+ *   basetenApiKey: "my-key",
+ * };
+ * ```
+ */
+export interface BasetenChatInput extends Omit<ChatOpenAIFields, "model"> {
+  /**
+   * Baseten model slug in `org/model-name` format.
+   * Optional when `modelUrl` is provided (the model ID will be
+   * extracted from the URL).
+   *
+   * @example "deepseek-ai/DeepSeek-V3.1"
+   * @example "zai-org/GLM-5"
+   * @example "moonshotai/Kimi-K2.5"
+   */
+  model?: string;
+
+  /**
+   * Dedicated model URL for self-deployed Baseten models.
+   * Supports `/predict`, `/sync`, and `/sync/v1` endpoint formats;
+   * the URL is automatically normalized to `/sync/v1`.
+   *
+   * When provided, overrides `baseURL`.
+   *
+   * @example "https://model-abc123.api.baseten.co/environments/production/predict"
+   */
+  modelUrl?: string;
+
+  /**
+   * Baseten API key. If not provided, falls back to the `BASETEN_API_KEY`
+   * environment variable.
+   */
+  basetenApiKey?: string;
+
+  /**
+   * Override the base URL for Baseten's API.
+   * Defaults to `https://inference.baseten.co/v1`.
+   *
+   * Set this for self-deployed models:
+   * `https://model-{model_id}.api.baseten.co/v1`
+   */
+  baseURL?: string;
+}

--- a/libs/providers/langchain-baseten/src/types.ts
+++ b/libs/providers/langchain-baseten/src/types.ts
@@ -1,47 +1,6 @@
 import type { ChatOpenAIFields } from "@langchain/openai";
 
 /**
- * Default base URL for Baseten's managed inference API.
- * Supports all open-source models hosted on Baseten's Model APIs.
- *
- * For self-deployed models, override with the model-specific URL:
- * `https://model-{model_id}.api.baseten.co/v1`
- */
-export const DEFAULT_BASE_URL = "https://inference.baseten.co/v1";
-
-/**
- * Default environment variable name for the Baseten API key.
- */
-export const DEFAULT_API_KEY_ENV_VAR = "BASETEN_API_KEY";
-
-/**
- * Normalize a dedicated model URL to OpenAI-compatible `/sync/v1` format.
- *
- * Baseten dedicated model endpoints come in several forms:
- * - `.../predict` -> converted to `.../sync/v1`
- * - `.../sync` -> appended with `/v1`
- * - anything else -> ensures trailing `/v1`
- *
- * See: Python `langchain-baseten._normalize_model_url`
- */
-export function normalizeModelUrl(url: string): string {
-  if (url.endsWith("/predict")) {
-    return `${url.slice(0, -"/predict".length)}/sync/v1`;
-  }
-  if (url.endsWith("/sync")) {
-    return `${url}/v1`;
-  }
-  if (!url.endsWith("/v1")) {
-    let trimmed = url;
-    while (trimmed.endsWith("/")) {
-      trimmed = trimmed.slice(0, -1);
-    }
-    return `${trimmed}/v1`;
-  }
-  return url;
-}
-
-/**
  * Input fields for constructing a `ChatBaseten` instance.
  *
  * Extends `ChatOpenAIFields` since Baseten exposes an OpenAI-compatible API.

--- a/libs/providers/langchain-baseten/src/types.ts
+++ b/libs/providers/langchain-baseten/src/types.ts
@@ -26,13 +26,17 @@ export const DEFAULT_API_KEY_ENV_VAR = "BASETEN_API_KEY";
  */
 export function normalizeModelUrl(url: string): string {
   if (url.endsWith("/predict")) {
-    return url.replace(/\/predict$/, "/sync/v1");
+    return `${url.slice(0, -"/predict".length)}/sync/v1`;
   }
   if (url.endsWith("/sync")) {
     return `${url}/v1`;
   }
   if (!url.endsWith("/v1")) {
-    return `${url.replace(/\/+$/, "")}/v1`;
+    let trimmed = url;
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.slice(0, -1);
+    }
+    return `${trimmed}/v1`;
   }
   return url;
 }

--- a/libs/providers/langchain-baseten/tsconfig.json
+++ b/libs/providers/langchain-baseten/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@langchain/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../../langchain-core" },
+    { "path": "../langchain-openai" }
+  ]
+}

--- a/libs/providers/langchain-baseten/tsdown.config.ts
+++ b/libs/providers/langchain-baseten/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { getBuildConfig, cjsCompatPlugin } from "@langchain/build";
+import pkg from "./package.json" with { type: "json" };
+
+export default getBuildConfig({
+  entry: ["./src/index.ts"],
+  define: { __PKG_VERSION__: JSON.stringify(pkg.version) },
+  plugins: [
+    cjsCompatPlugin({
+      files: ["dist/", "CHANGELOG.md", "README.md", "LICENSE"],
+    }),
+  ],
+});

--- a/libs/providers/langchain-baseten/vitest.config.ts
+++ b/libs/providers/langchain-baseten/vitest.config.ts
@@ -1,0 +1,73 @@
+import {
+  configDefaults,
+  defineConfig,
+  type UserConfigExport,
+} from "vitest/config";
+import pkg from "./package.json" with { type: "json" };
+const define = { __PKG_VERSION__: JSON.stringify(pkg.version) };
+
+export default defineConfig((env) => {
+  const common: UserConfigExport = {
+    test: {
+      environment: "node",
+      hideSkippedTests: true,
+      testTimeout: 30_000,
+      maxWorkers: 0.5,
+      exclude: ["**/*.int.test.ts", ...configDefaults.exclude],
+      setupFiles: ["dotenv/config"],
+    },
+  };
+
+  if (env.mode === "standard-unit") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.standard.test.ts"],
+        name: "standard-unit",
+        environment: "node",
+      },
+    };
+  }
+
+  if (env.mode === "standard-int") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.standard.int.test.ts"],
+        name: "standard-int",
+        environment: "node",
+      },
+    };
+  }
+
+  if (env.mode === "int") {
+    return {
+      define,
+      test: {
+        ...common.test,
+        globals: false,
+        testTimeout: 100_000,
+        exclude: configDefaults.exclude,
+        include: ["**/*.int.test.ts"],
+        name: "int",
+        environment: "node",
+      },
+    };
+  }
+
+  return {
+    define,
+    test: {
+      ...common.test,
+      environment: "node",
+      include: configDefaults.include,
+      typecheck: { enabled: true },
+    },
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1270,6 +1270,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@3.2.4)(vite@7.3.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^3.25.76 || ^4
+        version: 4.3.6
 
   libs/providers/langchain-cloudflare:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1237,6 +1237,40 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
+  libs/providers/langchain-baseten:
+    dependencies:
+      '@langchain/openai':
+        specifier: workspace:*
+        version: link:../langchain-openai
+    devDependencies:
+      '@langchain/core':
+        specifier: workspace:^
+        version: link:../../langchain-core
+      '@langchain/standard-tests':
+        specifier: workspace:*
+        version: link:../../../internal/standard-tests
+      '@langchain/tsconfig':
+        specifier: workspace:*
+        version: link:../../../internal/tsconfig
+      '@tsconfig/recommended':
+        specifier: ^1.0.3
+        version: 1.0.13
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@4.1.5)
+      dotenv:
+        specifier: ^17.4.0
+        version: 17.4.2
+      dpdm:
+        specifier: ^3.14.0
+        version: 3.15.1
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@3.2.4)(vite@7.3.2(@types/node@25.6.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   libs/providers/langchain-cloudflare:
     devDependencies:
       '@cloudflare/workers-types':
@@ -19535,7 +19569,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4
@@ -20459,7 +20493,7 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Adds a new `@langchain/baseten` package — a LangChain chat model provider for [Baseten's](https://www.baseten.co/) OpenAI-compatible inference API. This is a TypeScript port of the official Python [`langchain-baseten`](https://github.com/basetenlabs/langchain-baseten) package.

- Introduces `ChatBaseten`, extending `ChatOpenAI` and pointing it at Baseten's `https://inference.baseten.co/v1` endpoint
- Ports TensorRT-LLM streaming fixes from Python: tool-call chunk normalization (`normalizeToolCallChunks`) and cumulative usage metadata stripping
- Adds dedicated model URL support (`modelUrl`) with automatic normalization of `/predict`, `/sync`, and `/sync/v1` endpoint formats (via `normalizeModelUrl`)
- Tags all responses with `model_provider: "baseten"` in `response_metadata` and `ls_provider: "baseten"` for LangSmith tracing
- Reasoning content (`additional_kwargs.reasoning_content`) flows through via the parent `@langchain/openai` completions converters — verified with pass-through tests
- Defaults `streamUsage: true` to match the Python package behavior
- Includes 38 unit tests and 3 integration tests (direct invoke, streaming, `createDeepAgent` end-to-end)