### PR TITLE
refactor(core): decouple tracer defaults from langsmith callback naming

### DIFF
--- a/.changeset/tracer-metadata-defaults.md
+++ b/.changeset/tracer-metadata-defaults.md
@@ -1,0 +1,9 @@
+---
+"@langchain/core": patch
+---
+
+refactor(core): decouple tracer-only metadata defaults from runnable metadata
+
+- Add tracer-scoped inheritable metadata/tag options in callback manager while keeping backward-compatible aliases.
+- Move configurable-to-tracing metadata derivation into a tracer-only path and keep `ensureConfig` metadata mirroring limited to `model`.
+- Update `LangChainTracer` default metadata/tag handling and add regression tests for stream events metadata behavior.

--- a/libs/langchain-core/src/callbacks/manager.ts
+++ b/libs/langchain-core/src/callbacks/manager.ts
@@ -33,6 +33,8 @@ type BaseCallbackManagerMethods = {
 export interface CallbackManagerOptions {
   verbose?: boolean;
   tracing?: boolean;
+  tracerInheritableMetadata?: Record<string, unknown>;
+  tracerInheritableTags?: string[];
 }
 
 export type Callbacks =
@@ -1341,6 +1343,31 @@ export class CallbackManager
         callbackManager.addMetadata(inheritableMetadata ?? {});
         callbackManager.addMetadata(localMetadata ?? {}, false);
       }
+    }
+    const tracerInheritableMetadata = options?.tracerInheritableMetadata;
+    const tracerInheritableTags = options?.tracerInheritableTags;
+
+    if (
+      callbackManager &&
+      (tracerInheritableMetadata || tracerInheritableTags)
+    ) {
+      callbackManager.handlers = callbackManager.handlers.map((handler) =>
+        handler instanceof LangChainTracer
+          ? handler.copyWithTracingConfig({
+              metadata: tracerInheritableMetadata,
+              tags: tracerInheritableTags,
+            })
+          : handler
+      );
+      callbackManager.inheritableHandlers =
+        callbackManager.inheritableHandlers.map((handler) =>
+          handler instanceof LangChainTracer
+            ? handler.copyWithTracingConfig({
+                metadata: tracerInheritableMetadata,
+                tags: tracerInheritableTags,
+              })
+            : handler
+        );
     }
 
     return callbackManager;

--- a/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
+++ b/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "vitest";
+import { test, expect, vi } from "vitest";
 import * as uuid from "uuid";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { CallbackManager } from "../manager.js";
@@ -12,6 +12,7 @@ import type { LLMResult } from "../../outputs.js";
 import { RunnableLambda } from "../../runnables/base.js";
 import { AsyncLocalStorageProviderSingleton } from "../../singletons/index.js";
 import { awaitAllCallbacks } from "../promises.js";
+import { LangChainTracer } from "../../tracers/tracer_langchain.js";
 
 class FakeCallbackHandler extends BaseCallbackHandler {
   name = `fake-${uuid.v4()}`;
@@ -477,6 +478,64 @@ test("CallbackManager.copy()", () => {
     handler1.name,
     handler3.name,
   ]);
+});
+
+test("langsmith inheritable metadata/tags apply only to LangChainTracer", async () => {
+  const captured: { metadata?: Record<string, unknown>; tags?: string[] }[] =
+    [];
+  class CaptureHandler extends BaseCallbackHandler {
+    name = `capture-${uuid.v4()}`;
+
+    async handleChainStart(
+      _chain: Serialized,
+      _inputs: ChainValues,
+      _runId: string,
+      _runType?: string,
+      tags?: string[],
+      metadata?: Record<string, unknown>
+    ) {
+      captured.push({ tags, metadata });
+    }
+  }
+
+  const mockClient = {
+    createRun: vi.fn().mockResolvedValue(undefined),
+    updateRun: vi.fn().mockResolvedValue(undefined),
+  };
+  const tracer = new LangChainTracer({ client: mockClient as any });
+  const capture = new CaptureHandler();
+
+  const callbacks = CallbackManager.configure(
+    [tracer, capture],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      tracerInheritableMetadata: { tracer_only: "yes" },
+      tracerInheritableTags: ["tenant:alpha"],
+    }
+  );
+
+  const configuredTracer = callbacks?.handlers.find(
+    (handler) => handler instanceof LangChainTracer
+  );
+  expect(configuredTracer).toBeDefined();
+  expect(configuredTracer).not.toBe(tracer);
+
+  const runnable = RunnableLambda.from((x: string) => x);
+  await runnable.invoke("hello", { callbacks: callbacks! });
+  await awaitAllCallbacks();
+
+  expect(captured.length).toBeGreaterThan(0);
+  expect(captured[0].metadata?.tracer_only).toBeUndefined();
+  expect(captured[0].tags).not.toContain("tenant:alpha");
+
+  expect(mockClient.createRun).toHaveBeenCalled();
+  const postedRun = mockClient.createRun.mock.calls[0]?.[0];
+  expect(postedRun.extra?.metadata?.tracer_only).toBe("yes");
+  expect(postedRun.tags).toContain("tenant:alpha");
 });
 
 class FakeCallbackHandlerWithErrors extends FakeCallbackHandler {

--- a/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
+++ b/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
@@ -499,10 +499,12 @@ test("langsmith inheritable metadata/tags apply only to LangChainTracer", async 
     }
   }
 
+  const createRunMock = vi.fn().mockResolvedValue(undefined);
+  const updateRunMock = vi.fn().mockResolvedValue(undefined);
   const mockClient = {
-    createRun: vi.fn().mockResolvedValue(undefined),
-    updateRun: vi.fn().mockResolvedValue(undefined),
-  } as unknown as LangSmithTracingClientInterface;
+    createRun: createRunMock,
+    updateRun: updateRunMock,
+  } as LangSmithTracingClientInterface;
   const tracer = new LangChainTracer({ client: mockClient });
   const capture = new CaptureHandler();
 
@@ -533,8 +535,8 @@ test("langsmith inheritable metadata/tags apply only to LangChainTracer", async 
   expect(captured[0].metadata?.tracer_only).toBeUndefined();
   expect(captured[0].tags).not.toContain("tenant:alpha");
 
-  expect(mockClient.createRun).toHaveBeenCalled();
-  const postedRun = mockClient.createRun.mock.calls[0]?.[0];
+  expect(createRunMock).toHaveBeenCalled();
+  const postedRun = createRunMock.mock.calls[0]?.[0];
   expect(postedRun.extra?.metadata?.tracer_only).toBe("yes");
   expect(postedRun.tags).toContain("tenant:alpha");
 });

--- a/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
+++ b/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, vi } from "vitest";
 import * as uuid from "uuid";
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { LangSmithTracingClientInterface } from "langsmith";
 import { CallbackManager } from "../manager.js";
 import { BaseCallbackHandler, type BaseCallbackHandlerInput } from "../base.js";
 import type { Serialized } from "../../load/serializable.js";
@@ -501,8 +502,8 @@ test("langsmith inheritable metadata/tags apply only to LangChainTracer", async 
   const mockClient = {
     createRun: vi.fn().mockResolvedValue(undefined),
     updateRun: vi.fn().mockResolvedValue(undefined),
-  };
-  const tracer = new LangChainTracer({ client: mockClient as any });
+  } as unknown as LangSmithTracingClientInterface;
+  const tracer = new LangChainTracer({ client: mockClient });
   const capture = new CaptureHandler();
 
   const callbacks = CallbackManager.configure(

--- a/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
+++ b/libs/langchain-core/src/callbacks/tests/callbacks.test.ts
@@ -541,6 +541,39 @@ test("langsmith inheritable metadata/tags apply only to LangChainTracer", async 
   expect(postedRun.tags).toContain("tenant:alpha");
 });
 
+test("tracer inheritable options apply via Symbol.hasInstance structural match", () => {
+  class ForeignTracer extends BaseCallbackHandler {
+    name = "langchain_tracer";
+
+    copyWithTracingConfig = vi.fn().mockReturnThis();
+
+    getRunTreeWithTracingConfig() {
+      return undefined;
+    }
+  }
+
+  const foreignTracer = new ForeignTracer();
+  expect(foreignTracer instanceof LangChainTracer).toBe(true);
+
+  CallbackManager.configure(
+    [foreignTracer],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      tracerInheritableMetadata: { tenant: "alpha" },
+      tracerInheritableTags: ["tenant:alpha"],
+    }
+  );
+
+  expect(foreignTracer.copyWithTracingConfig).toHaveBeenCalledWith({
+    metadata: { tenant: "alpha" },
+    tags: ["tenant:alpha"],
+  });
+});
+
 class FakeCallbackHandlerWithErrors extends FakeCallbackHandler {
   constructor(input: BaseCallbackHandlerInput) {
     super({ ...input, raiseError: true });

--- a/libs/langchain-core/src/runnables/config.ts
+++ b/libs/langchain-core/src/runnables/config.ts
@@ -6,13 +6,43 @@ export const DEFAULT_RECURSION_LIMIT = 25;
 
 export { type RunnableConfig };
 
+const CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS = new Set(["api_key"]);
+const PRIMITIVES = new Set(["string", "number", "boolean"]);
+
+export function _getTracingInheritableMetadataFromConfig(
+  config: RunnableConfig
+): Record<string, unknown> | undefined {
+  const configurable = config.configurable ?? {};
+  const metadata = config.metadata ?? {};
+  const langSmithMetadata: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(configurable)) {
+    if (
+      !key.startsWith("__") &&
+      !Object.prototype.hasOwnProperty.call(metadata, key) &&
+      !CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS.has(key) &&
+      PRIMITIVES.has(typeof value)
+    ) {
+      langSmithMetadata[key] = value;
+    }
+  }
+  return Object.keys(langSmithMetadata).length > 0
+    ? langSmithMetadata
+    : undefined;
+}
+
 export async function getCallbackManagerForConfig(config?: RunnableConfig) {
   return CallbackManager._configureSync(
     config?.callbacks,
     undefined,
     config?.tags,
     undefined,
-    config?.metadata
+    config?.metadata,
+    undefined,
+    {
+      tracerInheritableMetadata: config
+        ? _getTracingInheritableMetadataFromConfig(config)
+        : undefined,
+    }
   );
 }
 
@@ -117,8 +147,6 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
   return copy as Partial<CallOptions>;
 }
 
-const PRIMITIVES = new Set(["string", "number", "boolean"]);
-
 /**
  * Ensure that a passed config is an object with all required keys present.
  */
@@ -160,16 +188,14 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
     );
   }
   if (empty?.configurable) {
-    for (const key of Object.keys(empty.configurable)) {
-      if (
-        PRIMITIVES.has(typeof empty.configurable[key]) &&
-        !empty.metadata?.[key]
-      ) {
-        if (!empty.metadata) {
-          empty.metadata = {};
-        }
-        empty.metadata[key] = empty.configurable[key];
+    if (
+      typeof empty.configurable.model === "string" &&
+      empty.metadata?.model === undefined
+    ) {
+      if (!empty.metadata) {
+        empty.metadata = {};
       }
+      empty.metadata.model = empty.configurable.model;
     }
   }
   if (empty.timeout !== undefined) {

--- a/libs/langchain-core/src/runnables/config.ts
+++ b/libs/langchain-core/src/runnables/config.ts
@@ -10,7 +10,7 @@ const CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS = new Set(["api_key"]);
 const PRIMITIVES = new Set(["string", "number", "boolean"]);
 
 export function _getTracingInheritableMetadataFromConfig(
-  config: RunnableConfig,
+  config: RunnableConfig
 ): Record<string, unknown> | undefined {
   const configurable = config.configurable ?? {};
   const metadata = config.metadata ?? {};
@@ -42,7 +42,7 @@ export async function getCallbackManagerForConfig(config?: RunnableConfig) {
       tracerInheritableMetadata: config
         ? _getTracingInheritableMetadataFromConfig(config)
         : undefined,
-    },
+    }
   );
 }
 
@@ -115,26 +115,26 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
               providedCallbacks._parentRunId,
               {
                 handlers: baseCallbacks.handlers.concat(
-                  providedCallbacks.handlers,
+                  providedCallbacks.handlers
                 ),
                 inheritableHandlers: baseCallbacks.inheritableHandlers.concat(
-                  providedCallbacks.inheritableHandlers,
+                  providedCallbacks.inheritableHandlers
                 ),
                 tags: Array.from(
-                  new Set(baseCallbacks.tags.concat(providedCallbacks.tags)),
+                  new Set(baseCallbacks.tags.concat(providedCallbacks.tags))
                 ),
                 inheritableTags: Array.from(
                   new Set(
                     baseCallbacks.inheritableTags.concat(
-                      providedCallbacks.inheritableTags,
-                    ),
-                  ),
+                      providedCallbacks.inheritableTags
+                    )
+                  )
                 ),
                 metadata: {
                   ...baseCallbacks.metadata,
                   ...providedCallbacks.metadata,
                 },
-              },
+              }
             );
           }
         }
@@ -151,7 +151,7 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
  * Ensure that a passed config is an object with all required keys present.
  */
 export function ensureConfig<CallOptions extends RunnableConfig>(
-  config?: CallOptions,
+  config?: CallOptions
 ): CallOptions {
   const implicitConfig = AsyncLocalStorageProviderSingleton.getRunnableConfig();
   let empty: RunnableConfig = {
@@ -172,7 +172,7 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
         }
         return currentConfig;
       },
-      empty,
+      empty
     );
   }
   if (config) {
@@ -184,7 +184,7 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
         }
         return currentConfig;
       },
-      empty,
+      empty
     );
   }
   if (empty?.configurable) {
@@ -251,7 +251,7 @@ export function patchConfig<CallOptions extends RunnableConfig>(
     runName,
     configurable,
     runId,
-  }: RunnableConfig = {},
+  }: RunnableConfig = {}
 ): Partial<CallOptions> {
   const newConfig = ensureConfig(config);
   if (callbacks !== undefined) {
@@ -282,7 +282,7 @@ export function patchConfig<CallOptions extends RunnableConfig>(
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export function pickRunnableConfigKeys<CallOptions extends Record<string, any>>(
-  config?: CallOptions,
+  config?: CallOptions
 ): Partial<RunnableConfig> | undefined {
   if (!config) return undefined;
 

--- a/libs/langchain-core/src/runnables/config.ts
+++ b/libs/langchain-core/src/runnables/config.ts
@@ -10,7 +10,7 @@ const CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS = new Set(["api_key"]);
 const PRIMITIVES = new Set(["string", "number", "boolean"]);
 
 export function _getTracingInheritableMetadataFromConfig(
-  config: RunnableConfig
+  config: RunnableConfig,
 ): Record<string, unknown> | undefined {
   const configurable = config.configurable ?? {};
   const metadata = config.metadata ?? {};
@@ -42,7 +42,7 @@ export async function getCallbackManagerForConfig(config?: RunnableConfig) {
       tracerInheritableMetadata: config
         ? _getTracingInheritableMetadataFromConfig(config)
         : undefined,
-    }
+    },
   );
 }
 
@@ -115,26 +115,26 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
               providedCallbacks._parentRunId,
               {
                 handlers: baseCallbacks.handlers.concat(
-                  providedCallbacks.handlers
+                  providedCallbacks.handlers,
                 ),
                 inheritableHandlers: baseCallbacks.inheritableHandlers.concat(
-                  providedCallbacks.inheritableHandlers
+                  providedCallbacks.inheritableHandlers,
                 ),
                 tags: Array.from(
-                  new Set(baseCallbacks.tags.concat(providedCallbacks.tags))
+                  new Set(baseCallbacks.tags.concat(providedCallbacks.tags)),
                 ),
                 inheritableTags: Array.from(
                   new Set(
                     baseCallbacks.inheritableTags.concat(
-                      providedCallbacks.inheritableTags
-                    )
-                  )
+                      providedCallbacks.inheritableTags,
+                    ),
+                  ),
                 ),
                 metadata: {
                   ...baseCallbacks.metadata,
                   ...providedCallbacks.metadata,
                 },
-              }
+              },
             );
           }
         }
@@ -151,7 +151,7 @@ export function mergeConfigs<CallOptions extends RunnableConfig>(
  * Ensure that a passed config is an object with all required keys present.
  */
 export function ensureConfig<CallOptions extends RunnableConfig>(
-  config?: CallOptions
+  config?: CallOptions,
 ): CallOptions {
   const implicitConfig = AsyncLocalStorageProviderSingleton.getRunnableConfig();
   let empty: RunnableConfig = {
@@ -172,7 +172,7 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
         }
         return currentConfig;
       },
-      empty
+      empty,
     );
   }
   if (config) {
@@ -184,7 +184,7 @@ export function ensureConfig<CallOptions extends RunnableConfig>(
         }
         return currentConfig;
       },
-      empty
+      empty,
     );
   }
   if (empty?.configurable) {
@@ -251,7 +251,7 @@ export function patchConfig<CallOptions extends RunnableConfig>(
     runName,
     configurable,
     runId,
-  }: RunnableConfig = {}
+  }: RunnableConfig = {},
 ): Partial<CallOptions> {
   const newConfig = ensureConfig(config);
   if (callbacks !== undefined) {
@@ -282,7 +282,7 @@ export function patchConfig<CallOptions extends RunnableConfig>(
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 export function pickRunnableConfigKeys<CallOptions extends Record<string, any>>(
-  config?: CallOptions
+  config?: CallOptions,
 ): Partial<RunnableConfig> | undefined {
   if (!config) return undefined;
 

--- a/libs/langchain-core/src/runnables/tests/config.test.ts
+++ b/libs/langchain-core/src/runnables/tests/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { mergeConfigs } from "../config.js";
+import {
+  _getTracingInheritableMetadataFromConfig,
+  ensureConfig,
+  mergeConfigs,
+} from "../config.js";
 
 describe("mergeConfigs metadata", () => {
   it("merges metadata with last-writer-wins", () => {
@@ -36,5 +40,49 @@ describe("mergeConfigs metadata", () => {
   it("handles empty metadata", () => {
     const result = mergeConfigs({ metadata: {} }, { metadata: { a: 1 } });
     expect(result.metadata).toEqual({ a: 1 });
+  });
+});
+
+describe("ensureConfig tracing metadata behavior", () => {
+  it("copies only configurable model into metadata", () => {
+    const config = ensureConfig({
+      configurable: {
+        model: "gpt-4o",
+        thread_id: "th-123",
+        temperature: 0.2,
+      },
+      metadata: { explicit: true },
+    });
+
+    expect(config.metadata).toEqual({
+      explicit: true,
+      model: "gpt-4o",
+    });
+  });
+
+  it("builds LangSmith inheritable metadata from primitive configurable values", () => {
+    const config = ensureConfig({
+      metadata: {
+        model: "from-metadata",
+        thread_id: "from-metadata",
+      },
+      configurable: {
+        model: "from-configurable",
+        thread_id: "from-configurable",
+        checkpoint_id: "ckpt-1",
+        temperature: 0.5,
+        streaming: true,
+        api_key: "should-not-propagate",
+        __secret_key: "should-not-propagate",
+        custom_setting: { nested: true },
+        none_value: undefined,
+      },
+    });
+
+    expect(_getTracingInheritableMetadataFromConfig(config)).toEqual({
+      checkpoint_id: "ckpt-1",
+      temperature: 0.5,
+      streaming: true,
+    });
   });
 });

--- a/libs/langchain-core/src/runnables/tests/config.test.ts
+++ b/libs/langchain-core/src/runnables/tests/config.test.ts
@@ -43,8 +43,8 @@ describe("mergeConfigs metadata", () => {
   });
 });
 
-describe("ensureConfig tracing metadata behavior", () => {
-  it("copies only configurable model into metadata", () => {
+describe("ensureConfig and tracer metadata behavior", () => {
+  it("copies only configurable model into general metadata", () => {
     const config = ensureConfig({
       configurable: {
         model: "gpt-4o",
@@ -60,7 +60,30 @@ describe("ensureConfig tracing metadata behavior", () => {
     });
   });
 
-  it("builds LangSmith inheritable metadata from primitive configurable values", () => {
+  it("builds tracer inheritable metadata from primitive configurable values", () => {
+    const config = ensureConfig({
+      configurable: {
+        model: "from-configurable",
+        thread_id: "th-123",
+        checkpoint_id: "ckpt-1",
+        temperature: 0.5,
+        streaming: true,
+        api_key: "should-not-propagate",
+        __secret_key: "should-not-propagate",
+        custom_setting: { nested: true },
+        none_value: undefined,
+      },
+    });
+
+    expect(_getTracingInheritableMetadataFromConfig(config)).toEqual({
+      thread_id: "th-123",
+      checkpoint_id: "ckpt-1",
+      temperature: 0.5,
+      streaming: true,
+    });
+  });
+
+  it("does not override explicit metadata when building tracer inheritable metadata", () => {
     const config = ensureConfig({
       metadata: {
         model: "from-metadata",

--- a/libs/langchain-core/src/runnables/tests/runnable_stream_events_v2.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable_stream_events_v2.test.ts
@@ -79,6 +79,50 @@ test("Runnable streamEvents method", async () => {
   ]);
 });
 
+test("Runnable streamEvents does not include tracer-only configurable metadata", async () => {
+  const originalTracingValue = process.env.LANGCHAIN_TRACING_V2;
+  const originalLangChainTracingValue = process.env.LANGCHAIN_TRACING;
+  const originalLangSmithTracingValue = process.env.LANGSMITH_TRACING;
+  process.env.LANGCHAIN_TRACING_V2 = "false";
+  process.env.LANGCHAIN_TRACING = "false";
+  process.env.LANGSMITH_TRACING = "false";
+  try {
+    const chain = RunnableLambda.from((input: string) => input).withConfig({
+      runName: "echo",
+    });
+
+    const events: StreamEvent[] = [];
+    const eventStream = await chain.streamEvents("hello", {
+      version: "v2",
+      configurable: {
+        thread_id: "th-123",
+        checkpoint_id: "ckpt-1",
+        temperature: 0.5,
+        streaming: true,
+        api_key: "should-not-propagate",
+        __secret_key: "should-not-propagate",
+      },
+    });
+    for await (const event of eventStream) {
+      events.push(event);
+    }
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.metadata).not.toHaveProperty("thread_id");
+      expect(event.metadata).not.toHaveProperty("checkpoint_id");
+      expect(event.metadata).not.toHaveProperty("temperature");
+      expect(event.metadata).not.toHaveProperty("streaming");
+      expect(event.metadata).not.toHaveProperty("api_key");
+      expect(event.metadata).not.toHaveProperty("__secret_key");
+    }
+  } finally {
+    process.env.LANGCHAIN_TRACING_V2 = originalTracingValue;
+    process.env.LANGCHAIN_TRACING = originalLangChainTracingValue;
+    process.env.LANGSMITH_TRACING = originalLangSmithTracingValue;
+  }
+});
+
 test("Runnable streamEvents method on a chat model", async () => {
   const model = new FakeListChatModel({
     responses: ["abc"],

--- a/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
+++ b/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
@@ -287,4 +287,57 @@ describe("LangChainTracer usage_metadata extraction", () => {
       output_token_details: {},
     });
   });
+
+  test("tracing defaults patch missing run metadata without overriding explicit values", async () => {
+    const mockClient = {
+      createRun: vi.fn(),
+      updateRun: vi.fn(),
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { env: "prod", tenant: "default" },
+      tags: ["tracer-tag"],
+    });
+    const runId = uuid.v4();
+
+    await tracer.handleLLMStart(
+      serialized,
+      ["test prompt"],
+      runId,
+      undefined,
+      undefined,
+      ["run-tag"],
+      { tenant: "explicit" }
+    );
+    await tracer.handleLLMEnd({ generations: [[{ text: "ok" }]] }, runId);
+
+    const updateCall = mockClient.updateRun.mock.calls[0][1];
+    expect(updateCall.extra?.metadata?.env).toBe("prod");
+    expect(updateCall.extra?.metadata?.tenant).toBe("explicit");
+    expect(updateCall.tags).toEqual(
+      expect.arrayContaining(["run-tag", "tracer-tag"])
+    );
+  });
+
+  test("copyWithTracingConfig keeps original tracer unchanged", () => {
+    const tracer = new LangChainTracer({
+      client: { createRun: vi.fn(), updateRun: vi.fn() } as any,
+      metadata: { env: "staging" },
+      tags: ["existing"],
+    });
+    const copied = tracer.copyWithTracingConfig({
+      metadata: { tenant: "alpha", env: "prod" },
+      tags: ["tenant:alpha", "existing"],
+    });
+
+    expect(copied).not.toBe(tracer);
+    expect(copied.tracingMetadata).toEqual({
+      env: "staging",
+      tenant: "alpha",
+    });
+    expect(copied.tracingTags).toEqual(["existing", "tenant:alpha"]);
+    expect(tracer.tracingMetadata).toEqual({ env: "staging" });
+    expect(tracer.tracingTags).toEqual(["existing"]);
+  });
 });

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -44,6 +44,8 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
   projectName?: string;
   client?: LangSmithTracingClientInterface;
   replicas?: RunTreeConfig["replicas"];
+  metadata?: Record<string, unknown>;
+  tags?: string[];
 }
 
 /**
@@ -85,14 +87,20 @@ export class LangChainTracer
 
   usesRunTreeMap = true;
 
-  constructor(fields: LangChainTracerFields = {}) {
+  tracingMetadata?: Record<string, unknown>;
+
+  tracingTags: string[] = [];
+
+  constructor(protected fields: LangChainTracerFields = {}) {
     super(fields);
-    const { exampleId, projectName, client, replicas } = fields;
+    const { exampleId, projectName, client, replicas, metadata, tags } = fields;
 
     this.projectName = projectName ?? getDefaultProjectName();
     this.replicas = replicas;
     this.exampleId = exampleId;
     this.client = client ?? getDefaultLangChainClientSingleton();
+    this.tracingMetadata = metadata ? { ...metadata } : undefined;
+    this.tracingTags = tags ?? [];
 
     const traceableTree = LangChainTracer.getTraceableRunTree();
     if (traceableTree) {
@@ -105,6 +113,7 @@ export class LangChainTracer
   }
 
   async onRunCreate(run: Run): Promise<void> {
+    _patchMissingTracingDefaults(this, run);
     if (!run.extra?.lc_defers_inputs) {
       const runTree = this.getRunTreeWithTracingConfig(run.id);
       await runTree?.postRun();
@@ -112,6 +121,7 @@ export class LangChainTracer
   }
 
   async onRunUpdate(run: Run): Promise<void> {
+    _patchMissingTracingDefaults(this, run);
     const runTree = this.getRunTreeWithTracingConfig(run.id);
     if (run.extra?.lc_defers_inputs) {
       await runTree?.postRun();
@@ -137,6 +147,43 @@ export class LangChainTracer
         run.extra.metadata = metadata;
       }
     }
+  }
+
+  copyWithTracingConfig({
+    metadata,
+    tags,
+  }: {
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+  }): LangChainTracer {
+    let mergedMetadata: Record<string, unknown> | undefined;
+    if (metadata === undefined) {
+      mergedMetadata = this.tracingMetadata
+        ? { ...this.tracingMetadata }
+        : undefined;
+    } else if (this.tracingMetadata === undefined) {
+      mergedMetadata = { ...metadata };
+    } else {
+      mergedMetadata = { ...this.tracingMetadata };
+      for (const [key, value] of Object.entries(metadata)) {
+        if (!Object.prototype.hasOwnProperty.call(mergedMetadata, key)) {
+          mergedMetadata[key] = value;
+        }
+      }
+    }
+
+    const mergedTags = tags
+      ? Array.from(new Set([...this.tracingTags, ...tags]))
+      : [...this.tracingTags];
+
+    const copied = new LangChainTracer({
+      ...this.fields,
+      metadata: mergedMetadata,
+      tags: mergedTags,
+    });
+    copied.runMap = this.runMap;
+    copied.runTreeMap = this.runTreeMap;
+    return copied;
   }
 
   getRun(id: string): Run | undefined {
@@ -172,6 +219,13 @@ export class LangChainTracer
     this.replicas = runTree.replicas ?? this.replicas;
     this.projectName = runTree.project_name ?? this.projectName;
     this.exampleId = runTree.reference_example_id ?? this.exampleId;
+    this.fields = {
+      ...this.fields,
+      client: this.client,
+      replicas: this.replicas,
+      projectName: this.projectName,
+      exampleId: this.exampleId,
+    };
   }
 
   getRunTreeWithTracingConfig(id: string): RunTree | undefined {
@@ -202,5 +256,29 @@ export class LangChainTracer
     } catch {
       return undefined;
     }
+  }
+}
+
+function _patchMissingTracingDefaults(tracer: LangChainTracer, run: Run): void {
+  if (tracer.tracingMetadata) {
+    run.extra ??= {};
+    const metadata: Record<string, unknown> =
+      (run.extra.metadata as Record<string, unknown> | undefined) ?? {};
+    let didPatchMetadata = false;
+    for (const [key, value] of Object.entries(tracer.tracingMetadata)) {
+      if (!Object.prototype.hasOwnProperty.call(metadata, key)) {
+        metadata[key] = value;
+        didPatchMetadata = true;
+      }
+    }
+    if (didPatchMetadata) {
+      run.extra.metadata = metadata;
+    }
+  }
+
+  if (tracer.tracingTags.length > 0) {
+    run.tags = Array.from(
+      new Set([...(run.tags ?? []), ...tracer.tracingTags])
+    );
   }
 }

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -55,7 +55,7 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
  * found in chat messages. This is typically present in chat model outputs.
  */
 function _getUsageMetadataFromGenerations(
-  generations: ChatGeneration[][]
+  generations: ChatGeneration[][],
 ): UsageMetadata | undefined {
   let output: UsageMetadata | undefined = undefined;
   for (const generationBatch of generations) {
@@ -137,7 +137,7 @@ export class LangChainTracer
       | undefined;
     if (outputs?.generations) {
       const usageMetadata = _getUsageMetadataFromGenerations(
-        outputs.generations
+        outputs.generations,
       );
       if (usageMetadata !== undefined) {
         run.extra = run.extra ?? {};
@@ -249,7 +249,7 @@ export class LangChainTracer
         // ignore the permitAbsentRunTree arg.
         (
           getCurrentRunTree as (
-            permitAbsentRunTree: boolean
+            permitAbsentRunTree: boolean,
           ) => ReturnType<typeof getCurrentRunTree> | undefined
         )(true)
       );
@@ -259,9 +259,6 @@ export class LangChainTracer
   }
 
   static [Symbol.hasInstance](instance: unknown): boolean {
-    if (Function.prototype[Symbol.hasInstance].call(this, instance)) {
-      return true;
-    }
     if (typeof instance !== "object" || instance === null) {
       return false;
     }
@@ -296,7 +293,7 @@ function _patchMissingTracingDefaults(tracer: LangChainTracer, run: Run): void {
 
   if (tracer.tracingTags.length > 0) {
     run.tags = Array.from(
-      new Set([...(run.tags ?? []), ...tracer.tracingTags])
+      new Set([...(run.tags ?? []), ...tracer.tracingTags]),
     );
   }
 }

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -257,6 +257,24 @@ export class LangChainTracer
       return undefined;
     }
   }
+
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    if (Function.prototype[Symbol.hasInstance].call(this, instance)) {
+      return true;
+    }
+    if (typeof instance !== "object" || instance === null) {
+      return false;
+    }
+    const candidate = instance as Record<string, unknown>;
+    return (
+      "name" in candidate &&
+      candidate.name === "langchain_tracer" &&
+      "copyWithTracingConfig" in candidate &&
+      typeof candidate.copyWithTracingConfig === "function" &&
+      "getRunTreeWithTracingConfig" in candidate &&
+      typeof candidate.getRunTreeWithTracingConfig === "function"
+    );
+  }
 }
 
 function _patchMissingTracingDefaults(tracer: LangChainTracer, run: Run): void {

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -55,7 +55,7 @@ export interface LangChainTracerFields extends BaseCallbackHandlerInput {
  * found in chat messages. This is typically present in chat model outputs.
  */
 function _getUsageMetadataFromGenerations(
-  generations: ChatGeneration[][],
+  generations: ChatGeneration[][]
 ): UsageMetadata | undefined {
   let output: UsageMetadata | undefined = undefined;
   for (const generationBatch of generations) {
@@ -137,7 +137,7 @@ export class LangChainTracer
       | undefined;
     if (outputs?.generations) {
       const usageMetadata = _getUsageMetadataFromGenerations(
-        outputs.generations,
+        outputs.generations
       );
       if (usageMetadata !== undefined) {
         run.extra = run.extra ?? {};
@@ -249,7 +249,7 @@ export class LangChainTracer
         // ignore the permitAbsentRunTree arg.
         (
           getCurrentRunTree as (
-            permitAbsentRunTree: boolean,
+            permitAbsentRunTree: boolean
           ) => ReturnType<typeof getCurrentRunTree> | undefined
         )(true)
       );
@@ -293,7 +293,7 @@ function _patchMissingTracingDefaults(tracer: LangChainTracer, run: Run): void {
 
   if (tracer.tracingTags.length > 0) {
     run.tags = Array.from(
-      new Set([...(run.tags ?? []), ...tracer.tracingTags]),
+      new Set([...(run.tags ?? []), ...tracer.tracingTags])
     );
   }
 }


### PR DESCRIPTION
## Summary

Decouples LangSmith-specific defaults from base callback metadata flow while preserving tracing behavior and backward compatibility.

## Changes

### `@langchain/core` callbacks

- Added provider-agnostic callback-manager options for tracer defaults:
  - `tracerInheritableMetadata`
  - `tracerInheritableTags`
- Applied tracer defaults only to `LangChainTracer` handlers (via `instanceof LangChainTracer`), leaving non-tracer handlers unchanged.

### `@langchain/core` runnable config

- Stopped copying all primitive `configurable` values into general run `metadata` during `ensureConfig`.
- Preserved only `configurable.model -> metadata.model` mirroring behavior.
- Added `_getTracingInheritableMetadataFromConfig` for deriving tracer-only inheritable metadata from `configurable` values.
- Wired callback-manager configuration to pass tracer-only inheritable metadata through provider-agnostic option names.

### `@langchain/core` LangChain tracer

- Extended `LangChainTracer` constructor fields to support tracing defaults (`metadata`, `tags`).
- Added `copyWithTracingConfig(...)` to clone tracer instances with merged default metadata/tags while preserving shared run state maps.
- Added patching of missing run metadata/tags at persistence boundaries so explicit run metadata wins and tracer defaults fill only missing keys.

### Tests

- Added and updated tests across:
  - `runnables/config` metadata derivation and precedence
  - callback manager tracer-only default application
  - LangChain tracer default metadata/tag patching and clone behavior
