### PR TITLE
fix(google-genai): throw clear error when input has no HumanMessage

### DIFF
--- a/.changeset/tall-trains-cheer.md
+++ b/.changeset/tall-trains-cheer.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+Improve ChatGoogleGenerativeAI error handling for prompts that omit HumanMessage by failing fast with a clear SDK-side validation message before any provider request is made.

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -45,6 +45,7 @@ import {
   convertBaseMessagesToContent,
   convertResponseContentToChatGenerationChunk,
   convertUsageMetadata,
+  getMessageAuthor,
   mapGenerateContentResultToChatResult,
 } from "./utils/common.js";
 import { GoogleGenerativeAIToolsOutputParser } from "./output_parsers.js";
@@ -74,6 +75,9 @@ export type BaseMessageExamplePair = {
   input: BaseMessage;
   output: BaseMessage;
 };
+
+const NO_HUMAN_MESSAGE_ERROR =
+  "ChatGoogleGenerativeAI requires at least one HumanMessage in the input messages.";
 
 export interface GoogleGenerativeAIChatCallOptions extends BaseChatModelCallOptions {
   tools?: GoogleGenerativeAIToolType[];
@@ -850,12 +854,24 @@ export class ChatGoogleGenerativeAI
     };
   }
 
+  private assertHasHumanMessage(messages: BaseMessage[]): void {
+    const hasHumanMessage = messages.some((message) => {
+      const author = getMessageAuthor(message);
+      return author === "human" || author === "user";
+    });
+
+    if (!hasHumanMessage) {
+      throw new Error(NO_HUMAN_MESSAGE_ERROR);
+    }
+  }
+
   async _generate(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     options.signal?.throwIfAborted();
+    this.assertHasHumanMessage(messages);
     const prompt = convertBaseMessagesToContent(
       messages,
       this._isMultimodalModel,
@@ -925,6 +941,7 @@ export class ChatGoogleGenerativeAI
     options: this["ParsedCallOptions"],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    this.assertHasHumanMessage(messages);
     const prompt = convertBaseMessagesToContent(
       messages,
       this._isMultimodalModel,

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -660,12 +660,12 @@ export class ChatGoogleGenerativeAI
 
   constructor(
     model: ModelParams["model"],
-    fields?: Omit<GoogleGenerativeAIChatInput, "model">
+    fields?: Omit<GoogleGenerativeAIChatInput, "model">,
   );
   constructor(fields: GoogleGenerativeAIChatInput);
   constructor(
     modelOrFields: ModelParams["model"] | GoogleGenerativeAIChatInput,
-    fieldsArg?: Omit<GoogleGenerativeAIChatInput, "model">
+    fieldsArg?: Omit<GoogleGenerativeAIChatInput, "model">,
   ) {
     const fields =
       typeof modelOrFields === "string"
@@ -709,18 +709,18 @@ export class ChatGoogleGenerativeAI
         "Please set an API key for Google GenerativeAI " +
           "in the environment variable GOOGLE_API_KEY " +
           "or in the `apiKey` field of the " +
-          "ChatGoogleGenerativeAI constructor"
+          "ChatGoogleGenerativeAI constructor",
       );
     }
 
     this.safetySettings = fields.safetySettings ?? this.safetySettings;
     if (this.safetySettings && this.safetySettings.length > 0) {
       const safetySettingsSet = new Set(
-        this.safetySettings.map((s) => s.category)
+        this.safetySettings.map((s) => s.category),
       );
       if (safetySettingsSet.size !== this.safetySettings.length) {
         throw new Error(
-          "The categories in `safetySettings` array must be unique"
+          "The categories in `safetySettings` array must be unique",
         );
       }
     }
@@ -750,7 +750,7 @@ export class ChatGoogleGenerativeAI
         apiVersion: fields.apiVersion,
         baseUrl: fields.baseUrl,
         customHeaders: fields.customHeaders,
-      }
+      },
     );
     this.streamUsage = fields.streamUsage ?? this.streamUsage;
   }
@@ -758,15 +758,15 @@ export class ChatGoogleGenerativeAI
   useCachedContent(
     cachedContent: CachedContent,
     modelParams?: ModelParams,
-    requestOptions?: RequestOptions
+    requestOptions?: RequestOptions,
   ): void {
     if (!this.apiKey) return;
     this.client = new GenerativeAI(
-      this.apiKey
+      this.apiKey,
     ).getGenerativeModelFromCachedContent(
       cachedContent,
       modelParams,
-      requestOptions
+      requestOptions,
     );
   }
 
@@ -814,7 +814,7 @@ export class ChatGoogleGenerativeAI
 
   override bindTools(
     tools: GoogleGenerativeAIToolType[],
-    kwargs?: Partial<GoogleGenerativeAIChatCallOptions>
+    kwargs?: Partial<GoogleGenerativeAIChatCallOptions>,
   ): Runnable<
     BaseLanguageModelInput,
     AIMessageChunk,
@@ -827,7 +827,7 @@ export class ChatGoogleGenerativeAI
   }
 
   invocationParams(
-    options?: this["ParsedCallOptions"]
+    options?: this["ParsedCallOptions"],
   ): Omit<GenerateContentRequest, "contents"> {
     const toolsAndConfig = options?.tools?.length
       ? convertToolsToGenAI(options.tools, {
@@ -868,7 +868,7 @@ export class ChatGoogleGenerativeAI
   async _generate(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
-    runManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun,
   ): Promise<ChatResult> {
     options.signal?.throwIfAborted();
     this.assertHasHumanMessage(messages);
@@ -876,7 +876,7 @@ export class ChatGoogleGenerativeAI
       messages,
       this._isMultimodalModel,
       this.useSystemInstruction,
-      this.model
+      this.model,
     );
     let actualPrompt = prompt;
     if (prompt[0].role === "system") {
@@ -902,7 +902,7 @@ export class ChatGoogleGenerativeAI
         }
       }
       const generations = finalChunks.filter(
-        (c): c is ChatGenerationChunk => c !== undefined
+        (c): c is ChatGenerationChunk => c !== undefined,
       );
 
       return { generations, llmOutput: { estimatedTokenUsage: tokenUsage } };
@@ -917,7 +917,7 @@ export class ChatGoogleGenerativeAI
     if ("usageMetadata" in res.response) {
       usageMetadata = convertUsageMetadata(
         res.response.usageMetadata,
-        this.model
+        this.model,
       );
     }
 
@@ -925,12 +925,12 @@ export class ChatGoogleGenerativeAI
       res.response,
       {
         usageMetadata,
-      }
+      },
     );
     // may not have generations in output if there was a refusal for safety reasons, malformed function call, etc.
     if (generationResult.generations?.length > 0) {
       await runManager?.handleLLMNewToken(
-        generationResult.generations[0]?.text ?? ""
+        generationResult.generations[0]?.text ?? "",
       );
     }
     return generationResult;
@@ -939,14 +939,14 @@ export class ChatGoogleGenerativeAI
   async *_streamResponseChunks(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
-    runManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun,
   ): AsyncGenerator<ChatGenerationChunk> {
     this.assertHasHumanMessage(messages);
     const prompt = convertBaseMessagesToContent(
       messages,
       this._isMultimodalModel,
       this.useSystemInstruction,
-      this.model
+      this.model,
     );
     let actualPrompt = prompt;
     if (prompt[0].role === "system") {
@@ -966,7 +966,7 @@ export class ChatGoogleGenerativeAI
           signal: options?.signal,
         });
         return stream;
-      }
+      },
     );
 
     let usageMetadata: UsageMetadata | undefined;
@@ -987,7 +987,7 @@ export class ChatGoogleGenerativeAI
       ) {
         usageMetadata = convertUsageMetadata(
           response.usageMetadata,
-          this.model
+          this.model,
         );
 
         // Under the hood, LangChain combines the prompt tokens. Google returns the updated
@@ -996,7 +996,7 @@ export class ChatGoogleGenerativeAI
           response.usageMetadata.promptTokenCount ?? 0;
         usageMetadata.input_tokens = Math.max(
           0,
-          newPromptTokenCount - prevPromptTokenCount
+          newPromptTokenCount - prevPromptTokenCount,
         );
         prevPromptTokenCount = newPromptTokenCount;
 
@@ -1004,14 +1004,14 @@ export class ChatGoogleGenerativeAI
           response.usageMetadata.candidatesTokenCount ?? 0;
         usageMetadata.output_tokens = Math.max(
           0,
-          newCandidatesTokenCount - prevCandidatesTokenCount
+          newCandidatesTokenCount - prevCandidatesTokenCount,
         );
         prevCandidatesTokenCount = newCandidatesTokenCount;
 
         const newTotalTokenCount = response.usageMetadata.totalTokenCount ?? 0;
         usageMetadata.total_tokens = Math.max(
           0,
-          newTotalTokenCount - prevTotalTokenCount
+          newTotalTokenCount - prevTotalTokenCount,
         );
         prevTotalTokenCount = newTotalTokenCount;
       }
@@ -1032,7 +1032,7 @@ export class ChatGoogleGenerativeAI
 
   async completionWithRetry(
     request: string | GenerateContentRequest | (string | GenerativeAIPart)[],
-    options?: this["ParsedCallOptions"]
+    options?: this["ParsedCallOptions"],
   ) {
     return this.caller.callWithOptions(
       { signal: options?.signal },
@@ -1049,7 +1049,7 @@ export class ChatGoogleGenerativeAI
           }
           throw e;
         }
-      }
+      },
     );
   }
 
@@ -1083,7 +1083,7 @@ export class ChatGoogleGenerativeAI
       | SerializableSchema<RunOutput>
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       | Record<string, any>,
-    config?: StructuredOutputMethodOptions<false>
+    config?: StructuredOutputMethodOptions<false>,
   ): Runnable<BaseLanguageModelInput, RunOutput>;
 
   withStructuredOutput<
@@ -1095,7 +1095,7 @@ export class ChatGoogleGenerativeAI
       | SerializableSchema<RunOutput>
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       | Record<string, any>,
-    config?: StructuredOutputMethodOptions<true>
+    config?: StructuredOutputMethodOptions<true>,
   ): Runnable<BaseLanguageModelInput, { raw: BaseMessage; parsed: RunOutput }>;
 
   withStructuredOutput<
@@ -1107,7 +1107,7 @@ export class ChatGoogleGenerativeAI
       | SerializableSchema<RunOutput>
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       | Record<string, any>,
-    config?: StructuredOutputMethodOptions<boolean>
+    config?: StructuredOutputMethodOptions<boolean>,
   ):
     | Runnable<BaseLanguageModelInput, RunOutput>
     | Runnable<
@@ -1121,7 +1121,7 @@ export class ChatGoogleGenerativeAI
 
     if (method === "jsonMode") {
       throw new Error(
-        `ChatGoogleGenerativeAI only supports "jsonSchema" or "functionCalling" as a method.`
+        `ChatGoogleGenerativeAI only supports "jsonSchema" or "functionCalling" as a method.`,
       );
     }
 
@@ -1146,7 +1146,7 @@ export class ChatGoogleGenerativeAI
       ) {
         geminiFunctionDeclaration = schema as GenerativeAIFunctionDeclaration;
         geminiFunctionDeclaration.parameters = removeAdditionalProperties(
-          schema.parameters
+          schema.parameters,
         ) as GenerativeAIFunctionDeclarationSchema;
         functionName = schema.name;
       } else {
@@ -1154,7 +1154,7 @@ export class ChatGoogleGenerativeAI
           name: functionName,
           description: schema.description ?? "",
           parameters: removeAdditionalProperties(
-            schema
+            schema,
           ) as GenerativeAIFunctionDeclarationSchema,
         };
       }
@@ -1171,7 +1171,7 @@ export class ChatGoogleGenerativeAI
       outputParser = createFunctionCallingParser(
         schema,
         functionName,
-        GoogleGenerativeAIToolsOutputParser
+        GoogleGenerativeAIToolsOutputParser,
       );
     } else {
       const jsonSchema = schemaToGenerativeAIParameters(schema);
@@ -1187,7 +1187,7 @@ export class ChatGoogleGenerativeAI
       includeRaw,
       includeRaw
         ? "StructuredOutputRunnable"
-        : "ChatGoogleGenerativeAIStructuredOutput"
+        : "ChatGoogleGenerativeAIStructuredOutput",
     );
   }
 }

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -9,7 +9,6 @@ import {
   HumanMessage,
   SystemMessage,
   ToolMessage,
-  type MessageContentComplex,
 } from "@langchain/core/messages";
 import { OutputParserException } from "@langchain/core/output_parsers";
 import { ChatGoogleGenerativeAI } from "../chat_models.js";
@@ -32,6 +31,9 @@ function extractKeys(obj: Record<string, any>, keys: string[] = []) {
   }
   return keys;
 }
+
+const NO_HUMAN_MESSAGE_ERROR =
+  "ChatGoogleGenerativeAI requires at least one HumanMessage in the input messages.";
 
 test("Google AI - `temperature` must be in range [0.0,2.0]", async () => {
   expect(
@@ -505,7 +507,12 @@ test("convertBaseMessagesToContent correctly creates properly formatted content"
     }),
   ];
 
-  const messagesAsGoogleContent = convertBaseMessagesToContent(messages, false);
+  const messagesAsGoogleContent = convertBaseMessagesToContent(
+    messages,
+    false,
+    false,
+    "model"
+  );
   // console.log(messagesAsGoogleContent);
   // Google Generative AI API only allows for 'model' and 'user' roles
   // This means that 'system', 'human' and 'tool' messages are converted
@@ -551,7 +558,8 @@ test("Input has single system message followed by one user message, convert syst
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    false
+    false,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -571,7 +579,7 @@ test("Input has a system message that is not the first message, convert system m
     new SystemMessage("You are a helpful assistant"),
   ];
   expect(() => {
-    convertBaseMessagesToContent(messages, false, false);
+    convertBaseMessagesToContent(messages, false, false, "model");
   }).toThrow("System message should be the first one");
 });
 
@@ -581,7 +589,7 @@ test("Input has multiple system messages, convert system message is false", asyn
     new SystemMessage("You are not a helpful assistant"),
   ];
   expect(() => {
-    convertBaseMessagesToContent(messages, false, false);
+    convertBaseMessagesToContent(messages, false, false, "model");
   }).toThrow("System message should be the first one");
 });
 
@@ -590,7 +598,8 @@ test("Input has no system message and one user message, convert system message i
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    false
+    false,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -610,7 +619,8 @@ test("Input has no system message and multiple user message, convert system mess
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    false
+    false,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -638,7 +648,8 @@ test("Input has single system message followed by one user message, convert syst
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    true
+    true,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -659,7 +670,7 @@ test("Input has single system message that is not the first message, convert sys
     new SystemMessage("You are a helpful assistant"),
   ];
 
-  expect(() => convertBaseMessagesToContent(messages, false, true)).toThrow(
+  expect(() => convertBaseMessagesToContent(messages, false, true, "model")).toThrow(
     "System message should be the first one"
   );
 });
@@ -670,7 +681,7 @@ test("Input has multiple system message, convert system message is true", async 
     new SystemMessage("You are a helpful assistant"),
   ];
 
-  expect(() => convertBaseMessagesToContent(messages, false, true)).toThrow(
+  expect(() => convertBaseMessagesToContent(messages, false, true, "model")).toThrow(
     "System message should be the first one"
   );
 });
@@ -681,7 +692,8 @@ test("Input has no system message and one user message, convert system message i
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    true
+    true,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -702,7 +714,8 @@ test("Input has no system message and multiple user messages, convert system mes
   const messagesAsGoogleContent = convertBaseMessagesToContent(
     messages,
     false,
-    true
+    true,
+    "model"
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -894,7 +907,7 @@ test("convertMessageContentToParts: correctly handles ToolMessage with array con
     tool_calls: [{ name: toolName, args: { input: "test" }, id: toolCallId }],
   });
 
-  const toolMessageContentArray: MessageContentComplex[] = [
+  const toolMessageContentArray: ContentBlock[] = [
     { type: "text", text: "Tool response text." },
     {
       type: "image_url",
@@ -938,7 +951,7 @@ test("convertMessageContentToParts: correctly handles ToolMessage with array con
     tool_calls: [{ name: toolName, args: { input: "test" }, id: toolCallId }],
   });
 
-  const toolMessageContentArray: MessageContentComplex[] = [
+  const toolMessageContentArray: ContentBlock[] = [
     { type: "text", text: "Tool error details text." },
     {
       type: "image_url",
@@ -1013,6 +1026,95 @@ test("convertBaseMessagesToContent should handle AIMessages with custom names", 
   expect(result[1].role).toBe("model");
 });
 
+test("invoke throws a descriptive error for system-only input before network call", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    model: "gemini-2.0-flash",
+    apiKey: "testing",
+  });
+  const completionWithRetrySpy = vi.spyOn(model, "completionWithRetry");
+
+  await expect(
+    model.invoke([new SystemMessage("You are a helpful assistant")])
+  ).rejects.toThrow(NO_HUMAN_MESSAGE_ERROR);
+
+  expect(completionWithRetrySpy).not.toHaveBeenCalled();
+});
+
+test("invoke throws the same descriptive error for empty message arrays", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    model: "gemini-2.0-flash",
+    apiKey: "testing",
+  });
+  const completionWithRetrySpy = vi.spyOn(model, "completionWithRetry");
+
+  await expect(model.invoke([])).rejects.toThrow(NO_HUMAN_MESSAGE_ERROR);
+
+  expect(completionWithRetrySpy).not.toHaveBeenCalled();
+});
+
+test("invoke with system and human messages succeeds", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    model: "gemini-2.0-flash",
+    apiKey: "testing",
+  });
+  const completionWithRetrySpy = vi
+    .spyOn(model, "completionWithRetry")
+    .mockResolvedValue({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "It is sunny." }],
+            },
+          },
+        ],
+      },
+    } as Awaited<ReturnType<ChatGoogleGenerativeAI["completionWithRetry"]>>);
+
+  const result = await model.invoke([
+    new SystemMessage("You are a helpful assistant"),
+    new HumanMessage("How is the weather?"),
+  ]);
+
+  expect(result.content).toBe("It is sunny.");
+  expect(completionWithRetrySpy).toHaveBeenCalledOnce();
+  expect(completionWithRetrySpy.mock.calls[0]?.[0]).toMatchObject({
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: "How is the weather?" }],
+      },
+    ],
+  });
+});
+
+test("invoke with a human-only message succeeds", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    model: "gemini-2.0-flash",
+    apiKey: "testing",
+  });
+  const completionWithRetrySpy = vi
+    .spyOn(model, "completionWithRetry")
+    .mockResolvedValue({
+      response: {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "Hello there." }],
+            },
+          },
+        ],
+      },
+    } as Awaited<ReturnType<ChatGoogleGenerativeAI["completionWithRetry"]>>);
+
+  const result = await model.invoke([
+    new HumanMessage("Say hello in two words."),
+  ]);
+
+  expect(result.content).toBe("Hello there.");
+  expect(completionWithRetrySpy).toHaveBeenCalledOnce();
+});
+
 describe("withStructuredOutput - StandardSchema", () => {
   function makeSerializableSchema() {
     return {
@@ -1048,7 +1150,7 @@ describe("withStructuredOutput - StandardSchema", () => {
       apiKey: "testing",
     });
     vi.spyOn(model, "invoke").mockResolvedValue(
-      new AIMessage({
+      new AIMessageChunk({
         content: "",
         tool_calls: [
           {
@@ -1107,7 +1209,7 @@ describe("withStructuredOutput - StandardSchema", () => {
       apiKey: "testing",
     });
     vi.spyOn(model, "invoke").mockResolvedValue(
-      new AIMessage({
+      new AIMessageChunk({
         content: "",
         tool_calls: [
           {
@@ -1131,7 +1233,7 @@ describe("withStructuredOutput - StandardSchema", () => {
   });
 
   test("functionCalling with includeRaw returns raw and parsed", async () => {
-    const mockResponse = new AIMessage({
+    const mockResponse = new AIMessageChunk({
       content: "",
       tool_calls: [
         {

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -41,14 +41,14 @@ test("Google AI - `temperature` must be in range [0.0,2.0]", async () => {
       new ChatGoogleGenerativeAI({
         temperature: -1.0,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
   expect(
     () =>
       new ChatGoogleGenerativeAI({
         temperature: 2.1,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
 });
 
@@ -65,7 +65,7 @@ test("Google AI - `maxOutputTokens` must be positive", async () => {
       new ChatGoogleGenerativeAI({
         maxOutputTokens: -1,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
 });
 
@@ -75,7 +75,7 @@ test("Google AI - `topP` must be positive", async () => {
       new ChatGoogleGenerativeAI({
         topP: -1,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
 });
 
@@ -85,7 +85,7 @@ test("Google AI - `topP` must be in the range [0,1]", async () => {
       new ChatGoogleGenerativeAI({
         topP: 3,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
 });
 
@@ -95,7 +95,7 @@ test("Google AI - `topK` must be positive", async () => {
       new ChatGoogleGenerativeAI({
         topK: -1,
         model: "gemini-2.0-flash",
-      })
+      }),
   ).toThrow();
 });
 
@@ -118,7 +118,7 @@ test("Google AI - `safetySettings` category array must be unique", async () => {
             threshold: "BLOCK_ONLY_HIGH" as HarmBlockThreshold,
           },
         ],
-      })
+      }),
   ).toThrow();
 });
 
@@ -149,14 +149,14 @@ test("removeAdditionalProperties can remove all instances of additionalPropertie
   const parsedSchemaArr = removeAdditionalProperties(toJsonSchema(schema));
   const arrSchemaKeys = extractKeys(parsedSchemaArr);
   expect(
-    arrSchemaKeys.find((key) => key === "additionalProperties")
+    arrSchemaKeys.find((key) => key === "additionalProperties"),
   ).toBeUndefined();
   const parsedSchemaObj = removeAdditionalProperties(
-    toJsonSchema(questionSchema)
+    toJsonSchema(questionSchema),
   );
   const arrSchemaObj = extractKeys(parsedSchemaObj);
   expect(
-    arrSchemaObj.find((key) => key === "additionalProperties")
+    arrSchemaObj.find((key) => key === "additionalProperties"),
   ).toBeUndefined();
 
   const analysisSchema = z.object({
@@ -172,11 +172,11 @@ test("removeAdditionalProperties can remove all instances of additionalPropertie
       .optional(),
   });
   const parsedAnalysisSchema = removeAdditionalProperties(
-    toJsonSchema(analysisSchema)
+    toJsonSchema(analysisSchema),
   );
   const analysisSchemaObj = extractKeys(parsedAnalysisSchema);
   expect(
-    analysisSchemaObj.find((key) => key === "additionalProperties")
+    analysisSchemaObj.find((key) => key === "additionalProperties"),
   ).toBeUndefined();
 });
 
@@ -204,7 +204,7 @@ test("convertMessageContentToParts correctly handles message types", () => {
   ];
   const messagesAsGoogleParts = messages
     .map((msg, i) =>
-      convertMessageContentToParts(msg, false, messages.slice(0, i))
+      convertMessageContentToParts(msg, false, messages.slice(0, i)),
     )
     .flat();
   // console.log(messagesAsGoogleParts);
@@ -263,7 +263,7 @@ test("convertMessageContentToParts: correctly handles http url standard image bl
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support images");
 });
 
@@ -288,7 +288,7 @@ test("convertMessageContentToParts: correctly handles base64 standard image bloc
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support images");
 });
 
@@ -312,7 +312,7 @@ test("convertMessageContentToParts: correctly handles base64 data url standard i
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support images");
 });
 
@@ -358,7 +358,7 @@ test("convertMessageContentToParts: correctly handles base64 data url standard a
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support audio");
 });
 
@@ -383,7 +383,7 @@ test("convertMessageContentToParts: correctly handles http url standard audio bl
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support audio");
 });
 
@@ -408,7 +408,7 @@ test("convertMessageContentToParts: correctly handles base64 standard file block
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support files");
 });
 
@@ -433,7 +433,7 @@ test("convertMessageContentToParts: correctly handles http url standard file blo
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support files");
 });
 
@@ -457,7 +457,7 @@ test("convertMessageContentToParts: correctly handles base64 data url standard f
     },
   ]);
   expect(() =>
-    convertMessageContentToParts(message, false /* not multimodal */, [])
+    convertMessageContentToParts(message, false /* not multimodal */, []),
   ).toThrowError("This model does not support files");
 });
 
@@ -511,7 +511,7 @@ test("convertBaseMessagesToContent correctly creates properly formatted content"
     messages,
     false,
     false,
-    "model"
+    "model",
   );
   // console.log(messagesAsGoogleContent);
   // Google Generative AI API only allows for 'model' and 'user' roles
@@ -559,7 +559,7 @@ test("Input has single system message followed by one user message, convert syst
     messages,
     false,
     false,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -599,7 +599,7 @@ test("Input has no system message and one user message, convert system message i
     messages,
     false,
     false,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -620,7 +620,7 @@ test("Input has no system message and multiple user message, convert system mess
     messages,
     false,
     false,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -649,7 +649,7 @@ test("Input has single system message followed by one user message, convert syst
     messages,
     false,
     true,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -670,9 +670,9 @@ test("Input has single system message that is not the first message, convert sys
     new SystemMessage("You are a helpful assistant"),
   ];
 
-  expect(() => convertBaseMessagesToContent(messages, false, true, "model")).toThrow(
-    "System message should be the first one"
-  );
+  expect(() =>
+    convertBaseMessagesToContent(messages, false, true, "model"),
+  ).toThrow("System message should be the first one");
 });
 
 test("Input has multiple system message, convert system message is true", async () => {
@@ -681,9 +681,9 @@ test("Input has multiple system message, convert system message is true", async 
     new SystemMessage("You are a helpful assistant"),
   ];
 
-  expect(() => convertBaseMessagesToContent(messages, false, true, "model")).toThrow(
-    "System message should be the first one"
-  );
+  expect(() =>
+    convertBaseMessagesToContent(messages, false, true, "model"),
+  ).toThrow("System message should be the first one");
 });
 
 test("Input has no system message and one user message, convert system message is true", async () => {
@@ -693,7 +693,7 @@ test("Input has no system message and one user message, convert system message i
     messages,
     false,
     true,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -715,7 +715,7 @@ test("Input has no system message and multiple user messages, convert system mes
     messages,
     false,
     true,
-    "model"
+    "model",
   );
 
   expect(messagesAsGoogleContent).toEqual([
@@ -752,7 +752,7 @@ test("convertMessageContentToParts: should handle AIMessage with mixed content a
     }),
   ];
   expect(
-    convertMessageContentToParts(aiMessageWithString, isMultimodalModel, [])
+    convertMessageContentToParts(aiMessageWithString, isMultimodalModel, []),
   ).toEqual(expectedPartsAiString);
 
   const aiMessageWithArray = new AIMessage({
@@ -773,7 +773,7 @@ test("convertMessageContentToParts: should handle AIMessage with mixed content a
     }),
   ];
   expect(
-    convertMessageContentToParts(aiMessageWithArray, isMultimodalModel, [])
+    convertMessageContentToParts(aiMessageWithArray, isMultimodalModel, []),
   ).toEqual(expectedPartsAiArray);
 
   const humanMessageWithArray = new HumanMessage({
@@ -790,7 +790,7 @@ test("convertMessageContentToParts: should handle AIMessage with mixed content a
     { inlineData: { mimeType: "image/png", data: base64ImageData } },
   ];
   expect(
-    convertMessageContentToParts(humanMessageWithArray, isMultimodalModel, [])
+    convertMessageContentToParts(humanMessageWithArray, isMultimodalModel, []),
   ).toEqual(expectedPartsHumanArray);
 });
 
@@ -802,7 +802,7 @@ test("convertMessageContentToParts: should handle messages with content only (no
   });
   const expectedPartsAiString = [{ text: "Just an AI text response." }];
   expect(
-    convertMessageContentToParts(aiMessageWithString, isMultimodalModel, [])
+    convertMessageContentToParts(aiMessageWithString, isMultimodalModel, []),
   ).toEqual(expectedPartsAiString);
 
   const humanMessageWithString = new HumanMessage({
@@ -810,7 +810,7 @@ test("convertMessageContentToParts: should handle messages with content only (no
   });
   const expectedPartsHumanString = [{ text: "Just a human text input." }];
   expect(
-    convertMessageContentToParts(humanMessageWithString, isMultimodalModel, [])
+    convertMessageContentToParts(humanMessageWithString, isMultimodalModel, []),
   ).toEqual(expectedPartsHumanString);
 
   const aiMessageWithArray = new AIMessage({
@@ -824,7 +824,7 @@ test("convertMessageContentToParts: should handle messages with content only (no
     { text: "AI array part 2." },
   ];
   expect(
-    convertMessageContentToParts(aiMessageWithArray, isMultimodalModel, [])
+    convertMessageContentToParts(aiMessageWithArray, isMultimodalModel, []),
   ).toEqual(expectedPartsAiArray);
 
   const humanMessageWithArray = new HumanMessage({
@@ -838,7 +838,7 @@ test("convertMessageContentToParts: should handle messages with content only (no
     { text: "Human array part 2." },
   ];
   expect(
-    convertMessageContentToParts(humanMessageWithArray, isMultimodalModel, [])
+    convertMessageContentToParts(humanMessageWithArray, isMultimodalModel, []),
   ).toEqual(expectedPartsHumanArray);
 });
 
@@ -853,7 +853,7 @@ test("convertMessageContentToParts: should handle AIMessage with tool_calls only
     expect.objectContaining({ functionCall: { name: "get_time", args: {} } }),
   ];
   expect(
-    convertMessageContentToParts(messageWithEmptyString, isMultimodalModel, [])
+    convertMessageContentToParts(messageWithEmptyString, isMultimodalModel, []),
   ).toEqual(expectedParts);
 });
 
@@ -881,7 +881,7 @@ test("convertMessageContentToParts: should handle ToolMessage correctly (includi
   expect(
     convertMessageContentToParts(toolMessageSuccess, isMultimodalModel, [
       previousAiMessage,
-    ])
+    ]),
   ).toEqual(expectedPartsSuccess);
 
   const toolMessageError = new ToolMessage({
@@ -889,9 +889,9 @@ test("convertMessageContentToParts: should handle ToolMessage correctly (includi
     tool_call_id: "unknown_tool_id",
   });
   expect(() =>
-    convertMessageContentToParts(toolMessageError, isMultimodalModel, [])
+    convertMessageContentToParts(toolMessageError, isMultimodalModel, []),
   ).toThrow(
-    'Google requires a tool name for each tool call response, and we could not infer a called tool name for ToolMessage "undefined" from your passed messages. Please populate a "name" field on that ToolMessage explicitly.'
+    'Google requires a tool name for each tool call response, and we could not infer a called tool name for ToolMessage "undefined" from your passed messages. Please populate a "name" field on that ToolMessage explicitly.',
   );
 });
 
@@ -1017,7 +1017,7 @@ test("convertBaseMessagesToContent should handle AIMessages with custom names", 
   ];
 
   expect(() =>
-    convertBaseMessagesToContent(messages, true, false, "model")
+    convertBaseMessagesToContent(messages, true, false, "model"),
   ).not.toThrow();
 
   const result = convertBaseMessagesToContent(messages, true, false, "model");
@@ -1034,7 +1034,7 @@ test("invoke throws a descriptive error for system-only input before network cal
   const completionWithRetrySpy = vi.spyOn(model, "completionWithRetry");
 
   await expect(
-    model.invoke([new SystemMessage("You are a helpful assistant")])
+    model.invoke([new SystemMessage("You are a helpful assistant")]),
   ).rejects.toThrow(NO_HUMAN_MESSAGE_ERROR);
 
   expect(completionWithRetrySpy).not.toHaveBeenCalled();
@@ -1160,7 +1160,7 @@ describe("withStructuredOutput - StandardSchema", () => {
             type: "tool_call",
           },
         ],
-      })
+      }),
     );
 
     const schema = makeSerializableSchema();
@@ -1189,7 +1189,7 @@ describe("withStructuredOutput - StandardSchema", () => {
             type: "tool_call",
           },
         ],
-      })
+      }),
     );
 
     const schema = makeSerializableSchema();
@@ -1219,7 +1219,7 @@ describe("withStructuredOutput - StandardSchema", () => {
             type: "tool_call",
           },
         ],
-      })
+      }),
     );
 
     const schema = makeSerializableSchema();


### PR DESCRIPTION
## Summary  
Fixes #7741 by adding a preflight validation step in `ChatGoogleGenerativeAI` to ensure at least one `HumanMessage` is present before making a request.

## Context  
Google GenAI requires human input in every request. Today, if that’s missing, the failure comes back as a provider-side 400, which can be pretty opaque when it shows up deep in a chain.  

This change moves that validation into the SDK so we can fail fast with a clearer, more actionable error.

## What’s changed  
- Added a preflight check for the presence of a `HumanMessage` before dispatch  
- Applied the check to both invoke and streaming paths  
- Left all valid flows unchanged  
- Did not attempt to coerce or reinterpret system-only input  
- Added test coverage for:
  - system-only input → throws a clear SDK error  
  - empty input → same error  
  - system + human → works as expected  
  - human-only → works as expected  
  - invalid input → does not reach the provider layer  

## Error message  
`ChatGoogleGenerativeAI requires at least one HumanMessage in the input messages.`

## Verification  
- `@langchain/google-genai` tests pass  
- Lint and type checks pass  
- Manual verification:
  - system-only input fails fast with SDK error  
  - system + human input succeeds with Gemini  
  - invalid inputs never hit the provider  