### PR TITLE
feat(openrouter): surface reasoning as v1 standard content blocks

### DIFF
--- a/.changeset/openrouter-reasoning-content.md
+++ b/.changeset/openrouter-reasoning-content.md
@@ -1,0 +1,21 @@
+---
+"@langchain/openrouter": minor
+"@langchain/core": patch
+---
+
+feat(openrouter): surface reasoning content as v1 standard content blocks
+
+`convertOpenRouterResponseToBaseMessage` and
+`convertOpenRouterDeltaToBaseMessageChunk` now copy OpenRouter's
+`reasoning` (flat string) and `reasoning_details` (structured array) fields
+onto `additional_kwargs.reasoning_content` / `additional_kwargs.reasoning_details`.
+A new `ChatOpenRouterTranslator` is registered in `@langchain/core` under
+the `"openrouter"` provider key so `AIMessage.contentBlocks` emits standard
+`{type: "reasoning"}` blocks alongside text and tool calls.
+
+Previously, reasoning text returned by reasoning-capable models routed
+through OpenRouter (DeepSeek R1, Minimax M2, Claude extended thinking,
+o-series, etc.) was silently dropped: only the `reasoning_tokens` count
+was preserved via `usage_metadata`. Consumers using standard content blocks
+(including the frontend agent UI patterns shown in the docs) could not
+display the model's chain of thought.

--- a/libs/langchain-core/src/messages/block_translators/index.ts
+++ b/libs/langchain-core/src/messages/block_translators/index.ts
@@ -9,6 +9,7 @@ import { ChatVertexTranslator } from "./google_vertexai.js";
 import { ChatGroqTranslator } from "./groq.js";
 import { ChatOllamaTranslator } from "./ollama.js";
 import { ChatOpenAITranslator } from "./openai.js";
+import { ChatOpenRouterTranslator } from "./openrouter.js";
 import { ChatXAITranslator } from "./xai.js";
 import { ChatGoogleTranslator } from "./google.js";
 
@@ -33,6 +34,7 @@ globalThis.lc_block_translators_registry ??= new Map([
   ["groq", ChatGroqTranslator],
   ["ollama", ChatOllamaTranslator],
   ["openai", ChatOpenAITranslator],
+  ["openrouter", ChatOpenRouterTranslator],
   ["xai", ChatXAITranslator],
 ]);
 

--- a/libs/langchain-core/src/messages/block_translators/openrouter.ts
+++ b/libs/langchain-core/src/messages/block_translators/openrouter.ts
@@ -1,0 +1,127 @@
+import { AIMessage } from "../ai.js";
+import { ContentBlock } from "../content/index.js";
+import type { StandardContentBlockTranslator } from "./index.js";
+import { _isString } from "./utils.js";
+
+/**
+ * Converts an OpenRouter AI message to an array of v1 standard content blocks.
+ *
+ * OpenRouter returns reasoning output through two places on the Chat
+ * Completions response:
+ *
+ * 1. `message.reasoning` / `delta.reasoning` — a flat string that summarizes
+ *    the model's chain of thought. The `@langchain/openrouter` converter
+ *    normalizes this into `additional_kwargs.reasoning_content` so it matches
+ *    the DeepSeek convention already used elsewhere in LangChain.
+ * 2. `message.reasoning_details` / `delta.reasoning_details` — a structured
+ *    array of provider-specific reasoning artifacts (see the
+ *    `reasoning.summary` / `reasoning.encrypted` / `reasoning.text` union in
+ *    the OpenRouter API types). The converter preserves these verbatim under
+ *    `additional_kwargs.reasoning_details` for round-tripping back to the
+ *    provider on subsequent turns (e.g. Anthropic extended thinking requires
+ *    the original `signature` to be echoed back).
+ *
+ * This translator prefers the structured `reasoning_details` form when
+ * present (so no information is lost), and falls back to the flat
+ * `reasoning_content` string otherwise.
+ *
+ * @param message - The AI message containing OpenRouter-formatted content
+ * @returns Array of content blocks in v1 standard format
+ *
+ * @example
+ * ```typescript
+ * const message = new AIMessage({
+ *   content: "The answer is 42",
+ *   additional_kwargs: { reasoning_content: "Let me think about this..." },
+ *   response_metadata: { model_provider: "openrouter" },
+ * });
+ * message.contentBlocks;
+ * // [
+ * //   { type: "reasoning", reasoning: "Let me think about this..." },
+ * //   { type: "text", text: "The answer is 42" }
+ * // ]
+ * ```
+ */
+export function convertToV1FromOpenRouterMessage(
+  message: AIMessage
+): Array<ContentBlock.Standard> {
+  const blocks: Array<ContentBlock.Standard> = [];
+
+  // Prefer structured reasoning_details when present — they can carry
+  // multiple distinct reasoning artifacts (summary, encrypted, text).
+  const reasoningDetails = message.additional_kwargs?.reasoning_details;
+  if (Array.isArray(reasoningDetails) && reasoningDetails.length > 0) {
+    for (const detail of reasoningDetails) {
+      if (detail == null || typeof detail !== "object") continue;
+      const type = (detail as { type?: unknown }).type;
+      if (type === "reasoning.summary") {
+        const summary = (detail as { summary?: unknown }).summary;
+        if (_isString(summary) && summary.length > 0) {
+          blocks.push({ type: "reasoning", reasoning: summary });
+        }
+      } else if (type === "reasoning.text") {
+        const text = (detail as { text?: unknown }).text;
+        if (_isString(text) && text.length > 0) {
+          blocks.push({ type: "reasoning", reasoning: text });
+        }
+      }
+      // `reasoning.encrypted` details carry no human-readable text (only an
+      // opaque `data` blob that must be echoed back to the provider), so they
+      // do not become visible reasoning blocks. They stay in
+      // `additional_kwargs.reasoning_details` for round-tripping.
+    }
+  } else {
+    // Fall back to the flat `reasoning_content` string (the DeepSeek-style
+    // convention that `@langchain/openrouter` normalizes to when no
+    // structured details are present).
+    const reasoningContent = message.additional_kwargs?.reasoning_content;
+    if (_isString(reasoningContent) && reasoningContent.length > 0) {
+      blocks.push({
+        type: "reasoning",
+        reasoning: reasoningContent,
+      });
+    }
+  }
+
+  // Handle text content (string or multi-block array).
+  if (typeof message.content === "string") {
+    if (message.content.length > 0) {
+      blocks.push({
+        type: "text",
+        text: message.content,
+      });
+    }
+  } else {
+    for (const block of message.content) {
+      if (
+        typeof block === "object" &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        _isString(block.text)
+      ) {
+        blocks.push({
+          type: "text",
+          text: block.text,
+        });
+      }
+    }
+  }
+
+  // Add tool calls if present.
+  for (const toolCall of message.tool_calls ?? []) {
+    blocks.push({
+      type: "tool_call",
+      id: toolCall.id,
+      name: toolCall.name,
+      args: toolCall.args,
+    });
+  }
+
+  return blocks;
+}
+
+export const ChatOpenRouterTranslator: StandardContentBlockTranslator = {
+  translateContent: convertToV1FromOpenRouterMessage,
+  translateContentChunk: convertToV1FromOpenRouterMessage,
+};

--- a/libs/langchain-core/src/messages/block_translators/openrouter.ts
+++ b/libs/langchain-core/src/messages/block_translators/openrouter.ts
@@ -21,9 +21,10 @@ import { _isString } from "./utils.js";
  *    provider on subsequent turns (e.g. Anthropic extended thinking requires
  *    the original `signature` to be echoed back).
  *
- * This translator prefers the structured `reasoning_details` form when
- * present (so no information is lost), and falls back to the flat
- * `reasoning_content` string otherwise.
+ * When `reasoning_details` is present, visible blocks are emitted from
+ * `reasoning.summary` / `reasoning.text` entries. If the array contains only
+ * opaque artifacts (e.g. `reasoning.encrypted`), the flat `reasoning_content`
+ * string is used as a fallback when available.
  *
  * @param message - The AI message containing OpenRouter-formatted content
  * @returns Array of content blocks in v1 standard format
@@ -50,6 +51,7 @@ export function convertToV1FromOpenRouterMessage(
   // Prefer structured reasoning_details when present — they can carry
   // multiple distinct reasoning artifacts (summary, encrypted, text).
   const reasoningDetails = message.additional_kwargs?.reasoning_details;
+  let hasVisibleReasoningFromDetails = false;
   if (Array.isArray(reasoningDetails) && reasoningDetails.length > 0) {
     for (const detail of reasoningDetails) {
       if (detail == null || typeof detail !== "object") continue;
@@ -58,11 +60,13 @@ export function convertToV1FromOpenRouterMessage(
         const summary = (detail as { summary?: unknown }).summary;
         if (_isString(summary) && summary.length > 0) {
           blocks.push({ type: "reasoning", reasoning: summary });
+          hasVisibleReasoningFromDetails = true;
         }
       } else if (type === "reasoning.text") {
         const text = (detail as { text?: unknown }).text;
         if (_isString(text) && text.length > 0) {
           blocks.push({ type: "reasoning", reasoning: text });
+          hasVisibleReasoningFromDetails = true;
         }
       }
       // `reasoning.encrypted` details carry no human-readable text (only an
@@ -70,10 +74,9 @@ export function convertToV1FromOpenRouterMessage(
       // do not become visible reasoning blocks. They stay in
       // `additional_kwargs.reasoning_details` for round-tripping.
     }
-  } else {
-    // Fall back to the flat `reasoning_content` string (the DeepSeek-style
-    // convention that `@langchain/openrouter` normalizes to when no
-    // structured details are present).
+  }
+
+  if (!hasVisibleReasoningFromDetails) {
     const reasoningContent = message.additional_kwargs?.reasoning_content;
     if (_isString(reasoningContent) && reasoningContent.length > 0) {
       blocks.push({

--- a/libs/langchain-core/src/messages/block_translators/tests/openrouter.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openrouter.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import { AIMessage, AIMessageChunk } from "../../ai.js";
+import { ContentBlock } from "../../content/index.js";
+
+describe("openrouterTranslator", () => {
+  it("should translate reasoning_content in additional_kwargs to reasoning block", () => {
+    const message = new AIMessage({
+      content: "The answer is 42",
+      additional_kwargs: {
+        reasoning_content: "Let me think about this carefully...",
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "Let me think about this carefully..." },
+      { type: "text", text: "The answer is 42" },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should handle messages without reasoning content", () => {
+    const message = new AIMessage({
+      content: "Hello world",
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "text", text: "Hello world" },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should handle empty reasoning content", () => {
+    const message = new AIMessage({
+      content: "Hello world",
+      additional_kwargs: { reasoning_content: "" },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "text", text: "Hello world" },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should translate reasoning with tool calls", () => {
+    const message = new AIMessage({
+      content: "Let me check the weather for you.",
+      additional_kwargs: {
+        reasoning_content: "The user wants to know the weather in SF.",
+      },
+      tool_calls: [
+        {
+          id: "call_123",
+          name: "get_weather",
+          args: { location: "San Francisco" },
+        },
+      ],
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      {
+        type: "reasoning",
+        reasoning: "The user wants to know the weather in SF.",
+      },
+      { type: "text", text: "Let me check the weather for you." },
+      {
+        type: "tool_call",
+        id: "call_123",
+        name: "get_weather",
+        args: { location: "San Francisco" },
+      },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should translate AIMessageChunk with reasoning content", () => {
+    const chunk = new AIMessageChunk({
+      content: "Calculating...",
+      additional_kwargs: { reasoning_content: "Step 1: analyze the input" },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "Step 1: analyze the input" },
+      { type: "text", text: "Calculating..." },
+    ];
+
+    expect(chunk.contentBlocks).toEqual(expected);
+  });
+
+  it("should handle array content with text blocks", () => {
+    const message = new AIMessage({
+      content: [
+        { type: "text", text: "First part" },
+        { type: "text", text: "Second part" },
+      ],
+      additional_kwargs: { reasoning_content: "Thinking..." },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "Thinking..." },
+      { type: "text", text: "First part" },
+      { type: "text", text: "Second part" },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should handle empty text content with reasoning", () => {
+    const message = new AIMessage({
+      content: "",
+      additional_kwargs: { reasoning_content: "Just thinking, no output yet" },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "Just thinking, no output yet" },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should translate reasoning.summary details into reasoning blocks", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_details: [
+          {
+            type: "reasoning.summary",
+            summary: "First I considered A, then B.",
+          },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "First I considered A, then B." },
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should translate reasoning.text details into reasoning blocks", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_details: [
+          {
+            type: "reasoning.text",
+            text: "Let me work through this step by step.",
+            signature: "sig_abc",
+          },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      {
+        type: "reasoning",
+        reasoning: "Let me work through this step by step.",
+      },
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should skip reasoning.encrypted details (opaque, not human-readable)", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_details: [
+          {
+            type: "reasoning.encrypted",
+            data: "opaque-blob-from-anthropic",
+          },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    // Encrypted reasoning has no visible text — it only exists to be
+    // round-tripped back to the provider on the next turn.
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should prefer reasoning_details when both are present", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_content: "fallback flat text",
+        reasoning_details: [
+          {
+            type: "reasoning.summary",
+            summary: "structured summary",
+          },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    // When both are present, reasoning_details wins (it's the richer form
+    // and the one that round-trips cleanly).
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "structured summary" },
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should handle multiple reasoning.summary details as separate blocks", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_details: [
+          { type: "reasoning.summary", summary: "Step 1 summary" },
+          { type: "reasoning.summary", summary: "Step 2 summary" },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "Step 1 summary" },
+      { type: "reasoning", reasoning: "Step 2 summary" },
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+});

--- a/libs/langchain-core/src/messages/block_translators/tests/openrouter.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openrouter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AIMessage, AIMessageChunk } from "../../ai.js";
 import { ContentBlock } from "../../content/index.js";
+import { convertToV1FromOpenRouterMessage } from "../openrouter.js";
 
 describe("openrouterTranslator", () => {
   it("should translate reasoning_content in additional_kwargs to reasoning block", () => {
@@ -199,6 +200,29 @@ describe("openrouterTranslator", () => {
     expect(message.contentBlocks).toEqual(expected);
   });
 
+  it("should fall back to reasoning_content when reasoning_details are encrypted-only", () => {
+    const message = new AIMessage({
+      content: "Done.",
+      additional_kwargs: {
+        reasoning_content: "visible chain of thought",
+        reasoning_details: [
+          {
+            type: "reasoning.encrypted",
+            data: "opaque-blob-from-anthropic",
+          },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const expected: Array<ContentBlock.Standard> = [
+      { type: "reasoning", reasoning: "visible chain of thought" },
+      { type: "text", text: "Done." },
+    ];
+
+    expect(message.contentBlocks).toEqual(expected);
+  });
+
   it("should prefer reasoning_details when both are present", () => {
     const message = new AIMessage({
       content: "Done.",
@@ -222,6 +246,43 @@ describe("openrouterTranslator", () => {
     ];
 
     expect(message.contentBlocks).toEqual(expected);
+  });
+
+  it("should merge streaming reasoning_details by index on AIMessageChunk concat", () => {
+    const c1 = new AIMessageChunk({
+      additional_kwargs: {
+        reasoning_details: [
+          { type: "reasoning.text", text: "Let me ", index: 0 },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+    const c2 = new AIMessageChunk({
+      additional_kwargs: {
+        reasoning_details: [
+          { type: "reasoning.text", text: "think.", index: 0 },
+        ],
+      },
+      response_metadata: { model_provider: "openrouter" },
+    });
+    const c3 = new AIMessageChunk({
+      content: "42.",
+      response_metadata: { model_provider: "openrouter" },
+    });
+
+    const merged = c1.concat(c2).concat(c3);
+
+    expect(merged.additional_kwargs.reasoning_details).toEqual([
+      { type: "reasoning.text", text: "Let me think.", index: 0 },
+    ]);
+    expect(convertToV1FromOpenRouterMessage(merged)).toEqual([
+      { type: "reasoning", reasoning: "Let me think." },
+      { type: "text", text: "42." },
+    ]);
+    expect(merged.contentBlocks).toEqual([
+      { type: "reasoning", reasoning: "Let me think." },
+      { type: "text", text: "42." },
+    ]);
   });
 
   it("should handle multiple reasoning.summary details as separate blocks", () => {

--- a/libs/providers/langchain-openrouter/src/converters/messages.ts
+++ b/libs/providers/langchain-openrouter/src/converters/messages.ts
@@ -44,6 +44,14 @@ export function convertMessagesToOpenRouterParams(
  * Delegates to the OpenAI completions converter for tool call parsing,
  * multi-modal output handling, and audio support, then patches
  * response_metadata to reflect the OpenRouter provider.
+ *
+ * Reasoning (chain-of-thought) output is preserved on
+ * `additional_kwargs.reasoning_content` (flat string, DeepSeek convention)
+ * and `additional_kwargs.reasoning_details` (structured array, OpenRouter
+ * native shape). Together with the `model_provider: "openrouter"` stamp,
+ * this causes `AIMessage.contentBlocks` to emit standard
+ * `{type: "reasoning"}` blocks via `ChatOpenRouterTranslator` from
+ * `@langchain/core`.
  */
 export function convertOpenRouterResponseToBaseMessage(
   choice: OpenRouter.ChatResponseChoice,
@@ -55,6 +63,24 @@ export function convertOpenRouterResponseToBaseMessage(
     rawResponse:
       rawResponse as unknown as OpenAIClient.Chat.Completions.ChatCompletion,
   });
+
+  // Surface reasoning fields that the OpenAI completions converter doesn't
+  // know about. Both are OpenRouter-specific extensions to the Chat
+  // Completions response (see `OpenRouter.AssistantMessage` in api-types.ts).
+  const assistantMessage = choice.message;
+  if (
+    typeof assistantMessage.reasoning === "string" &&
+    assistantMessage.reasoning.length > 0
+  ) {
+    message.additional_kwargs.reasoning_content = assistantMessage.reasoning;
+  }
+  if (
+    Array.isArray(assistantMessage.reasoning_details) &&
+    assistantMessage.reasoning_details.length > 0
+  ) {
+    message.additional_kwargs.reasoning_details =
+      assistantMessage.reasoning_details;
+  }
 
   message.response_metadata = {
     ...message.response_metadata,
@@ -74,6 +100,13 @@ export function convertOpenRouterResponseToBaseMessage(
  * Delegates to the OpenAI completions converter for tool call chunk
  * parsing, audio handling, and role-specific message types, then
  * patches response_metadata to reflect the OpenRouter provider.
+ *
+ * Reasoning delta text (`delta.reasoning`) and structured reasoning details
+ * (`delta.reasoning_details`) are copied onto `additional_kwargs` so they
+ * concatenate across chunks under the standard merge rules — string fields
+ * are concatenated by `_mergeDicts` and arrays are merged by index-aware
+ * `_mergeLists`. See `ChatOpenRouterTranslator` in `@langchain/core` for how
+ * the accumulated fields become v1 `{type:"reasoning"}` content blocks.
  */
 export function convertOpenRouterDeltaToBaseMessageChunk(
   delta: OpenRouter.ChatStreamingMessageChunk,
@@ -87,6 +120,16 @@ export function convertOpenRouterDeltaToBaseMessageChunk(
     defaultRole: (defaultRole ??
       "assistant") as OpenAIClient.Chat.ChatCompletionRole,
   });
+
+  if (typeof delta.reasoning === "string" && delta.reasoning.length > 0) {
+    chunk.additional_kwargs.reasoning_content = delta.reasoning;
+  }
+  if (
+    Array.isArray(delta.reasoning_details) &&
+    delta.reasoning_details.length > 0
+  ) {
+    chunk.additional_kwargs.reasoning_details = delta.reasoning_details;
+  }
 
   chunk.response_metadata = {
     ...chunk.response_metadata,

--- a/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
 import { formatToolChoice } from "../tools.js";
 import {
   convertUsageMetadata,
@@ -143,5 +144,187 @@ describe("convertOpenRouterDeltaToBaseMessageChunk metadata", () => {
 
     const meta = chunk.response_metadata as Record<string, unknown>;
     expect(meta.model_provider).toBe("openrouter");
+  });
+});
+
+// ─── reasoning extraction ────────────────────────────────────────────
+
+describe("convertOpenRouterResponseToBaseMessage reasoning", () => {
+  it("copies message.reasoning into additional_kwargs.reasoning_content", () => {
+    const choice: OpenRouter.ChatResponseChoice = {
+      index: 0,
+      finish_reason: "stop",
+      message: {
+        role: "assistant",
+        content: "The answer is 42.",
+        reasoning: "Let me think... 6 * 7 = 42.",
+      },
+    };
+    const rawResponse: OpenRouter.ChatResponse = {
+      id: "gen-r1",
+      choices: [choice],
+      created: 0,
+      model: "deepseek/deepseek-reasoner",
+      object: "chat.completion",
+    };
+
+    const msg = convertOpenRouterResponseToBaseMessage(choice, rawResponse);
+
+    expect(msg.additional_kwargs.reasoning_content).toBe(
+      "Let me think... 6 * 7 = 42."
+    );
+    // And through contentBlocks, it becomes a v1 reasoning block.
+    const blocks = (msg as AIMessage).contentBlocks;
+    expect(blocks).toContainEqual({
+      type: "reasoning",
+      reasoning: "Let me think... 6 * 7 = 42.",
+    });
+    expect(blocks).toContainEqual({
+      type: "text",
+      text: "The answer is 42.",
+    });
+  });
+
+  it("copies message.reasoning_details into additional_kwargs.reasoning_details", () => {
+    const choice: OpenRouter.ChatResponseChoice = {
+      index: 0,
+      finish_reason: "stop",
+      message: {
+        role: "assistant",
+        content: "Done.",
+        reasoning_details: [
+          {
+            type: "reasoning.text",
+            text: "Step 1, step 2, step 3.",
+            signature: "sig_abc",
+          },
+        ],
+      },
+    };
+    const rawResponse: OpenRouter.ChatResponse = {
+      id: "gen-r2",
+      choices: [choice],
+      created: 0,
+      model: "anthropic/claude-3.7-sonnet",
+      object: "chat.completion",
+    };
+
+    const msg = convertOpenRouterResponseToBaseMessage(choice, rawResponse);
+
+    expect(msg.additional_kwargs.reasoning_details).toEqual([
+      {
+        type: "reasoning.text",
+        text: "Step 1, step 2, step 3.",
+        signature: "sig_abc",
+      },
+    ]);
+    const blocks = (msg as AIMessage).contentBlocks;
+    expect(blocks).toContainEqual({
+      type: "reasoning",
+      reasoning: "Step 1, step 2, step 3.",
+    });
+  });
+
+  it("omits reasoning fields when the response has none", () => {
+    const choice: OpenRouter.ChatResponseChoice = {
+      index: 0,
+      finish_reason: "stop",
+      message: { role: "assistant", content: "plain reply" },
+    };
+    const rawResponse: OpenRouter.ChatResponse = {
+      id: "gen-plain",
+      choices: [choice],
+      created: 0,
+      model: "openai/gpt-4o-mini",
+      object: "chat.completion",
+    };
+
+    const msg = convertOpenRouterResponseToBaseMessage(choice, rawResponse);
+
+    expect(msg.additional_kwargs.reasoning_content).toBeUndefined();
+    expect(msg.additional_kwargs.reasoning_details).toBeUndefined();
+  });
+});
+
+describe("convertOpenRouterDeltaToBaseMessageChunk reasoning", () => {
+  const rawChunk = (delta: OpenRouter.ChatStreamingMessageChunk) => ({
+    id: "gen-r-stream",
+    choices: [{ delta, finish_reason: null, index: 0 }],
+    created: 0,
+    model: "deepseek/deepseek-reasoner",
+    object: "chat.completion.chunk" as const,
+  });
+
+  it("copies delta.reasoning into additional_kwargs.reasoning_content", () => {
+    const delta: OpenRouter.ChatStreamingMessageChunk = {
+      role: "assistant",
+      reasoning: "first thought ",
+    };
+
+    const chunk = convertOpenRouterDeltaToBaseMessageChunk(
+      delta,
+      rawChunk(delta),
+      "assistant"
+    );
+
+    expect(chunk.additional_kwargs.reasoning_content).toBe("first thought ");
+  });
+
+  it("concatenates reasoning across streaming chunks via chunk merge", () => {
+    const d1: OpenRouter.ChatStreamingMessageChunk = {
+      role: "assistant",
+      reasoning: "Let me ",
+    };
+    const d2: OpenRouter.ChatStreamingMessageChunk = { reasoning: "think " };
+    const d3: OpenRouter.ChatStreamingMessageChunk = {
+      content: "42.",
+      reasoning: "carefully.",
+    };
+
+    const c1 = convertOpenRouterDeltaToBaseMessageChunk(
+      d1,
+      rawChunk(d1),
+      "assistant"
+    ) as AIMessageChunk;
+    const c2 = convertOpenRouterDeltaToBaseMessageChunk(
+      d2,
+      rawChunk(d2),
+      "assistant"
+    ) as AIMessageChunk;
+    const c3 = convertOpenRouterDeltaToBaseMessageChunk(
+      d3,
+      rawChunk(d3),
+      "assistant"
+    ) as AIMessageChunk;
+
+    const merged = c1.concat(c2).concat(c3);
+
+    expect(merged.additional_kwargs.reasoning_content).toBe(
+      "Let me think carefully."
+    );
+    expect(merged.contentBlocks).toContainEqual({
+      type: "reasoning",
+      reasoning: "Let me think carefully.",
+    });
+    expect(merged.contentBlocks).toContainEqual({
+      type: "text",
+      text: "42.",
+    });
+  });
+
+  it("omits reasoning fields when the delta has none", () => {
+    const delta: OpenRouter.ChatStreamingMessageChunk = {
+      role: "assistant",
+      content: "hi",
+    };
+
+    const chunk = convertOpenRouterDeltaToBaseMessageChunk(
+      delta,
+      rawChunk(delta),
+      "assistant"
+    );
+
+    expect(chunk.additional_kwargs.reasoning_content).toBeUndefined();
+    expect(chunk.additional_kwargs.reasoning_details).toBeUndefined();
   });
 });

--- a/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
@@ -327,4 +327,55 @@ describe("convertOpenRouterDeltaToBaseMessageChunk reasoning", () => {
     expect(chunk.additional_kwargs.reasoning_content).toBeUndefined();
     expect(chunk.additional_kwargs.reasoning_details).toBeUndefined();
   });
+
+  it("merges streaming reasoning_details by index via chunk concat", () => {
+    const d1: OpenRouter.ChatStreamingMessageChunk = {
+      role: "assistant",
+      reasoning_details: [
+        {
+          type: "reasoning.text",
+          text: "Let me ",
+          index: 0,
+        },
+      ],
+    };
+    const d2: OpenRouter.ChatStreamingMessageChunk = {
+      reasoning_details: [
+        {
+          type: "reasoning.text",
+          text: "think.",
+          index: 0,
+        },
+      ],
+    };
+    const d3: OpenRouter.ChatStreamingMessageChunk = {
+      content: "42.",
+    };
+
+    const c1 = convertOpenRouterDeltaToBaseMessageChunk(
+      d1,
+      rawChunk(d1),
+      "assistant"
+    ) as AIMessageChunk;
+    const c2 = convertOpenRouterDeltaToBaseMessageChunk(
+      d2,
+      rawChunk(d2),
+      "assistant"
+    ) as AIMessageChunk;
+    const c3 = convertOpenRouterDeltaToBaseMessageChunk(
+      d3,
+      rawChunk(d3),
+      "assistant"
+    ) as AIMessageChunk;
+
+    const merged = c1.concat(c2).concat(c3);
+
+    expect(merged.additional_kwargs.reasoning_details).toEqual([
+      {
+        type: "reasoning.text",
+        text: "Let me think.",
+        index: 0,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

Reasoning-capable models routed through OpenRouter (DeepSeek R1, Minimax M2, Claude 3.7 Sonnet extended thinking, xAI Grok reasoning, OpenAI o-series, Qwen reasoning, etc.) return their chain-of-thought output via two OpenRouter-specific extensions to the Chat Completions response:

  - non-streaming: `choice.message.reasoning` (string) and `choice.message.reasoning_details` (ReasoningDetail[])
  - streaming:     `choice.delta.reasoning` (string) and
    `choice.delta.reasoning_details` (ReasoningDetail[])

Both fields are already declared in
`libs/providers/langchain-openrouter/src/api-types.ts` (see the `AssistantMessage` and `ChatStreamingMessageChunk` interfaces), but the converter functions that translate OpenRouter wire messages into LangChain `BaseMessage` / `BaseMessageChunk` do not copy them through. Both `convertOpenRouterResponseToBaseMessage` and
`convertOpenRouterDeltaToBaseMessageChunk` delegate to `@langchain/openai`'s `convertCompletions*` helpers — which have no knowledge of OpenRouter-specific fields — and then only patch `response_metadata` to stamp `model_provider: "openrouter"`.

The stamp is also currently dead metadata: `@langchain/core`'s translator registry (`globalThis.lc_block_translators_registry` in `libs/langchain-core/src/messages/block_translators/index.ts`) does not contain an `"openrouter"` entry, so `AIMessage.contentBlocks` falls through to the base path and never produces a `{type: "reasoning"}` standard block either.

Net effect: the only reasoning-related information that survives a round trip through `@langchain/openrouter` is the `reasoning_tokens` count in `usage_metadata.output_token_details.reasoning`. The reasoning text itself is silently dropped on every request, breaking the standard content-blocks UX for any consumer routing through OpenRouter.

Related, longstanding reports confirming the gap on the JS side:
  - langchain-ai/langgraphjs#1836 (contentBlocks missing reasoning)
  - langchain-ai/langchain#32981 (reasoning tokens not passing through)
  - langchain-ai/langchain#34328 (OpenRouter/LiteLLM compatibility)
  - langchain-ai/langchain#35059 (ChatOpenAI drops reasoning_content; Python fixed in PR #35065 / #35067, JS still open)

## Minimal reproduction (on main before this commit)

  import { ChatOpenRouter } from "@langchain/openrouter";
  import { HumanMessage } from "@langchain/core/messages";

  const model = new ChatOpenRouter({
    model: "deepseek/deepseek-r1",
    apiKey: process.env.OPENROUTER_API_KEY!,
  });

  const response = await model.invoke([
    new HumanMessage("What is 17 * 23? Show your reasoning."),
  ]);

  // On main:
  response.additional_kwargs.reasoning_content; // undefined ❌
  response.additional_kwargs.reasoning_details; // undefined ❌
  response.contentBlocks;
  // [ { type: "text", text: "17 × 23 = 391" } ]
  // ^ reasoning block missing entirely, even though DeepSeek R1 clearly
  //   generated a long chain-of-thought that was returned in the HTTP
  //   response.
  response.usage_metadata?.output_token_details?.reasoning;
  // 512  ← only the count survives

The same bug manifests in streaming: no chunk carries `additional_kwargs.reasoning_content`, and merging the chunks produces an `AIMessageChunk` whose `.contentBlocks` contains only text / tool call blocks.

## Solution

Two focused changes, mirroring the existing `@langchain/deepseek` / `ChatDeepSeekTranslator` pattern that already handles the DeepSeek- native Chat Completions extension.

1. `@langchain/openrouter`: extract reasoning fields in the converter

Teach `convertOpenRouterResponseToBaseMessage` and `convertOpenRouterDeltaToBaseMessageChunk` about the two OpenRouter-specific reasoning fields:

  - `message.reasoning` / `delta.reasoning` → `additional_kwargs.reasoning_content` (matches the DeepSeek convention already used elsewhere).
  - `message.reasoning_details` / `delta.reasoning_details` → `additional_kwargs.reasoning_details` (preserved verbatim so that provider-specific artifacts — especially Anthropic extended thinking's `reasoning.encrypted` blocks whose `signature` must be echoed back on the next turn — can be round-tripped).

Both paths are strict no-ops when reasoning fields are absent, so non-reasoning models are entirely unaffected. Chunk concatenation needs no special handling: string fields in `additional_kwargs` are already concatenated by the existing `_mergeDicts` rule in `libs/langchain-core/src/messages/base.ts`, so reasoning text accumulates across streamed deltas automatically.

2. `@langchain/core`: add a `ChatOpenRouterTranslator` and register it

Add a new `libs/langchain-core/src/messages/block_translators/openrouter.ts` that reads the two fields the converter now populates and emits v1 standard content blocks:

  - When `additional_kwargs.reasoning_details` is present, iterate it and emit one `{type: "reasoning", reasoning}` block per `reasoning.summary` (using its `summary` field) and per `reasoning.text` (using its `text` field). This is the richer form and is preferred because it does not lose information when there are multiple distinct reasoning artifacts.
  - `reasoning.encrypted` details are intentionally NOT turned into visible reasoning blocks — they carry no human-readable text, only an opaque `data` blob that must be echoed back to the provider on the next turn. They remain on `additional_kwargs.reasoning_details` so round-tripping still works.
  - When only `additional_kwargs.reasoning_content` is present (the flat string fallback), emit a single `{type: "reasoning", reasoning}` block using that string. This mirrors `ChatDeepSeekTranslator` so projects that already write to `reasoning_content` just work under the `"openrouter"` key too.
  - Follow with the standard text-content and tool-call blocks.

Register the translator alongside the existing entries in `libs/langchain-core/src/messages/block_translators/index.ts` under the `"openrouter"` provider key. That key is the same string `@langchain/openrouter` has already been stamping onto `response_metadata.model_provider`, so no changes are required in the openrouter package to connect the two ends — the `stamp → translator lookup` path starts working automatically.

The file and test shape is a direct mirror of the existing `deepseek.ts` / `tests/deepseek.test.ts` pair so the contribution is consistent with the translators that already exist.

## Changes

New files

  - libs/langchain-core/src/messages/block_translators/openrouter.ts — `convertToV1FromOpenRouterMessage` + `ChatOpenRouterTranslator`.
  - libs/langchain-core/src/messages/block_translators/tests/openrouter.test.ts — 12 unit tests.
  - .changeset/openrouter-reasoning-content.md — `@langchain/openrouter` minor, `@langchain/core` patch.

Modified

  - libs/langchain-core/src/messages/block_translators/index.ts — import the new translator and add `["openrouter", ChatOpenRouterTranslator]` to the global registry Map.
  - libs/providers/langchain-openrouter/src/converters/messages.ts — copy reasoning fields onto `additional_kwargs` in both the non-streaming `convertOpenRouterResponseToBaseMessage` and the streaming `convertOpenRouterDeltaToBaseMessageChunk`. Added JSDoc explaining the reasoning round-trip story and the link to `ChatOpenRouterTranslator`.
  - libs/providers/langchain-openrouter/src/converters/tests/index.test.ts — added `AIMessage` / `AIMessageChunk` imports and 6 converter test cases.

Test cases added

`@langchain/core` translator tests (12 total, mirrored from DeepSeek):

  1. Translates `reasoning_content` in `additional_kwargs` into a reasoning block.
  2. Handles messages without reasoning content (passthrough).
  3. Handles empty reasoning content (no reasoning block emitted).
  4. Translates reasoning together with tool calls (correct ordering: reasoning → text → tool_call).
  5. Translates an `AIMessageChunk` with reasoning content.
  6. Handles array content with text blocks.
  7. Handles empty text content with only reasoning.
  8. Translates `reasoning.summary` details into reasoning blocks.
  9. Translates `reasoning.text` details into reasoning blocks.
  10. Skips `reasoning.encrypted` details (opaque — not human-readable).
  11. Prefers `reasoning_details` when both `reasoning_content` and `reasoning_details` are present.
  12. Handles multiple `reasoning.summary` details as separate reasoning blocks.

`@langchain/openrouter` converter tests (6 total):

  1. `convertOpenRouterResponseToBaseMessage` copies `message.reasoning` onto `additional_kwargs.reasoning_content` and `.contentBlocks` contains the reasoning block.
  2. `convertOpenRouterResponseToBaseMessage` copies `message.reasoning_details` onto `additional_kwargs.reasoning_details` and the details surface as reasoning blocks.
  3. `convertOpenRouterResponseToBaseMessage` is a no-op on a plain response with no reasoning.
  4. `convertOpenRouterDeltaToBaseMessageChunk` copies `delta.reasoning` onto `additional_kwargs.reasoning_content`.
  5. Multi-chunk streaming: three streaming deltas with successive `reasoning` strings are converted, merged via `AIMessageChunk.concat`, and the accumulated `reasoning_content` concatenates cleanly and surfaces as a single reasoning block on the merged chunk's `.contentBlocks`.
  6. `convertOpenRouterDeltaToBaseMessageChunk` is a no-op on a plain delta with no reasoning.

## Behavior after this commit (same minimal repro)

  response.additional_kwargs.reasoning_content;
  // "Let me compute 17 × 23. I'll use the distributive..."  ✓
  response.contentBlocks;
  // [
  //   { type: "reasoning", reasoning: "Let me compute 17 × 23..." },
  //   { type: "text",      text:      "17 × 23 = 391" }
  // ]  ✓
  response.usage_metadata?.output_token_details?.reasoning;
  // 512  (unchanged, still reported)

For models that return structured `reasoning_details` (e.g. Anthropic extended thinking via OpenRouter), those details are preserved on `additional_kwargs.reasoning_details` so subsequent turns can round-trip the `signature` / `encrypted` blobs that the provider requires.

## Test plan

  - pnpm --filter @langchain/core build — clean.
  - pnpm --filter @langchain/openai build — clean.
  - pnpm --filter @langchain/core test — 1325 passed / 1 skipped, no regressions, no type errors.
  - pnpm --filter @langchain/core exec vitest run src/messages/block_translators/tests/openrouter.test.ts --reporter=verbose — 12 passed.
  - pnpm --filter @langchain/openrouter test — 72 passed (was 66 on main — +6 new converter tests).
  - pnpm format:check — clean on all touched files.
  - pnpm lint — 0 warnings, 0 errors on all touched files.
  - pnpm --filter @langchain/openrouter test:int — not run locally (requires OPENROUTER_API_KEY); CI will cover.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
