### PR TITLE
fix(core): advance fakeModel response queue across repeated bindTools() calls

### DIFF
--- a/.changeset/fake-model-bindtools-sequence.md
+++ b/.changeset/fake-model-bindtools-sequence.md
@@ -1,0 +1,14 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): advance fakeModel response queue across repeated bindTools() calls
+
+`FakeBuiltModel.bindTools()` copied the call-index counter by value, so a
+second `bindTools()` on the same base model produced a clone that reset the
+response queue to index 0. In flows like `createAgent`, which re-bind tools
+on every model step, this silently returned the first queued response for
+every step instead of walking through the queue.
+
+The per-instance counter is now derived from the shared `_calls` array, so
+all clones stay in sync with the base model.

--- a/libs/langchain-core/src/testing/fake_model_builder.ts
+++ b/libs/langchain-core/src/testing/fake_model_builder.ts
@@ -60,8 +60,6 @@ export class FakeBuiltModel extends BaseChatModel {
 
   private _tools: (StructuredTool | ToolSpec)[] = [];
 
-  private _callIndex = 0;
-
   private _calls: FakeModelCall[] = [];
 
   /**
@@ -166,7 +164,6 @@ export class FakeBuiltModel extends BaseChatModel {
     next._structuredResponseValue = this._structuredResponseValue;
     next._tools = merged;
     next._calls = this._calls;
-    next._callIndex = this._callIndex;
 
     return next.withConfig({} as BaseChatModelCallOptions);
   }
@@ -205,8 +202,9 @@ export class FakeBuiltModel extends BaseChatModel {
   ): Promise<ChatResult> {
     this._calls.push({ messages: [...messages], options });
 
-    const currentCallIndex = this._callIndex;
-    this._callIndex += 1;
+    // Derive the call index from the shared `_calls` array so that
+    // clones produced by `bindTools()` stay in sync with the base model.
+    const currentCallIndex = this._calls.length - 1;
 
     if (this._alwaysThrowError) {
       throw this._alwaysThrowError;

--- a/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
+++ b/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
@@ -277,6 +277,26 @@ describe("fakeModel", () => {
 
       expect(model.calls).toHaveLength(1);
     });
+
+    test("advances the response queue across repeated bindTools calls", async () => {
+      // Regression for #10723: `createAgent` re-binds tools on every model
+      // step, so each step gets a fresh RunnableBinding. The response queue
+      // must advance across those bindings, not reset back to the first
+      // queued response.
+      const model = fakeModel()
+        .respond(new AIMessage("First."))
+        .respond(new AIMessage("Second."));
+
+      const firstBound = model.bindTools([]);
+      const r1 = await firstBound.invoke([new HumanMessage("first")]);
+      expect(r1.content).toBe("First.");
+
+      const secondBound = model.bindTools([]);
+      const r2 = await secondBound.invoke([new HumanMessage("second")]);
+      expect(r2.content).toBe("Second.");
+
+      expect(model.callCount).toBe(2);
+    });
   });
 
   describe(".structuredResponse()", () => {


### PR DESCRIPTION
Fixes #10723.

`bindTools()` copied the call-index counter by value, so every extra
`bindTools()` call on the same base model produced a clone that reset
the response queue to index 0. `createAgent` re-binds tools on every
model step, so each step silently returned the first queued AIMessage
instead of walking through the queue.

The per-instance counter is now derived from the shared `_calls`
array, so clones stay in sync with the base model. Added a regression
test covering the exact repro from the issue.