### PR TITLE
 Fix(core): propagate `tool_call_id` to `on_tool_start` stream events

### DIFF
--- a/libs/langchain-core/src/callbacks/manager.ts
+++ b/libs/langchain-core/src/callbacks/manager.ts
@@ -950,7 +950,8 @@ export class CallbackManager
             this._parentRunId,
             this.tags,
             this.metadata,
-            runName
+            runName,
+            toolCallId
           );
         }
         return consumeCallback(async () => {

--- a/libs/langchain-core/src/runnables/tests/runnable_stream_events_v2.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable_stream_events_v2.test.ts
@@ -1994,6 +1994,51 @@ test("Runnable streamEvents method with simple tools", async () => {
   ]);
 });
 
+test("Runnable streamEvents method with tool calls includes tool_call_id on tool events", async () => {
+  const expectedToolCallId = "call_abc123";
+  const testTool = tool((params: { x: number; y: string }) => params.y, {
+    schema: z.object({
+      x: z.number(),
+      y: z.string(),
+    }),
+    name: "with_parameters",
+    description: "A tool that echoes a value",
+  });
+  const toolCall = {
+    id: expectedToolCallId,
+    name: "with_parameters",
+    args: { x: 1, y: "2" },
+    type: "tool_call" as const,
+  };
+  const chain = RunnableLambda.from(async (_input: string, config) =>
+    testTool.invoke(toolCall, config)
+  );
+  const events: StreamEvent[] = [];
+  const eventStream = await chain.streamEvents("run", { version: "v2" });
+  for await (const event of eventStream) {
+    events.push(event);
+  }
+
+  const toolStartEvent = events.find(
+    (event) =>
+      event.event === "on_tool_start" && event.name === "with_parameters"
+  );
+  const toolEndEvent = events.find(
+    (event) => event.event === "on_tool_end" && event.name === "with_parameters"
+  );
+
+  expect(toolStartEvent).toBeDefined();
+  expect(toolEndEvent).toBeDefined();
+  expect(toolStartEvent?.data.input).toEqual({
+    input: JSON.stringify(toolCall.args),
+    tool_call_id: expectedToolCallId,
+  });
+  expect(toolEndEvent?.data.input).toEqual({
+    input: JSON.stringify(toolCall.args),
+    tool_call_id: expectedToolCallId,
+  });
+});
+
 test("Runnable methods with a custom event", async () => {
   const lambda = RunnableLambda.from(
     async (params: { x: number; y: string }, config) => {

--- a/libs/langchain-core/src/tracers/base.ts
+++ b/libs/langchain-core/src/tracers/base.ts
@@ -530,7 +530,8 @@ export abstract class BaseTracer extends BaseCallbackHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: KVMap,
-    name?: string
+    name?: string,
+    toolCallId?: string
   ) {
     const execution_order = this._getExecutionOrder(parentRunId);
     const start_time = Date.now();
@@ -546,7 +547,10 @@ export abstract class BaseTracer extends BaseCallbackHandler {
           time: new Date(start_time).toISOString(),
         },
       ],
-      inputs: { input },
+      inputs:
+        toolCallId !== undefined
+          ? { input, tool_call_id: toolCallId }
+          : { input },
       execution_order,
       child_execution_order: execution_order,
       run_type: "tool",
@@ -564,7 +568,8 @@ export abstract class BaseTracer extends BaseCallbackHandler {
     parentRunId?: string,
     tags?: string[],
     metadata?: KVMap,
-    name?: string
+    name?: string,
+    toolCallId?: string
   ): Promise<Run> {
     const run =
       this.getRunById(runId) ??
@@ -575,8 +580,12 @@ export abstract class BaseTracer extends BaseCallbackHandler {
         parentRunId,
         tags,
         metadata,
-        name
+        name,
+        toolCallId
       );
+    if (toolCallId !== undefined) {
+      run.inputs.tool_call_id = toolCallId;
+    }
     await this.onRunCreate?.(run);
     await this.onToolStart?.(run);
     return run;

--- a/libs/langchain-core/src/tracers/tests/tracer.test.ts
+++ b/libs/langchain-core/src/tracers/tests/tracer.test.ts
@@ -218,6 +218,29 @@ test("Test Tool Run", async () => {
   expect(run).toMatchObject(compareRun);
 });
 
+test("Test Tool Run with tool call id", async () => {
+  const tracer = new FakeTracer();
+  const runId = uuid.v4();
+  const toolCallId = "call_abc123";
+  await tracer.handleToolStart(
+    serialized,
+    "test",
+    runId,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    toolCallId
+  );
+  await tracer.handleToolEnd("output", runId);
+  expect(tracer.runs.length).toBe(1);
+  const run = tracer.runs[0];
+  expect(run.inputs).toEqual({
+    input: "test",
+    tool_call_id: toolCallId,
+  });
+});
+
 test("Test Retriever Run", async () => {
   const tracer = new FakeTracer();
   const runId = uuid.v4();


### PR DESCRIPTION
## Summary

Propagate `tool_call_id` into tool start tracing data so `on_tool_start` events include the same identifier already present in tool call chunks and `on_tool_end` outputs.

## Problem

During agent streaming, `on_chat_model_stream` emits tool call chunks with an ID, and `on_tool_end` includes that same ID, but `on_tool_start` did not.  
Without `tool_call_id` on start events, consumers had to rely on tool name matching, which is ambiguous.

## Root cause

`toolCallId` was passed to `handleToolStart`, but the synchronous tracer run pre-creation path (`CallbackManager -> _createRunForToolStart`) dropped it. `EventStreamCallbackHandler` emits `on_tool_start` from tracer `run.inputs`, so the ID was missing there.

## Changes

- Pass `toolCallId` through `CallbackManager.handleToolStart` into `_createRunForToolStart`.
- Extend `BaseTracer._createRunForToolStart` to accept `toolCallId` and store `run.inputs.tool_call_id` when present.
- Add regression tests for tracer state and stream events.

`on_tool_start` and `on_tool_end` now carry the same `tool_call_id`, enabling consistent correlation across model stream chunks and tool lifecycle events. 

 ## Tests
 
 - `src/tracers/tests/tracer.test.ts`
 - `src/runnables/tests/runnable_stream_events_v2.test.ts`
 - `src/tools/tests/tools.test.ts`

```bash
pnpm --filter @langchain/core test src/tools/tests/tools.test.ts src/runnables/tests/runnable_stream_events_v2.test.ts src/tracers/tests/tracer.test.ts
```

All passed.
