### PR TITLE
fix(openai): add index to streaming reasoning content blocks for proper chunk merging

### DIFF
--- a/.changeset/tricky-pens-repeat.md
+++ b/.changeset/tricky-pens-repeat.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): add index to streaming reasoning content blocks for proper chunk merging

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -840,6 +840,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       content.push({
         type: "reasoning",
         reasoning: event.part.text,
+        index: event.summary_index,
       });
     }
   } else if (event.type === "response.reasoning_summary_text.delta") {
@@ -859,6 +860,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       content.push({
         type: "reasoning",
         reasoning: event.delta,
+        index: event.summary_index,
       });
     }
   } else if (event.type === "response.image_generation_call.partial_image") {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -422,6 +422,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "Initial reasoning step",
+        index: 0,
       });
     });
 
@@ -459,6 +460,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "more reasoning text",
+        index: 0,
       });
     });
 


### PR DESCRIPTION
## Summary

Streaming reasoning content blocks from OpenAI reasoning models were not being consolidated during chunk merging. Each token arrived as a separate `{ type: "reasoning", reasoning: "<token>" }` content block, producing hundreds of single-token blocks in the final message instead of one merged block per reasoning summary part.

## Changes

**`@langchain/openai`** — `src/converters/responses.ts`

The streaming elevation code in `convertResponsesDeltaToChatGenerationChunk` pushes reasoning text into the `content` array for UI rendering. However, these content blocks were missing the `index` field that `_mergeLists` / `_findMergeTarget` in `@langchain/core` relies on to identify merge targets during `AIMessageChunk.concat()`. Without an `index`, each token's reasoning block was appended as a new entry rather than being concatenated with the previous one.

Added `index: event.summary_index` to the reasoning content blocks emitted by:
- `response.reasoning_summary_part.added` — the initial summary part event
- `response.reasoning_summary_text.delta` — the per-token text delta events

The `response.output_item.added` handler is unchanged — it receives the complete reasoning item at once, so its summary parts are correctly joined into a single content block without needing an index.

Updated test expectations in `responses.test.ts` to reflect the new `index` field on the two streaming handlers.
