### PR TITLE
feat(anthropic): support strict tool calling for custom tools

### DIFF
--- a/.changeset/anthropic-strict-tool-calling.md
+++ b/.changeset/anthropic-strict-tool-calling.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": minor
+---
+
+feat(anthropic): support strict tool calling for custom tools

--- a/libs/providers/langchain-anthropic/README.md
+++ b/libs/providers/langchain-anthropic/README.md
@@ -75,6 +75,91 @@ const response = await model.stream({
 });
 ```
 
+### Strict Tool Use
+
+Anthropic supports [strict tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use), which uses grammar-constrained sampling to guarantee that Claude's tool inputs match your schema (no missing required fields, no wrong types). Enable it on a per-call, per-binding, or per-tool basis.
+
+**Per-call** with `bindTools` (applies to every tool in the binding):
+
+```typescript
+import { ChatAnthropic } from "@langchain/anthropic";
+import { tool } from "langchain";
+import { z } from "zod";
+
+const getWeather = tool(async ({ location }) => `Weather in ${location}`, {
+  name: "get_weather",
+  description: "Get the current weather in a given location",
+  schema: z.object({ location: z.string() }),
+});
+
+const model = new ChatAnthropic({ model: "claude-opus-4-7" });
+
+const response = await model
+  .bindTools([getWeather], { strict: true })
+  .invoke("What's the weather in San Francisco?");
+```
+
+**Default for a tool-bound model** with `withConfig` (applies to every subsequent call on the bound model):
+
+```typescript
+const strictModelWithTools = model
+  .bindTools([getWeather])
+  .withConfig({ strict: true });
+
+const response = await strictModelWithTools.invoke(
+  "What's the weather in San Francisco?"
+);
+```
+
+**Per-tool** with `extras.strict` for mixed strict/non-strict tool sets:
+
+```typescript
+const lookupCustomer = tool(async ({ id }) => `...`, {
+  name: "lookup_customer",
+  description: "Look up a customer by id",
+  schema: z.object({ id: z.string() }),
+  // Strict on this critical tool only.
+  extras: { strict: true },
+});
+
+const searchDocs = tool(async ({ query }) => `...`, {
+  name: "search_docs",
+  description: "Free-form documentation search",
+  schema: z.object({ query: z.string() }),
+});
+
+const response = await model
+  .bindTools([lookupCustomer, searchDocs])
+  .invoke("Find customer 12345 and any onboarding docs");
+```
+
+**With `withStructuredOutput`** to guarantee schema-conforming output:
+
+```typescript
+const Weather = z.object({
+  location: z.string(),
+  temperature_celsius: z.number(),
+});
+
+const structured = model.withStructuredOutput(Weather, {
+  method: "functionCalling",
+  strict: true,
+});
+
+const result = await structured.invoke("What's the weather in San Francisco?");
+```
+
+Precedence when multiple sources are set:
+
+1. Per-call `strict` (e.g. `bindTools(..., { strict })`, `withConfig({ strict })`, or `withStructuredOutput(..., { strict })`)
+2. Per-tool `strict` (e.g. `extras.strict`, `function.strict` on OpenAI-shaped tools, or `strict` on raw Anthropic-shaped tools)
+
+In other words, per-tool acts as a fallback default for tools that opt in; if the call already specifies `strict`, that value wins for every tool in the request.
+
+> **Note on `withStructuredOutput` methods:** Anthropic's `strict` is a property of a tool definition, so it only applies when `method: "functionCalling"` (the default), where the structured output is produced by a strict tool call.
+>
+> The other method, `"jsonSchema"`, uses Anthropic's [native structured outputs](https://docs.claude.com/en/docs/build-with-claude/structured-outputs) and does not accept `strict`. Passing `strict` together with `"jsonSchema"` or `"jsonMode"` throws, to avoid silently dropping the option. If you want strict-validated output, stick with the default `functionCalling` method.
+
 ## Tools
 
 This package provides LangChain-compatible wrappers for Anthropic's built-in tools. These tools can be bound to `ChatAnthropic` using `bindTools()` or any [`ReactAgent`](https://docs.langchain.com/oss/javascript/langchain/agents).

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -183,6 +183,19 @@ export interface ChatAnthropicCallOptions
    * @see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
    */
   cache_control?: AnthropicCacheControl;
+
+  /**
+   * If `true`, model output is guaranteed to exactly match the JSON Schema
+   * provided in the tool definition. If `true`, the input schema will also be
+   * validated according to
+   * https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use.
+   *
+   * If `false`, input schema will not be validated and model output will not
+   * be validated.
+   *
+   * If `undefined`, `strict` argument will not be passed to the model.
+   */
+  strict?: boolean;
 }
 
 function _toolsInParams(
@@ -1096,10 +1109,12 @@ export class ChatAnthropicMessages<
    * Formats LangChain StructuredTools to AnthropicTools.
    *
    * @param {ChatAnthropicCallOptions["tools"]} tools The tools to format
+   * @param fields Optional `strict` flag applied to every formatted custom tool.
    * @returns {AnthropicTool[] | undefined} The formatted tools, or undefined if none are passed.
    */
   formatStructuredToolToAnthropic(
-    tools: ChatAnthropicCallOptions["tools"]
+    tools: ChatAnthropicCallOptions["tools"],
+    fields?: { strict?: boolean }
   ): Anthropic.Messages.ToolUnion[] | undefined {
     if (!tools) {
       return undefined;
@@ -1113,24 +1128,44 @@ export class ChatAnthropicMessages<
         return tool;
       }
       if (isAnthropicTool(tool)) {
+        if (fields?.strict !== undefined) {
+          return {
+            ...tool,
+            strict: fields.strict,
+          };
+        }
         return tool;
       }
       if (isOpenAITool(tool)) {
+        // LangChain's OpenAI tool type doesn't surface the optional `strict`
+        // flag that the OpenAI API itself supports on function definitions,
+        // so we read it through a runtime check rather than a type assertion.
+        const functionStrict =
+          "strict" in tool.function && typeof tool.function.strict === "boolean"
+            ? tool.function.strict
+            : undefined;
+        const strict = fields?.strict ?? functionStrict;
         return {
           name: tool.function.name,
           description: tool.function.description,
           input_schema: tool.function
             .parameters as Anthropic.Messages.Tool.InputSchema,
+          ...(strict !== undefined ? { strict } : {}),
         };
       }
       if (isLangChainTool(tool)) {
+        const { strict: extrasStrict, ...restExtras } = tool.extras
+          ? AnthropicToolExtrasSchema.parse(tool.extras)
+          : {};
+        const strict = fields?.strict ?? extrasStrict;
         return {
           name: tool.name,
           description: tool.description,
           input_schema: (isInteropZodSchema(tool.schema)
             ? toJsonSchema(tool.schema)
             : tool.schema) as Anthropic.Messages.Tool.InputSchema,
-          ...(tool.extras ? AnthropicToolExtrasSchema.parse(tool.extras) : {}),
+          ...restExtras,
+          ...(strict !== undefined ? { strict } : {}),
         };
       }
       throw new Error(
@@ -1148,7 +1183,9 @@ export class ChatAnthropicMessages<
     kwargs?: Partial<CallOptions>
   ): Runnable<BaseLanguageModelInput, AIMessageChunk, CallOptions> {
     return this.withConfig({
-      tools: this.formatStructuredToolToAnthropic(tools),
+      tools: this.formatStructuredToolToAnthropic(tools, {
+        strict: kwargs?.strict,
+      }),
       ...kwargs,
     } as Partial<CallOptions>);
   }
@@ -1205,7 +1242,9 @@ export class ChatAnthropicMessages<
       stop_sequences: options?.stop ?? this.stopSequences,
       stream: this.streaming,
       max_tokens: this.maxTokens,
-      tools: this.formatStructuredToolToAnthropic(options?.tools),
+      tools: this.formatStructuredToolToAnthropic(options?.tools, {
+        strict: options?.strict,
+      }),
       tool_choice,
       thinking: this.thinking,
       context_management: this.contextManagement,
@@ -1632,6 +1671,12 @@ export class ChatAnthropicMessages<
     };
     let method = config?.method ?? "functionCalling";
 
+    if (config?.strict !== undefined && method !== "functionCalling") {
+      throw new Error(
+        `Argument \`strict\` is only supported for \`method\` = "functionCalling" on Anthropic models. Got method = "${method}".`
+      );
+    }
+
     if (method === "jsonMode") {
       console.warn(
         `"jsonMode" is not supported for Anthropic models. Falling back to "jsonSchema".`
@@ -1712,6 +1757,7 @@ export class ChatAnthropicMessages<
             kwargs: { method: "functionCalling" },
             schema: toJsonSchema(schema),
           },
+          ...(config?.strict !== undefined ? { strict: config.strict } : {}),
         } as Partial<CallOptions>);
 
         const raiseIfNoToolCalls = (message: AIMessageChunk) => {
@@ -1734,6 +1780,7 @@ export class ChatAnthropicMessages<
             kwargs: { method: "functionCalling" },
             schema: toJsonSchema(schema),
           },
+          ...(config?.strict !== undefined ? { strict: config.strict } : {}),
         } as Partial<CallOptions>);
       }
     } else {

--- a/libs/providers/langchain-anthropic/src/tests/chat_models-strict.int.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models-strict.int.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import { tool } from "@langchain/core/tools";
+import { HumanMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import { ChatAnthropic } from "../chat_models.js";
+
+const weatherToolSchema = z.object({
+  location: z.string().describe("The city and state, e.g. San Francisco, CA"),
+  units: z
+    .enum(["celsius", "fahrenheit"])
+    .describe("Preferred temperature units."),
+});
+
+function fakeWeather({
+  location,
+  units,
+}: z.infer<typeof weatherToolSchema>): string {
+  const celsius = 22;
+  const isCelsius = units === "celsius";
+  const value = isCelsius ? celsius : (celsius * 9) / 5 + 32;
+  return `Weather in ${location}: ${value}°${isCelsius ? "C" : "F"}`;
+}
+
+const getWeather = tool(fakeWeather, {
+  name: "get_weather",
+  description: "Get the current weather in a given location.",
+  schema: weatherToolSchema,
+});
+
+const strictGetWeather = tool(fakeWeather, {
+  name: "get_weather",
+  description: "Get the current weather in a given location.",
+  schema: weatherToolSchema,
+  extras: { strict: true },
+});
+
+const weatherReportSchema = z.object({
+  location: z.string().describe("The city and state, e.g. San Francisco, CA"),
+  temperature: z.number().describe("Numeric temperature value."),
+  units: z.enum(["celsius", "fahrenheit"]).describe("Temperature units."),
+  conditions: z
+    .enum(["sunny", "cloudy", "rainy", "snowy"])
+    .describe("Current weather conditions."),
+});
+
+const model = new ChatAnthropic({
+  model: "claude-haiku-4-5-20251001",
+});
+
+function expectStrictWeatherCall(
+  toolCall: { name: string; args: unknown } | undefined
+): asserts toolCall is { name: string; args: unknown } {
+  if (!toolCall) expect.fail("expected a tool call");
+  expect(toolCall.name).toBe("get_weather");
+  weatherToolSchema.parse(toolCall.args);
+}
+
+describe("ChatAnthropic strict tool calling", () => {
+  test("strict via .bindTools(tools, { strict: true })", async () => {
+    const modelWithTools = model.bindTools([getWeather], { strict: true });
+    const response = await modelWithTools.invoke(
+      "What's the weather in San Francisco in fahrenheit?"
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("strict via .bindTools(...).withConfig({ strict: true })", async () => {
+    const modelWithTools = model
+      .bindTools([getWeather])
+      .withConfig({ strict: true });
+    const response = await modelWithTools.invoke(
+      "What's the weather in Paris in celsius?"
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("strict via .withConfig({ tools, strict: true })", async () => {
+    const modelWithTools = model.withConfig({
+      tools: [getWeather],
+      strict: true,
+    });
+    const response = await modelWithTools.invoke(
+      "What's the weather in London in celsius?"
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("strict via .invoke(input, { strict: true })", async () => {
+    const modelWithTools = model.bindTools([getWeather]);
+    const response = await modelWithTools.invoke(
+      "What's the weather in Tokyo in celsius?",
+      { strict: true }
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("strict via tool() extras.strict", async () => {
+    const modelWithTools = model.bindTools([strictGetWeather]);
+    const response = await modelWithTools.invoke(
+      "What's the weather in Berlin in celsius?"
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("per-call strict=false overrides tool() extras.strict=true", async () => {
+    const modelWithTools = model.bindTools([strictGetWeather], {
+      strict: false,
+    });
+    const response = await modelWithTools.invoke(
+      "What's the weather in Madrid in fahrenheit?"
+    );
+    expectStrictWeatherCall(response.tool_calls?.[0]);
+  });
+
+  test("strict via .withStructuredOutput(schema, { strict: true })", async () => {
+    const structured = model.withStructuredOutput(weatherReportSchema, {
+      method: "functionCalling",
+      strict: true,
+    });
+    const result = await structured.invoke(
+      "What's the weather in San Francisco in fahrenheit?"
+    );
+    weatherReportSchema.parse(result);
+  });
+
+  test("strict tool call composes with strict structured output", async () => {
+    const modelWithTools = model.bindTools([getWeather], { strict: true });
+    const userQuery = new HumanMessage(
+      "What's the weather in San Francisco in fahrenheit?"
+    );
+    const toolResponse = await modelWithTools.invoke([userQuery]);
+    const toolCall = toolResponse.tool_calls?.[0];
+    expectStrictWeatherCall(toolCall);
+
+    const toolOutput = await getWeather.invoke(toolCall);
+    expect(toolOutput.content).toContain("San Francisco");
+
+    const structured = model.withStructuredOutput(weatherReportSchema, {
+      method: "functionCalling",
+      strict: true,
+    });
+    const result = await structured.invoke([
+      userQuery,
+      toolResponse,
+      toolOutput,
+    ]);
+    weatherReportSchema.parse(result);
+  });
+});

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -722,6 +722,275 @@ describe("Tool extras validation", () => {
   });
 });
 
+describe("strict tool calling", () => {
+  const weatherTool = tool(
+    async (input: { location: string }) => `Weather in ${input.location}`,
+    {
+      name: "get_current_weather",
+      description: "Get the current weather in a location",
+      schema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+    }
+  );
+
+  const strictWeatherTool = tool(
+    async (input: { location: string }) => `Weather in ${input.location}`,
+    {
+      name: "get_current_weather",
+      description: "Get the current weather in a location",
+      schema: z.object({ location: z.string() }),
+      extras: { strict: true },
+    }
+  );
+
+  const openAIShapedWeatherTool = {
+    type: "function" as const,
+    function: {
+      name: "get_current_weather",
+      description: "Get the current weather in a location",
+      parameters: {
+        type: "object",
+        properties: { location: { type: "string" } },
+        required: ["location"],
+      },
+      strict: true,
+    },
+  };
+
+  const anthropicShapedWeatherTool = {
+    name: "get_current_weather",
+    description: "Get the current weather in a location",
+    input_schema: {
+      type: "object" as const,
+      properties: { location: { type: "string" } },
+      required: ["location"],
+    },
+    strict: true,
+  };
+
+  type MockFetch = ReturnType<
+    typeof vi.fn<
+      (url: string | URL | Request, options?: RequestInit) => Promise<Response>
+    >
+  >;
+
+  function makeMockFetch(): MockFetch {
+    const mockFetch =
+      vi.fn<
+        (
+          url: string | URL | Request,
+          options?: RequestInit
+        ) => Promise<Response>
+      >();
+    mockFetch.mockImplementation((_url, _options) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "msg_test",
+            type: "message",
+            role: "assistant",
+            model: "claude-haiku-4-5-20251001",
+            // `tool_use` shape (not text) is required so `withStructuredOutput`
+            // can parse a tool call out of the response.
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_test",
+                name: "get_current_weather",
+                input: { location: "test" },
+              },
+            ],
+            stop_reason: "tool_use",
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        )
+      )
+    );
+    return mockFetch;
+  }
+
+  function makeMockedModel(): { model: ChatAnthropic; mockFetch: MockFetch } {
+    const mockFetch = makeMockFetch();
+    const model = new ChatAnthropic({
+      model: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+      clientOptions: { fetch: mockFetch },
+      maxRetries: 0,
+    });
+    return { model, mockFetch };
+  }
+
+  function getRequestTools(
+    mockFetch: MockFetch
+  ): Array<Record<string, unknown>> {
+    expect(mockFetch).toHaveBeenCalled();
+    const [, init] = mockFetch.mock.calls[0];
+    if (!init || !init.body) {
+      throw new Error("Body not found in request.");
+    }
+    const body = JSON.parse(init.body as string) as {
+      tools: Array<Record<string, unknown>>;
+    };
+    return body.tools;
+  }
+
+  test("applies strict from .bindTools call args", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([weatherTool], { strict: true });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("applies strict from .withConfig call options", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.withConfig({
+      tools: [weatherTool],
+      strict: true,
+    });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("applies strict from .bindTools(...).withConfig({ strict })", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model
+      .bindTools([weatherTool])
+      .withConfig({ strict: true });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("applies strict from per-call invoke options", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([weatherTool]);
+    await modelWithTools.invoke("What's the weather like?", { strict: true });
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("per-call invoke strict overrides .bindTools strict", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([weatherTool], { strict: true });
+    await modelWithTools.invoke("What's the weather like?", { strict: false });
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", false);
+  });
+
+  test("applies strict from .withStructuredOutput config", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.withStructuredOutput(
+      z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      { strict: true, method: "functionCalling" }
+    );
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("omits strict when not provided anywhere", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([weatherTool]);
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).not.toHaveProperty("strict");
+  });
+
+  test("omits strict when not passed in .withStructuredOutput", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.withStructuredOutput(
+      z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      { method: "functionCalling" }
+    );
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).not.toHaveProperty("strict");
+  });
+
+  test("per-tool extras.strict applies to that tool only", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const looseSearchTool = tool(
+      async (input: { query: string }) => `Results for ${input.query}`,
+      {
+        name: "search",
+        description: "Search the web",
+        schema: z.object({ query: z.string() }),
+      }
+    );
+    const modelWithTools = model.bindTools([
+      strictWeatherTool,
+      looseSearchTool,
+    ]);
+    await modelWithTools.invoke("What's the weather like?");
+    const tools = getRequestTools(mockFetch);
+    const strictTool = tools.find((t) => t.name === "get_current_weather");
+    const looseTool = tools.find((t) => t.name === "search");
+    expect(strictTool).toHaveProperty("strict", true);
+    expect(looseTool).not.toHaveProperty("strict");
+  });
+
+  test("per-tool function.strict applies on OpenAI-shaped tools", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([openAIShapedWeatherTool]);
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("per-call strict overrides OpenAI-shaped tool's function.strict", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([openAIShapedWeatherTool], {
+      strict: false,
+    });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", false);
+  });
+
+  test("per-tool native strict applies on Anthropic-shaped tools", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([anthropicShapedWeatherTool]);
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", true);
+  });
+
+  test("per-call strict overrides Anthropic-shaped tool's own strict", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([anthropicShapedWeatherTool], {
+      strict: false,
+    });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", false);
+  });
+
+  test("per-call strict overrides per-tool extras.strict", async () => {
+    const { model, mockFetch } = makeMockedModel();
+    const modelWithTools = model.bindTools([strictWeatherTool], {
+      strict: false,
+    });
+    await modelWithTools.invoke("What's the weather like?");
+    expect(getRequestTools(mockFetch)[0]).toHaveProperty("strict", false);
+  });
+
+  test.each([["jsonSchema"], ["jsonMode"]])(
+    "withStructuredOutput throws when strict is set with method = %s",
+    (method) => {
+      const model = new ChatAnthropic({
+        model: "claude-haiku-4-5-20251001",
+        anthropicApiKey: "testing",
+      });
+      expect(() =>
+        model.withStructuredOutput(z.object({ location: z.string() }), {
+          strict: true,
+          method: method as "jsonSchema" | "jsonMode",
+        })
+      ).toThrow(/strict.*functionCalling/);
+    }
+  );
+});
+
 describe("formatStructuredToolToAnthropic", () => {
   test("returns undefined when tools is undefined", () => {
     const model = new ChatAnthropic({

--- a/libs/providers/langchain-anthropic/src/utils/tools.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tools.ts
@@ -43,6 +43,7 @@ export const AnthropicToolExtrasSchema = z.object({
   defer_loading: z.boolean().optional(),
   input_examples: z.array(z.unknown()).optional(),
   allowed_callers: z.array(z.unknown()).optional(),
+  strict: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Adds `strict` tool calling support to `@langchain/anthropic`. Mirrors the user-facing shape of `@langchain/openai` where it makes sense, but scoped to call options + per-tool defaults (no constructor capability flag). Setting `strict: true` opts a tool definition into Anthropic's [grammar-constrained sampling](https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use), guaranteeing tool inputs match the provided JSON Schema.

### Public API additions

- `ChatAnthropicCallOptions.strict?: boolean`. Pass via:
  - `model.bindTools(tools, { strict: true })`
  - `model.withConfig({ strict: true })` (or chained: `model.bindTools(tools).withConfig({ strict: true })`)
  - `model.invoke(input, { strict: true })`
  - `model.withStructuredOutput(schema, { method: "functionCalling", strict: true })`
- `AnthropicToolExtrasSchema.strict?: boolean`. Per-tool default for LangChain tools, alongside `cache_control` / `defer_loading` / `input_examples` / `allowed_callers`.

### Precedence

1. Per-call `strict` (any of the call options above).
2. Per-tool `strict`: `extras.strict` (LangChain shape), `function.strict` (OpenAI shape), or native `strict` (Anthropic shape).

If neither is set, `strict` is omitted from the request and Anthropic's default (non-strict) behavior applies.

### Safety guard for `withStructuredOutput`

Anthropic's `strict` is a property of a tool definition, so it only applies under `method: "functionCalling"`. The `"jsonSchema"` path uses Anthropic's [native structured outputs](https://docs.claude.com/en/docs/build-with-claude/structured-outputs) and does not accept `strict`. `withStructuredOutput` throws when `strict` is combined with `"jsonSchema"` or `"jsonMode"` instead of silently dropping it.

### Documentation

Added a "Strict Tool Use" section to `libs/providers/langchain-anthropic/README.md` covering per-call, bound-model default, per-tool, and `withStructuredOutput` usage, plus precedence and the `jsonSchema`/`jsonMode` guard.

Fixes #10731.

## Test plan

### Unit tests (`chat_models.test.ts`, mocked fetch)

The mocked fetch returns a valid Anthropic `Messages` response with a `tool_use` block, so `.invoke()` succeeds and tests assert directly on the captured request body.

**Single-source coverage**
- [x] `applies strict from .bindTools call args`
- [x] `applies strict from .withConfig call options`
- [x] `applies strict from .bindTools(...).withConfig({ strict })`
- [x] `applies strict from per-call invoke options`
- [x] `applies strict from .withStructuredOutput config`
- [x] `per-tool extras.strict applies to that tool only` (LangChain shape)
- [x] `per-tool function.strict applies on OpenAI-shaped tools`
- [x] `per-tool native strict applies on Anthropic-shaped tools`

**Baseline / negative**
- [x] `omits strict when not provided anywhere`
- [x] `omits strict when not passed in .withStructuredOutput`

**Precedence (per-call beats per-tool, across every tool shape)**
- [x] `per-call invoke strict overrides .bindTools strict`
- [x] `per-call strict overrides per-tool extras.strict` (LangChain shape)
- [x] `per-call strict overrides OpenAI-shaped tool's function.strict`
- [x] `per-call strict overrides Anthropic-shaped tool's own strict`

**Error cases**
- [x] `withStructuredOutput throws when strict is set with method = jsonSchema` (parameterized)
- [x] `withStructuredOutput throws when strict is set with method = jsonMode` (parameterized)

### Integration tests (`chat_models-strict.int.test.ts`, live API against `claude-haiku-4-5-20251001`)

- [x] `strict via .bindTools(tools, { strict: true })`
- [x] `strict via .bindTools(...).withConfig({ strict: true })`
- [x] `strict via .withConfig({ tools, strict: true })`
- [x] `strict via .invoke(input, { strict: true })`
- [x] `strict via tool() extras.strict`
- [x] `per-call strict=false overrides tool() extras.strict=true`
- [x] `strict via .withStructuredOutput(schema, { strict: true })` (round-trips through Zod)
- [x] `strict tool call composes with strict structured output` (exercises both strict surfaces end-to-end)

### Quality gates

- [x] 184/184 unit tests in \`@langchain/anthropic\` pass, no type errors
- [x] 8/8 integration tests pass against \`claude-haiku-4-5-20251001\`
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean

Made with [Cursor](https://cursor.com)