### PR TITLE
fix(google-cloud-sql-pg): parameterize delete id bindings

### DIFF
--- a/.changeset/cloudsql-pg-delete-bindings.md
+++ b/.changeset/cloudsql-pg-delete-bindings.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-cloud-sql-pg": patch
+---
+
+fix(google-cloud-sql-pg): parameterize delete id bindings in vector store deletion

--- a/libs/providers/langchain-google-cloud-sql-pg/src/tests/vectorstore.int.test.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/tests/vectorstore.int.test.ts
@@ -397,6 +397,23 @@ describe("VectorStore methods", () => {
     expect(results.rows).toHaveLength(3);
   });
 
+  test("delete rejects SQL injection payload in ids", async () => {
+    await PEInstance.pool.raw(`TRUNCATE TABLE "${CUSTOM_TABLE}"`);
+    const ids = Array.from(texts).map(() => uuidv4());
+    await vectorStoreInstance.addDocuments(docs, { ids });
+
+    await expect(
+      vectorStoreInstance.delete({
+        ids: ["00000000-0000-0000-0000-000000000000') OR true --"],
+      })
+    ).rejects.toThrow();
+
+    const { rows } = await PEInstance.pool.raw(
+      `SELECT * FROM "${CUSTOM_TABLE}"`
+    );
+    expect(rows).toHaveLength(3);
+  });
+
   test("maxMarginalRelevanceSearch", async () => {
     const results = await vectorStoreInstance.maxMarginalRelevanceSearch(
       "bar",

--- a/libs/providers/langchain-google-cloud-sql-pg/src/vectorstore.ts
+++ b/libs/providers/langchain-google-cloud-sql-pg/src/vectorstore.ts
@@ -547,9 +547,12 @@ export class PostgresVectorStore extends VectorStore {
    */
   async delete(params: { ids?: string[] }): Promise<void> {
     if (params.ids === undefined) return;
-    const idList = params.ids.map((id) => `'${id}'`).join(", ");
-    const query = `DELETE FROM "${this.schemaName}"."${this.tableName}" WHERE "${this.idColumn}" in (${idList})`;
-    await this.engine.pool.raw(query);
+    const placeholders = params.ids.map((_, i) => `:id${i}`).join(", ");
+    const query = `DELETE FROM "${this.schemaName}"."${this.tableName}" WHERE "${this.idColumn}" in (${placeholders})`;
+    const bindings = Object.fromEntries(
+      params.ids.map((id, i) => [`id${i}`, id])
+    );
+    await this.engine.pool.raw(query, bindings);
   }
 
   async similaritySearchVectorWithScore(


### PR DESCRIPTION
## Summary

Improves `PostgresVectorStore.delete()` in `@langchain/google-cloud-sql-pg` by switching ID handling to bound query parameters rather than inline string construction. This keeps delete behavior consistent for valid IDs while making query construction resilient to special characters in input values.

## Changes

### @langchain/google-cloud-sql-pg

- Updated `PostgresVectorStore.delete()` to construct `IN (...)` with named placeholders and pass IDs via bindings to `knex.raw`.
- Added an integration regression test to confirm malformed ID payloads are handled as values and do not alter delete behavior.
