### PR TITLE
fix: treat null the same as undefined for topK, topP, and temperature params

### DIFF
--- a/.changeset/rude-windows-jam.md
+++ b/.changeset/rude-windows-jam.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix: treat null the same as undefined for topK, topP, and temperature params

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -9,9 +9,9 @@ import {
 type InvocationCompatibilityFields = {
   model?: string;
   thinking: AnthropicThinkingConfigParam;
-  topK?: number;
-  topP?: number;
-  temperature?: number;
+  topK?: number | null;
+  topP?: number | null;
+  temperature?: number | null;
 };
 
 function isThinkingEnabled(thinking: AnthropicThinkingConfigParam): boolean {
@@ -59,17 +59,17 @@ export function validateInvocationParamCompatibility(
     );
   }
   if (opus47) {
-    if (topK !== undefined) {
+    if (topK != null) {
       throw new Error(
         "topK is not supported for claude-opus-4-7; omit topK/topP/temperature or use model prompting instead"
       );
     }
-    if (topP !== undefined && topP !== 1) {
+    if (topP != null && topP !== 1) {
       throw new Error(
         "topP is not supported for claude-opus-4-7 when set to non-default values"
       );
     }
-    if (temperature !== undefined && temperature !== 1) {
+    if (temperature != null && temperature !== 1) {
       throw new Error(
         "temperature is not supported for claude-opus-4-7 when set to non-default values"
       );
@@ -77,13 +77,13 @@ export function validateInvocationParamCompatibility(
   }
 
   if (isThinkingEnabled(thinking)) {
-    if (topK !== undefined) {
+    if (topK != null) {
       throw new Error("topK is not supported when thinking is enabled");
     }
-    if (topP !== undefined) {
+    if (topP != null) {
       throw new Error("topP is not supported when thinking is enabled");
     }
-    if (temperature !== undefined && temperature !== 1) {
+    if (temperature != null && temperature !== 1) {
       throw new Error("temperature is not supported when thinking is enabled");
     }
   }
@@ -102,13 +102,13 @@ export function getSamplingParams(
     return output;
   }
 
-  if (temperature !== undefined) {
+  if (temperature != null) {
     output.temperature = temperature;
   }
-  if (topK !== undefined) {
+  if (topK != null) {
     output.top_k = topK;
   }
-  if (topP !== undefined) {
+  if (topP != null) {
     output.top_p = topP;
   }
 


### PR DESCRIPTION
In `libs/providers/langchain-anthropic/src/utils/params.ts`, the `validateInvocationParamCompatibility` and `getSamplingParams` functions checked `topK`, `topP`, and `temperature` against `undefined` only. When callers explicitly passed `null` for any of these fields (a common pattern in TypeScript when clearing an optional field), the checks would silently skip — allowing null values through to the API and bypassing the compatibility guards for certain model versions and for thinking-enabled invocations.

The fix changes all `!== undefined` / `=== undefined` guards in those functions to use the looser null-check (`!= null` / `== null`), which catches both `null` and `undefined`. The type signatures for `topK`, `topP`, and `temperature` in the `InvocationCompatibilityFields` type are updated accordingly to allow `number | null`. The sampling-param inclusion guards in `getSamplingParams` are updated in the same way so that a null value is not accidentally forwarded to the API call.

Fixes #10709