### PR TITLE
fix(openai): set output_index on output_item.added reasoning content

### DIFF
--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -827,6 +827,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       content.push({
         type: "reasoning",
         reasoning: reasoningText,
+        index: event.output_index,
       });
     }
   } else if (event.type === "response.reasoning_summary_part.added") {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -382,6 +382,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "Thinking about this...Let me reason through.",
+        index: 0,
       });
     });
 
@@ -461,6 +462,35 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
         type: "reasoning",
         reasoning: "more reasoning text",
         index: 0,
+      });
+    });
+
+    it("should include output index on output_item.added reasoning content", () => {
+      const event = {
+        type: "response.output_item.added",
+        output_index: 3,
+        item: {
+          type: "reasoning",
+          id: "rs_abc123",
+          summary: [{ type: "summary_text", text: "indexed reasoning" }],
+        },
+      };
+
+      const result = convertResponsesDeltaToChatGenerationChunk(event as any);
+      const aiMessageChunk = result?.message as AIMessageChunk;
+      const contentArray = aiMessageChunk.content as Array<{
+        type: string;
+        [key: string]: unknown;
+      }>;
+      const reasoningBlocks = contentArray.filter(
+        (block) => block.type === "reasoning"
+      );
+
+      expect(reasoningBlocks.length).toBe(1);
+      expect(reasoningBlocks[0]).toMatchObject({
+        type: "reasoning",
+        reasoning: "indexed reasoning",
+        index: 3,
       });
     });
 


### PR DESCRIPTION
## Summary

Adds `index: event.output_index` to elevated `reasoning` content blocks emitted from `response.output_item.added` in `convertResponsesDeltaToChatGenerationChunk`. Other reasoning-related stream events already carried an index; this path did not, so `AIMessageChunk.concat` → `_mergeLists` could not merge consecutive reasoning deltas and users saw hundreds of tiny reasoning fragments instead of one block (see issue).

## Testing

- `pnpm --filter @langchain/openai test src/converters/tests/responses.test.ts`

## Related

Fixes #10684

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md
-->