### PR TITLE
TextLoader Dynamic encoding detection similar to python

### DIFF
--- a/.changeset/tiny-numbers-drive.md
+++ b/.changeset/tiny-numbers-drive.md
@@ -1,0 +1,5 @@
+---
+"@langchain/classic": patch
+---
+
+Fixed the TextLoader Dynamic encoding detection similar to python

--- a/libs/langchain-classic/package.json
+++ b/libs/langchain-classic/package.json
@@ -135,6 +135,8 @@
     "@langchain/ollama": "workspace:*",
     "@langchain/redis": "workspace:*",
     "@langchain/textsplitters": "workspace:*",
+    "@langchain/together-ai": "workspace:*",
+    "@langchain/tsconfig": "workspace:*",
     "@langchain/xai": "workspace:*",
     "@layerup/layerup-security": "^1.5.12",
     "@opensearch-project/opensearch": "^2.2.0",
@@ -145,7 +147,6 @@
     "@rockset/client": "^0.9.1",
     "@supabase/supabase-js": "^2.53.0",
     "@tensorflow/tfjs-backend-cpu": "^4.22.0",
-    "@langchain/tsconfig": "workspace:*",
     "@tsconfig/recommended": "^1.0.2",
     "@types/js-yaml": "^4",
     "@types/jsdom": "^28.0.1",
@@ -195,8 +196,7 @@
     "vitest": "^4.1.2",
     "voy-search": "0.6.3",
     "weaviate-client": "^3.12.0",
-    "zod-to-json-schema": "^3.25.2",
-    "@langchain/together-ai": "workspace:*"
+    "zod-to-json-schema": "^3.25.2"
   },
   "peerDependencies": {
     "@langchain/core": "^1.0.0",
@@ -220,6 +220,7 @@
     "@langchain/textsplitters": "workspace:*",
     "handlebars": "^4.7.9",
     "js-yaml": "^4.1.1",
+    "jschardet": "3.1.4",
     "jsonpointer": "^5.0.1",
     "openapi-types": "^12.1.3",
     "uuid": "^10.0.0",

--- a/libs/langchain-classic/src/document_loaders/fs/helpers.ts
+++ b/libs/langchain-classic/src/document_loaders/fs/helpers.ts
@@ -1,0 +1,58 @@
+import * as jschardet from "jschardet";
+import * as fs from "fs";
+
+/**
+ * Represents file encoding information
+ */
+export interface FileEncoding {
+  encoding: BufferEncoding | null;
+  confidence: number;
+}
+
+const EXECUTION_TIMEOUT = 5000;
+
+/**
+ * Detects file encodings for a given file path
+ * @param filePath - Path to the file
+ * @param timeout - Timeout in milliseconds
+ * @returns Promise containing list of detected encodings ordered by confidence
+ */
+export async function detectFileEncodings(
+  filePath: fs.PathLike,
+  timeout: number = EXECUTION_TIMEOUT
+): Promise<FileEncoding[]> {
+  try {
+    // Create a promise that rejects after the timeout
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(
+          new Error(`Timeout reached while detecting encoding for ${filePath}`)
+        );
+      }, timeout);
+    });
+
+    // Create the detection promise
+    const detectionPromise = async (): Promise<FileEncoding[]> => {
+      const buffer = fs.readFileSync(filePath);
+      const results = jschardet.detectAll(buffer);
+
+      if (!results || results.every((result) => result.encoding === null)) {
+        throw new Error(`Could not detect encoding for ${filePath}`);
+      }
+
+      return results
+        .filter((result) => result.encoding !== null)
+        .map((result) => ({
+          encoding: result.encoding.toLowerCase() as BufferEncoding,
+          confidence: result.confidence,
+        }));
+    };
+
+    // Race between timeout and detection
+    return await Promise.race([detectionPromise(), timeoutPromise]);
+  } catch (error) {
+    throw new Error(
+      `An unknown error occurred during encoding detection ${error}`
+    );
+  }
+}

--- a/libs/langchain-classic/src/document_loaders/fs/helpers.ts
+++ b/libs/langchain-classic/src/document_loaders/fs/helpers.ts
@@ -1,5 +1,5 @@
 import * as jschardet from "jschardet";
-import * as fs from "fs";
+import { readFile } from "fs/promises";
 
 /**
  * Represents file encoding information
@@ -18,41 +18,38 @@ const EXECUTION_TIMEOUT = 5000;
  * @returns Promise containing list of detected encodings ordered by confidence
  */
 export async function detectFileEncodings(
-  filePath: fs.PathLike,
+  filePath: string,
   timeout: number = EXECUTION_TIMEOUT
 ): Promise<FileEncoding[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
   try {
-    // Create a promise that rejects after the timeout
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
-        reject(
-          new Error(`Timeout reached while detecting encoding for ${filePath}`)
-        );
-      }, timeout);
-    });
+    const buffer = await readFile(filePath, { signal: controller.signal });
+    clearTimeout(timeoutId);
 
-    // Create the detection promise
-    const detectionPromise = async (): Promise<FileEncoding[]> => {
-      const buffer = fs.readFileSync(filePath);
-      const results = jschardet.detectAll(buffer);
+    const results = jschardet.detectAll(buffer);
 
-      if (!results || results.every((result) => result.encoding === null)) {
-        throw new Error(`Could not detect encoding for ${filePath}`);
-      }
+    if (!results || results.every((result) => result.encoding === null)) {
+      throw new Error(`Could not detect encoding for ${filePath}`);
+    }
 
-      return results
-        .filter((result) => result.encoding !== null)
-        .map((result) => ({
-          encoding: result.encoding.toLowerCase() as BufferEncoding,
-          confidence: result.confidence,
-        }));
-    };
-
-    // Race between timeout and detection
-    return await Promise.race([detectionPromise(), timeoutPromise]);
+    return results
+      .filter((result) => result.encoding !== null)
+      .map((result) => ({
+        encoding: result.encoding.toLowerCase() as BufferEncoding,
+        confidence: result.confidence,
+      }));
   } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Timeout reached while detecting encoding for ${filePath}`);
+    } else if (error instanceof Error) {
+      throw new Error("Encoding detection failed", { cause: error });
+    }
+
     throw new Error(
-      `An unknown error occurred during encoding detection ${error}`
+      `An unknown error occurred during encoding detection ${JSON.stringify(error)}`
     );
   }
 }

--- a/libs/langchain-classic/src/document_loaders/fs/text.ts
+++ b/libs/langchain-classic/src/document_loaders/fs/text.ts
@@ -2,6 +2,7 @@ import type { readFile as ReadFileT } from "node:fs/promises";
 import { Document } from "@langchain/core/documents";
 import { getEnv } from "@langchain/core/utils/env";
 import { BaseDocumentLoader } from "@langchain/core/document_loaders/base";
+import { detectFileEncodings, FileEncoding } from "./helpers";
 
 /**
  * A class that extends the `BaseDocumentLoader` class. It represents a
@@ -46,9 +47,26 @@ export class TextLoader extends BaseDocumentLoader {
   public async load(): Promise<Document[]> {
     let text: string;
     let metadata: Record<string, string>;
+    let currentEncoding: BufferEncoding | null = null;
+
     if (typeof this.filePathOrBlob === "string") {
       const { readFile } = await TextLoader.imports();
-      text = await readFile(this.filePathOrBlob, "utf8");
+      const detectedEncodings: FileEncoding[] = await detectFileEncodings(
+        this.filePathOrBlob
+      );
+
+      for (const encoding of detectedEncodings) {
+        try {
+          await readFile(this.filePathOrBlob, { encoding: encoding.encoding });
+          currentEncoding = encoding.encoding;
+          break;
+        } catch (error) {
+          continue;
+        }
+      }
+      text = (await readFile(this.filePathOrBlob, {
+        encoding: currentEncoding,
+      })) as string;
       metadata = { source: this.filePathOrBlob };
     } else {
       text = await this.filePathOrBlob.text();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      jschardet:
+        specifier: 3.1.4
+        version: 3.1.4
       jsonpointer:
         specifier: ^5.0.1
         version: 5.0.1
@@ -9410,6 +9413,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jschardet@3.1.4:
+    resolution: {integrity: sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==}
+    engines: {node: '>=0.1.90'}
 
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -21285,6 +21292,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jschardet@3.1.4: {}
 
   jsdom@28.1.0:
     dependencies:


### PR DESCRIPTION
Implemented the python logic of file encoding detection using [(JsChardet)](https://www.npmjs.com/package/jschardet) to detect all the file encodings and tested out with `utf-16le` encoded legacy file for raw text. This PR fixes the issue of raw text format representation in the Text loder `load()` medthod which creates documents in raw format.
python helpers.py
https://github.com/langchain-ai/langchain/blob/b075eab3e0af9a578af80c6e38f869419e770b5c/libs/community/langchain_community/document_loaders/helpers.py#L19
python Textloader.py
https://github.com/langchain-ai/langchain/blob/b075eab3e0af9a578af80c6e38f869419e770b5c/libs/community/langchain_community/document_loaders/text.py#L13
<!-- Remove if not applicable -->

Fixes # [(issue)](https://github.com/langchain-ai/langchainjs/issues/7923)
