### PR TITLE
docs: restore @langchain/community npm homepage target

### DIFF
--- a/libs/community/langchain-community/README.md
+++ b/libs/community/langchain-community/README.md
@@ -1,0 +1,9 @@
+# @langchain/community
+
+The `@langchain/community` package was removed from this repository and is no
+longer published from `main`.
+
+Most compatibility exports that previously depended on `@langchain/community`
+now live in [`@langchain/classic`](../../langchain-classic). For new projects,
+use the current [`langchain`](../../langchain) package and first-party provider
+packages under [`libs/providers`](../../providers).


### PR DESCRIPTION
## What

Adds a small README at `libs/community/langchain-community/` so the published `@langchain/community` npm homepage URL resolves instead of linking to a missing folder.

## Why

The current npm metadata for `@langchain/community@1.1.27` points to `https://github.com/langchain-ai/langchainjs/tree/main/libs/community/langchain-community/`, but that path was removed from `main` in #10600. This leaves npm users on a 404 when following the package homepage.

## How

The package source remains removed. This PR restores only a docs landing page at the old path and directs users to the current `@langchain/classic` compatibility package, the main `langchain` package, and first-party provider packages.

## Issue

Fixes #10720

## Validation

- `npm view @langchain/community homepage version --json` confirmed the published homepage still points at `libs/community/langchain-community/` for version `1.1.27`.
- `git ls-tree -r --name-only origin/main -- libs/community/langchain-community` confirmed the target path is absent on `main`.
- `Test-Path libs/community/langchain-community/README.md` confirmed the path exists locally after the fix.
- `npx oxfmt@0.43.0 --check libs/community/langchain-community/README.md` passed.
- `git diff --check` passed.

Note: I did not run the full workspace checks because this is a markdown-only change, local Node is `v22.12.0` while the repo asks for Node v24, and Corepack failed to launch pnpm due to a package-manager signature key mismatch.
