### PR TITLE
fix(google-common): include cache_read and reasoning in streaming usage_metadata

### DIFF
--- a/libs/providers/langchain-google-common/src/chat_models.ts
+++ b/libs/providers/langchain-google-common/src/chat_models.ts
@@ -407,11 +407,14 @@ export abstract class ChatGoogleBase<AuthOptions>
         this.streamUsage !== false &&
         options.streamUsage !== false
       ) {
-        usageMetadata = {
-          input_tokens: output.usageMetadata.promptTokenCount,
-          output_tokens: output.usageMetadata.candidatesTokenCount,
-          total_tokens: output.usageMetadata.totalTokenCount,
-        };
+        usageMetadata =
+          this.connection.api.responseToUsageMetadata?.({
+            data: output,
+          }) ?? {
+            input_tokens: output.usageMetadata.promptTokenCount ?? 0,
+            output_tokens: output.usageMetadata.candidatesTokenCount ?? 0,
+            total_tokens: output.usageMetadata.totalTokenCount ?? 0,
+          };
       }
       const chunk =
         output !== null

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -3347,6 +3347,38 @@ test("Can set streaming param", () => {
   expect(modelWithStreamingTrue.streaming).toBe(true);
 });
 
+test("Streaming includes cache_read and reasoning in usage_metadata", async () => {
+  const record: Record<string, any> = {};
+  const projectId = mockId();
+  const authOptions: MockClientAuthInfo = {
+    record,
+    projectId,
+    resultFile: "chat-stream-usage-mock.json",
+  };
+  const model = new ChatGoogle({
+    authOptions,
+    streaming: true,
+  });
+  const messages: BaseMessageLike[] = [
+    new HumanMessage("Hello"),
+  ];
+
+  const chunks: any[] = [];
+  const stream = await model.stream(messages);
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+
+  // Find the chunk that has usage_metadata
+  const chunkWithUsage = chunks.find((c) => c.usage_metadata);
+  expect(chunkWithUsage).toBeDefined();
+  expect(chunkWithUsage.usage_metadata.input_tokens).toBe(10);
+  expect(chunkWithUsage.usage_metadata.output_tokens).toBe(8); // 5 + 3 (thoughts)
+  expect(chunkWithUsage.usage_metadata.total_tokens).toBe(20);
+  expect(chunkWithUsage.usage_metadata.input_token_details?.cache_read).toBe(7);
+  expect(chunkWithUsage.usage_metadata.output_token_details?.reasoning).toBe(3);
+});
+
 describe("withStructuredOutput - StandardSchema", () => {
   function makeSerializableSchema() {
     return {

--- a/libs/providers/langchain-google-common/src/tests/data/chat-stream-usage-mock.json
+++ b/libs/providers/langchain-google-common/src/tests/data/chat-stream-usage-mock.json
@@ -1,0 +1,49 @@
+[
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": "Hello"
+            }
+          ],
+          "role": "model"
+        },
+        "index": 0
+      }
+    ]
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            {
+              "text": " world"
+            }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 10,
+      "candidatesTokenCount": 5,
+      "totalTokenCount": 20,
+      "cachedContentTokenCount": 7,
+      "thoughtsTokenCount": 3,
+      "toolUsePromptTokenCount": 0,
+      "promptTokensDetails": [
+        { "modality": "TEXT", "tokenCount": 10 }
+      ],
+      "toolUsePromptTokensDetails": [],
+      "cacheTokensDetails": [],
+      "candidatesTokensDetails": [
+        { "modality": "TEXT", "tokenCount": 5 }
+      ]
+    }
+  }
+]

--- a/libs/providers/langchain-google-common/src/tests/utils.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/utils.test.ts
@@ -848,6 +848,110 @@ describe("streaming", () => {
   });
 });
 
+describe("gemini responseToUsageMetadata", () => {
+  test("includes cache_read and reasoning in usage metadata", () => {
+    const api = getGeminiAPI();
+    const response = {
+      data: {
+        candidates: [],
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 50,
+          totalTokenCount: 160,
+          cachedContentTokenCount: 30,
+          thoughtsTokenCount: 10,
+          toolUsePromptTokenCount: 0,
+          promptTokensDetails: [{ modality: "TEXT", tokenCount: 100 }],
+          toolUsePromptTokensDetails: [],
+          cacheTokensDetails: [],
+          candidatesTokensDetails: [{ modality: "TEXT", tokenCount: 50 }],
+        },
+      },
+    };
+
+    const usage = api.responseToUsageMetadata!(response as any);
+    expect(usage).toBeDefined();
+    expect(usage!.input_tokens).toBe(100);
+    expect(usage!.output_tokens).toBe(60); // candidatesTokenCount + thoughtsTokenCount
+    expect(usage!.total_tokens).toBe(160);
+    expect(usage!.input_token_details?.cache_read).toBe(30);
+    expect(usage!.output_token_details?.reasoning).toBe(10);
+  });
+
+  test("omits cache_read when cachedContentTokenCount is absent", () => {
+    const api = getGeminiAPI();
+    const response = {
+      data: {
+        candidates: [],
+        usageMetadata: {
+          promptTokenCount: 50,
+          candidatesTokenCount: 20,
+          totalTokenCount: 70,
+          toolUsePromptTokenCount: 0,
+          promptTokensDetails: [],
+          toolUsePromptTokensDetails: [],
+          cacheTokensDetails: [],
+          candidatesTokensDetails: [],
+        },
+      },
+    };
+
+    const usage = api.responseToUsageMetadata!(response as any);
+    expect(usage).toBeDefined();
+    expect(usage!.input_token_details?.cache_read).toBeUndefined();
+  });
+
+  test("streaming responseToChatGeneration includes usage_metadata on last chunk", () => {
+    const api = getGeminiAPI();
+
+    // Middle chunk - no finishReason, no usageMetadata
+    const midResponse = {
+      data: {
+        candidates: [
+          {
+            content: { parts: [{ text: "Hello" }], role: "model" },
+            index: 0,
+          },
+        ],
+      },
+    };
+    const midChunk = api.responseToChatGeneration(midResponse as any);
+    const midMessage = midChunk?.message as AIMessageChunk;
+    expect(midMessage.usage_metadata).toBeUndefined();
+
+    // Last chunk - has finishReason and usageMetadata
+    const lastResponse = {
+      data: {
+        candidates: [
+          {
+            content: { parts: [{ text: " world" }], role: "model" },
+            finishReason: "STOP",
+            index: 0,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5,
+          totalTokenCount: 20,
+          cachedContentTokenCount: 7,
+          thoughtsTokenCount: 3,
+          toolUsePromptTokenCount: 0,
+          promptTokensDetails: [],
+          toolUsePromptTokensDetails: [],
+          cacheTokensDetails: [],
+          candidatesTokensDetails: [],
+        },
+      },
+    };
+    const lastChunk = api.responseToChatGeneration(lastResponse as any);
+    const lastMessage = lastChunk?.message as AIMessageChunk;
+    expect(lastMessage.usage_metadata).toBeDefined();
+    expect(lastMessage.usage_metadata?.input_tokens).toBe(10);
+    expect(lastMessage.usage_metadata?.input_token_details?.cache_read).toBe(7);
+    expect(lastMessage.usage_metadata?.output_token_details?.reasoning).toBe(3);
+  });
+});
+
 describe("gemini image URL handling", () => {
   test("handles image_url with external URL and infers MIME type", async () => {
     const api = getGeminiAPI();

--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -7,6 +7,7 @@ import {
   BaseMessage,
   BaseMessageChunk,
   MessageContent,
+  type UsageMetadata,
 } from "@langchain/core/messages";
 import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import { EmbeddingsParams } from "@langchain/core/embeddings";
@@ -888,6 +889,10 @@ export type GoogleAIAPI = {
   responseToBaseMessage: (response: GoogleLLMResponse) => BaseMessage;
 
   responseToChatResult: (response: GoogleLLMResponse) => ChatResult;
+
+  responseToUsageMetadata?: (
+    response: GoogleLLMResponse
+  ) => UsageMetadata | undefined;
 
   formatData: (
     input: unknown,

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1316,10 +1316,17 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
   function responseToChatGeneration(
     response: GoogleLLMResponse
   ): ChatGenerationChunk {
+    const generationInfo = responseToGenerationInfo(response);
+    const message = partToMessageChunk(
+      responseToParts(response)[0]
+    ) as AIMessageChunk;
+    if (generationInfo.usage_metadata) {
+      message.usage_metadata = generationInfo.usage_metadata;
+    }
     return new ChatGenerationChunk({
       text: responseToString(response),
-      message: partToMessageChunk(responseToParts(response)[0]),
-      generationInfo: responseToGenerationInfo(response),
+      message,
+      generationInfo,
     });
   }
 
@@ -2029,6 +2036,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     chunkToString,
     responseToBaseMessage: safeResponseToBaseMessage,
     responseToChatResult: safeResponseToChatResult,
+    responseToUsageMetadata,
     formatData,
   };
 }


### PR DESCRIPTION
## Summary

- Streaming path was missing `cachedContentTokenCount` → `cache_read` and `thoughtsTokenCount` → `reasoning` mappings that the non-streaming path (`responseToUsageMetadata`) already handled correctly
- Expose `responseToUsageMetadata` via `GoogleAIAPI` interface so `_streamResponseChunks` can reuse it instead of manual assembly
- Propagate `generationInfo.usage_metadata` to `message.usage_metadata` in `responseToChatGeneration` so downstream consumers (`.stream()`, `.streamEvents()`) receive complete token details

Fixes #10715

## Test plan

- [x] Unit test: `responseToUsageMetadata` returns `cache_read` and `reasoning` from Gemini response
- [x] Unit test: `responseToUsageMetadata` omits `cache_read` when `cachedContentTokenCount` is absent
- [x] Unit test: `responseToChatGeneration` sets `message.usage_metadata` on last chunk only
- [x] Integration test: streaming with mock data includes `cache_read` and `reasoning` in `usage_metadata`