### PR TITLE
feat(openai): add gpt-image-2 to imageGeneration tool model union

### DIFF
--- a/.changeset/openai-image-generation-gpt-image-2.md
+++ b/.changeset/openai-image-generation-gpt-image-2.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+feat(openai): add `gpt-image-2` to the `imageGeneration` tool model union and widen the type to accept future OpenAI image models

--- a/libs/providers/langchain-openai/src/tools/imageGeneration.ts
+++ b/libs/providers/langchain-openai/src/tools/imageGeneration.ts
@@ -40,8 +40,8 @@ export interface ImageGenerationOptions {
 
   /**
    * Control how much effort the model will exert to match the style and features,
-   * especially facial features, of input images. This parameter is only supported
-   * for `gpt-image-1`. Unsupported for `gpt-image-1-mini`.
+   * especially facial features, of input images. This parameter is supported by
+   * `gpt-image-1`, `gpt-image-1.5`, and later models. Unsupported for `gpt-image-1-mini`.
    * - `high`: Higher fidelity to input images
    * - `low`: Lower fidelity to input images
    * @default "low"
@@ -55,10 +55,17 @@ export interface ImageGenerationOptions {
   inputImageMask?: ImageGenerationInputMask;
 
   /**
-   * The image generation model to use.
+   * The image generation model to use. Accepts any model string the OpenAI
+   * Responses API supports (e.g. `gpt-image-2`), with autocomplete for
+   * currently-known models.
    * @default "gpt-image-1"
    */
-  model?: "gpt-image-1" | "gpt-image-1-mini" | "gpt-image-1.5";
+  model?:
+    | (string & {})
+    | "gpt-image-1"
+    | "gpt-image-1-mini"
+    | "gpt-image-1.5"
+    | "gpt-image-2";
 
   /**
    * Moderation level for the generated image.
@@ -220,7 +227,8 @@ function convertInputImageMask(
  *
  * @remarks
  * - Supported models: gpt-4o, gpt-4o-mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, o3
- * - The image generation process always uses `gpt-image-1` model internally
+ * - The underlying image generation model defaults to `gpt-image-1` and can be
+ *   configured via the `model` option (e.g. `gpt-image-1.5`, `gpt-image-2`)
  * - The model will automatically revise prompts for improved performance
  * - Access the revised prompt via `revised_prompt` field in the output
  * - Multi-turn editing is supported by passing previous response messages

--- a/libs/providers/langchain-openai/src/tools/tests/imageGeneration.test.ts
+++ b/libs/providers/langchain-openai/src/tools/tests/imageGeneration.test.ts
@@ -51,4 +51,24 @@ describe("OpenAI Image Generation Tool Tests", () => {
       expect(tool).toMatchObject({ type: "image_generation", action });
     }
   });
+
+  it("imageGeneration supports all known model values", () => {
+    for (const model of [
+      "gpt-image-1",
+      "gpt-image-1-mini",
+      "gpt-image-1.5",
+      "gpt-image-2",
+    ] as const) {
+      const tool = tools.imageGeneration({ model });
+      expect(tool).toMatchObject({ type: "image_generation", model });
+    }
+  });
+
+  it("imageGeneration passes through unknown model strings", () => {
+    const tool = tools.imageGeneration({ model: "gpt-image-future" });
+    expect(tool).toMatchObject({
+      type: "image_generation",
+      model: "gpt-image-future",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

OpenAI released **GPT Image 2** (`gpt-image-2`) on 2026-04-22. This PR extends the `@langchain/openai` built-in `imageGeneration` Responses API tool so users can select the new model without TypeScript errors.

## Changes

- **`libs/providers/langchain-openai/src/tools/imageGeneration.ts`**
  - Widen `ImageGenerationOptions.model` from `"gpt-image-1" | "gpt-image-1-mini" | "gpt-image-1.5"` to `(string & {}) | "gpt-image-1" | "gpt-image-1-mini" | "gpt-image-1.5" | "gpt-image-2"`. The `(string & {})` escape hatch matches the pattern used by the upstream `openai` Node SDK (`OpenAIClient.Responses.Tool.ImageGeneration`) so future OpenAI image models pass through without requiring further LangChain releases, while `gpt-image-2` is explicitly listed for autocomplete/discoverability.
  - Update the `inputFidelity` docstring to match the upstream OpenAI SDK, which notes the option is supported on `gpt-image-1`, `gpt-image-1.5`, and later models (not only `gpt-image-1`).
  - Remove the outdated `@remarks` line claiming the tool "always uses `gpt-image-1` model internally" — the `model` option has been user-configurable for a while. Replaced with a line noting the default and that it can be overridden.

- **`libs/providers/langchain-openai/src/tools/tests/imageGeneration.test.ts`**
  - Add a test iterating over all known model values including `gpt-image-2`.
  - Add a passthrough test confirming arbitrary model strings (e.g. `gpt-image-future`) propagate to the tool definition.

- **`.changeset/openai-image-generation-gpt-image-2.md`**
  - `@langchain/openai` patch entry.

## Why this matters

Before this PR, the only way to use `gpt-image-2` with the LangChain image-generation tool was to cast the option to `any`. Since the underlying OpenAI Responses API already accepts arbitrary model strings (the openai SDK types `model` with `(string & {})` too), tightening our local union to a closed enum was the only thing preventing use of the new model.

## Test plan

- [x] `pnpm --filter @langchain/core build` — success
- [x] `pnpm --filter @langchain/openai build` — success (`attw` + `publint` clean)
- [x] `pnpm --filter @langchain/openai exec vitest run src/tools/tests/imageGeneration.test.ts` — 5/5 tests pass, 0 type errors
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — all 2340 files formatted

Two pre-existing type errors surfaced by the full `pnpm --filter @langchain/openai test` run (`src/converters/tests/responses.test.ts:2161` and `src/tools/tests/webSearch.int.test.ts:12`) exist on `main` and are unrelated to this change.

## References

- OpenAI announcement: [ChatGPT Images 2.0 launch](https://openai.com/) (2026-04-22)
- Upstream `openai-node` type: [`responses.ts`](https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts) — `Responses.Tool.ImageGeneration#model`

Made with [Cursor](https://cursor.com)