### PR TITLE
fix(core): merge consecutive text blocks in AIMessageChunk.concat()

### DIFF
--- a/.changeset/merge-consecutive-text-blocks.md
+++ b/.changeset/merge-consecutive-text-blocks.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): merge consecutive text blocks in AIMessageChunk.concat()

--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -156,6 +156,23 @@ export function mergeContent(
       ];
     } else {
       const left = contentBlocksFromNonStringFirst(firstContent);
+      const lastIdx = left.length - 1;
+      const lastBlock = left[lastIdx];
+      if (
+        lastBlock != null &&
+        typeof lastBlock === "object" &&
+        "type" in lastBlock &&
+        lastBlock.type === "text" &&
+        "text" in lastBlock
+      ) {
+        // Merge into the trailing text block to keep consecutive text joined
+        const merged = [...left];
+        merged[lastIdx] = {
+          ...lastBlock,
+          text: `${(lastBlock as unknown as { text: string }).text}${secondContent}`,
+        };
+        return merged;
+      }
       return [...left, { type: "text", text: secondContent }];
     }
   }

--- a/libs/langchain-core/src/messages/tests/base_message.test.ts
+++ b/libs/langchain-core/src/messages/tests/base_message.test.ts
@@ -140,9 +140,71 @@ test("mergeContent merges single block object with string second content", () =>
     singleBlock as unknown as MessageContent,
     " world"
   );
-  expect(result).toEqual([
-    { type: "text", text: "Hello" },
-    { type: "text", text: " world" },
+  expect(result).toEqual([{ type: "text", text: "Hello world" }]);
+});
+
+test("AIMessageChunk.concat merges text chunks after non-text block", () => {
+  const chunks: AIMessageChunk[] = [
+    new AIMessageChunk({ content: "Sure, " }),
+    new AIMessageChunk({ content: "here you go." }),
+    new AIMessageChunk({
+      content: [
+        {
+          type: "executableCode",
+          executableCode: {
+            language: "PYTHON",
+            code: "print(42)",
+          },
+        },
+      ],
+    }),
+    new AIMessageChunk({ content: "The result " }),
+    new AIMessageChunk({ content: "is 42." }),
+  ];
+
+  const [first, ...rest] = chunks;
+  const collected = rest.reduce(
+    (acc, chunk) => acc.concat(chunk),
+    first!
+  );
+
+  expect(collected.content).toHaveLength(3);
+  expect(collected.content).toEqual([
+    { type: "text", text: "Sure, here you go." },
+    {
+      type: "executableCode",
+      executableCode: { language: "PYTHON", code: "print(42)" },
+    },
+    { type: "text", text: "The result is 42." },
+  ]);
+});
+
+test("AIMessageChunk.concat merges text after inlineData block", () => {
+  const chunks: AIMessageChunk[] = [
+    new AIMessageChunk({ content: "Before " }),
+    new AIMessageChunk({
+      content: [
+        {
+          type: "inlineData",
+          inlineData: { mimeType: "image/png", data: "abc" },
+        },
+      ],
+    }),
+    new AIMessageChunk({ content: "After " }),
+    new AIMessageChunk({ content: "image." }),
+  ];
+
+  const [first, ...rest] = chunks;
+  const collected = rest.reduce(
+    (acc, chunk) => acc.concat(chunk),
+    first!
+  );
+
+  expect(collected.content).toHaveLength(3);
+  expect(collected.content).toEqual([
+    { type: "text", text: "Before " },
+    { type: "inlineData", inlineData: { mimeType: "image/png", data: "abc" } },
+    { type: "text", text: "After image." },
   ]);
 });
 

--- a/libs/langchain-core/src/messages/tests/system.test.ts
+++ b/libs/langchain-core/src/messages/tests/system.test.ts
@@ -69,8 +69,7 @@ describe("SystemMessage", () => {
       });
       const result = message.concat(" world");
       expect(result.content).toEqual([
-        { type: "text", text: "Hello" },
-        { type: "text", text: " world" },
+        { type: "text", text: "Hello world" },
       ]);
     });
 


### PR DESCRIPTION
## Summary

Fixes #10561.

`AIMessageChunk.concat()` now correctly merges consecutive text chunks that arrive after a non-text content block (e.g. `executableCode`, `inlineData`).

---

## Root Cause

In `mergeContent()` (`libs/langchain-core/src/messages/base.ts`), the branch handling `firstContent` as an array and `secondContent` as a string always appended a **new** `{ type: "text" }` block via:

```ts
return [...left, { type: "text", text: secondContent }];
```

This worked correctly when the last element in `left` was **not** a text block (e.g. after an `executableCode` chunk, we correctly start a new text block). However, on subsequent text chunks the trailing block was already `type: "text"`, yet the code still created a new block instead of merging into it.

**Result:** streaming `[text, text, executableCode, text, text]` produced `[text, executableCode, text, text]` instead of the expected `[text, executableCode, text]`.

---

## Solution

Before appending a new text block, check whether the last element in the accumulated array is already a text block. If it is, merge the incoming string into it. Otherwise, append as before.

The check is intentionally conservative — it verifies `type === "text"` **and** the presence of a `text` property before merging, so non-text trailing blocks are never affected.

---

## Testing

- Added `test("AIMessageChunk.concat merges text chunks after non-text block")` — reproduces the exact scenario from the issue (text → text → executableCode → text → text → expect 3 blocks)
- Added `test("AIMessageChunk.concat merges text after inlineData block")` — covers a second non-text block type
- Updated two existing tests (`mergeContent merges single block object with string second content` in `base_message.test.ts` and `SystemMessage` concat in `system.test.ts`) whose expectations were asserting the old broken behaviour
- All 1315 tests in `@langchain/core` pass, including type checks

Run with: `cd libs/langchain-core && npx vitest run src/messages/`

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New tests cover the exact failing scenario from the issue
- [x] All existing tests pass (1315/1315)
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md and followed its requirements