### PR TITLE
fix(core): prevent merging reasoning and text blocks on index collision (#10691)

### DIFF
--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -566,11 +566,45 @@ function hasMergeableId(value: unknown): value is { id: string | number } {
 }
 
 /**
+ * Whether two content blocks with the same merge key may be merged when their
+ * `type` fields differ. Most blocks must match on `type`; exceptions cover
+ * provider-specific streaming pairs (e.g. Anthropic text_block + text_block_delta).
+ */
+function contentBlockTypesAllowMerge(leftItem: unknown, item: unknown): boolean {
+  if (
+    typeof leftItem !== "object" ||
+    leftItem === null ||
+    typeof item !== "object" ||
+    item === null
+  ) {
+    return true;
+  }
+  if (!("type" in leftItem) || !("type" in item)) {
+    return true;
+  }
+  const leftType = (leftItem as { type: unknown }).type;
+  const rightType = (item as { type: unknown }).type;
+  if (leftType === rightType) {
+    return true;
+  }
+  if (
+    (leftType === "text_block" && rightType === "text_block_delta") ||
+    (leftType === "text_block_delta" && rightType === "text_block")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Find the index of an existing item in `merged` that should be merged with
  * `item`, based on index and/or id matching.
  *
  * Matching priority:
- * 1. Both have index → match on index (+ id when both present)
+ * 1. Both have index → match on index and compatible content block type (+ id when both present).
+ *    Indices from different provider namespaces (e.g. summary_index vs content_index) can
+ *    collide; incompatible `type` values prevent merging (e.g. reasoning vs text). Streaming
+ *    pairs like text_block + text_block_delta still merge.
  * 2. Neither has index, both have id → match on id alone
  * 3. Otherwise → no match (item should be appended)
  */
@@ -591,6 +625,9 @@ function _findMergeTarget<Content extends ContentBlock>(
       // Both have index: match on index, with id as tiebreaker
       const indicesMatch = leftItem.index === item.index;
       if (!indicesMatch) return false;
+      if (!contentBlockTypesAllowMerge(leftItem, item)) {
+        return false;
+      }
       if (leftHasId && itemHasId) return leftItem.id === item.id;
       return true; // indices match, one or both missing id
     }

--- a/libs/langchain-core/src/messages/tests/base_message.test.ts
+++ b/libs/langchain-core/src/messages/tests/base_message.test.ts
@@ -178,6 +178,42 @@ test("_mergeLists merges blocks by numeric index", () => {
   ]);
 });
 
+test("AIMessageChunk.concat does not merge reasoning and text blocks that share the same index (issue #10691)", () => {
+  const chunk1 = new AIMessageChunk({
+    content: [
+      {
+        type: "reasoning",
+        reasoning: "The user wants",
+        index: 0,
+      },
+    ],
+  });
+
+  const chunk2 = new AIMessageChunk({
+    content: [
+      {
+        type: "text",
+        text: "Here are the results",
+        index: 0,
+      },
+    ],
+  });
+
+  const merged = chunk1.concat(chunk2);
+  expect(merged.content).toEqual([
+    {
+      type: "reasoning",
+      reasoning: "The user wants",
+      index: 0,
+    },
+    {
+      type: "text",
+      text: "Here are the results",
+      index: 0,
+    },
+  ]);
+});
+
 test("_mergeLists merges blocks by string index", () => {
   const chunk1 = new AIMessageChunk({
     content: [


### PR DESCRIPTION
## Summary

Fixes a bug where `AIMessageChunk.concat()` / `_mergeLists` merged **different** content block types when they shared the same `index`, producing a single malformed block (e.g. `type: "reasoning"` with both `reasoning` and `text`). This showed up when streaming the OpenAI Responses API with reasoning summaries: `summary_index` and `content_index` are separate namespaces but were both mapped to `index` on blocks ([issue description](https://github.com/langchain-ai/langchainjs/issues/10691)).

## Changes

- **`_findMergeTarget`** (`libs/langchain-core/src/messages/base.ts`): After index matches, require **`contentBlockTypesAllowMerge`**: both blocks must have compatible `type` values before merging.
- **Exception**: Preserve the existing Anthropic streaming behavior where `text_block` and `text_block_delta` intentionally share an index but represent one logical text stream.
- **Test**: Regression test for `reasoning` + `text` at `index: 0` staying as two blocks.

## Testing

- `pnpm --filter @langchain/core test src/messages/tests/base_message.test.ts`

Fixes #10691
