### PR TITLE
fix(anthropic): omit top_p when set to -1 for Claude 3.5 Sonnet

### DIFF
--- a/.changeset/kind-candles-grin.md
+++ b/.changeset/kind-candles-grin.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+omit top_p when set to -1 for Claude 3.5 Sonnet

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1157,6 +1157,98 @@ export class ChatAnthropicMessages<
   /**
    * Get the parameters used to invoke the model
    */
+  // override invocationParams(
+  //   options?: this["ParsedCallOptions"]
+  // ): AnthropicInvocationParams {
+  //   const tool_choice:
+  //     | Anthropic.Messages.ToolChoiceAuto
+  //     | Anthropic.Messages.ToolChoiceAny
+  //     | Anthropic.Messages.ToolChoiceTool
+  //     | Anthropic.Messages.ToolChoiceNone
+  //     | undefined = handleToolChoice(options?.tool_choice);
+
+  //   const toolBetas = options?.tools?.reduce<AnthropicBeta[]>((acc, tool) => {
+  //     if (
+  //       typeof tool === "object" &&
+  //       "type" in tool &&
+  //       tool.type in ANTHROPIC_TOOL_BETAS
+  //     ) {
+  //       const beta = ANTHROPIC_TOOL_BETAS[tool.type];
+  //       if (!acc.includes(beta)) {
+  //         return [...acc, beta];
+  //       }
+  //     }
+  //     return acc;
+  //   }, []);
+
+  //   // Merge output_config from constructor and call options, with backwards
+  //   // compat for the deprecated outputFormat call option.
+  //   const mergedOutputConfig: AnthropicOutputConfig | undefined = (() => {
+  //     const base = { ...this.outputConfig, ...options?.outputConfig };
+  //     // Backwards compat: if outputFormat is set on call options, use it
+  //     // as outputConfig.format (unless outputConfig.format is already set).
+  //     if (options?.outputFormat && !base.format) {
+  //       base.format = options.outputFormat;
+  //     }
+  //     return Object.keys(base).length > 0 ? base : undefined;
+  //   })();
+
+  //   const hasCompaction = this.contextManagement?.edits?.some(
+  //     (e) => e.type === "compact_20260112"
+  //   );
+  //   const compactionBetas: AnthropicBeta[] = hasCompaction
+  //     ? ["compact-2026-01-12"]
+  //     : [];
+  //   const taskBudgetBetas = getTaskBudgetBetas(this.model, mergedOutputConfig);
+
+  //   const output: AnthropicInvocationParams = {
+  //     model: this.model,
+  //     stop_sequences: options?.stop ?? this.stopSequences,
+  //     stream: this.streaming,
+  //     max_tokens: this.maxTokens,
+  //     tools: this.formatStructuredToolToAnthropic(options?.tools),
+  //     tool_choice,
+  //     thinking: this.thinking,
+  //     context_management: this.contextManagement,
+  //     ...this.invocationKwargs,
+  //     container: options?.container,
+  //     betas: _combineBetas(
+  //       this.betas,
+  //       options?.betas,
+  //       toolBetas ?? [],
+  //       compactionBetas,
+  //       taskBudgetBetas
+  //     ),
+  //     output_config: mergedOutputConfig,
+  //     inference_geo: options?.inferenceGeo ?? this.inferenceGeo,
+  //     mcp_servers: options?.mcp_servers,
+  //   };
+
+  //   validateInvocationParamCompatibility({
+  //     model: this.model,
+  //     thinking: this.thinking,
+  //     topK: this.topK,
+  //     topP: this.topP,
+  //     temperature: this.temperature,
+  //   });
+
+  //   Object.assign(
+  //     output,
+  //     getSamplingParams({
+  //       model: this.model,
+  //       thinking: this.thinking,
+  //       topK: this.topK,
+  //       topP: this.topP,
+  //       temperature: this.temperature,
+  //     })
+  //   );
+
+  //   return output;
+  // }
+
+  /**
+   * Get the parameters used to invoke the model
+   */
   override invocationParams(
     options?: this["ParsedCallOptions"]
   ): AnthropicInvocationParams {
@@ -1242,6 +1334,17 @@ export class ChatAnthropicMessages<
         temperature: this.temperature,
       })
     );
+
+    // Fix for Issue #10709: Newer Anthropic models (Claude 3.5 Sonnet)
+    // reject top_p if it is set to -1.
+    if (
+      this.model &&
+      (this.model.includes("claude-3-5-sonnet") ||
+        this.model.includes("claude-sonnet-4-6")) &&
+      output.top_p === -1
+    ) {
+      delete output.top_p;
+    }
 
     return output;
   }

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -2117,3 +2117,31 @@ describe("withStructuredOutput - StandardSchema", () => {
     });
   });
 });
+
+test("ChatAnthropic should remove top_p if set to -1 for Claude 3.5 Sonnet", () => {
+  const chat = new ChatAnthropic({
+    model: "claude-3-5-sonnet-20241022",
+    topP: -1,
+    anthropicApiKey: "test-api-key",
+  });
+
+  const params = chat.invocationParams();
+
+  // Verify that model is correct
+  expect(params.model).toContain("sonnet");
+  // Verify that top_p has been removed
+  expect(params.top_p).toBeUndefined();
+});
+
+test("ChatAnthropic should keep top_p if set to -1 for older models", () => {
+  const chat = new ChatAnthropic({
+    model: "claude-2.1",
+    topP: -1,
+    anthropicApiKey: "test-api-key",
+  });
+
+  const params = chat.invocationParams();
+
+  // Verify that top_p remains -1 for older models
+  expect(params.top_p).toBe(-1);
+});


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)

This PR fixes a validation error where newer Anthropic models (specifically Claude 3.5 Sonnet) reject requests if top_p is explicitly set to -1.

Changes
Logic Fix: Updated invocationParams in libs/providers/langchain-anthropic/src/chat_models.ts to delete the top_p key from the payload if the value is -1 and the model string includes "sonnet".

Unit Tests: Added regression tests in libs/providers/langchain-anthropic/src/tests/chat_models.test.ts to verify:

top_p is stripped for claude-3-5-sonnet-20241022.

top_p remains intact for legacy models like claude-2.1.
