### PR TITLE
fix(core): advance fakeModel response queue across bindTools calls

### DIFF
--- a/.changeset/fake-model-bindtools-queue.md
+++ b/.changeset/fake-model-bindtools-queue.md
@@ -1,0 +1,9 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): advance fakeModel response queue across bindTools calls
+
+`bindTools()` created a new `FakeBuiltModel` that shared the response queue and call history by reference but copied `_callIndex` by value. Each bound instance kept its own cursor snapshot, so re-binding tools (as `createAgent` does on every model step) reset the cursor to the parent's snapshot and replayed the first queued response.
+
+Derive the cursor from the shared `_calls` array length so every bound instance consumes responses in order.

--- a/libs/langchain-core/src/testing/fake_model_builder.ts
+++ b/libs/langchain-core/src/testing/fake_model_builder.ts
@@ -60,8 +60,6 @@ export class FakeBuiltModel extends BaseChatModel {
 
   private _tools: (StructuredTool | ToolSpec)[] = [];
 
-  private _callIndex = 0;
-
   private _calls: FakeModelCall[] = [];
 
   /**
@@ -166,7 +164,6 @@ export class FakeBuiltModel extends BaseChatModel {
     next._structuredResponseValue = this._structuredResponseValue;
     next._tools = merged;
     next._calls = this._calls;
-    next._callIndex = this._callIndex;
 
     return next.withConfig({} as BaseChatModelCallOptions);
   }
@@ -203,10 +200,8 @@ export class FakeBuiltModel extends BaseChatModel {
     options?: this["ParsedCallOptions"],
     _runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
+    const currentCallIndex = this._calls.length;
     this._calls.push({ messages: [...messages], options });
-
-    const currentCallIndex = this._callIndex;
-    this._callIndex += 1;
 
     if (this._alwaysThrowError) {
       throw this._alwaysThrowError;

--- a/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
+++ b/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
@@ -277,6 +277,33 @@ describe("fakeModel", () => {
 
       expect(model.calls).toHaveLength(1);
     });
+
+    test("advances response queue across separate bindTools calls", async () => {
+      const model = fakeModel()
+        .respond(new AIMessage("first"))
+        .respond(new AIMessage("second"));
+
+      const firstBound = model.bindTools([]);
+      const firstResult = await firstBound.invoke([new HumanMessage("a")]);
+      expect(firstResult.content).toBe("first");
+
+      const secondBound = model.bindTools([]);
+      const secondResult = await secondBound.invoke([new HumanMessage("b")]);
+      expect(secondResult.content).toBe("second");
+    });
+
+    test("advances response queue when mixing parent and bound invocations", async () => {
+      const model = fakeModel()
+        .respond(new AIMessage("first"))
+        .respond(new AIMessage("second"));
+
+      const bound = model.bindTools([]);
+      const firstResult = await model.invoke([new HumanMessage("a")]);
+      expect(firstResult.content).toBe("first");
+
+      const secondResult = await bound.invoke([new HumanMessage("b")]);
+      expect(secondResult.content).toBe("second");
+    });
   });
 
   describe(".structuredResponse()", () => {


### PR DESCRIPTION
`bindTools()` created a new `FakeBuiltModel` that shared the response queue and call history by reference but copied `_callIndex` by value. Each bound instance kept its own cursor snapshot, so re-binding tools (as `createAgent` does on every model step) reset the cursor to the parent's snapshot and replayed the first queued response.

Derive the cursor from the shared `_calls` array length so every bound instance consumes responses in order.

Fixes #10723
