### PR TITLE
fix(core): Patch metadata with current tracing context for allowlisted keys

### DIFF
--- a/.changeset/neat-fishes-develop.md
+++ b/.changeset/neat-fishes-develop.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): Patch metadata with current tracing context for allowlisted keys

--- a/examples/package.json
+++ b/examples/package.json
@@ -43,7 +43,7 @@
     "@langchain/google-vertexai": "workspace:*",
     "@langchain/google-vertexai-web": "workspace:*",
     "@langchain/groq": "workspace:*",
-    "@langchain/langgraph": "^1.2.6",
+    "@langchain/langgraph": "^1.2.9",
     "@langchain/mistralai": "workspace:*",
     "@langchain/mongodb": "workspace:*",
     "@langchain/ollama": "workspace:*",

--- a/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
+++ b/libs/langchain-core/src/tracers/tests/langchain_tracer.test.ts
@@ -3,6 +3,8 @@
 import { vi, test, expect, describe } from "vitest";
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as uuid from "uuid";
+import { RunTree } from "langsmith/run_trees";
+import { withRunTree } from "langsmith/singletons/traceable";
 
 import { RunnableLambda } from "../../runnables/base.js";
 import { LangChainTracer } from "../tracer_langchain.js";
@@ -339,5 +341,188 @@ describe("LangChainTracer usage_metadata extraction", () => {
     expect(copied.tracingTags).toEqual(["existing", "tenant:alpha"]);
     expect(tracer.tracingMetadata).toEqual({ env: "staging" });
     expect(tracer.tracingTags).toEqual(["existing"]);
+  });
+});
+
+describe("LangChainTracer allowlisted inheritable metadata overrides", () => {
+  /**
+   * Build a fresh `RunTree` suitable for use as the target of
+   * `withRunTree(...)` with the given metadata. We attach a no-op mock
+   * client so that any accidental `postRun`/`patchRun` called against
+   * the passed-in RunTree itself (as opposed to clones made by the
+   * tracer) doesn't blow up.
+   */
+  function makeScopedRunTree(
+    metadata: Record<string, unknown>,
+    name = "scoped_root"
+  ): RunTree {
+    return new RunTree({
+      name,
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      client: {
+        createRun: vi.fn().mockResolvedValue(undefined),
+        updateRun: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      tracingEnabled: false,
+      metadata,
+    });
+  }
+
+  test("withRunTree rescopes allowlisted `ls_agent_type` mid-run for tracer only", async () => {
+    // Mirrors the Python
+    // `test_live_tracing_context_overrides_allowlisted_keys_tracer_only`:
+    // the outer tracer is configured with a default `ls_agent_type`;
+    // mid-run the caller enters `withRunTree(...)` with a RunTree whose
+    // metadata overrides `ls_agent_type`; the inner run's LangSmith
+    // payload must show the rescoped value while non-tracer callback
+    // handlers must never observe `ls_agent_type` at all.
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn().mockResolvedValue(undefined),
+      updateRun: vi.fn().mockResolvedValue(undefined),
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { ls_agent_type: "root" },
+    });
+
+    // Directly drive the tracer's lifecycle instead of going through
+    // Runnable so we have precise control over which run is inside
+    // the `withRunTree` scope and which is outside.
+    const outerRunId = uuid.v4();
+    const innerRunId = uuid.v4();
+
+    // Outer run: starts before `withRunTree`, so it inherits the
+    // tracer's default `ls_agent_type: "root"` from its configure-time
+    // `tracingMetadata`.
+    await tracer.handleChainStart(
+      serialized,
+      { input: 1 },
+      outerRunId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "outer"
+    );
+
+    // Inner run: starts while `withRunTree(scoped, ...)` is active.
+    // The scoped RunTree overrides `ls_agent_type` to "subagent".
+    const scoped = makeScopedRunTree({ ls_agent_type: "subagent" });
+    await withRunTree(scoped, async () => {
+      await tracer.handleChainStart(
+        serialized,
+        { input: 1 },
+        innerRunId,
+        outerRunId,
+        undefined,
+        undefined,
+        undefined,
+        "inner"
+      );
+      await tracer.handleChainEnd({ output: 1 }, innerRunId);
+    });
+    await tracer.handleChainEnd({ output: 1 }, outerRunId);
+    await awaitAllCallbacks();
+
+    // Inspect the update payloads (patches to LangSmith) rather than
+    // the initial create payloads: `_patchMissingTracingDefaults` runs
+    // on update for non-allowlisted keys, and the allowlisted
+    // override is re-applied at read time in
+    // `getRunTreeWithTracingConfig`, so the final-state metadata is
+    // what LangSmith ends up with.
+    const updates = mockClient.updateRun.mock.calls.map(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (call: any) => ({ id: call[0], update: call[1] })
+    );
+    const outerUpdate = updates.find(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (u: any) => u.id === outerRunId
+    );
+    const innerUpdate = updates.find(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (u: any) => u.id === innerRunId
+    );
+    expect(outerUpdate).toBeDefined();
+    expect(innerUpdate).toBeDefined();
+
+    // Outer run keeps the tracer's default `ls_agent_type: "root"` —
+    // the mid-run `withRunTree` scope opened AFTER it started and
+    // closed BEFORE it ended, so the override never applied.
+    expect(outerUpdate.update.extra?.metadata?.ls_agent_type).toBe("root");
+
+    // Inner run is posted while the `withRunTree` scope is active, so
+    // the allowlisted override wins over the outer tracer default.
+    expect(innerUpdate.update.extra?.metadata?.ls_agent_type).toBe("subagent");
+  });
+
+  test("withRunTree does NOT rescope non-allowlisted keys (first-wins preserved)", async () => {
+    // Mirrors the Python
+    // `test_live_tracing_context_non_allowlisted_keys_do_not_override`:
+    // a non-allowlisted key like `env` must keep the outer tracer's
+    // default value for every posted run, even if a mid-run `withRunTree`
+    // scope carries a different value.
+    AsyncLocalStorageProviderSingleton.initializeGlobalInstance(
+      new AsyncLocalStorage()
+    );
+
+    const mockClient = {
+      createRun: vi.fn().mockResolvedValue(undefined),
+      updateRun: vi.fn().mockResolvedValue(undefined),
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const tracer = new LangChainTracer({
+      client: mockClient,
+      metadata: { env: "prod" },
+    });
+
+    const outerRunId = uuid.v4();
+    const innerRunId = uuid.v4();
+
+    await tracer.handleChainStart(
+      serialized,
+      { input: 1 },
+      outerRunId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "outer"
+    );
+
+    const scoped = makeScopedRunTree({ env: "staging" });
+    await withRunTree(scoped, async () => {
+      await tracer.handleChainStart(
+        serialized,
+        { input: 1 },
+        innerRunId,
+        outerRunId,
+        undefined,
+        undefined,
+        undefined,
+        "inner"
+      );
+      await tracer.handleChainEnd({ output: 1 }, innerRunId);
+    });
+    await tracer.handleChainEnd({ output: 1 }, outerRunId);
+    await awaitAllCallbacks();
+
+    const updates = mockClient.updateRun.mock.calls.map(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (call: any) => ({ id: call[0], update: call[1] })
+    );
+    expect(updates.length).toBe(2);
+    // `env` is not allowlisted, so the tracer's default ("prod") must
+    // survive on every posted run regardless of any mid-run
+    // `withRunTree` scope setting a different value.
+    for (const { update } of updates) {
+      expect(update.extra?.metadata?.env).toBe("prod");
+    }
   });
 });

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -27,6 +27,27 @@ export interface Run extends BaseRun {
   trace_id?: string;
 }
 
+/**
+ * Metadata keys that should be re-read live from the currently-active
+ * LangSmith `RunTree` each time a run is posted or patched, and applied
+ * with "last-wins" semantics (overriding any value already baked in by
+ * an ancestor's configure-time tracing metadata).
+ *
+ * This exists so that callers can rescope these keys mid-run via
+ * `withRunTree(...)` (e.g. to label nested subagent runs with a
+ * different `ls_agent_type`) without having to thread new callback
+ * managers through every intermediate layer.
+ *
+ * Non-allowlisted keys keep the default "first-wins" behavior applied
+ * at callback configure time.
+ *
+ * TODO: expand as additional allowlisted LangSmith-only metadata keys
+ * are introduced.
+ */
+export const LANGSMITH_INHERITABLE_METADATA_KEYS: ReadonlySet<string> = new Set(
+  ["ls_agent_type"]
+);
+
 export interface RunCreate2 extends RunCreate {
   trace_id?: string;
   dotted_order?: string;
@@ -110,6 +131,31 @@ export class LangChainTracer
 
   protected async persistRun(_run: Run): Promise<void> {
     // empty
+  }
+
+  _addRunToRunMap(run: Run) {
+    // Apply last-wins overrides for allowlisted LangSmith-only metadata
+    // keys (e.g. `ls_agent_type`) from the currently-active RunTree.
+    //
+    // This must happen *synchronously*, while we're still inside the
+    // caller's async-local-storage context: `consumeCallback` wraps
+    // later async handler invocations (including `onRunCreate`) in
+    // `asyncLocalStorage.run(undefined, ...)`, which wipes out any
+    // `withRunTree(...)` scope set by the caller. So we can't read it
+    // from an async handler.
+    //
+    // This is the JS analog of the Python implementation, which reads
+    // `get_tracing_context()` inside `_patch_missing_metadata` — Python
+    // `contextvars` propagate across awaits by default, so the read
+    // can happen later there. JS ALS does not, so we read earlier.
+    const overrides = _computeAllowlistedRunTreeMetadataOverrides(
+      run.extra?.metadata as Record<string, unknown> | undefined
+    );
+    if (overrides !== undefined) {
+      run.extra ??= {};
+      run.extra.metadata = overrides;
+    }
+    return super._addRunToRunMap(run);
   }
 
   async onRunCreate(run: Run): Promise<void> {
@@ -232,8 +278,28 @@ export class LangChainTracer
     const runTree = this.runTreeMap.get(id);
     if (!runTree) return undefined;
 
+    // Re-apply last-wins overrides for allowlisted LangSmith-only metadata
+    // keys from the currently-active RunTree. This complements the
+    // synchronous write-time override in `_addRunToRunMap`: some callers
+    // (notably langgraph's Pregel executor via
+    // `AsyncLocalStorageProviderSingleton.runWithConfig`) use this method
+    // to derive a fresh ALS RunTree for nested execution, ignoring the
+    // RunTree currently held in ALS. Without re-applying the override
+    // here, those nested executions would re-seed ALS with the parent
+    // run's original metadata, silently overwriting a `withRunTree(...)`
+    // scope that the caller set at the boundary (e.g. to label a
+    // subagent's runs with a different `ls_agent_type`).
+    const overrides = _computeAllowlistedRunTreeMetadataOverrides(
+      runTree.extra?.metadata as Record<string, unknown> | undefined
+    );
+    const extra =
+      overrides !== undefined
+        ? { ...runTree.extra, metadata: overrides }
+        : runTree.extra;
+
     return new RunTree({
       ...runTree,
+      extra,
       client: this.client as Client,
       project_name: this.projectName,
       replicas: this.replicas,
@@ -296,4 +362,47 @@ function _patchMissingTracingDefaults(tracer: LangChainTracer, run: Run): void {
       new Set([...(run.tags ?? []), ...tracer.tracingTags])
     );
   }
+}
+
+/**
+ * Compute a new metadata object containing last-wins overrides for
+ * allowlisted LangSmith-only metadata keys (e.g. `ls_agent_type`) read
+ * from the currently-active `RunTree`.
+ *
+ * Returns `undefined` if no overrides apply — the caller should leave
+ * the existing metadata unchanged in that case. Otherwise returns a
+ * fresh object: `{ ...existingMetadata, ...overrides }`. The input
+ * `existingMetadata` is never mutated.
+ *
+ * Used by:
+ *   - `LangChainTracer._addRunToRunMap` (write-time), which writes the
+ *     returned object back onto `run.extra.metadata` synchronously so
+ *     that it's visible to the async callback handlers that post the
+ *     run to LangSmith. This must happen before `consumeCallback`
+ *     wipes the ALS scope.
+ *   - `LangChainTracer.getRunTreeWithTracingConfig` (read-time), which
+ *     wraps the returned object into a fresh `extra` for the cloned
+ *     RunTree it produces. Callers like langgraph's Pregel executor
+ *     re-seed ALS from that clone, so without this re-application the
+ *     caller's `withRunTree(...)` override would be silently lost when
+ *     traversing into nested execution.
+ */
+function _computeAllowlistedRunTreeMetadataOverrides(
+  existingMetadata?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const currentRunTreeMetadata = LangChainTracer.getTraceableRunTree()
+    ?.metadata as Record<string, unknown> | undefined;
+  if (!currentRunTreeMetadata) return undefined;
+
+  let overrideMetadata: Record<string, unknown> | undefined;
+  for (const key of LANGSMITH_INHERITABLE_METADATA_KEYS) {
+    if (!(key in currentRunTreeMetadata)) {
+      continue;
+    }
+    if (overrideMetadata === undefined) {
+      overrideMetadata = { ...(existingMetadata ?? {}) };
+    }
+    overrideMetadata[key] = currentRunTreeMetadata[key];
+  }
+  return overrideMetadata;
 }

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -133,7 +133,7 @@ export class LangChainTracer
     // empty
   }
 
-  _addRunToRunMap(run: Run) {
+  _addRunToRunMap(run: BaseTracerRun) {
     // Apply last-wins overrides for allowlisted LangSmith-only metadata
     // keys (e.g. `ls_agent_type`) from the currently-active RunTree.
     //

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -70,7 +70,7 @@
     "@langchain/core": "workspace:^"
   },
   "dependencies": {
-    "@langchain/langgraph": "^1.2.8",
+    "@langchain/langgraph": "^1.2.9",
     "@langchain/langgraph-checkpoint": "^1.0.1",
     "langsmith": ">=0.5.0 <1.0.0",
     "uuid": "^11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: workspace:*
         version: link:../libs/providers/langchain-groq
       '@langchain/langgraph':
-        specifier: ^1.2.6
-        version: 1.2.6(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+        specifier: ^1.2.9
+        version: 1.2.9(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@langchain/mistralai':
         specifier: workspace:*
         version: link:../libs/providers/langchain-mistralai
@@ -587,8 +587,8 @@ importers:
   libs/langchain:
     dependencies:
       '@langchain/langgraph':
-        specifier: ^1.2.8
-        version: 1.2.8(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+        specifier: ^1.2.9
+        version: 1.2.9(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.0.1
         version: 1.0.1(@langchain/core@libs+langchain-core)
@@ -4561,28 +4561,8 @@ packages:
       react-dom:
         optional: true
 
-  '@langchain/langgraph-sdk@1.8.2':
-    resolution: {integrity: sha512-TQSw5O0NiE0W6D+UKcv6AdvCqQD2Xbv96oaUFUSSL3nnQ0WfZLcF5nPNTQm6KLUo4EuhKZeeoAgnDb2hRDW2Hw==}
-    peerDependencies:
-      '@langchain/core': workspace:^
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
-      svelte: ^4.0.0 || ^5.0.0
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-
-  '@langchain/langgraph-sdk@1.8.8':
-    resolution: {integrity: sha512-4OoqFAvPloOTZ6oPxXbJngz4FLJO8QSXb+BQV3qvNTvmfu1LQA7cCEqSNLYX9MoC340PbnDkHNgUtjajwkDHRg==}
+  '@langchain/langgraph-sdk@1.8.9':
+    resolution: {integrity: sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==}
     peerDependencies:
       '@langchain/core': workspace:^
       react: ^18 || ^19
@@ -4623,19 +4603,8 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@langchain/langgraph@1.2.6':
-    resolution: {integrity: sha512-5cX402dNGN6w9+0mlMU2dgUiKx6Y1tlENp7x05e9ByDbQCHSDc0kyqRWNFLGc7vatQ92S4ylxQrcCJvi8Fr4SQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/core': workspace:^
-      zod: ^3.25.32 || ^4.2.0
-      zod-to-json-schema: ^3.x
-    peerDependenciesMeta:
-      zod-to-json-schema:
-        optional: true
-
-  '@langchain/langgraph@1.2.8':
-    resolution: {integrity: sha512-kKkRpC5xFz1e6vPivE7lwRJa5oahLAMaVQvVGZdTa6uJIchIYJDIuM1n93FqGvg8aYVcgYU4FENtKKC5Eh1JYw==}
+  '@langchain/langgraph@1.2.9':
+    resolution: {integrity: sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': workspace:^
@@ -15778,18 +15747,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.2.4(react@19.0.0)
 
-  '@langchain/langgraph-sdk@1.8.2(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      p-queue: 9.1.2
-      p-retry: 7.1.1
-      uuid: 13.0.0
-    optionalDependencies:
-      '@langchain/core': link:libs/langchain-core
-      react: 19.0.0
-      react-dom: 19.2.4(react@19.0.0)
-
-  '@langchain/langgraph-sdk@1.8.8(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)':
+  '@langchain/langgraph-sdk@1.8.9(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -15827,27 +15785,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.2.6(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.2.9(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@langchain/core': link:libs/langchain-core
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@libs+langchain-core)
-      '@langchain/langgraph-sdk': 1.8.2(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - react
-      - react-dom
-      - svelte
-      - vue
-
-  '@langchain/langgraph@1.2.8(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
-    dependencies:
-      '@langchain/core': link:libs/langchain-core
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@libs+langchain-core)
-      '@langchain/langgraph-sdk': 1.8.8(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@libs+langchain-core)(react-dom@19.2.4(react@19.0.0))(react@19.0.0)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6


### PR DESCRIPTION
Tracing-only keys are currently impossible to override by children once set without adding to standard metadata. This creates an allowlist of overridable keys.

Python: https://github.com/langchain-ai/langchain/pull/36879