### PR TITLE
chore(ci): use pnpm and peerDeps for pkg.pr.new previews

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -47,8 +47,8 @@ jobs:
           API_URL: https://pkg.pr.new
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            pnpm dlx pkg-pr-new@latest publish './libs/*'
+            pnpm dlx pkg-pr-new@latest publish --pnpm --peerDeps './libs/*'
           else
-            pnpm dlx pkg-pr-new@latest publish ${{ steps.changed_packages.outputs.paths }}
+            pnpm dlx pkg-pr-new@latest publish --pnpm --peerDeps ${{ steps.changed_packages.outputs.paths }}
           fi
         continue-on-error: true


### PR DESCRIPTION
## Summary

Update `pkg.pr.new` preview publish commands to use pnpm packing and peer dependency rewriting.

## Changes

- Add `--pnpm` to `pkg-pr-new publish` commands
- Add `--peerDeps` to `pkg-pr-new publish` commands
- Apply to both `workflow_dispatch` and changed-packages paths in the preview workflow

## Why

This avoids preview tarballs leaking `workspace:*` references and improves dependency resolution for preview installs.
