### PR TITLE
fix(redis): harden RediSearch filter query construction

### DIFF
--- a/.changeset/neat-trains-decide.md
+++ b/.changeset/neat-trains-decide.md
@@ -1,0 +1,9 @@
+---
+"@langchain/redis": patch
+---
+
+fix(redis): improve RediSearch query escaping and filter validation
+
+- add shared query escaping and field validation helpers for Redis filter builders
+- apply escaping and type validation to `buildCustomQuery` tag/text/numeric paths
+- add regression tests covering escaped values, wildcard handling, and invalid filter inputs

--- a/libs/providers/langchain-redis/src/filters.ts
+++ b/libs/providers/langchain-redis/src/filters.ts
@@ -1,3 +1,8 @@
+import {
+  assertSafeRedisearchFieldName,
+  escapeRedisearchValue,
+} from "./query_safety.js";
+
 /**
  * Filter expression classes for advanced metadata filtering in Redis vector stores.
  *
@@ -227,14 +232,18 @@ export class TagFilter extends FilterExpression {
       return "*"; // Return wildcard for empty filters
     }
 
-    let valueStr: string;
-    if (typeof this.values === "string") {
-      valueStr = this.values;
-    } else if (Array.isArray(this.values)) {
-      valueStr = this.values.join("|");
-    } else {
-      valueStr = Array.from(this.values).join("|");
-    }
+    assertSafeRedisearchFieldName(this.field);
+
+    const normalizedValues =
+      typeof this.values === "string"
+        ? [this.values]
+        : Array.isArray(this.values)
+          ? this.values
+          : Array.from(this.values);
+
+    const valueStr = normalizedValues
+      .map((value) => escapeRedisearchValue(value))
+      .join("|");
 
     const filter = `@${this.field}:{${valueStr}}`;
     return this.negate ? `(-${filter})` : filter;
@@ -308,6 +317,8 @@ export class NumericFilter extends FilterExpression {
   }
 
   toString(): string {
+    assertSafeRedisearchFieldName(this.field);
+
     let rangeStr: string;
 
     switch (this.operator) {
@@ -416,26 +427,39 @@ export class TextFilter extends FilterExpression {
       return "*"; // Return wildcard for empty queries
     }
 
+    assertSafeRedisearchFieldName(this.field);
+
     let queryStr: string;
     switch (this.operator) {
       case "exact":
         // Exact phrase match using quotes
-        queryStr = `"${this.query}"`;
+        queryStr = `"${escapeRedisearchValue(this.query, {
+          preserveWhitespace: true,
+        })}"`;
         break;
       case "match":
         // Tokenized word matching
-        queryStr = this.query;
+        queryStr = escapeRedisearchValue(this.query, {
+          preserveWhitespace: true,
+        });
         break;
       case "wildcard":
         // Wildcard matching - wildcards should be included in the query string
-        queryStr = this.query;
+        queryStr = escapeRedisearchValue(this.query, {
+          preserveWhitespace: true,
+          preserveWildcard: true,
+        });
         break;
       case "fuzzy":
         // Fuzzy matching using %% prefix and suffix
-        queryStr = `%%${this.query}%%`;
+        queryStr = `%%${escapeRedisearchValue(this.query, {
+          preserveWhitespace: true,
+        })}%%`;
         break;
       default:
-        queryStr = this.query;
+        queryStr = escapeRedisearchValue(this.query, {
+          preserveWhitespace: true,
+        });
     }
 
     const filter = `@${this.field}:(${queryStr})`;
@@ -511,6 +535,8 @@ export class GeoFilter extends FilterExpression {
   }
 
   toString(): string {
+    assertSafeRedisearchFieldName(this.field);
+
     const filter = `@${this.field}:[${this.longitude} ${this.latitude} ${this.radius} ${this.unit}]`;
     return this.negate ? `(-${filter})` : filter;
   }
@@ -653,6 +679,8 @@ export class TimestampFilter extends FilterExpression {
   }
 
   toString(): string {
+    assertSafeRedisearchFieldName(this.field);
+
     let rangeStr: string;
 
     switch (this.operator) {

--- a/libs/providers/langchain-redis/src/query_safety.ts
+++ b/libs/providers/langchain-redis/src/query_safety.ts
@@ -1,0 +1,72 @@
+const SAFE_FIELD_NAME_REGEX = /^[a-zA-Z0-9_.-]+$/;
+
+const REDISEARCH_SPECIAL_CHARS = new Set([
+  ",",
+  ".",
+  "<",
+  ">",
+  "{",
+  "}",
+  "[",
+  "]",
+  '"',
+  "'",
+  ":",
+  ";",
+  "!",
+  "@",
+  "#",
+  "$",
+  "%",
+  "^",
+  "&",
+  "*",
+  "(",
+  ")",
+  "-",
+  "+",
+  "=",
+  "~",
+  "\\",
+  "|",
+  "?",
+]);
+
+function shouldEscapeChar(
+  char: string,
+  options?: { preserveWildcard?: boolean; preserveWhitespace?: boolean }
+): boolean {
+  if (options?.preserveWhitespace && /\s/.test(char)) {
+    return false;
+  }
+  if (options?.preserveWildcard && (char === "*" || char === "?")) {
+    return false;
+  }
+  if (/\s/.test(char)) {
+    return true;
+  }
+  return REDISEARCH_SPECIAL_CHARS.has(char);
+}
+
+export function assertSafeRedisearchFieldName(fieldName: string): void {
+  if (!SAFE_FIELD_NAME_REGEX.test(fieldName)) {
+    throw new Error(`Unsafe field name: ${fieldName}`);
+  }
+}
+
+export function escapeRedisearchValue(
+  value: string,
+  options?: { preserveWildcard?: boolean; preserveWhitespace?: boolean }
+): string {
+  let escaped = "";
+
+  for (const char of value) {
+    if (shouldEscapeChar(char, options)) {
+      escaped += `\\${char}`;
+    } else {
+      escaped += char;
+    }
+  }
+
+  return escaped;
+}

--- a/libs/providers/langchain-redis/src/tests/filters.test.ts
+++ b/libs/providers/langchain-redis/src/tests/filters.test.ts
@@ -40,6 +40,13 @@ describe("TagFilter", () => {
     expect(filter.toString()).toBe("(-@category:{electronics})");
   });
 
+  test("escapes special characters in tag values", () => {
+    const filter = new TagFilter("tenant_id", "tenant_a} @tenant_id:{*");
+    expect(filter.toString()).toBe(
+      "@tenant_id:{tenant_a\\}\\ \\@tenant_id\\:\\{\\*}"
+    );
+  });
+
   test("returns wildcard for empty array", () => {
     const filter = new TagFilter("category", []);
     expect(filter.toString()).toBe("*");
@@ -59,6 +66,11 @@ describe("TagFilter", () => {
   test("Tag convenience function with ne works", () => {
     const filter = Tag("category").ne("archived");
     expect(filter.toString()).toBe("(-@category:{archived})");
+  });
+
+  test("rejects unsafe tag field names", () => {
+    const filter = new TagFilter("tenant_id:{*}", "tenant_a");
+    expect(() => filter.toString()).toThrow("Unsafe field name");
   });
 });
 
@@ -143,6 +155,22 @@ describe("TextFilter", () => {
     expect(filter.toString()).toBe('(-@title:("laptop"))');
   });
 
+  test("escapes syntax characters in text query", () => {
+    const filter = new TextFilter(
+      "title",
+      'foo") @secret_field:("bar',
+      "exact"
+    );
+    expect(filter.toString()).toBe(
+      '@title:("foo\\\"\\) \\@secret_field\\:\\(\\\"bar")'
+    );
+  });
+
+  test("preserves wildcard operators for wildcard search", () => {
+    const filter = new TextFilter("title", "*phone?", "wildcard");
+    expect(filter.toString()).toBe("@title:(*phone?)");
+  });
+
   test("returns wildcard for empty query", () => {
     const filter = new TextFilter("title", "", "exact");
     expect(filter.toString()).toBe("*");
@@ -166,6 +194,11 @@ describe("TextFilter", () => {
 
     const neFilter = Text("title").ne("archived");
     expect(neFilter.toString()).toBe('(-@title:("archived"))');
+  });
+
+  test("rejects unsafe text field names", () => {
+    const filter = new TextFilter("title) @secret", "query");
+    expect(() => filter.toString()).toThrow("Unsafe field name");
   });
 });
 

--- a/libs/providers/langchain-redis/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-redis/src/tests/vectorstores.test.ts
@@ -730,6 +730,52 @@ describe("RedisVectorStore with Custom Schema", () => {
     );
   });
 
+  test("buildCustomQuery escapes tag and text filter values", async () => {
+    const client = createRedisClientWithCustomSchema();
+    const embeddings = new FakeEmbeddings();
+
+    const customSchema = {
+      category: { type: SchemaFieldTypes.TAG },
+      title: { type: SchemaFieldTypes.TEXT },
+    };
+
+    const store = new RedisVectorStore(embeddings, {
+      redisClient: client as any,
+      indexName: "test-escaped-filters",
+      customSchema,
+    });
+
+    const [query] = store.buildCustomQuery([0.1, 0.2, 0.3, 0.4], 5, {
+      category: "tenant_a} @tenant_id:{*",
+      title: 'foo") @secret_field:("bar',
+    });
+
+    expect(query).toBe(
+      '@metadata.category:{tenant_a\\}\\ \\@tenant_id\\:\\{\\*} @metadata.title:(foo\\\"\\) \\@secret_field\\:\\(\\\"bar) => [KNN 5 @content_vector $vector AS vector_score]'
+    );
+  });
+
+  test("buildCustomQuery rejects non-numeric values for numeric schema fields", async () => {
+    const client = createRedisClientWithCustomSchema();
+    const embeddings = new FakeEmbeddings();
+
+    const customSchema = {
+      score: { type: SchemaFieldTypes.NUMERIC },
+    };
+
+    const store = new RedisVectorStore(embeddings, {
+      redisClient: client as any,
+      indexName: "test-invalid-numeric-filter",
+      customSchema,
+    });
+
+    expect(() =>
+      store.buildCustomQuery([0.1, 0.2, 0.3, 0.4], 5, {
+        score: "not-a-number",
+      })
+    ).toThrow("Invalid numeric value");
+  });
+
   test("includes custom schema fields in search return fields", async () => {
     const client = createRedisClientWithCustomSchema();
     const embeddings = new FakeEmbeddings();

--- a/libs/providers/langchain-redis/src/vectorstores.ts
+++ b/libs/providers/langchain-redis/src/vectorstores.ts
@@ -8,6 +8,10 @@ import type {
   SearchOptions,
 } from "redis";
 import { VectorAlgorithms, SchemaFieldTypes } from "redis";
+import {
+  assertSafeRedisearchFieldName,
+  escapeRedisearchValue,
+} from "./query_safety.js";
 
 // Import schema types from schema.ts to avoid duplication
 import type {
@@ -686,10 +690,31 @@ export class RedisVectorStore extends VectorStore {
         if (this.customSchema[fieldName]) {
           const fieldConfig = this.customSchema[fieldName];
           const indexedFieldName = `${this.metadataKey}.${fieldName}`;
+          assertSafeRedisearchFieldName(indexedFieldName);
 
           if (fieldConfig.type === SchemaFieldTypes.NUMERIC) {
             // Handle numeric range queries
             if (typeof value === "object" && value !== null) {
+              const min = "min" in value ? value.min : undefined;
+              const max = "max" in value ? value.max : undefined;
+
+              if (
+                min !== undefined &&
+                (typeof min !== "number" || !Number.isFinite(min))
+              ) {
+                throw new Error(
+                  `Invalid numeric minimum for metadata field '${fieldName}'`
+                );
+              }
+              if (
+                max !== undefined &&
+                (typeof max !== "number" || !Number.isFinite(max))
+              ) {
+                throw new Error(
+                  `Invalid numeric maximum for metadata field '${fieldName}'`
+                );
+              }
+
               if ("min" in value && "max" in value) {
                 filterClauses.push(
                   `@${indexedFieldName}:[${value.min} ${value.max}]`
@@ -700,20 +725,50 @@ export class RedisVectorStore extends VectorStore {
                 filterClauses.push(`@${indexedFieldName}:[-inf ${value.max}]`);
               }
             } else {
+              if (typeof value !== "number" || !Number.isFinite(value)) {
+                throw new Error(
+                  `Invalid numeric value for metadata field '${fieldName}'`
+                );
+              }
               // Exact numeric match
               filterClauses.push(`@${indexedFieldName}:[${value} ${value}]`);
             }
           } else if (fieldConfig.type === SchemaFieldTypes.TAG) {
             // Handle tag filtering
             if (Array.isArray(value)) {
-              const tagFilter = value.map((v) => `{${v}}`).join("|");
+              const tagFilter = value
+                .map((v) => {
+                  if (typeof v !== "string") {
+                    throw new Error(
+                      `Invalid tag value for metadata field '${fieldName}'`
+                    );
+                  }
+                  return `{${escapeRedisearchValue(v)}}`;
+                })
+                .join("|");
               filterClauses.push(`@${indexedFieldName}:(${tagFilter})`);
             } else {
-              filterClauses.push(`@${indexedFieldName}:{${value}}`);
+              if (typeof value !== "string") {
+                throw new Error(
+                  `Invalid tag value for metadata field '${fieldName}'`
+                );
+              }
+              filterClauses.push(
+                `@${indexedFieldName}:{${escapeRedisearchValue(value)}}`
+              );
             }
           } else if (fieldConfig.type === SchemaFieldTypes.TEXT) {
             // Handle text search
-            filterClauses.push(`@${indexedFieldName}:(${value})`);
+            if (typeof value !== "string") {
+              throw new Error(
+                `Invalid text value for metadata field '${fieldName}'`
+              );
+            }
+            filterClauses.push(
+              `@${indexedFieldName}:(${escapeRedisearchValue(value, {
+                preserveWhitespace: true,
+              })})`
+            );
           }
         }
       }
@@ -751,7 +806,11 @@ export class RedisVectorStore extends VectorStore {
 
   private prepareFilter(filter: RedisVectorStoreFilterType) {
     if (Array.isArray(filter)) {
-      return filter.map(this.escapeSpecialChars).join("|");
+      return filter
+        .map((value) =>
+          escapeRedisearchValue(value, { preserveWhitespace: true })
+        )
+        .join("|");
     }
     return filter;
   }


### PR DESCRIPTION
## Summary

This PR improves RediSearch query construction in `@langchain/redis` by centralizing escaping and field-name validation utilities, then applying them across fluent filter classes and legacy custom-schema query building paths. It also strengthens input validation for numeric/tag/text metadata filters to produce more consistent query generation behavior with malformed values.

## Changes

### @langchain/redis query robustness improvements
- Added a new shared query safety module in `libs/providers/langchain-redis/src/query_safety.ts`.
- Implemented `escapeRedisearchValue()` to escape RediSearch-special syntax characters and whitespace (with optional wildcard/whitespace-preserving modes).
- Implemented `assertSafeRedisearchFieldName()` to reject unsafe field-name tokens before query generation.

### Fluent filter construction (`filters.ts`)
- Updated `TagFilter` to validate field names and escape tag values before building `@field:{...}` expressions.
- Updated `TextFilter` to validate field names and escape text payloads for `exact`, `match`, `wildcard`, and `fuzzy` operators.
- Added field-name validation to `NumericFilter`, `GeoFilter`, and `TimestampFilter` for consistent query construction.

### Legacy custom-schema filtering (`vectorstores.ts`)
- Hardened `buildCustomQuery()` by validating indexed field names (`metadata.<field>`), escaping TAG/TEXT values, and rejecting invalid types.
- Added finite-number validation for NUMERIC filters (`eq`, `min`, `max`) to prevent malformed query fragments.
- Updated array-based `prepareFilter()` escaping path to reuse shared query escaping.

### Test coverage
- Added regression tests in `src/tests/filters.test.ts` for:
  - escaping injection-shaped TAG/TEXT payloads,
  - preserving wildcard behavior where expected,
  - rejecting unsafe field names.
- Added regression tests in `src/tests/vectorstores.test.ts` for:
  - escaped TAG/TEXT values in `buildCustomQuery()`,
  - type rejection for invalid numeric filter values.
