### PR TITLE
chore(ci): add label-gated publish-preview workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -2,7 +2,7 @@ name: publish-preview
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   publish-preview-packages:
     name: Publish Preview Packages
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'publish-preview' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'publish-preview') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,10 +43,12 @@ jobs:
 
       - name: Publish to pkg.pr.new
         if: ${{ github.event_name == 'workflow_dispatch' || steps.changed_packages.outputs.paths != '' }}
+        env:
+          API_URL: https://pkg.pr.new
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            pnpm dlx pkg-pr-new publish './libs/*'
+            pnpm dlx pkg-pr-new@latest publish './libs/*'
           else
-            pnpm dlx pkg-pr-new publish ${{ steps.changed_packages.outputs.paths }}
+            pnpm dlx pkg-pr-new@latest publish ${{ steps.changed_packages.outputs.paths }}
           fi
         continue-on-error: true


### PR DESCRIPTION
## Summary
Adds a dedicated `publish-preview` workflow for pkg.pr.new preview publishes and keeps it opt-in via PR label.

## Changes
- Adds `.github/workflows/publish-preview.yml`.
- Adds `.github/workflows/scripts/get-changed-changeset-package-paths.sh` to derive package paths from changed changesets.
- Runs on normal PR events but only executes when the PR has the `publish-preview` label.
- Sets `API_URL=https://pkg.pr.new` and uses `pkg-pr-new@latest` to avoid localhost artifact URLs.
- On PR runs, publishes only packages referenced by changed changesets; manual dispatch still supports full publish.
