### PR TITLE
fix(google-genai): normalize responseSchema in invocationParams

### DIFF
--- a/.changeset/google-genai-normalize-response-schema.md
+++ b/.changeset/google-genai-normalize-response-schema.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): normalize `responseSchema` through `schemaToGenerativeAIParameters` in `invocationParams` so agents passing raw Zod / JSON schemas (e.g. `createAgent({ responseFormat: providerStrategy(zodSchema) })`) no longer send `additionalProperties`/`$schema` fields that the Gemini API rejects with `Invalid JSON payload received`.

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -90,9 +90,16 @@ export interface GoogleGenerativeAIChatCallOptions extends BaseChatModelCallOpti
   streamUsage?: boolean;
 
   /**
-   * JSON schema to be returned by the model.
+   * Schema to be returned by the model. Accepts either a Gemini `Schema`,
+   * a Zod/Standard Schema, or a JSON Schema object. Non-Gemini shapes are
+   * normalized via `schemaToGenerativeAIParameters` before being sent to the
+   * API (Zod → JSON Schema, `additionalProperties`/`$schema`/`strict` stripped).
    */
-  responseSchema?: Schema;
+  responseSchema?:
+    | Schema
+    | InteropZodType<unknown>
+    | SerializableSchema
+    | Record<string, unknown>;
 }
 
 /**
@@ -833,7 +840,13 @@ export class ChatGoogleGenerativeAI
       : undefined;
 
     if (options?.responseSchema) {
-      this.client.generationConfig.responseSchema = options.responseSchema;
+      this.client.generationConfig.responseSchema =
+        schemaToGenerativeAIParameters(
+          options.responseSchema as
+            | InteropZodType
+            | SerializableSchema
+            | Record<string, unknown>
+        ) as Schema;
       this.client.generationConfig.responseMimeType = "application/json";
     } else {
       this.client.generationConfig.responseSchema = undefined;

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, vi, test } from "vitest";
-import type { HarmBlockThreshold, HarmCategory } from "@google/generative-ai";
+import type {
+  HarmBlockThreshold,
+  HarmCategory,
+  Schema,
+} from "@google/generative-ai";
 import { z } from "zod/v3";
 import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import {
@@ -1160,5 +1164,104 @@ describe("withStructuredOutput - StandardSchema", () => {
     expect(result).toHaveProperty("parsed");
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     expect((result as any).parsed).toEqual({ name: "cobalt" });
+  });
+});
+
+describe("invocationParams responseSchema normalization", () => {
+  // Regression for https://github.com/langchain-ai/langchainjs/issues/10712
+  // `createAgent({ responseFormat: providerStrategy(zodSchema) })` forwards the
+  // raw Zod schema via `options.responseSchema`. The Gemini API rejects
+  // `additionalProperties`, so invocationParams must normalize the schema
+  // through `schemaToGenerativeAIParameters` (matching the withStructuredOutput
+  // path) before writing it to `generationConfig`.
+  function getGenerationConfig(
+    model: ChatGoogleGenerativeAI
+  ): Record<string, unknown> {
+    return (
+      model as unknown as {
+        client: { generationConfig: Record<string, unknown> };
+      }
+    ).client.generationConfig;
+  }
+
+  test("Zod schema is converted to Gemini-compatible JSON schema", () => {
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.0-flash" });
+    const zodSchema = z.object({
+      firstName: z.string(),
+      lastName: z.string(),
+    });
+
+    model.invocationParams({ responseSchema: zodSchema });
+
+    const config = getGenerationConfig(model);
+    const schema = config.responseSchema as Record<string, unknown>;
+    expect(schema).toBeDefined();
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toMatchObject({
+      firstName: { type: "string" },
+      lastName: { type: "string" },
+    });
+    expect("additionalProperties" in schema).toBe(false);
+    expect("$schema" in schema).toBe(false);
+    expect(config.responseMimeType).toBe("application/json");
+  });
+
+  test("JSON schema with additionalProperties is stripped", () => {
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.0-flash" });
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        tags: {
+          type: "array",
+          items: { type: "string", additionalProperties: false },
+        },
+      },
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#",
+    };
+
+    model.invocationParams({ responseSchema: jsonSchema as Schema });
+
+    const schema = getGenerationConfig(model).responseSchema as Record<
+      string,
+      unknown
+    >;
+    expect("additionalProperties" in schema).toBe(false);
+    expect("$schema" in schema).toBe(false);
+    const items = (schema.properties as Record<string, Record<string, unknown>>)
+      .tags.items as Record<string, unknown>;
+    expect("additionalProperties" in items).toBe(false);
+  });
+
+  test("Plain Gemini Schema passes through unchanged", () => {
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.0-flash" });
+    const geminiSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+    };
+
+    model.invocationParams({ responseSchema: geminiSchema as Schema });
+
+    const schema = getGenerationConfig(model).responseSchema as Record<
+      string,
+      unknown
+    >;
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["answer"]);
+    expect(schema.properties).toMatchObject({
+      answer: { type: "string" },
+    });
+  });
+
+  test("No responseSchema clears generationConfig.responseSchema", () => {
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.0-flash" });
+    const config = getGenerationConfig(model);
+    config.responseSchema = { type: "object" };
+
+    model.invocationParams({});
+
+    expect(config.responseSchema).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #10712

`invocationParams` currently writes `options.responseSchema` verbatim into `generationConfig.responseSchema`:

```ts
if (options?.responseSchema) {
  this.client.generationConfig.responseSchema = options.responseSchema;
  this.client.generationConfig.responseMimeType = "application/json";
}
```

When the schema arrives from a Zod/JSON-Schema-shaped caller — e.g. `createAgent({ responseFormat: providerStrategy(zodSchema) })`, which forwards the raw schema as a Google-style option from [`AgentNode`](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain/src/agents/nodes/AgentNode.ts#L990) — the Gemini API rejects it:

```
GoogleGenerativeAIFetchError: [400 Bad Request] Invalid JSON payload received.
Unknown name "additionalProperties" at 'generation_config.response_schema':
Cannot find field.
```

## Fix

Route `options.responseSchema` through `schemaToGenerativeAIParameters` before writing it to `generationConfig`. This is the same helper `withStructuredOutput`'s `jsonSchema` path uses ([`chat_models.ts#L1160`](https://github.com/langchain-ai/langchainjs/blob/main/libs/providers/langchain-google-genai/src/chat_models.ts#L1160)), so Zod / Standard Schema inputs get `toJsonSchema`'d and `additionalProperties`/`$schema`/`strict` are stripped from raw JSON Schema inputs. Plain Gemini `Schema` values remain a no-op pass-through.

`responseSchema` in `GoogleGenerativeAIChatCallOptions` is widened accordingly — previously `Schema` only, now `Schema | InteropZodType | SerializableSchema | Record<string, unknown>` to match the shapes callers (agents, user code) already pass at runtime.

## Tests

Four new unit tests in `chat_models.test.ts` under `describe("invocationParams responseSchema normalization")`:
- Zod schema → Gemini-compatible JSON schema (no `additionalProperties`/`$schema`)
- JSON schema with `additionalProperties` → stripped (recursively, incl. nested `items`)
- Plain Gemini `Schema` → passes through unchanged
- No `responseSchema` → `generationConfig.responseSchema` cleared

Removing the `schemaToGenerativeAIParameters` call makes the Zod test fail, confirming the fix is exercised. Existing 43 unit tests still pass.

## AI Disclosure

This bug was diagnosed and fixed with AI assistance.