### PR TITLE
perf(core): reduce streaming metadata by moving configurable keys to tracer-only defaults

### DIFF
--- a/libs/langchain-core/src/runnables/config.ts
+++ b/libs/langchain-core/src/runnables/config.ts
@@ -1,4 +1,5 @@
 import { CallbackManager, ensureHandler } from "../callbacks/manager.js";
+import { applyConfigurableMetadataToTracers } from "../tracers/tracer_langchain.js";
 import { AsyncLocalStorageProviderSingleton } from "../singletons/index.js";
 import { RunnableConfig } from "./types.js";
 
@@ -7,13 +8,19 @@ export const DEFAULT_RECURSION_LIMIT = 25;
 export { type RunnableConfig };
 
 export async function getCallbackManagerForConfig(config?: RunnableConfig) {
-  return CallbackManager._configureSync(
+  const callbackManager = CallbackManager._configureSync(
     config?.callbacks,
     undefined,
     config?.tags,
     undefined,
     config?.metadata
   );
+
+  if (callbackManager) {
+    applyConfigurableMetadataToTracers(callbackManager, config?.configurable);
+  }
+
+  return callbackManager;
 }
 
 export function mergeConfigs<CallOptions extends RunnableConfig>(
@@ -117,8 +124,6 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
   return copy as Partial<CallOptions>;
 }
 
-const PRIMITIVES = new Set(["string", "number", "boolean"]);
-
 /**
  * Ensure that a passed config is an object with all required keys present.
  */
@@ -159,19 +164,7 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
       empty
     );
   }
-  if (empty?.configurable) {
-    for (const key of Object.keys(empty.configurable)) {
-      if (
-        PRIMITIVES.has(typeof empty.configurable[key]) &&
-        !empty.metadata?.[key]
-      ) {
-        if (!empty.metadata) {
-          empty.metadata = {};
-        }
-        empty.metadata[key] = empty.configurable[key];
-      }
-    }
-  }
+
   if (empty.timeout !== undefined) {
     if (empty.timeout <= 0) {
       throw new Error("Timeout must be a positive number");

--- a/libs/langchain-core/src/runnables/config.ts
+++ b/libs/langchain-core/src/runnables/config.ts
@@ -5,6 +5,13 @@ import { RunnableConfig } from "./types.js";
 
 export const DEFAULT_RECURSION_LIMIT = 25;
 
+/**
+ * Configurable keys that are copied into the shared `metadata` dict
+ * (and therefore appear in stream events). Keep this minimal —
+ * everything else is forwarded to LangSmith tracers only.
+ */
+const CONFIGURABLE_TO_SHARED_METADATA_KEYS: readonly string[] = ["model"];
+
 export { type RunnableConfig };
 
 export async function getCallbackManagerForConfig(config?: RunnableConfig) {
@@ -17,7 +24,11 @@ export async function getCallbackManagerForConfig(config?: RunnableConfig) {
   );
 
   if (callbackManager) {
-    applyConfigurableMetadataToTracers(callbackManager, config?.configurable);
+    applyConfigurableMetadataToTracers(
+      callbackManager,
+      config?.configurable,
+      config?.metadata
+    );
   }
 
   return callbackManager;
@@ -163,6 +174,21 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
       },
       empty
     );
+  }
+
+  // Copy a small set of configurable keys into shared metadata (so they
+  // appear in stream events). All other keys are forwarded to tracers
+  // only via applyConfigurableMetadataToTracers.
+  if (empty.configurable) {
+    for (const key of CONFIGURABLE_TO_SHARED_METADATA_KEYS) {
+      const value = empty.configurable[key];
+      if (typeof value === "string" && !empty.metadata?.[key]) {
+        if (!empty.metadata) {
+          empty.metadata = {};
+        }
+        empty.metadata[key] = value;
+      }
+    }
   }
 
   if (empty.timeout !== undefined) {

--- a/libs/langchain-core/src/runnables/tests/config.test.ts
+++ b/libs/langchain-core/src/runnables/tests/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { mergeConfigs } from "../config.js";
+import { mergeConfigs, ensureConfig } from "../config.js";
+import { getInheritableMetadataFromConfigurable } from "../../tracers/tracer_langchain.js";
 
 describe("mergeConfigs metadata", () => {
   it("merges metadata with last-writer-wins", () => {
@@ -36,5 +37,92 @@ describe("mergeConfigs metadata", () => {
   it("handles empty metadata", () => {
     const result = mergeConfigs({ metadata: {} }, { metadata: { a: 1 } });
     expect(result.metadata).toEqual({ a: 1 });
+  });
+});
+
+describe("ensureConfig configurable-to-metadata", () => {
+  it("does not copy configurable primitives to metadata", () => {
+    const config = ensureConfig({
+      configurable: {
+        thread_id: "th-123",
+        checkpoint_id: "ckpt-1",
+        checkpoint_ns: "ns-1",
+        task_id: "task-1",
+        run_id: "run-456",
+        assistant_id: "asst-789",
+        graph_id: "graph-0",
+        model: "gpt-4o",
+        user_id: "uid-1",
+        cron_id: "cron-1",
+        langgraph_auth_user_id: "user-1",
+        some_api_key: "opaque-token",
+        custom_setting: 42,
+      },
+      metadata: { nooverride: 18 },
+    });
+
+    // Metadata should only contain the explicitly provided key
+    expect(config.metadata).toEqual({ nooverride: 18 });
+    // Configurable should be untouched
+    expect(config.configurable).toEqual({
+      thread_id: "th-123",
+      checkpoint_id: "ckpt-1",
+      checkpoint_ns: "ns-1",
+      task_id: "task-1",
+      run_id: "run-456",
+      assistant_id: "asst-789",
+      graph_id: "graph-0",
+      model: "gpt-4o",
+      user_id: "uid-1",
+      cron_id: "cron-1",
+      langgraph_auth_user_id: "user-1",
+      some_api_key: "opaque-token",
+      custom_setting: 42,
+    });
+  });
+
+  it("metadata is not overridden by configurable", () => {
+    const config = ensureConfig({
+      configurable: {
+        thread_id: "from-configurable",
+        run_id: "from-configurable",
+      },
+      metadata: {
+        thread_id: "from-metadata",
+        run_id: "from-metadata",
+      },
+    });
+
+    expect(config.metadata).toEqual({
+      thread_id: "from-metadata",
+      run_id: "from-metadata",
+    });
+  });
+});
+
+describe("getInheritableMetadataFromConfigurable", () => {
+  it("extracts known string keys from configurable", () => {
+    const result = getInheritableMetadataFromConfigurable({
+      thread_id: "th-123",
+      model: "gpt-4o",
+      user_id: "uid-1",
+      some_api_key: "opaque-token", // not in CONFIGURABLE_TO_METADATA_KEYS
+      custom_setting: 42, // not a string
+    });
+    expect(result).toEqual({
+      thread_id: "th-123",
+      model: "gpt-4o",
+      user_id: "uid-1",
+    });
+  });
+
+  it("returns undefined when no configurable keys match", () => {
+    expect(
+      getInheritableMetadataFromConfigurable({ custom_key: "value" })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when configurable is undefined", () => {
+    expect(getInheritableMetadataFromConfigurable(undefined)).toBeUndefined();
   });
 });

--- a/libs/langchain-core/src/runnables/tests/config.test.ts
+++ b/libs/langchain-core/src/runnables/tests/config.test.ts
@@ -41,84 +41,96 @@ describe("mergeConfigs metadata", () => {
 });
 
 describe("ensureConfig configurable-to-metadata", () => {
-  it("does not copy configurable primitives to metadata", () => {
+  it("copies only model to shared metadata", () => {
     const config = ensureConfig({
       configurable: {
         thread_id: "th-123",
         checkpoint_id: "ckpt-1",
-        checkpoint_ns: "ns-1",
-        task_id: "task-1",
-        run_id: "run-456",
-        assistant_id: "asst-789",
-        graph_id: "graph-0",
         model: "gpt-4o",
         user_id: "uid-1",
-        cron_id: "cron-1",
-        langgraph_auth_user_id: "user-1",
-        some_api_key: "opaque-token",
         custom_setting: 42,
       },
       metadata: { nooverride: 18 },
     });
 
-    // Metadata should only contain the explicitly provided key
-    expect(config.metadata).toEqual({ nooverride: 18 });
-    // Configurable should be untouched
-    expect(config.configurable).toEqual({
-      thread_id: "th-123",
-      checkpoint_id: "ckpt-1",
-      checkpoint_ns: "ns-1",
-      task_id: "task-1",
-      run_id: "run-456",
-      assistant_id: "asst-789",
-      graph_id: "graph-0",
-      model: "gpt-4o",
-      user_id: "uid-1",
-      cron_id: "cron-1",
-      langgraph_auth_user_id: "user-1",
-      some_api_key: "opaque-token",
-      custom_setting: 42,
-    });
+    // Only model is copied; everything else stays out of shared metadata
+    expect(config.metadata).toEqual({ nooverride: 18, model: "gpt-4o" });
   });
 
-  it("metadata is not overridden by configurable", () => {
+  it("does not override existing model in metadata", () => {
     const config = ensureConfig({
-      configurable: {
-        thread_id: "from-configurable",
-        run_id: "from-configurable",
-      },
-      metadata: {
-        thread_id: "from-metadata",
-        run_id: "from-metadata",
-      },
+      configurable: { model: "from-configurable" },
+      metadata: { model: "from-metadata" },
     });
 
-    expect(config.metadata).toEqual({
-      thread_id: "from-metadata",
-      run_id: "from-metadata",
+    expect(config.metadata).toEqual({ model: "from-metadata" });
+  });
+
+  it("skips non-string model values", () => {
+    const config = ensureConfig({
+      configurable: { model: 42 },
+      metadata: {},
     });
+
+    expect(config.metadata).toEqual({});
   });
 });
 
 describe("getInheritableMetadataFromConfigurable", () => {
-  it("extracts known string keys from configurable", () => {
+  it("extracts all primitive configurable keys", () => {
     const result = getInheritableMetadataFromConfigurable({
       thread_id: "th-123",
       model: "gpt-4o",
       user_id: "uid-1",
-      some_api_key: "opaque-token", // not in CONFIGURABLE_TO_METADATA_KEYS
-      custom_setting: 42, // not a string
+      temperature: 0.5,
+      streaming: true,
+      custom_setting: { nested: true }, // not a primitive
+      none_value: null, // not a primitive
     });
     expect(result).toEqual({
       thread_id: "th-123",
       model: "gpt-4o",
       user_id: "uid-1",
+      temperature: 0.5,
+      streaming: true,
     });
+  });
+
+  it("excludes keys starting with __", () => {
+    const result = getInheritableMetadataFromConfigurable({
+      __secret_key: "hidden",
+      visible: "shown",
+    });
+    expect(result).toEqual({ visible: "shown" });
+  });
+
+  it("excludes api_key", () => {
+    const result = getInheritableMetadataFromConfigurable({
+      api_key: "should-not-propagate",
+      thread_id: "th-123",
+    });
+    expect(result).toEqual({ thread_id: "th-123" });
+  });
+
+  it("excludes keys already in existingMetadata", () => {
+    const result = getInheritableMetadataFromConfigurable(
+      {
+        model: "from-configurable",
+        checkpoint_ns: "from-configurable",
+        thread_id: "th-123",
+      },
+      { model: "from-metadata", checkpoint_ns: "from-metadata" }
+    );
+    expect(result).toEqual({ thread_id: "th-123" });
   });
 
   it("returns undefined when no configurable keys match", () => {
     expect(
-      getInheritableMetadataFromConfigurable({ custom_key: "value" })
+      getInheritableMetadataFromConfigurable({
+        __hidden: "value",
+        api_key: "secret",
+        nested: { a: 1 },
+      })
     ).toBeUndefined();
   });
 

--- a/libs/langchain-core/src/singletons/async_local_storage/index.ts
+++ b/libs/langchain-core/src/singletons/async_local_storage/index.ts
@@ -56,7 +56,11 @@ class AsyncLocalStorageProvider {
       config?.metadata
     );
     if (callbackManager) {
-      applyConfigurableMetadataToTracers(callbackManager, config?.configurable);
+      applyConfigurableMetadataToTracers(
+        callbackManager,
+        config?.configurable,
+        config?.metadata
+      );
     }
     const storage = this.getInstance();
     const previousValue = storage.getStore();

--- a/libs/langchain-core/src/singletons/async_local_storage/index.ts
+++ b/libs/langchain-core/src/singletons/async_local_storage/index.ts
@@ -7,7 +7,10 @@ import {
   _CONTEXT_VARIABLES_KEY,
 } from "./globals.js";
 import { CallbackManager } from "../../callbacks/manager.js";
-import { LangChainTracer } from "../../tracers/tracer_langchain.js";
+import {
+  LangChainTracer,
+  applyConfigurableMetadataToTracers,
+} from "../../tracers/tracer_langchain.js";
 
 export class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
   getStore(): any {
@@ -52,6 +55,9 @@ class AsyncLocalStorageProvider {
       undefined,
       config?.metadata
     );
+    if (callbackManager) {
+      applyConfigurableMetadataToTracers(callbackManager, config?.configurable);
+    }
     const storage = this.getInstance();
     const previousValue = storage.getStore();
     const parentRunId = callbackManager?.getParentRunId();

--- a/libs/langchain-core/src/tracers/base.ts
+++ b/libs/langchain-core/src/tracers/base.ts
@@ -87,16 +87,22 @@ export function isBaseTracer(x: BaseCallbackHandler): x is BaseTracer {
   return typeof (x as BaseTracer)._addRunToRunMap === "function";
 }
 
+export interface BaseTracerInput extends BaseCallbackHandlerInput {
+  /** Optional shared map so that copied tracers see the same run state. */
+  runTreeMap?: Map<string, RunTree>;
+}
+
 export abstract class BaseTracer extends BaseCallbackHandler {
   /** @deprecated Use `runTreeMap` instead. */
   protected runMap: Map<string, Run> = new Map();
 
-  protected runTreeMap: Map<string, RunTree> = new Map();
+  protected runTreeMap: Map<string, RunTree>;
 
   protected usesRunTreeMap = false;
 
-  constructor(_fields?: BaseCallbackHandlerInput) {
+  constructor(_fields?: BaseTracerInput) {
     super(...arguments);
+    this.runTreeMap = _fields?.runTreeMap ?? new Map();
   }
 
   copy(): this {

--- a/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
+++ b/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
@@ -5,11 +5,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as uuid from "uuid";
 
 import { RunnableLambda } from "../../runnables/base.js";
-import {
-  LangChainTracer,
-  _patchMissingMetadata,
-  getInheritableMetadataFromConfigurable,
-} from "../tracer_langchain.js";
+import { LangChainTracer, _patchMissingMetadata } from "../tracer_langchain.js";
 import { getCallbackManagerForConfig } from "../../runnables/config.js";
 import { BaseCallbackHandler } from "../../callbacks/base.js";
 import { awaitAllCallbacks } from "../../singletons/callbacks.js";
@@ -344,38 +340,10 @@ describe("_patchMissingMetadata", () => {
   });
 });
 
-describe("getInheritableMetadataFromConfigurable", () => {
-  it("extracts known string keys from configurable", () => {
-    const result = getInheritableMetadataFromConfigurable({
-      thread_id: "th-123",
-      model: "gpt-4o",
-      user_id: "uid-1",
-      some_api_key: "opaque-token", // not in CONFIGURABLE_TO_METADATA_KEYS
-      custom_setting: 42, // not a string
-    });
-    expect(result).toEqual({
-      thread_id: "th-123",
-      model: "gpt-4o",
-      user_id: "uid-1",
-    });
-  });
-
-  it("returns undefined when no configurable keys match", () => {
-    expect(
-      getInheritableMetadataFromConfigurable({ custom_key: "value" })
-    ).toBeUndefined();
-  });
-
-  it("returns undefined when configurable is undefined", () => {
-    expect(getInheritableMetadataFromConfigurable(undefined)).toBeUndefined();
-  });
-});
-
 describe("copyWithMetadataDefaults", () => {
   test("copies configuration, does not mutate original", () => {
     const tracer = _makeTracer({ env: "staging" });
     tracer.projectName = "project";
-    tracer.tracingTags = ["tag"];
 
     const copied = tracer.copyWithMetadataDefaults({
       metadata: { service: "api" },
@@ -410,17 +378,6 @@ describe("copyWithMetadataDefaults", () => {
     expect(copied.tracingMetadata).toEqual({ env: "staging" });
   });
 
-  test("merges tags and deduplicates", () => {
-    const tracer = _makeTracer();
-    tracer.tracingTags = ["existing"];
-    const copied = tracer.copyWithMetadataDefaults({
-      tags: ["tenant:alpha", "existing"],
-    });
-    expect(copied).not.toBe(tracer);
-    expect(copied.tracingTags).toEqual(["existing", "tenant:alpha"]);
-    expect(tracer.tracingTags).toEqual(["existing"]);
-  });
-
   test("separate copies are isolated", () => {
     const tracer = _makeTracer();
     const alpha = tracer.copyWithMetadataDefaults({
@@ -444,7 +401,11 @@ describe("getCallbackManagerForConfig langsmith metadata", () => {
       configurable: {
         thread_id: "th-123",
         model: "gpt-4o",
-        custom_key: "ignored",
+        temperature: 0.5,
+        streaming: true,
+        custom_obj: { nested: true }, // not a primitive, excluded
+        __secret: "hidden", // __ prefix, excluded
+        api_key: "secret", // excluded
       },
     });
     const lcTracers = cm?.handlers.filter(
@@ -455,6 +416,8 @@ describe("getCallbackManagerForConfig langsmith metadata", () => {
     expect(lcTracers[0].tracingMetadata).toEqual({
       thread_id: "th-123",
       model: "gpt-4o",
+      temperature: 0.5,
+      streaming: true,
     });
     // Original unchanged
     expect(tracer.tracingMetadata).toBeUndefined();

--- a/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
+++ b/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
@@ -5,7 +5,13 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as uuid from "uuid";
 
 import { RunnableLambda } from "../../runnables/base.js";
-import { LangChainTracer } from "../tracer_langchain.js";
+import {
+  LangChainTracer,
+  _patchMissingMetadata,
+  getInheritableMetadataFromConfigurable,
+} from "../tracer_langchain.js";
+import { getCallbackManagerForConfig } from "../../runnables/config.js";
+import { BaseCallbackHandler } from "../../callbacks/base.js";
 import { awaitAllCallbacks } from "../../singletons/callbacks.js";
 import { AsyncLocalStorageProviderSingleton } from "../../singletons/async_local_storage/index.js";
 import { AIMessage } from "../../messages/ai.js";
@@ -286,5 +292,391 @@ describe("LangChainTracer usage_metadata extraction", () => {
       input_token_details: {},
       output_token_details: {},
     });
+  });
+});
+
+function _makeTracer(metadata?: Record<string, string>): LangChainTracer {
+  const mockClient = {
+    createRun: vi.fn(),
+    updateRun: vi.fn(),
+  } as any;
+  return new LangChainTracer({ client: mockClient, metadata });
+}
+
+describe("_patchMissingMetadata", () => {
+  test("adds metadata when run has none", () => {
+    const tracer = _makeTracer({ env: "prod", service: "api" });
+    const run = { extra: { metadata: {} } };
+    _patchMissingMetadata(tracer, run);
+    expect(run.extra.metadata).toEqual({ env: "prod", service: "api" });
+  });
+
+  test("does not overwrite existing keys", () => {
+    const tracer = _makeTracer({ env: "prod", service: "api" });
+    const run = { extra: { metadata: { env: "staging" } } };
+    _patchMissingMetadata(tracer, run);
+    expect(run.extra.metadata).toEqual({ env: "staging", service: "api" });
+  });
+
+  test("noop when tracer has no metadata", () => {
+    const tracer = _makeTracer(undefined);
+    const original = { existing: "value" };
+    const run = { extra: { metadata: { ...original } } };
+    _patchMissingMetadata(tracer, run);
+    expect(run.extra.metadata).toEqual(original);
+  });
+
+  test("noop when all keys already present", () => {
+    const tracer = _makeTracer({ env: "prod" });
+    const run = { extra: { metadata: { env: "dev" } } };
+    _patchMissingMetadata(tracer, run);
+    expect(run.extra.metadata).toEqual({ env: "dev" });
+  });
+
+  test("merges disjoint keys", () => {
+    const tracer = _makeTracer({ tracer_key: "tracer_val" });
+    const run = { extra: { metadata: { config_key: "config_val" } } };
+    _patchMissingMetadata(tracer, run);
+    expect(run.extra.metadata).toEqual({
+      tracer_key: "tracer_val",
+      config_key: "config_val",
+    });
+  });
+});
+
+describe("getInheritableMetadataFromConfigurable", () => {
+  it("extracts known string keys from configurable", () => {
+    const result = getInheritableMetadataFromConfigurable({
+      thread_id: "th-123",
+      model: "gpt-4o",
+      user_id: "uid-1",
+      some_api_key: "opaque-token", // not in CONFIGURABLE_TO_METADATA_KEYS
+      custom_setting: 42, // not a string
+    });
+    expect(result).toEqual({
+      thread_id: "th-123",
+      model: "gpt-4o",
+      user_id: "uid-1",
+    });
+  });
+
+  it("returns undefined when no configurable keys match", () => {
+    expect(
+      getInheritableMetadataFromConfigurable({ custom_key: "value" })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when configurable is undefined", () => {
+    expect(getInheritableMetadataFromConfigurable(undefined)).toBeUndefined();
+  });
+});
+
+describe("copyWithMetadataDefaults", () => {
+  test("copies configuration, does not mutate original", () => {
+    const tracer = _makeTracer({ env: "staging" });
+    tracer.projectName = "project";
+    tracer.tracingTags = ["tag"];
+
+    const copied = tracer.copyWithMetadataDefaults({
+      metadata: { service: "api" },
+    });
+
+    expect(copied).not.toBe(tracer);
+    expect(copied.client).toBe(tracer.client);
+    expect(copied.projectName).toBe("project");
+    expect(copied.tracingMetadata).toEqual({
+      env: "staging",
+      service: "api",
+    });
+    // Original is unchanged
+    expect(tracer.tracingMetadata).toEqual({ env: "staging" });
+  });
+
+  test("tracer metadata takes precedence over incoming metadata", () => {
+    const tracer = _makeTracer({ env: "staging" });
+    const copied = tracer.copyWithMetadataDefaults({
+      metadata: { env: "prod", service: "api" },
+    });
+    expect(copied.tracingMetadata).toEqual({
+      env: "staging",
+      service: "api",
+    });
+  });
+
+  test("null metadata preserves existing", () => {
+    const tracer = _makeTracer({ env: "staging" });
+    const copied = tracer.copyWithMetadataDefaults({ metadata: undefined });
+    expect(copied).not.toBe(tracer);
+    expect(copied.tracingMetadata).toEqual({ env: "staging" });
+  });
+
+  test("merges tags and deduplicates", () => {
+    const tracer = _makeTracer();
+    tracer.tracingTags = ["existing"];
+    const copied = tracer.copyWithMetadataDefaults({
+      tags: ["tenant:alpha", "existing"],
+    });
+    expect(copied).not.toBe(tracer);
+    expect(copied.tracingTags).toEqual(["existing", "tenant:alpha"]);
+    expect(tracer.tracingTags).toEqual(["existing"]);
+  });
+
+  test("separate copies are isolated", () => {
+    const tracer = _makeTracer();
+    const alpha = tracer.copyWithMetadataDefaults({
+      metadata: { tenant: "alpha" },
+    });
+    const beta = tracer.copyWithMetadataDefaults({
+      metadata: { tenant: "beta" },
+    });
+    expect(tracer.tracingMetadata).toBeUndefined();
+    expect(alpha.tracingMetadata).toEqual({ tenant: "alpha" });
+    expect(beta.tracingMetadata).toEqual({ tenant: "beta" });
+    expect(alpha).not.toBe(beta);
+  });
+});
+
+describe("getCallbackManagerForConfig langsmith metadata", () => {
+  test("configurable keys flow as tracer metadata", async () => {
+    const tracer = _makeTracer();
+    const cm = await getCallbackManagerForConfig({
+      callbacks: [tracer],
+      configurable: {
+        thread_id: "th-123",
+        model: "gpt-4o",
+        custom_key: "ignored",
+      },
+    });
+    const lcTracers = cm?.handlers.filter(
+      (h) => h instanceof LangChainTracer
+    ) as LangChainTracer[];
+    expect(lcTracers).toHaveLength(1);
+    expect(lcTracers[0]).not.toBe(tracer);
+    expect(lcTracers[0].tracingMetadata).toEqual({
+      thread_id: "th-123",
+      model: "gpt-4o",
+    });
+    // Original unchanged
+    expect(tracer.tracingMetadata).toBeUndefined();
+  });
+
+  test("no configurable means no tracer copy", async () => {
+    const tracer = _makeTracer();
+    const cm = await getCallbackManagerForConfig({
+      callbacks: [tracer],
+    });
+    const lcTracer = cm?.handlers.find(
+      (h) => h instanceof LangChainTracer
+    ) as LangChainTracer;
+    // No configurable keys to forward, so same instance
+    expect(lcTracer).toBe(tracer);
+    expect(tracer.tracingMetadata).toBeUndefined();
+  });
+
+  test("tracer metadata takes precedence over configurable keys", async () => {
+    const tracer = _makeTracer({ thread_id: "from-tracer" });
+    const cm = await getCallbackManagerForConfig({
+      callbacks: [tracer],
+      configurable: { thread_id: "from-configurable", user_id: "uid-1" },
+    });
+    const lcTracer = cm?.handlers.find(
+      (h) => h instanceof LangChainTracer
+    ) as LangChainTracer;
+    expect(lcTracer.tracingMetadata).toEqual({
+      thread_id: "from-tracer",
+      user_id: "uid-1",
+    });
+  });
+
+  test("langsmith metadata does not affect non-tracer handlers", async () => {
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const tracer = _makeTracer();
+    const receivedMetadata: Record<string, unknown>[] = [];
+
+    class MetadataCapture extends BaseCallbackHandler {
+      name = "metadata_capture";
+      async handleChainStart(
+        _chain: any,
+        _inputs: any,
+        _runId?: string,
+        _parentRunId?: string,
+        _tags?: string[],
+        metadata?: Record<string, unknown>
+      ) {
+        receivedMetadata.push({ ...metadata });
+      }
+    }
+
+    const capture = new MetadataCapture();
+    const cm = await getCallbackManagerForConfig({
+      callbacks: [tracer, capture],
+      configurable: { thread_id: "th-123" },
+    });
+
+    const myFunc = RunnableLambda.from((x: number) => x);
+    await myFunc.invoke(1, { callbacks: cm });
+
+    await awaitAllCallbacks();
+
+    // Non-tracer handler should NOT see configurable metadata
+    expect(receivedMetadata.length).toBeGreaterThanOrEqual(1);
+    for (const md of receivedMetadata) {
+      expect(md).not.toHaveProperty("thread_id");
+    }
+  });
+});
+
+describe("tracer metadata through invoke", () => {
+  test("tracer metadata applied to all runs", async () => {
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { env: "prod", service: "api" },
+    });
+
+    const child = RunnableLambda.from((x: number) => x + 1);
+    const parent = RunnableLambda.from(async (x: number) => child.invoke(x));
+
+    await parent.invoke(1, { callbacks: [tracer] });
+    await awaitAllCallbacks();
+
+    expect(mockClient.createRun).toHaveBeenCalledTimes(2);
+    for (const call of mockClient.createRun.mock.calls) {
+      const payload = call[0];
+      expect(payload.extra?.metadata?.env).toBe("prod");
+      expect(payload.extra?.metadata?.service).toBe("api");
+    }
+  });
+
+  test("config metadata takes precedence over tracer metadata", async () => {
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { env: "prod", tracer_only: "yes" },
+    });
+
+    const myFunc = RunnableLambda.from((x: number) => x);
+
+    await myFunc.invoke(1, {
+      callbacks: [tracer],
+      metadata: { env: "staging", config_only: "yes" },
+    });
+    await awaitAllCallbacks();
+
+    expect(mockClient.createRun).toHaveBeenCalledTimes(1);
+    const payload = mockClient.createRun.mock.calls[0][0];
+    const md = payload.extra?.metadata;
+    // Config wins for overlapping key
+    expect(md.env).toBe("staging");
+    // Both non-overlapping keys present
+    expect(md.tracer_only).toBe("yes");
+    expect(md.config_only).toBe("yes");
+  });
+
+  test("nested calls inherit config and tracer metadata", async () => {
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { tracer_key: "tracer_val" },
+    });
+
+    const child = RunnableLambda.from((x: number) => x + 1);
+    const parent = RunnableLambda.from(async (x: number) => child.invoke(x));
+
+    await parent.invoke(1, {
+      callbacks: [tracer],
+      metadata: { config_key: "config_val" },
+    });
+    await awaitAllCallbacks();
+
+    expect(mockClient.createRun).toHaveBeenCalledTimes(2);
+    for (const call of mockClient.createRun.mock.calls) {
+      const md = call[0].extra?.metadata;
+      expect(md.config_key).toBe("config_val");
+      expect(md.tracer_key).toBe("tracer_val");
+    }
+  });
+
+  test("tracer metadata not applied to sibling handlers", async () => {
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { tracer_key: "tracer_val" },
+    });
+
+    const receivedMetadata: Record<string, unknown>[] = [];
+
+    class MetadataCapture extends BaseCallbackHandler {
+      name = "metadata_capture";
+      async handleChainStart(
+        _chain: any,
+        _inputs: any,
+        _runId?: string,
+        _parentRunId?: string,
+        _tags?: string[],
+        metadata?: Record<string, unknown>
+      ) {
+        receivedMetadata.push({ ...metadata });
+      }
+    }
+
+    const capture = new MetadataCapture();
+    const myFunc = RunnableLambda.from((x: number) => x);
+
+    await myFunc.invoke(1, {
+      callbacks: [tracer, capture],
+      metadata: { shared_key: "shared_val" },
+    });
+    await awaitAllCallbacks();
+
+    // Non-tracer handler should NOT see tracer metadata
+    expect(receivedMetadata.length).toBeGreaterThanOrEqual(1);
+    for (const md of receivedMetadata) {
+      expect(md.shared_key).toBe("shared_val");
+      expect(md).not.toHaveProperty("tracer_key");
+    }
+
+    // But the posted runs SHOULD have both
+    expect(mockClient.createRun).toHaveBeenCalled();
+    for (const call of mockClient.createRun.mock.calls) {
+      const md = call[0].extra?.metadata;
+      expect(md.shared_key).toBe("shared_val");
+      expect(md.tracer_key).toBe("tracer_val");
+    }
   });
 });

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -42,6 +42,9 @@ export interface RunUpdate extends BaseRunUpdate {
   dotted_order?: string;
 }
 
+/** Primitive types that are forwarded as tracer-only metadata. */
+type TracingMetadataValue = string | number | boolean;
+
 export interface LangChainTracerFields extends BaseCallbackHandlerInput {
   exampleId?: string;
   projectName?: string;
@@ -51,7 +54,7 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
    * Additional metadata to include on runs if it isn't already present.
    * Applied only at persist-time so it does not flow through stream events.
    */
-  metadata?: Record<string, string>;
+  metadata?: Record<string, TracingMetadataValue>;
 }
 
 /** @internal Constructor-only fields (not part of the `implements` contract). */
@@ -103,12 +106,7 @@ export class LangChainTracer
    * Tracer-only metadata defaults. Added to runs at persist-time for keys
    * that are not already present, so it never inflates stream events.
    */
-  tracingMetadata: Record<string, string> | undefined;
-
-  /**
-   * Tracer-only tags. Merged onto runs at persist-time.
-   */
-  tracingTags: string[];
+  tracingMetadata: Record<string, TracingMetadataValue> | undefined;
 
   constructor(fields: LangChainTracerConstructorFields = {}) {
     super(fields);
@@ -119,7 +117,6 @@ export class LangChainTracer
     this.exampleId = exampleId;
     this.client = client ?? getDefaultLangChainClientSingleton();
     this.tracingMetadata = metadata !== undefined ? { ...metadata } : undefined;
-    this.tracingTags = [];
 
     const traceableTree = LangChainTracer.getTraceableRunTree();
     if (traceableTree) {
@@ -135,13 +132,12 @@ export class LangChainTracer
    * - The original tracer is never mutated.
    */
   copyWithMetadataDefaults(options: {
-    metadata?: Record<string, string>;
-    tags?: string[];
+    metadata?: Record<string, TracingMetadataValue>;
   }): LangChainTracer {
-    const { metadata, tags } = options;
+    const { metadata } = options;
     const baseMetadata = this.tracingMetadata;
 
-    let mergedMetadata: Record<string, string> | undefined;
+    let mergedMetadata: Record<string, TracingMetadataValue> | undefined;
     if (metadata == null) {
       mergedMetadata = baseMetadata != null ? { ...baseMetadata } : undefined;
     } else if (baseMetadata == null) {
@@ -155,11 +151,7 @@ export class LangChainTracer
       }
     }
 
-    const mergedTags = tags
-      ? [...new Set([...this.tracingTags, ...tags])].sort()
-      : [...this.tracingTags];
-
-    const copied = new LangChainTracer({
+    return new LangChainTracer({
       exampleId: this.exampleId,
       projectName: this.projectName,
       client: this.client,
@@ -167,8 +159,6 @@ export class LangChainTracer
       metadata: mergedMetadata,
       runTreeMap: this.runTreeMap,
     });
-    copied.tracingTags = mergedTags;
-    return copied;
   }
 
   protected async persistRun(_run: Run): Promise<void> {
@@ -311,53 +301,47 @@ export function _patchMissingMetadata(
   }
 }
 
+const PRIMITIVES = new Set(["string", "number", "boolean"]);
+
 /**
- * Known configurable keys whose string values should be forwarded as
- * LangSmith-only inheritable metadata (instead of being copied into the
- * shared `metadata` dict that flows through every stream event).
+ * Configurable keys that should never be forwarded as tracing metadata.
  */
-export const CONFIGURABLE_TO_METADATA_KEYS = new Set([
-  "thread_id",
-  "run_id",
-  "task_id",
-  "checkpoint_id",
-  "checkpoint_ns",
-  "assistant_id",
-  "graph_id",
-  "model",
-  "user_id",
-  "cron_id",
-  "langgraph_auth_user_id",
-]);
+const CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS = new Set(["api_key"]);
 
 /**
  * Extract LangSmith-only inheritable metadata defaults from a
  * `configurable` dict.
  *
- * Only string values for keys in {@link CONFIGURABLE_TO_METADATA_KEYS} are
- * included. Returns `undefined` when there is nothing to forward.
+ * Includes all primitive values except keys starting with `__`, keys
+ * already present in `existingMetadata`, and keys in the exclusion set.
+ * Returns `undefined` when there is nothing to forward.
  */
 export function getInheritableMetadataFromConfigurable(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  configurable?: Record<string, any>
-): Record<string, string> | undefined {
+  configurable?: Record<string, any>,
+  existingMetadata?: Record<string, unknown>
+): Record<string, TracingMetadataValue> | undefined {
   if (!configurable) return undefined;
 
-  let metadata: Record<string, string> | undefined;
-  for (const key of CONFIGURABLE_TO_METADATA_KEYS) {
-    const value = configurable[key];
-    if (typeof value === "string") {
+  let metadata: Record<string, TracingMetadataValue> | undefined;
+  for (const [key, value] of Object.entries(configurable)) {
+    if (
+      PRIMITIVES.has(typeof value) &&
+      !key.startsWith("__") &&
+      !CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS.has(key) &&
+      !(existingMetadata && existingMetadata[key] !== undefined)
+    ) {
       if (!metadata) metadata = {};
-      metadata[key] = value;
+      metadata[key] = value as TracingMetadataValue;
     }
   }
   return metadata;
 }
 
 /**
- * Extract known configurable keys and apply them as LangSmith-only
- * metadata defaults on any {@link LangChainTracer} handlers found in
- * `handlers` and `inheritableHandlers`.
+ * Extract configurable keys and apply them as LangSmith-only metadata
+ * defaults on any {@link LangChainTracer} handlers found in `handlers`
+ * and `inheritableHandlers`.
  *
  * Tracers are replaced with shallow copies so the metadata never leaks
  * into the shared callback-manager metadata dict (which flows through
@@ -374,9 +358,13 @@ export function applyConfigurableMetadataToTracers(
     inheritableHandlers: BaseCallbackHandler[];
   },
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  configurable?: Record<string, any>
+  configurable?: Record<string, any>,
+  existingMetadata?: Record<string, unknown>
 ): void {
-  const metadata = getInheritableMetadataFromConfigurable(configurable);
+  const metadata = getInheritableMetadataFromConfigurable(
+    configurable,
+    existingMetadata
+  );
   if (!metadata) return;
 
   const replace = (list: BaseCallbackHandler[]) =>

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -13,7 +13,10 @@ import {
   KVMap,
 } from "langsmith/schemas";
 import { BaseTracer, Run as BaseTracerRun } from "./base.js";
-import { BaseCallbackHandlerInput } from "../callbacks/base.js";
+import {
+  BaseCallbackHandler,
+  BaseCallbackHandlerInput,
+} from "../callbacks/base.js";
 import { getDefaultLangChainClientSingleton } from "../singletons/tracer.js";
 import { ChatGeneration } from "../outputs.js";
 import { AIMessage } from "../messages/ai.js";
@@ -44,6 +47,17 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
   projectName?: string;
   client?: LangSmithTracingClientInterface;
   replicas?: RunTreeConfig["replicas"];
+  /**
+   * Additional metadata to include on runs if it isn't already present.
+   * Applied only at persist-time so it does not flow through stream events.
+   */
+  metadata?: Record<string, string>;
+}
+
+/** @internal Constructor-only fields (not part of the `implements` contract). */
+interface LangChainTracerConstructorFields extends LangChainTracerFields {
+  /** Optional shared runTreeMap so that copied tracers see the same run state. */
+  runTreeMap?: Map<string, RunTree>;
 }
 
 /**
@@ -85,19 +99,76 @@ export class LangChainTracer
 
   usesRunTreeMap = true;
 
-  constructor(fields: LangChainTracerFields = {}) {
+  /**
+   * Tracer-only metadata defaults. Added to runs at persist-time for keys
+   * that are not already present, so it never inflates stream events.
+   */
+  tracingMetadata: Record<string, string> | undefined;
+
+  /**
+   * Tracer-only tags. Merged onto runs at persist-time.
+   */
+  tracingTags: string[];
+
+  constructor(fields: LangChainTracerConstructorFields = {}) {
     super(fields);
-    const { exampleId, projectName, client, replicas } = fields;
+    const { exampleId, projectName, client, replicas, metadata } = fields;
 
     this.projectName = projectName ?? getDefaultProjectName();
     this.replicas = replicas;
     this.exampleId = exampleId;
     this.client = client ?? getDefaultLangChainClientSingleton();
+    this.tracingMetadata = metadata !== undefined ? { ...metadata } : undefined;
+    this.tracingTags = [];
 
     const traceableTree = LangChainTracer.getTraceableRunTree();
     if (traceableTree) {
       this.updateFromRunTree(traceableTree);
     }
+  }
+
+  /**
+   * Return a new tracer that shares the same `runTreeMap` (so parent/child
+   * linkage is preserved) but carries merged tracer-only metadata defaults.
+   *
+   * - Keys already present on the current tracer take precedence.
+   * - The original tracer is never mutated.
+   */
+  copyWithMetadataDefaults(options: {
+    metadata?: Record<string, string>;
+    tags?: string[];
+  }): LangChainTracer {
+    const { metadata, tags } = options;
+    const baseMetadata = this.tracingMetadata;
+
+    let mergedMetadata: Record<string, string> | undefined;
+    if (metadata == null) {
+      mergedMetadata = baseMetadata != null ? { ...baseMetadata } : undefined;
+    } else if (baseMetadata == null) {
+      mergedMetadata = { ...metadata };
+    } else {
+      mergedMetadata = { ...baseMetadata };
+      for (const [key, value] of Object.entries(metadata)) {
+        if (!(key in mergedMetadata)) {
+          mergedMetadata[key] = value;
+        }
+      }
+    }
+
+    const mergedTags = tags
+      ? [...new Set([...this.tracingTags, ...tags])].sort()
+      : [...this.tracingTags];
+
+    const copied = new LangChainTracer({
+      exampleId: this.exampleId,
+      projectName: this.projectName,
+      client: this.client,
+      replicas: this.replicas,
+      metadata: mergedMetadata,
+      runTreeMap: this.runTreeMap,
+    });
+    copied.tracingTags = mergedTags;
+    return copied;
   }
 
   protected async persistRun(_run: Run): Promise<void> {
@@ -178,7 +249,7 @@ export class LangChainTracer
     const runTree = this.runTreeMap.get(id);
     if (!runTree) return undefined;
 
-    return new RunTree({
+    const tree = new RunTree({
       ...runTree,
       client: this.client as Client,
       project_name: this.projectName,
@@ -186,6 +257,9 @@ export class LangChainTracer
       reference_example_id: this.exampleId,
       tracingEnabled: true,
     });
+
+    _patchMissingMetadata(this, tree);
+    return tree;
   }
 
   static getTraceableRunTree(): RunTree | undefined {
@@ -203,4 +277,115 @@ export class LangChainTracer
       return undefined;
     }
   }
+}
+
+/**
+ * Patch tracer-level metadata into a run/RunTree for any keys that are not
+ * already present. This ensures the metadata flows to LangSmith without
+ * inflating the metadata dict that travels through every stream event.
+ *
+ * The run's existing metadata is copied on the first miss to avoid mutating
+ * the shared dict owned by the callback manager.
+ */
+export function _patchMissingMetadata(
+  tracer: LangChainTracer,
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  run: { extra?: Record<string, any> }
+): void {
+  const tracingMetadata = tracer.tracingMetadata;
+  if (!tracingMetadata) return;
+
+  const metadata =
+    (run.extra?.metadata as Record<string, unknown> | undefined) ?? {};
+  let patched: Record<string, unknown> | undefined;
+
+  for (const [k, v] of Object.entries(tracingMetadata)) {
+    if (!(k in metadata)) {
+      if (patched == null) {
+        // Copy on first miss to avoid mutating the shared dict.
+        patched = { ...metadata };
+        run.extra = { ...(run.extra ?? {}), metadata: patched };
+      }
+      patched[k] = v;
+    }
+  }
+}
+
+/**
+ * Known configurable keys whose string values should be forwarded as
+ * LangSmith-only inheritable metadata (instead of being copied into the
+ * shared `metadata` dict that flows through every stream event).
+ */
+export const CONFIGURABLE_TO_METADATA_KEYS = new Set([
+  "thread_id",
+  "run_id",
+  "task_id",
+  "checkpoint_id",
+  "checkpoint_ns",
+  "assistant_id",
+  "graph_id",
+  "model",
+  "user_id",
+  "cron_id",
+  "langgraph_auth_user_id",
+]);
+
+/**
+ * Extract LangSmith-only inheritable metadata defaults from a
+ * `configurable` dict.
+ *
+ * Only string values for keys in {@link CONFIGURABLE_TO_METADATA_KEYS} are
+ * included. Returns `undefined` when there is nothing to forward.
+ */
+export function getInheritableMetadataFromConfigurable(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  configurable?: Record<string, any>
+): Record<string, string> | undefined {
+  if (!configurable) return undefined;
+
+  let metadata: Record<string, string> | undefined;
+  for (const key of CONFIGURABLE_TO_METADATA_KEYS) {
+    const value = configurable[key];
+    if (typeof value === "string") {
+      if (!metadata) metadata = {};
+      metadata[key] = value;
+    }
+  }
+  return metadata;
+}
+
+/**
+ * Extract known configurable keys and apply them as LangSmith-only
+ * metadata defaults on any {@link LangChainTracer} handlers found in
+ * `handlers` and `inheritableHandlers`.
+ *
+ * Tracers are replaced with shallow copies so the metadata never leaks
+ * into the shared callback-manager metadata dict (which flows through
+ * every stream event). Non-tracer handlers are left untouched.
+ *
+ * This is a no-op when `configurable` is `undefined` or contains no
+ * relevant keys.
+ *
+ * @internal
+ */
+export function applyConfigurableMetadataToTracers(
+  handlers: {
+    handlers: BaseCallbackHandler[];
+    inheritableHandlers: BaseCallbackHandler[];
+  },
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  configurable?: Record<string, any>
+): void {
+  const metadata = getInheritableMetadataFromConfigurable(configurable);
+  if (!metadata) return;
+
+  const replace = (list: BaseCallbackHandler[]) =>
+    list.map((h) =>
+      h instanceof LangChainTracer
+        ? h.copyWithMetadataDefaults({ metadata })
+        : h
+    );
+
+  handlers.handlers = replace(handlers.handlers);
+  handlers.inheritableHandlers = replace(handlers.inheritableHandlers);
 }


### PR DESCRIPTION
## Summary

Previously, `ensureConfig` copied all primitive values from `configurable` into the shared `metadata` dict. This metadata is attached to every stream event, so large configurable sections (e.g. with `thread_id`, `checkpoint_id`, `assistant_id`, etc.) inflated every streamed chunk. This change removes that copying and instead forwards a known subset of configurable keys as LangSmith-only metadata that is applied to tracer handlers at persist-time, so it reaches LangSmith without bloating stream payloads.

## Changes

### `@langchain/core`

**`runnables/config.ts`**
- Removed the block in `ensureConfig` that copied all primitive configurable keys into `metadata`.
- `getCallbackManagerForConfig` now calls `applyConfigurableMetadataToTracers` after configuring the callback manager, which extracts known configurable keys and applies them as tracer-only metadata defaults.

**`tracers/tracer_langchain.ts`** (owns all LangSmith-specific logic)
- `LangChainTracer` gains a `tracingMetadata` property -- metadata defaults that are applied to runs at persist-time, never flowing through stream events.
- `copyWithMetadataDefaults()` creates a shallow copy of the tracer with merged metadata/tags but a shared `runTreeMap`, so parent/child linkage is preserved across copies.
- `_patchMissingMetadata()` fills in tracer metadata on runs before posting, using copy-on-write to avoid mutating the shared metadata dict.
- `applyConfigurableMetadataToTracers()` replaces `LangChainTracer` handlers in a callback manager with copies carrying the configurable metadata defaults.
- `CONFIGURABLE_TO_METADATA_KEYS` defines the known set of configurable keys forwarded to LangSmith (`thread_id`, `checkpoint_id`, `assistant_id`, `model`, etc.).

**`tracers/base.ts`**
- `BaseTracer` constructor accepts an optional `runTreeMap` parameter so copied tracers can share run state.

**`singletons/async_local_storage/index.ts`**
- `runWithConfig` also applies configurable metadata to tracers, matching the `getCallbackManagerForConfig` path.
