### PR TITLE
feat(core): add `ToolPolicy` lifecycle hook to `StructuredTool`

### DIFF
--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -63,6 +63,8 @@ import type {
 } from "./types.js";
 import { type JSONSchema, validatesOnlyStrings } from "../utils/json_schema.js";
 import { consumeAsyncGenerator, isAsyncGenerator } from "../runnables/iter.js";
+import { composePolicies } from "./policy.js";
+import type { ToolPolicy, ToolPolicyContext } from "./policy.js";
 
 export type {
   BaseDynamicToolInput,
@@ -89,6 +91,10 @@ export {
 } from "./types.js";
 
 export { ToolInputParsingException };
+
+export type { ToolPolicy, ToolPolicyContext } from "./policy.js";
+
+export { composePolicies } from "./policy.js";
 /**
  * Base class for Tools that accept input of any shape defined by a Zod schema.
  */
@@ -149,6 +155,8 @@ export abstract class StructuredTool<
    */
   defaultConfig?: ToolRunnableConfig;
 
+  policies?: ToolPolicy[];
+
   constructor(fields?: ToolParams) {
     super(fields ?? {});
 
@@ -158,6 +166,7 @@ export abstract class StructuredTool<
     this.defaultConfig = fields?.defaultConfig ?? this.defaultConfig;
     this.metadata = fields?.metadata ?? this.metadata;
     this.extras = fields?.extras ?? this.extras;
+    this.policies = fields?.policies;
   }
 
   protected abstract _call(
@@ -305,8 +314,23 @@ export abstract class StructuredTool<
     );
     delete config.runId;
 
+    const policyCtx: ToolPolicyContext<unknown> = {
+      toolName: this.name,
+      args: parsed,
+      config,
+    };
+
+    const policy =
+      this.policies !== undefined
+        ? composePolicies(...this.policies)
+        : undefined;
+
     let result;
     try {
+      if (policy?.beforeInvoke !== undefined) {
+        await policy.beforeInvoke(policyCtx);
+      }
+
       const raw = await this._call(parsed, runManager, config);
       result = isAsyncGenerator(raw)
         ? await consumeAsyncGenerator(raw, async (chunk) => {
@@ -317,6 +341,10 @@ export abstract class StructuredTool<
             }
           })
         : raw;
+
+      if (policy?.afterInvoke !== undefined) {
+        result = await policy.afterInvoke(result, policyCtx);
+      }
     } catch (e) {
       await runManager?.handleToolError(e);
       throw e;
@@ -620,6 +648,12 @@ export interface ToolWrapperParams<
    * an agent should stop looping.
    */
   returnDirect?: boolean;
+  /**
+   * Policies that run around every invocation of this tool.
+   *
+   * See {@link ToolPolicy}
+   */
+  policies?: ToolPolicy[];
 }
 
 /**

--- a/libs/langchain-core/src/tools/policy.ts
+++ b/libs/langchain-core/src/tools/policy.ts
@@ -1,0 +1,80 @@
+import { ToolRunnableConfig } from "./types";
+
+/**
+ * Context passed to every {@link ToolPolicy} hook.
+ */
+export interface ToolPolicyContext<TIn> {
+  /**
+   * The name registered on the tool.
+   */
+  toolName: string;
+
+  /**
+   * Schema-validated input the tool will receive (or has just received, for `afterInvoke`).
+   */
+  args: TIn;
+
+  /**
+   * Merged {@link ToolRunnableConfig} for this invocation. Runtime data (e.g. permission
+   * rules) lives in `config.configurable`.
+   */
+  config: ToolRunnableConfig;
+}
+
+/**
+ * Generic lifecycle hook that runs around tool invocation.
+ *
+ * `ToolPolicy` is intentionally minimal. It does not attempt to model
+ * approval flows or interrupt-style pauses — for those, use agent-level
+ * middleware. Policies are for concerns that travel with the tool
+ * itself, regardless of caller.
+ *
+ * @typeParam TIn - The parsed input type (schema output).
+ * @typeParam TOut - The tool's raw output type.
+ */
+export interface ToolPolicy<TIn = unknown, TOut = unknown> {
+  /**
+   * Runs after schema validation, before `_call`. Throwing aborts the invocation;
+   * the thrown error flows through the same path as runtime errors (callbacks, error
+   * tool messages).
+   */
+  beforeInvoke?: (ctx: ToolPolicyContext<TIn>) => void | Promise<void>;
+
+  /**
+   * Runs after `_call` succeeds. Return a transformed output if needed; return the
+   * input unchanged otherwise.
+   */
+  afterInvoke?: (
+    output: TOut,
+    ctx: ToolPolicyContext<TIn>
+  ) => TOut | Promise<TOut>;
+}
+
+/**
+ * Compose multiple policies into a single policy.
+ *
+ * Both `beforeInvoke` and `afterInvoke` run in forward order (first policy first).
+ */
+export function composePolicies<TIn, TOut>(
+  ...policies: ToolPolicy<TIn, TOut>[]
+): ToolPolicy<TIn, TOut> {
+  const beforeInvoke = async (ctx: ToolPolicyContext<TIn>) => {
+    for (const policy of policies) {
+      if (policy.beforeInvoke !== undefined) {
+        await policy.beforeInvoke(ctx);
+      }
+    }
+  };
+
+  const afterInvoke = async (output: TOut, ctx: ToolPolicyContext<TIn>) => {
+    let current = output;
+    for (const policy of policies) {
+      if (policy.afterInvoke !== undefined) {
+        current = await policy.afterInvoke(current, ctx);
+      }
+    }
+    return current;
+  };
+
+  return { beforeInvoke, afterInvoke };
+}

--- a/libs/langchain-core/src/tools/tests/policy.test.ts
+++ b/libs/langchain-core/src/tools/tests/policy.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod/v3";
+
+import { tool, composePolicies } from "../index.js";
+import type { ToolPolicy } from "../policy.js";
+
+function createAdder(policies?: ToolPolicy[]) {
+  return tool(
+    (input: { a: number; b: number }) => {
+      return input.a + input.b;
+    },
+    {
+      name: "adder",
+      description: "Adds two numbers",
+      schema: z.object({ a: z.number(), b: z.number() }),
+      ...(policies !== undefined ? { policies } : {}),
+    }
+  );
+}
+
+describe("ToolPolicy", () => {
+  describe("beforeInvoke", () => {
+    it("runs before _call and can read args", async () => {
+      const seen: unknown[] = [];
+      const adder = createAdder([
+        {
+          beforeInvoke: (ctx) => {
+            seen.push(ctx.args);
+          },
+        },
+      ]);
+
+      const result = await adder.invoke({ a: 1, b: 2 });
+      expect(result).toBe(3);
+      expect(seen).toEqual([{ a: 1, b: 2 }]);
+    });
+
+    it("aborts _call when it throws", async () => {
+      const callSpy = vi.fn();
+      const failing = tool(
+        (input: { a: number; b: number }) => {
+          callSpy();
+          return input.a + input.b;
+        },
+        {
+          name: "adder",
+          description: "Adds two numbers",
+          schema: z.object({ a: z.number(), b: z.number() }),
+          policies: [
+            {
+              beforeInvoke: () => {
+                throw new Error("denied");
+              },
+            },
+          ],
+        }
+      );
+
+      await expect(failing.invoke({ a: 1, b: 2 })).rejects.toThrow("denied");
+      expect(callSpy).not.toHaveBeenCalled();
+    });
+
+    it("receives configurable from invoke config", async () => {
+      let captured: Record<string, unknown> | undefined;
+      const adder = createAdder([
+        {
+          beforeInvoke: (ctx) => {
+            captured = ctx.config.configurable;
+          },
+        },
+      ]);
+
+      await adder.invoke(
+        { a: 1, b: 2 },
+        { configurable: { "test-key": "test-value" } }
+      );
+      expect(captured).toMatchObject({ "test-key": "test-value" });
+    });
+  });
+
+  describe("afterInvoke", () => {
+    it("transforms tool output", async () => {
+      const adder = createAdder([
+        {
+          afterInvoke: (output) => {
+            return (output as number) * 10;
+          },
+        },
+      ]);
+
+      const result = await adder.invoke({ a: 1, b: 2 });
+      expect(result).toBe(30);
+    });
+
+    it("receives the original args in context", async () => {
+      let captured: unknown;
+      const adder = createAdder([
+        {
+          afterInvoke: (output, ctx) => {
+            captured = ctx.args;
+            return output;
+          },
+        },
+      ]);
+
+      await adder.invoke({ a: 5, b: 7 });
+      expect(captured).toEqual({ a: 5, b: 7 });
+    });
+
+    it("aborts when it throws", async () => {
+      const adder = createAdder([
+        {
+          afterInvoke: () => {
+            throw new Error("filter failed");
+          },
+        },
+      ]);
+
+      await expect(adder.invoke({ a: 1, b: 2 })).rejects.toThrow(
+        "filter failed"
+      );
+    });
+  });
+
+  describe("no policies", () => {
+    it("behaves normally without policies", async () => {
+      const adder = createAdder();
+      const result = await adder.invoke({ a: 3, b: 4 });
+      expect(result).toBe(7);
+    });
+  });
+
+  describe("multiple policies", () => {
+    it("runs beforeInvoke in forward order", async () => {
+      const order: string[] = [];
+      const adder = createAdder([
+        {
+          beforeInvoke: () => {
+            order.push("first");
+          },
+        },
+        {
+          beforeInvoke: () => {
+            order.push("second");
+          },
+        },
+        {
+          beforeInvoke: () => {
+            order.push("third");
+          },
+        },
+      ]);
+
+      await adder.invoke({ a: 1, b: 2 });
+      expect(order).toEqual(["first", "second", "third"]);
+    });
+
+    it("runs afterInvoke in forward order", async () => {
+      const order: string[] = [];
+      const adder = createAdder([
+        {
+          afterInvoke: (out) => {
+            order.push("first");
+            return out;
+          },
+        },
+        {
+          afterInvoke: (out) => {
+            order.push("second");
+            return out;
+          },
+        },
+        {
+          afterInvoke: (out) => {
+            order.push("third");
+            return out;
+          },
+        },
+      ]);
+
+      await adder.invoke({ a: 1, b: 2 });
+      expect(order).toEqual(["first", "second", "third"]);
+    });
+
+    it("chains afterInvoke transformations", async () => {
+      const adder = createAdder([
+        { afterInvoke: (out) => (out as number) + 100 },
+        { afterInvoke: (out) => (out as number) * 2 },
+      ]);
+
+      const result = await adder.invoke({ a: 1, b: 2 });
+      // _call returns 3, first adds 100 → 103, second doubles → 206
+      expect(result).toBe(206);
+    });
+
+    it("stops on beforeInvoke throw from any policy", async () => {
+      const callSpy = vi.fn();
+      const adder = createAdder([
+        {
+          beforeInvoke: () => {
+            callSpy();
+          },
+        },
+        {
+          beforeInvoke: () => {
+            throw new Error("blocked");
+          },
+        },
+        {
+          beforeInvoke: () => {
+            callSpy();
+          },
+        },
+      ]);
+
+      await expect(adder.invoke({ a: 1, b: 2 })).rejects.toThrow("blocked");
+      expect(callSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips undefined hooks gracefully", async () => {
+      const adder = createAdder([{}, { beforeInvoke: () => {} }, {}]);
+
+      const result = await adder.invoke({ a: 2, b: 3 });
+      expect(result).toBe(5);
+    });
+  });
+
+  describe("composePolicies", () => {
+    it("composes into a single policy that runs in forward order", async () => {
+      const order: string[] = [];
+      const composed = composePolicies(
+        {
+          beforeInvoke: () => {
+            order.push("first");
+          },
+        },
+        {
+          beforeInvoke: () => {
+            order.push("second");
+          },
+        }
+      );
+
+      const adder = createAdder([composed]);
+      await adder.invoke({ a: 1, b: 2 });
+      expect(order).toEqual(["first", "second"]);
+    });
+
+    it("chains afterInvoke transformations in forward order", async () => {
+      const composed = composePolicies(
+        { afterInvoke: (out) => (out as number) + 100 },
+        { afterInvoke: (out) => (out as number) * 2 }
+      );
+
+      const adder = createAdder([composed]);
+      const result = await adder.invoke({ a: 1, b: 2 });
+      expect(result).toBe(206);
+    });
+  });
+});

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -477,6 +477,159 @@ describe("DynamicTool", () => {
   });
 });
 
+describe("tool policies integration", () => {
+  test("beforeInvoke denial still produces handleToolError callback", async () => {
+    let errorHandled = false;
+
+    const myTool = tool((_) => "should not run", {
+      name: "guarded",
+      description: "A guarded tool",
+      schema: z.object({ path: z.string() }),
+      policies: [
+        {
+          beforeInvoke: () => {
+            throw new Error("permission denied");
+          },
+        },
+      ],
+    });
+
+    await expect(
+      myTool.invoke(
+        { path: "/secrets/key.txt" },
+        {
+          callbacks: [
+            {
+              handleToolError(err: unknown) {
+                errorHandled = true;
+                expect((err as Error).message).toBe("permission denied");
+              },
+            },
+          ],
+        }
+      )
+    ).rejects.toThrow("permission denied");
+
+    expect(errorHandled).toBe(true);
+  });
+
+  test("afterInvoke transforms output before ToolMessage wrapping", async () => {
+    const toolCall = {
+      id: "testid",
+      args: { location: "San Francisco" },
+      name: "weather",
+      type: "tool_call",
+    } as const;
+
+    const weatherTool = tool((_) => "72F", {
+      name: "weather",
+      description: "Get weather",
+      schema: z.object({ location: z.string() }),
+      policies: [
+        {
+          afterInvoke: (output) => `FILTERED: ${output}`,
+        },
+      ],
+    });
+
+    const result = await weatherTool.invoke(toolCall);
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect(result.content).toBe("FILTERED: 72F");
+  });
+
+  test("policies work with content_and_artifact responseFormat", async () => {
+    const toolCall = {
+      id: "testid",
+      args: { location: "San Francisco" },
+      name: "weather",
+      type: "tool_call",
+    } as const;
+
+    const weatherTool = tool((input) => ["sunny", { city: input.location }], {
+      name: "weather",
+      description: "Get weather",
+      schema: z.object({ location: z.string() }),
+      responseFormat: "content_and_artifact",
+      policies: [
+        {
+          beforeInvoke: (ctx) => {
+            if ((ctx.args as { location: string }).location === "blocked") {
+              throw new Error("blocked location");
+            }
+          },
+        },
+      ],
+    });
+
+    const result = await weatherTool.invoke(toolCall);
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect(result.content).toBe("sunny");
+
+    await expect(
+      weatherTool.invoke({
+        id: "testid2",
+        args: { location: "blocked" },
+        name: "weather",
+        type: "tool_call",
+      })
+    ).rejects.toThrow("blocked location");
+  });
+
+  test("policies work with DynamicStructuredTool class", async () => {
+    const seen: unknown[] = [];
+
+    const myTool = new DynamicStructuredTool({
+      name: "echo",
+      description: "Echo input",
+      schema: z.object({ msg: z.string() }),
+      policies: [
+        {
+          beforeInvoke: (ctx) => {
+            seen.push(ctx.args);
+          },
+        },
+      ],
+      func: async (input) => input.msg,
+    });
+
+    const result = await myTool.invoke({ msg: "hello" });
+    expect(result).toBe("hello");
+    expect(seen).toEqual([{ msg: "hello" }]);
+  });
+
+  test("policies work with generator tools", async () => {
+    const order: string[] = [];
+
+    const genTool = tool(
+      async function* (input) {
+        yield { status: "working" };
+        return `done: ${input.x}`;
+      },
+      {
+        name: "gen",
+        description: "Generator tool",
+        schema: z.object({ x: z.number() }),
+        policies: [
+          {
+            beforeInvoke: () => {
+              order.push("before");
+            },
+            afterInvoke: (output) => {
+              order.push("after");
+              return output;
+            },
+          },
+        ],
+      }
+    );
+
+    const result = await genTool.invoke({ x: 42 });
+    expect(result).toBe("done: 42");
+    expect(order).toEqual(["before", "after"]);
+  });
+});
+
 describe("tool()", () => {
   it("should propagate extras to the tool instance", () => {
     const testTool = tool(

--- a/libs/langchain-core/src/tools/types.ts
+++ b/libs/langchain-core/src/tools/types.ts
@@ -1,3 +1,4 @@
+import type { ToolPolicy } from "./policy.js";
 import type { ZodV3Like } from "../utils/types/zod.js";
 import { CallbackManagerForToolRun } from "../callbacks/manager.js";
 import type {
@@ -115,6 +116,11 @@ export interface ToolParams extends BaseLangChainParams {
    * standard tool fields.
    */
   extras?: Record<string, unknown>;
+  /**
+   * Optional policies that run around every invocation of this tool.
+   * See {@link ToolPolicy}.
+   */
+  policies?: ToolPolicy[];
 }
 
 export type ToolRunnableConfig<


### PR DESCRIPTION
### Summary
 Adds a generic `ToolPolicy` interface to `@langchain/core` that allows lifecycle hooks (`beforeInvoke`, `afterInvoke`) to be attached directly to tools via a `policies` field. Policies run around `_call` inside `StructuredTool.call()` — after schema validation, before output formatting.

This enables tool-scoped concerns like permission enforcement, rate limiting, and allow-list checks that need to fire regardless of how the tool is invoked (e.g. directly by an agent or transitively via programmatic tool calling in a sandbox).

Also exports a `composePolicies` utility for combining multiple policies into one.

### Tests
- `policy.test.ts`: `beforeInvoke` (runs before `_call`, aborts on throw, reads configurable), `afterInvoke` (transforms output, receives args, aborts on throw), no-policy passthrough, multiple policies (forward ordering for both hooks, early abort, undefined hook skipping), `composePolicies` (forward ordering, chained transformations)
- `tools.test.ts`: `handleToolError` callback fires on `beforeInvoke` throw, `afterInvoke` transforms before ToolMessage wrapping, policies with `content_and_artifact` responseFormat, `DynamicStructuredTool` class construction, generator tools
