### PR TITLE
chore(ci): add label-gated publish-preview workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,52 @@
+name: publish-preview
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-preview-packages:
+    name: Publish Preview Packages
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'publish-preview' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Detect packages from changed changesets
+        if: ${{ github.event_name == 'pull_request' }}
+        id: changed_packages
+        run: .github/workflows/scripts/get-changed-changeset-package-paths.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+
+      - name: Publish to pkg.pr.new
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.changed_packages.outputs.paths != '' }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            pnpm dlx pkg-pr-new publish './libs/*'
+          else
+            pnpm dlx pkg-pr-new publish ${{ steps.changed_packages.outputs.paths }}
+          fi
+        continue-on-error: true

--- a/.github/workflows/scripts/get-changed-changeset-package-paths.sh
+++ b/.github/workflows/scripts/get-changed-changeset-package-paths.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+
+if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+  echo "Usage: .github/workflows/scripts/get-changed-changeset-package-paths.sh <baseSha> <headSha>" >&2
+  exit 1
+fi
+
+set_github_output() {
+  local key="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "$key=$value" >> "$GITHUB_OUTPUT"
+  else
+    echo "$key=$value"
+  fi
+}
+
+echo "Comparing changed changesets between $BASE_SHA and $HEAD_SHA"
+changed_changesets="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.changeset/*.md' ':!.changeset/README.md')"
+
+if [ -z "$changed_changesets" ]; then
+  echo "No changed changeset files found."
+  set_github_output "paths" ""
+  exit 0
+fi
+
+paths="$(
+  CHANGESET_FILES="$changed_changesets" node <<'NODE'
+  const fs = require("fs");
+  const path = require("path");
+
+  const files = (process.env.CHANGESET_FILES ?? "")
+    .split("\n")
+    .map((x) => x.trim())
+    .filter(Boolean);
+
+  const packageNameToPath = new Map();
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const full = path.join(dir, entry.name);
+      const pkgJsonPath = path.join(full, "package.json");
+      if (fs.existsSync(pkgJsonPath)) {
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+        if (pkgJson.name && !pkgJson.private) {
+          packageNameToPath.set(pkgJson.name, `./${full}`);
+        }
+        continue;
+      }
+      walk(full);
+    }
+  }
+
+  walk("libs");
+
+  const packageNames = new Set();
+  for (const file of files) {
+    const content = fs.readFileSync(file, "utf8");
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) continue;
+    for (const line of match[1].split("\n")) {
+      const key = line.match(/^\s*["']?([^"':]+)["']?\s*:/);
+      if (key) packageNames.add(key[1].trim());
+    }
+  }
+
+  const paths = [...packageNames]
+    .map((name) => packageNameToPath.get(name))
+    .filter(Boolean)
+    .sort();
+
+  process.stdout.write(paths.join(" "));
+NODE
+)"
+
+if [ -z "$paths" ]; then
+  echo "No publishable package paths were found in changed changesets."
+  set_github_output "paths" ""
+  exit 0
+fi
+
+echo "Publishing package paths from changed changesets: $paths"
+set_github_output "paths" "$paths"


### PR DESCRIPTION
## Summary

Adds a dedicated `publish-preview` GitHub Actions workflow for on-demand preview publishing via `pkg-pr-new`, triggered by a PR label instead of running on every PR update.

The workflow builds the repo using Node from `.nvmrc`, then publishes only packages referenced by changeset files changed in the PR. This keeps preview publishes explicit and reduces unnecessary preview package churn.

## Changes

### CI / Workflows
- Added a new workflow at `.github/workflows/publish-preview.yml`.
- Workflow name and label gate are both `publish-preview`.
- Triggered on `pull_request` `labeled` events (plus `workflow_dispatch` for manual runs).
- Publishes with `pnpm dlx pkg-pr-new publish ...` and keeps `continue-on-error: true`.

### Workflow Script
- Added `.github/workflows/scripts/get-changed-changeset-package-paths.sh`.
- Script computes changed `.changeset/*.md` files between PR base/head SHAs.
- Parses package names from changeset frontmatter and maps them to non-private `libs/**` package paths.
- Exposes `paths` through `$GITHUB_OUTPUT` for the workflow publish step.

### Behavior
- Label-triggered runs publish only packages referenced by changed changesets.
- Manual dispatch continues to publish `./libs/*`.
