### PR TITLE
fix(aws): add claude-haiku-4 to supportedToolChoiceValuesForModel

### DIFF
--- a/.changeset/fix-aws-bedrock-haiku4-tool-choice.md
+++ b/.changeset/fix-aws-bedrock-haiku4-tool-choice.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): add claude-haiku-4 to supportedToolChoiceValuesForModel

--- a/libs/providers/langchain-aws/src/tests/convertToConverseTools.test.ts
+++ b/libs/providers/langchain-aws/src/tests/convertToConverseTools.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { convertToConverseTools } from "../utils/tools.js";
+import {
+  convertToConverseTools,
+  supportedToolChoiceValuesForModel,
+} from "../utils/tools.js";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod/v3";
 
@@ -214,5 +217,97 @@ describe("convertToConverseTools", () => {
     expect(result[1].toolSpec.name).toBe("openai-1");
     expect(result[2].toolSpec.name).toBe("langchain-2");
     expect(result[3].toolSpec.name).toBe("openai-2");
+  });
+});
+
+describe("supportedToolChoiceValuesForModel", () => {
+  const CLAUDE_TOOL_CHOICES: Array<"auto" | "any" | "tool"> = [
+    "auto",
+    "any",
+    "tool",
+  ];
+
+  it("returns tool choice values for Claude 3 models", () => {
+    expect(
+      supportedToolChoiceValuesForModel(
+        "anthropic.claude-3-sonnet-20240229-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+    expect(
+      supportedToolChoiceValuesForModel(
+        "anthropic.claude-3-5-haiku-20241022-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for Claude Sonnet 4 models", () => {
+    expect(
+      supportedToolChoiceValuesForModel(
+        "anthropic.claude-sonnet-4-5-20250929-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for Claude Opus 4 models", () => {
+    expect(
+      supportedToolChoiceValuesForModel("anthropic.claude-opus-4-20250514-v1:0")
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for Claude Haiku 4 models", () => {
+    expect(
+      supportedToolChoiceValuesForModel(
+        "anthropic.claude-haiku-4-5-20251001-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for Claude Haiku 4 regional inference profiles", () => {
+    expect(
+      supportedToolChoiceValuesForModel(
+        "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+    expect(
+      supportedToolChoiceValuesForModel(
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+    expect(
+      supportedToolChoiceValuesForModel(
+        "ap.anthropic.claude-haiku-4-5-20251001-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for other Claude 4 regional inference profiles", () => {
+    expect(
+      supportedToolChoiceValuesForModel(
+        "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+    expect(
+      supportedToolChoiceValuesForModel(
+        "us.anthropic.claude-opus-4-20250514-v1:0"
+      )
+    ).toEqual(CLAUDE_TOOL_CHOICES);
+  });
+
+  it("returns tool choice values for Mistral Large models", () => {
+    expect(
+      supportedToolChoiceValuesForModel("mistral.mistral-large-2407-v1:0")
+    ).toEqual(["auto", "any"]);
+  });
+
+  it("returns undefined for Claude 2 and other unsupported models", () => {
+    expect(
+      supportedToolChoiceValuesForModel("anthropic.claude-v2")
+    ).toBeUndefined();
+    expect(
+      supportedToolChoiceValuesForModel("cohere.command-text-v14")
+    ).toBeUndefined();
+    expect(
+      supportedToolChoiceValuesForModel("mistral.mistral-7b-instruct-v0:2")
+    ).toBeUndefined();
   });
 });

--- a/libs/providers/langchain-aws/src/utils/tools.ts
+++ b/libs/providers/langchain-aws/src/utils/tools.ts
@@ -130,15 +130,20 @@ export function convertToBedrockToolChoice(
 export function supportedToolChoiceValuesForModel(
   model: string
 ): Array<"auto" | "any" | "tool"> | undefined {
+  // Strip regional inference profile prefixes (e.g. "us.anthropic.", "eu.anthropic.", "ap.anthropic.")
+  // so model IDs like "eu.anthropic.claude-haiku-4-5-20251001-v1:0" match the same
+  // patterns as their non-prefixed equivalents.
+  const normalized = model.replace(/^(?:us|eu|ap)\.anthropic\./, "");
   if (
-    model.includes("claude-3") ||
-    model.includes("claude-4") ||
-    model.includes("claude-opus-4") ||
-    model.includes("claude-sonnet-4")
+    normalized.includes("claude-3") ||
+    normalized.includes("claude-4") ||
+    normalized.includes("claude-haiku-4") ||
+    normalized.includes("claude-opus-4") ||
+    normalized.includes("claude-sonnet-4")
   ) {
     return ["auto", "any", "tool"];
   }
-  if (model.includes("mistral-large")) {
+  if (normalized.includes("mistral-large")) {
     return ["auto", "any"];
   }
   return undefined;

--- a/libs/providers/langchain-aws/src/utils/tools.ts
+++ b/libs/providers/langchain-aws/src/utils/tools.ts
@@ -130,20 +130,16 @@ export function convertToBedrockToolChoice(
 export function supportedToolChoiceValuesForModel(
   model: string
 ): Array<"auto" | "any" | "tool"> | undefined {
-  // Strip regional inference profile prefixes (e.g. "us.anthropic.", "eu.anthropic.", "ap.anthropic.")
-  // so model IDs like "eu.anthropic.claude-haiku-4-5-20251001-v1:0" match the same
-  // patterns as their non-prefixed equivalents.
-  const normalized = model.replace(/^(?:us|eu|ap)\.anthropic\./, "");
   if (
-    normalized.includes("claude-3") ||
-    normalized.includes("claude-4") ||
-    normalized.includes("claude-haiku-4") ||
-    normalized.includes("claude-opus-4") ||
-    normalized.includes("claude-sonnet-4")
+    model.includes("claude-3") ||
+    model.includes("claude-4") ||
+    model.includes("claude-haiku-4") ||
+    model.includes("claude-opus-4") ||
+    model.includes("claude-sonnet-4")
   ) {
     return ["auto", "any", "tool"];
   }
-  if (normalized.includes("mistral-large")) {
+  if (model.includes("mistral-large")) {
     return ["auto", "any"];
   }
   return undefined;


### PR DESCRIPTION
## Summary

`ChatBedrockConverse` throws "does not currently support 'tool_choice'" for Claude Haiku 4.x models, including regional inference profiles like `eu.anthropic.claude-haiku-4-5-20251001-v1:0`.

`supportedToolChoiceValuesForModel` checks for `claude-3`, `claude-4`, `claude-opus-4`, and `claude-sonnet-4`, but not `claude-haiku-4`. Haiku 4 model IDs use the format `claude-haiku-4-N` (e.g. `claude-haiku-4-5`), which doesn't match any of those patterns. Since the check uses substring matching, adding `claude-haiku-4` covers both direct model IDs (`anthropic.claude-haiku-4-5-20251001-v1:0`) and regional inference profiles (`eu.anthropic.claude-haiku-4-5-20251001-v1:0`) without any additional prefix handling.

## Changes

- `libs/providers/langchain-aws/src/utils/tools.ts`: add `claude-haiku-4` to the supported pattern list
- `libs/providers/langchain-aws/src/tests/convertToConverseTools.test.ts`: 9 unit tests for `supportedToolChoiceValuesForModel` covering Claude 3, Opus 4, Sonnet 4, Haiku 4, regional inference profiles, and unsupported models

## Test plan

- [x] All 15 unit tests pass (`vitest run src/tests/convertToConverseTools.test.ts`)
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — no issues

Fixes #10710.