### PR TITLE
feat(perplexity): add Search retriever and tool to @langchain/perplexity

### DIFF
--- a/.changeset/perplexity-search-retriever-tool.md
+++ b/.changeset/perplexity-search-retriever-tool.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": minor
+---
+
+feat(perplexity): add Perplexity Search retriever (`PerplexitySearchRetriever`) and tool (`PerplexitySearchResults`)

--- a/libs/providers/langchain-perplexity/README.md
+++ b/libs/providers/langchain-perplexity/README.md
@@ -197,17 +197,17 @@ console.log(JSON.parse(json));
 
 Both classes accept the same Perplexity Search filters:
 
-| Parameter             | Type                                    | Description                                                                              |
-| --------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `apiKey`              | `string`                                | API key. Defaults to `PERPLEXITY_API_KEY` or `PPLX_API_KEY` env var.                     |
-| `k` / `maxResults`    | `number`                                | Maximum results (1-20). Defaults to `10`.                                                |
-| `maxTokens`           | `number`                                | Retriever only. Maximum tokens across all results. Defaults to `25000`.                  |
-| `maxTokensPerPage`    | `number`                                | Retriever only. Maximum tokens per page. Defaults to `1024`.                             |
-| `country`             | `string`                                | ISO country code (e.g. `"US"`).                                                          |
-| `searchDomainFilter`  | `string[]`                              | Restrict results to up to 20 domains.                                                    |
-| `searchRecencyFilter` | `"day" \| "week" \| "month" \| "year"`  | Time-based filter.                                                                       |
-| `searchAfterDate`     | `string`                                | Only include content after this date (`%m/%d/%Y`).                                       |
-| `searchBeforeDate`    | `string`                                | Only include content before this date (`%m/%d/%Y`).                                      |
+| Parameter             | Type                                   | Description                                                             |
+| --------------------- | -------------------------------------- | ----------------------------------------------------------------------- |
+| `apiKey`              | `string`                               | API key. Defaults to `PERPLEXITY_API_KEY` or `PPLX_API_KEY` env var.    |
+| `k` / `maxResults`    | `number`                               | Maximum results (1-20). Defaults to `10`.                               |
+| `maxTokens`           | `number`                               | Retriever only. Maximum tokens across all results. Defaults to `25000`. |
+| `maxTokensPerPage`    | `number`                               | Retriever only. Maximum tokens per page. Defaults to `1024`.            |
+| `country`             | `string`                               | ISO country code (e.g. `"US"`).                                         |
+| `searchDomainFilter`  | `string[]`                             | Restrict results to up to 20 domains.                                   |
+| `searchRecencyFilter` | `"day" \| "week" \| "month" \| "year"` | Time-based filter.                                                      |
+| `searchAfterDate`     | `string`                               | Only include content after this date (`%m/%d/%Y`).                      |
+| `searchBeforeDate`    | `string`                               | Only include content before this date (`%m/%d/%Y`).                     |
 
 ## License
 

--- a/libs/providers/langchain-perplexity/README.md
+++ b/libs/providers/langchain-perplexity/README.md
@@ -1,6 +1,6 @@
 # @langchain/perplexity
 
-This package provides a [LangChain.js](https://github.com/langchain-ai/langchainjs) integration for [Perplexity AI](https://www.perplexity.ai/) chat models.
+This package provides a [LangChain.js](https://github.com/langchain-ai/langchainjs) integration for [Perplexity AI](https://www.perplexity.ai/), including chat models, the Perplexity Search retriever, and the Perplexity Search tool.
 
 ## Installation
 
@@ -156,6 +156,58 @@ const model = new ChatPerplexity({
 | `searchBeforeDateFilter`  | `string`    | Only include content before this date.                                         |
 | `lastUpdatedAfterFilter`  | `string`    | Only include content updated after this date.                                  |
 | `lastUpdatedBeforeFilter` | `string`    | Only include content updated before this date.                                 |
+
+## Perplexity Search retriever
+
+`PerplexitySearchRetriever` calls the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) and returns each result as a LangChain `Document` whose `metadata` contains `title`, `url`, `date`, and `last_updated`.
+
+```typescript
+import { PerplexitySearchRetriever } from "@langchain/perplexity";
+
+const retriever = new PerplexitySearchRetriever({
+  k: 5,
+  searchRecencyFilter: "week",
+  searchDomainFilter: ["wikipedia.org"],
+});
+
+const docs = await retriever.invoke("Latest LLM benchmarks");
+for (const doc of docs) {
+  console.log(doc.metadata.title, doc.metadata.url);
+  console.log(doc.pageContent);
+}
+```
+
+## Perplexity Search tool
+
+`PerplexitySearchResults` is a LangChain `Tool` wrapper around the same `/search` endpoint. The tool name is `perplexity_search_results_json` and `_call` returns a JSON-encoded array of `{ title, url, snippet, date, last_updated }`.
+
+```typescript
+import { PerplexitySearchResults } from "@langchain/perplexity";
+
+const tool = new PerplexitySearchResults({
+  maxResults: 5,
+  searchRecencyFilter: "week",
+});
+
+const json = await tool.invoke("Latest LLM benchmarks");
+console.log(JSON.parse(json));
+```
+
+### Search constructor parameters
+
+Both classes accept the same Perplexity Search filters:
+
+| Parameter             | Type                                    | Description                                                                              |
+| --------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `apiKey`              | `string`                                | API key. Defaults to `PERPLEXITY_API_KEY` or `PPLX_API_KEY` env var.                     |
+| `k` / `maxResults`    | `number`                                | Maximum results (1-20). Defaults to `10`.                                                |
+| `maxTokens`           | `number`                                | Retriever only. Maximum tokens across all results. Defaults to `25000`.                  |
+| `maxTokensPerPage`    | `number`                                | Retriever only. Maximum tokens per page. Defaults to `1024`.                             |
+| `country`             | `string`                                | ISO country code (e.g. `"US"`).                                                          |
+| `searchDomainFilter`  | `string[]`                              | Restrict results to up to 20 domains.                                                    |
+| `searchRecencyFilter` | `"day" \| "week" \| "month" \| "year"`  | Time-based filter.                                                                       |
+| `searchAfterDate`     | `string`                                | Only include content after this date (`%m/%d/%Y`).                                       |
+| `searchBeforeDate`    | `string`                                | Only include content before this date (`%m/%d/%Y`).                                      |
 
 ## License
 

--- a/libs/providers/langchain-perplexity/package.json
+++ b/libs/providers/langchain-perplexity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@langchain/perplexity",
   "version": "0.1.0",
-  "description": "Perplexity integration for LangChain.js",
+  "description": "Perplexity integration for LangChain.js (chat models, Search retriever, and Search tool).",
   "author": "LangChain",
   "license": "MIT",
   "type": "module",

--- a/libs/providers/langchain-perplexity/src/index.ts
+++ b/libs/providers/langchain-perplexity/src/index.ts
@@ -3,3 +3,15 @@ export {
   ReasoningJsonOutputParser,
   ReasoningStructuredOutputParser,
 } from "./utils/output_parsers.js";
+export {
+  PerplexitySearchRetriever,
+  type PerplexitySearchRetrieverFields,
+  type PerplexitySearchRecencyFilter,
+  type PerplexitySearchResult,
+  type PerplexitySearchResponse,
+  type PerplexitySearchRequestBody,
+} from "./retrievers.js";
+export {
+  PerplexitySearchResults,
+  type PerplexitySearchResultsFields,
+} from "./tools.js";

--- a/libs/providers/langchain-perplexity/src/retrievers.ts
+++ b/libs/providers/langchain-perplexity/src/retrievers.ts
@@ -1,0 +1,209 @@
+import {
+  BaseRetriever,
+  type BaseRetrieverInput,
+} from "@langchain/core/retrievers";
+import { Document } from "@langchain/core/documents";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+
+/**
+ * Recency filters supported by the Perplexity Search API.
+ */
+export type PerplexitySearchRecencyFilter = "day" | "week" | "month" | "year";
+
+/**
+ * A single search result returned by the Perplexity Search API.
+ */
+export interface PerplexitySearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  date?: string | null;
+  last_updated?: string | null;
+}
+
+/**
+ * Raw response shape returned by `POST https://api.perplexity.ai/search`.
+ */
+export interface PerplexitySearchResponse {
+  id?: string;
+  results: PerplexitySearchResult[];
+}
+
+/**
+ * Constructor fields for {@link PerplexitySearchRetriever}.
+ */
+export interface PerplexitySearchRetrieverFields extends BaseRetrieverInput {
+  /** Maximum number of results to return (1-20). Defaults to 10. */
+  k?: number;
+
+  /** Maximum total tokens across all results. Defaults to 25000. */
+  maxTokens?: number;
+
+  /** Maximum tokens per page. Defaults to 1024. */
+  maxTokensPerPage?: number;
+
+  /** ISO country code (e.g. "US"). */
+  country?: string;
+
+  /** Domain filter (max 20). */
+  searchDomainFilter?: string[];
+
+  /** Time-based filter for results. */
+  searchRecencyFilter?: PerplexitySearchRecencyFilter;
+
+  /** Only include content published after this date (format: %m/%d/%Y). */
+  searchAfterDate?: string;
+
+  /** Only include content published before this date (format: %m/%d/%Y). */
+  searchBeforeDate?: string;
+
+  /**
+   * Perplexity API key. Defaults to the `PERPLEXITY_API_KEY` or
+   * `PPLX_API_KEY` environment variable.
+   */
+  apiKey?: string;
+}
+
+/**
+ * Body sent to the Perplexity `/search` endpoint.
+ *
+ * @internal
+ */
+export interface PerplexitySearchRequestBody {
+  query: string;
+  max_results?: number;
+  max_tokens?: number;
+  max_tokens_per_page?: number;
+  country?: string;
+  search_domain_filter?: string[];
+  search_recency_filter?: PerplexitySearchRecencyFilter;
+  search_after_date?: string;
+  search_before_date?: string;
+}
+
+const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
+
+/**
+ * Retriever that calls the Perplexity Search API.
+ *
+ * @example
+ * ```typescript
+ * import { PerplexitySearchRetriever } from "@langchain/perplexity";
+ *
+ * const retriever = new PerplexitySearchRetriever({
+ *   k: 5,
+ *   searchRecencyFilter: "week",
+ * });
+ *
+ * const docs = await retriever.invoke("Latest LLM benchmarks");
+ * ```
+ */
+export class PerplexitySearchRetriever extends BaseRetriever {
+  static lc_name() {
+    return "PerplexitySearchRetriever";
+  }
+
+  lc_namespace = ["langchain", "retrievers", "perplexity"];
+
+  k: number;
+
+  maxTokens: number;
+
+  maxTokensPerPage: number;
+
+  country?: string;
+
+  searchDomainFilter?: string[];
+
+  searchRecencyFilter?: PerplexitySearchRecencyFilter;
+
+  searchAfterDate?: string;
+
+  searchBeforeDate?: string;
+
+  apiKey: string;
+
+  constructor(fields: PerplexitySearchRetrieverFields = {}) {
+    super(fields);
+
+    this.k = fields.k ?? 10;
+    this.maxTokens = fields.maxTokens ?? 25000;
+    this.maxTokensPerPage = fields.maxTokensPerPage ?? 1024;
+    this.country = fields.country;
+    this.searchDomainFilter = fields.searchDomainFilter;
+    this.searchRecencyFilter = fields.searchRecencyFilter;
+    this.searchAfterDate = fields.searchAfterDate;
+    this.searchBeforeDate = fields.searchBeforeDate;
+
+    const apiKey =
+      fields.apiKey ??
+      getEnvironmentVariable("PERPLEXITY_API_KEY") ??
+      getEnvironmentVariable("PPLX_API_KEY");
+
+    if (!apiKey) {
+      throw new Error("Perplexity API key not found");
+    }
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Build the JSON body posted to the Perplexity Search API.
+   */
+  buildRequestBody(query: string): PerplexitySearchRequestBody {
+    const body: PerplexitySearchRequestBody = {
+      query,
+      max_results: this.k,
+      max_tokens: this.maxTokens,
+      max_tokens_per_page: this.maxTokensPerPage,
+    };
+    if (this.country !== undefined) body.country = this.country;
+    if (this.searchDomainFilter !== undefined) {
+      body.search_domain_filter = this.searchDomainFilter;
+    }
+    if (this.searchRecencyFilter !== undefined) {
+      body.search_recency_filter = this.searchRecencyFilter;
+    }
+    if (this.searchAfterDate !== undefined) {
+      body.search_after_date = this.searchAfterDate;
+    }
+    if (this.searchBeforeDate !== undefined) {
+      body.search_before_date = this.searchBeforeDate;
+    }
+    return body;
+  }
+
+  async _getRelevantDocuments(query: string): Promise<Document[]> {
+    const body = this.buildRequestBody(query);
+
+    const response = await fetch(PERPLEXITY_SEARCH_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(
+        `Perplexity Search API error (${response.status}): ${errorText}`
+      );
+    }
+
+    const data = (await response.json()) as PerplexitySearchResponse;
+
+    return (data.results ?? []).map(
+      (result) =>
+        new Document({
+          pageContent: result.snippet ?? "",
+          metadata: {
+            title: result.title,
+            url: result.url,
+            date: result.date ?? null,
+            last_updated: result.last_updated ?? null,
+          },
+        })
+    );
+  }
+}

--- a/libs/providers/langchain-perplexity/src/tests/retrievers.int.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/retrievers.int.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { PerplexitySearchRetriever } from "../retrievers.js";
 
-const hasKey =
-  !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
+const hasKey = !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
 
 describe.skipIf(!hasKey)("PerplexitySearchRetriever Integration", () => {
   test("returns documents from a real /search call", async () => {

--- a/libs/providers/langchain-perplexity/src/tests/retrievers.int.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/retrievers.int.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "vitest";
+import { PerplexitySearchRetriever } from "../retrievers.js";
+
+const hasKey =
+  !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
+
+describe.skipIf(!hasKey)("PerplexitySearchRetriever Integration", () => {
+  test("returns documents from a real /search call", async () => {
+    const retriever = new PerplexitySearchRetriever({ k: 3 });
+    const docs = await retriever.invoke("What is the capital of India?");
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs.length).toBeLessThanOrEqual(3);
+    for (const doc of docs) {
+      expect(typeof doc.pageContent).toBe("string");
+      expect(doc.metadata).toHaveProperty("title");
+      expect(doc.metadata).toHaveProperty("url");
+      expect(doc.metadata).toHaveProperty("date");
+      expect(doc.metadata).toHaveProperty("last_updated");
+    }
+  });
+
+  test("respects searchRecencyFilter and searchDomainFilter", async () => {
+    const retriever = new PerplexitySearchRetriever({
+      k: 2,
+      searchRecencyFilter: "month",
+      searchDomainFilter: ["wikipedia.org"],
+    });
+    const docs = await retriever.invoke("LangChain framework");
+    expect(docs.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
@@ -27,8 +27,7 @@ function mockFetchOnce(response: unknown, ok = true, status = 200) {
     ok,
     status,
     json: () => Promise.resolve(response),
-    text: () =>
-      Promise.resolve(typeof response === "string" ? response : ""),
+    text: () => Promise.resolve(typeof response === "string" ? response : ""),
   });
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).fetch = fetchMock;

--- a/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
@@ -1,0 +1,240 @@
+import { vi, test, expect, describe, beforeEach, afterEach } from "vitest";
+import { Document } from "@langchain/core/documents";
+import { PerplexitySearchRetriever } from "../retrievers.js";
+
+const MOCK_RESPONSE = {
+  id: "search-id-1",
+  results: [
+    {
+      title: "Result 1",
+      url: "https://example.com/1",
+      snippet: "First snippet",
+      date: "2025-01-01",
+      last_updated: "2025-01-02",
+    },
+    {
+      title: "Result 2",
+      url: "https://example.com/2",
+      snippet: "Second snippet",
+      date: null,
+      last_updated: null,
+    },
+  ],
+};
+
+function mockFetchOnce(response: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(response),
+    text: () =>
+      Promise.resolve(typeof response === "string" ? response : ""),
+  });
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = fetchMock;
+  return fetchMock;
+}
+
+describe("PerplexitySearchRetriever", () => {
+  let originalFetch: typeof fetch;
+  let originalApiKey: string | undefined;
+  let originalPplxKey: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalApiKey = process.env.PERPLEXITY_API_KEY;
+    originalPplxKey = process.env.PPLX_API_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.PERPLEXITY_API_KEY;
+    } else {
+      process.env.PERPLEXITY_API_KEY = originalApiKey;
+    }
+    if (originalPplxKey === undefined) {
+      delete process.env.PPLX_API_KEY;
+    } else {
+      process.env.PPLX_API_KEY = originalPplxKey;
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    test("creates instance with required fields and defaults", () => {
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      expect(retriever.k).toBe(10);
+      expect(retriever.maxTokens).toBe(25000);
+      expect(retriever.maxTokensPerPage).toBe(1024);
+      expect(retriever.apiKey).toBe("test-key");
+    });
+
+    test("throws error when no API key is provided", () => {
+      delete process.env.PERPLEXITY_API_KEY;
+      delete process.env.PPLX_API_KEY;
+      expect(() => new PerplexitySearchRetriever()).toThrow(
+        "Perplexity API key not found"
+      );
+    });
+
+    test("falls back to PERPLEXITY_API_KEY env var", () => {
+      process.env.PERPLEXITY_API_KEY = "env-key";
+      delete process.env.PPLX_API_KEY;
+      const retriever = new PerplexitySearchRetriever();
+      expect(retriever.apiKey).toBe("env-key");
+    });
+
+    test("falls back to PPLX_API_KEY env var", () => {
+      delete process.env.PERPLEXITY_API_KEY;
+      process.env.PPLX_API_KEY = "pplx-key";
+      const retriever = new PerplexitySearchRetriever();
+      expect(retriever.apiKey).toBe("pplx-key");
+    });
+
+    test("sets optional parameters correctly", () => {
+      const retriever = new PerplexitySearchRetriever({
+        apiKey: "test-key",
+        k: 5,
+        maxTokens: 1000,
+        maxTokensPerPage: 200,
+        country: "US",
+        searchDomainFilter: ["wikipedia.org"],
+        searchRecencyFilter: "week",
+        searchAfterDate: "01/01/2025",
+        searchBeforeDate: "12/31/2025",
+      });
+      expect(retriever.k).toBe(5);
+      expect(retriever.maxTokens).toBe(1000);
+      expect(retriever.maxTokensPerPage).toBe(200);
+      expect(retriever.country).toBe("US");
+      expect(retriever.searchDomainFilter).toEqual(["wikipedia.org"]);
+      expect(retriever.searchRecencyFilter).toBe("week");
+      expect(retriever.searchAfterDate).toBe("01/01/2025");
+      expect(retriever.searchBeforeDate).toBe("12/31/2025");
+    });
+
+    test("lc_name returns PerplexitySearchRetriever", () => {
+      expect(PerplexitySearchRetriever.lc_name()).toBe(
+        "PerplexitySearchRetriever"
+      );
+    });
+  });
+
+  describe("buildRequestBody", () => {
+    test("includes default parameters", () => {
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      const body = retriever.buildRequestBody("hello");
+      expect(body).toEqual({
+        query: "hello",
+        max_results: 10,
+        max_tokens: 25000,
+        max_tokens_per_page: 1024,
+      });
+    });
+
+    test("omits unset optional parameters", () => {
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      const body = retriever.buildRequestBody("hello");
+      expect(body).not.toHaveProperty("country");
+      expect(body).not.toHaveProperty("search_domain_filter");
+      expect(body).not.toHaveProperty("search_recency_filter");
+      expect(body).not.toHaveProperty("search_after_date");
+      expect(body).not.toHaveProperty("search_before_date");
+    });
+
+    test("includes all provided optional parameters", () => {
+      const retriever = new PerplexitySearchRetriever({
+        apiKey: "test-key",
+        k: 5,
+        maxTokens: 1000,
+        maxTokensPerPage: 200,
+        country: "US",
+        searchDomainFilter: ["wikipedia.org", "arxiv.org"],
+        searchRecencyFilter: "month",
+        searchAfterDate: "01/01/2025",
+        searchBeforeDate: "12/31/2025",
+      });
+      const body = retriever.buildRequestBody("query");
+      expect(body).toEqual({
+        query: "query",
+        max_results: 5,
+        max_tokens: 1000,
+        max_tokens_per_page: 200,
+        country: "US",
+        search_domain_filter: ["wikipedia.org", "arxiv.org"],
+        search_recency_filter: "month",
+        search_after_date: "01/01/2025",
+        search_before_date: "12/31/2025",
+      });
+    });
+  });
+
+  describe("_getRelevantDocuments", () => {
+    test("posts to /search and returns Document[] with metadata", async () => {
+      const fetchMock = mockFetchOnce(MOCK_RESPONSE);
+      const retriever = new PerplexitySearchRetriever({
+        apiKey: "test-key",
+        k: 3,
+        searchRecencyFilter: "day",
+      });
+
+      const docs = await retriever._getRelevantDocuments("test query");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.perplexity.ai/search");
+      expect(init.method).toBe("POST");
+      expect(init.headers).toEqual({
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+      });
+      expect(JSON.parse(init.body)).toEqual({
+        query: "test query",
+        max_results: 3,
+        max_tokens: 25000,
+        max_tokens_per_page: 1024,
+        search_recency_filter: "day",
+      });
+
+      expect(docs).toHaveLength(2);
+      expect(docs[0]).toBeInstanceOf(Document);
+      expect(docs[0].pageContent).toBe("First snippet");
+      expect(docs[0].metadata).toEqual({
+        title: "Result 1",
+        url: "https://example.com/1",
+        date: "2025-01-01",
+        last_updated: "2025-01-02",
+      });
+      expect(docs[1].metadata).toEqual({
+        title: "Result 2",
+        url: "https://example.com/2",
+        date: null,
+        last_updated: null,
+      });
+    });
+
+    test("returns empty list when results are missing", async () => {
+      mockFetchOnce({ id: "x" });
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      const docs = await retriever._getRelevantDocuments("q");
+      expect(docs).toEqual([]);
+    });
+
+    test("throws on non-OK response", async () => {
+      mockFetchOnce("rate limited", false, 429);
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      await expect(retriever._getRelevantDocuments("q")).rejects.toThrow(
+        /Perplexity Search API error \(429\)/
+      );
+    });
+
+    test("invoke proxies to _getRelevantDocuments", async () => {
+      mockFetchOnce(MOCK_RESPONSE);
+      const retriever = new PerplexitySearchRetriever({ apiKey: "test-key" });
+      const docs = await retriever.invoke("hi");
+      expect(docs).toHaveLength(2);
+      expect(docs[0].pageContent).toBe("First snippet");
+    });
+  });
+});

--- a/libs/providers/langchain-perplexity/src/tests/tools.int.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/tools.int.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "vitest";
+import { PerplexitySearchResults } from "../tools.js";
+
+const hasKey =
+  !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
+
+describe.skipIf(!hasKey)("PerplexitySearchResults Integration", () => {
+  test("returns JSON-encoded results from a real /search call", async () => {
+    const tool = new PerplexitySearchResults({ maxResults: 3 });
+    const result = await tool.invoke("What is the capital of India?");
+    const parsed = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.length).toBeLessThanOrEqual(3);
+    for (const item of parsed) {
+      expect(item).toHaveProperty("title");
+      expect(item).toHaveProperty("url");
+      expect(item).toHaveProperty("snippet");
+      expect(item).toHaveProperty("date");
+      expect(item).toHaveProperty("last_updated");
+    }
+  });
+});

--- a/libs/providers/langchain-perplexity/src/tests/tools.int.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/tools.int.test.ts
@@ -1,8 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { PerplexitySearchResults } from "../tools.js";
 
-const hasKey =
-  !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
+const hasKey = !!process.env.PERPLEXITY_API_KEY || !!process.env.PPLX_API_KEY;
 
 describe.skipIf(!hasKey)("PerplexitySearchResults Integration", () => {
   test("returns JSON-encoded results from a real /search call", async () => {

--- a/libs/providers/langchain-perplexity/src/tests/tools.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/tools.test.ts
@@ -1,0 +1,222 @@
+import { vi, test, expect, describe, beforeEach, afterEach } from "vitest";
+import { PerplexitySearchResults } from "../tools.js";
+
+const MOCK_RESPONSE = {
+  id: "search-id-1",
+  results: [
+    {
+      title: "Result 1",
+      url: "https://example.com/1",
+      snippet: "First snippet",
+      date: "2025-01-01",
+      last_updated: "2025-01-02",
+    },
+    {
+      title: "Result 2",
+      url: "https://example.com/2",
+      snippet: "Second snippet",
+    },
+  ],
+};
+
+function mockFetchOnce(response: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(response),
+    text: () =>
+      Promise.resolve(typeof response === "string" ? response : ""),
+  });
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = fetchMock;
+  return fetchMock;
+}
+
+describe("PerplexitySearchResults", () => {
+  let originalFetch: typeof fetch;
+  let originalApiKey: string | undefined;
+  let originalPplxKey: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalApiKey = process.env.PERPLEXITY_API_KEY;
+    originalPplxKey = process.env.PPLX_API_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.PERPLEXITY_API_KEY;
+    } else {
+      process.env.PERPLEXITY_API_KEY = originalApiKey;
+    }
+    if (originalPplxKey === undefined) {
+      delete process.env.PPLX_API_KEY;
+    } else {
+      process.env.PPLX_API_KEY = originalPplxKey;
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    test("uses default name and description", () => {
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      expect(tool.name).toBe("perplexity_search_results_json");
+      expect(tool.description).toBe(
+        "A wrapper around Perplexity Search. " +
+          "Input should be a search query. " +
+          "Output is a JSON array of the query results"
+      );
+      expect(tool.maxResults).toBe(10);
+    });
+
+    test("throws error when no API key is provided", () => {
+      delete process.env.PERPLEXITY_API_KEY;
+      delete process.env.PPLX_API_KEY;
+      expect(() => new PerplexitySearchResults()).toThrow(
+        "Perplexity API key not found"
+      );
+    });
+
+    test("falls back to PERPLEXITY_API_KEY env var", () => {
+      process.env.PERPLEXITY_API_KEY = "env-key";
+      delete process.env.PPLX_API_KEY;
+      const tool = new PerplexitySearchResults();
+      expect(tool.apiKey).toBe("env-key");
+    });
+
+    test("falls back to PPLX_API_KEY env var", () => {
+      delete process.env.PERPLEXITY_API_KEY;
+      process.env.PPLX_API_KEY = "pplx-key";
+      const tool = new PerplexitySearchResults();
+      expect(tool.apiKey).toBe("pplx-key");
+    });
+
+    test("sets optional parameters correctly", () => {
+      const tool = new PerplexitySearchResults({
+        apiKey: "test-key",
+        maxResults: 5,
+        country: "US",
+        searchDomainFilter: ["wikipedia.org"],
+        searchRecencyFilter: "week",
+        searchAfterDate: "01/01/2025",
+        searchBeforeDate: "12/31/2025",
+      });
+      expect(tool.maxResults).toBe(5);
+      expect(tool.country).toBe("US");
+      expect(tool.searchDomainFilter).toEqual(["wikipedia.org"]);
+      expect(tool.searchRecencyFilter).toBe("week");
+      expect(tool.searchAfterDate).toBe("01/01/2025");
+      expect(tool.searchBeforeDate).toBe("12/31/2025");
+    });
+
+    test("lc_name returns PerplexitySearchResults", () => {
+      expect(PerplexitySearchResults.lc_name()).toBe("PerplexitySearchResults");
+    });
+
+    test("has a defined schema", () => {
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      expect(tool.schema).toBeDefined();
+    });
+  });
+
+  describe("buildRequestBody", () => {
+    test("includes max_results and omits unset filters", () => {
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      const body = tool.buildRequestBody("query");
+      expect(body).toEqual({ query: "query", max_results: 10 });
+    });
+
+    test("includes all provided filters", () => {
+      const tool = new PerplexitySearchResults({
+        apiKey: "test-key",
+        maxResults: 3,
+        country: "US",
+        searchDomainFilter: ["arxiv.org"],
+        searchRecencyFilter: "month",
+        searchAfterDate: "01/01/2025",
+        searchBeforeDate: "12/31/2025",
+      });
+      const body = tool.buildRequestBody("query");
+      expect(body).toEqual({
+        query: "query",
+        max_results: 3,
+        country: "US",
+        search_domain_filter: ["arxiv.org"],
+        search_recency_filter: "month",
+        search_after_date: "01/01/2025",
+        search_before_date: "12/31/2025",
+      });
+    });
+  });
+
+  describe("_call", () => {
+    test("posts to /search and returns JSON-encoded results", async () => {
+      const fetchMock = mockFetchOnce(MOCK_RESPONSE);
+      const tool = new PerplexitySearchResults({
+        apiKey: "test-key",
+        maxResults: 4,
+        searchRecencyFilter: "day",
+      });
+
+      const result = await tool.invoke("test query");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.perplexity.ai/search");
+      expect(init.method).toBe("POST");
+      expect(init.headers).toEqual({
+        Authorization: "Bearer test-key",
+        "Content-Type": "application/json",
+      });
+      expect(JSON.parse(init.body)).toEqual({
+        query: "test query",
+        max_results: 4,
+        search_recency_filter: "day",
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual([
+        {
+          title: "Result 1",
+          url: "https://example.com/1",
+          snippet: "First snippet",
+          date: "2025-01-01",
+          last_updated: "2025-01-02",
+        },
+        {
+          title: "Result 2",
+          url: "https://example.com/2",
+          snippet: "Second snippet",
+          date: null,
+          last_updated: null,
+        },
+      ]);
+    });
+
+    test("returns error message string on non-OK response", async () => {
+      mockFetchOnce("server boom", false, 500);
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      const result = await tool.invoke("q");
+      expect(result).toContain("Perplexity search failed");
+      expect(result).toContain("500");
+    });
+
+    test("returns error message string on fetch throw", async () => {
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).fetch = vi.fn().mockRejectedValue(
+        new TypeError("network down")
+      );
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      const result = await tool.invoke("q");
+      expect(result).toBe("Perplexity search failed: TypeError");
+    });
+
+    test("returns empty array when results are missing", async () => {
+      mockFetchOnce({ id: "x" });
+      const tool = new PerplexitySearchResults({ apiKey: "test-key" });
+      const result = await tool.invoke("q");
+      expect(JSON.parse(result)).toEqual([]);
+    });
+  });
+});

--- a/libs/providers/langchain-perplexity/src/tests/tools.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/tools.test.ts
@@ -24,8 +24,7 @@ function mockFetchOnce(response: unknown, ok = true, status = 200) {
     ok,
     status,
     json: () => Promise.resolve(response),
-    text: () =>
-      Promise.resolve(typeof response === "string" ? response : ""),
+    text: () => Promise.resolve(typeof response === "string" ? response : ""),
   });
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).fetch = fetchMock;
@@ -204,9 +203,9 @@ describe("PerplexitySearchResults", () => {
 
     test("returns error message string on fetch throw", async () => {
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      (globalThis as any).fetch = vi.fn().mockRejectedValue(
-        new TypeError("network down")
-      );
+      (globalThis as any).fetch = vi
+        .fn()
+        .mockRejectedValue(new TypeError("network down"));
       const tool = new PerplexitySearchResults({ apiKey: "test-key" });
       const result = await tool.invoke("q");
       expect(result).toBe("Perplexity search failed: TypeError");

--- a/libs/providers/langchain-perplexity/src/tools.ts
+++ b/libs/providers/langchain-perplexity/src/tools.ts
@@ -1,0 +1,163 @@
+import { Tool, type ToolParams } from "@langchain/core/tools";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import type {
+  PerplexitySearchRecencyFilter,
+  PerplexitySearchRequestBody,
+  PerplexitySearchResponse,
+  PerplexitySearchResult,
+} from "./retrievers.js";
+
+const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
+
+/**
+ * Constructor fields for {@link PerplexitySearchResults}.
+ */
+export interface PerplexitySearchResultsFields extends ToolParams {
+  /** Maximum number of results to return (1-20). Defaults to 10. */
+  maxResults?: number;
+
+  /** ISO country code (e.g. "US"). */
+  country?: string;
+
+  /** Domain filter (max 20). */
+  searchDomainFilter?: string[];
+
+  /** Time-based filter for results. */
+  searchRecencyFilter?: PerplexitySearchRecencyFilter;
+
+  /** Only include content published after this date (format: %m/%d/%Y). */
+  searchAfterDate?: string;
+
+  /** Only include content published before this date (format: %m/%d/%Y). */
+  searchBeforeDate?: string;
+
+  /**
+   * Perplexity API key. Defaults to the `PERPLEXITY_API_KEY` or
+   * `PPLX_API_KEY` environment variable.
+   */
+  apiKey?: string;
+}
+
+/**
+ * Tool wrapper around the Perplexity Search API. Returns results as a
+ * JSON-encoded array of `{ title, url, snippet, date, last_updated }`.
+ *
+ * @example
+ * ```typescript
+ * import { PerplexitySearchResults } from "@langchain/perplexity";
+ *
+ * const tool = new PerplexitySearchResults({
+ *   maxResults: 5,
+ *   searchRecencyFilter: "week",
+ * });
+ *
+ * const json = await tool.invoke("Latest LLM benchmarks");
+ * ```
+ */
+export class PerplexitySearchResults extends Tool {
+  static lc_name(): string {
+    return "PerplexitySearchResults";
+  }
+
+  name = "perplexity_search_results_json";
+
+  description =
+    "A wrapper around Perplexity Search. " +
+    "Input should be a search query. " +
+    "Output is a JSON array of the query results";
+
+  maxResults: number;
+
+  country?: string;
+
+  searchDomainFilter?: string[];
+
+  searchRecencyFilter?: PerplexitySearchRecencyFilter;
+
+  searchAfterDate?: string;
+
+  searchBeforeDate?: string;
+
+  apiKey: string;
+
+  constructor(fields: PerplexitySearchResultsFields = {}) {
+    super(fields);
+
+    this.maxResults = fields.maxResults ?? 10;
+    this.country = fields.country;
+    this.searchDomainFilter = fields.searchDomainFilter;
+    this.searchRecencyFilter = fields.searchRecencyFilter;
+    this.searchAfterDate = fields.searchAfterDate;
+    this.searchBeforeDate = fields.searchBeforeDate;
+
+    const apiKey =
+      fields.apiKey ??
+      getEnvironmentVariable("PERPLEXITY_API_KEY") ??
+      getEnvironmentVariable("PPLX_API_KEY");
+
+    if (!apiKey) {
+      throw new Error("Perplexity API key not found");
+    }
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Build the JSON body posted to the Perplexity Search API.
+   */
+  buildRequestBody(query: string): PerplexitySearchRequestBody {
+    const body: PerplexitySearchRequestBody = {
+      query,
+      max_results: this.maxResults,
+    };
+    if (this.country !== undefined) body.country = this.country;
+    if (this.searchDomainFilter !== undefined) {
+      body.search_domain_filter = this.searchDomainFilter;
+    }
+    if (this.searchRecencyFilter !== undefined) {
+      body.search_recency_filter = this.searchRecencyFilter;
+    }
+    if (this.searchAfterDate !== undefined) {
+      body.search_after_date = this.searchAfterDate;
+    }
+    if (this.searchBeforeDate !== undefined) {
+      body.search_before_date = this.searchBeforeDate;
+    }
+    return body;
+  }
+
+  protected async _call(query: string): Promise<string> {
+    try {
+      const body = this.buildRequestBody(query);
+
+      const response = await fetch(PERPLEXITY_SEARCH_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        return `Perplexity search failed: HTTP ${response.status} ${errorText}`;
+      }
+
+      const data = (await response.json()) as PerplexitySearchResponse;
+
+      const formatted: PerplexitySearchResult[] = (data.results ?? []).map(
+        (result) => ({
+          title: result.title,
+          url: result.url,
+          snippet: result.snippet,
+          date: result.date ?? null,
+          last_updated: result.last_updated ?? null,
+        })
+      );
+      return JSON.stringify(formatted);
+    } catch (e) {
+      const name = e instanceof Error ? e.name : "Error";
+      return `Perplexity search failed: ${name}`;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Adds the Perplexity Search retriever and tool to the `@langchain/perplexity` partner package, mirroring the Python `langchain-perplexity` package. Today the JS package only exposes `ChatPerplexity`; this PR closes the gap so users can call the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) directly from LangChain.js.

## What's added

- `PerplexitySearchRetriever` (extends `BaseRetriever`) — calls `POST https://api.perplexity.ai/search` and returns each result as a `Document` with `metadata: { title, url, date, last_updated }`. Constructor mirrors the Python class: `k` (default `10`), `maxTokens` (default `25000`), `maxTokensPerPage` (default `1024`), `country`, `searchDomainFilter`, `searchRecencyFilter` (`"day" | "week" | "month" | "year"`), `searchAfterDate`, `searchBeforeDate`, `apiKey` (falls back to `PERPLEXITY_API_KEY` or `PPLX_API_KEY`).
- `PerplexitySearchResults` (extends `Tool`) — name `perplexity_search_results_json`, description matching the Python class, `_call(query)` returns a JSON-encoded array of `{ title, url, snippet, date, last_updated }`. Same Search API filters as the retriever, plus `maxResults` (default `10`).
- New unit tests (`retrievers.test.ts`, `tools.test.ts`) that mock the HTTP layer and assert request URL, headers, body, and returned shapes; new gated integration tests (`*.int.test.ts`) that hit the real `/search` endpoint when `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) is set.
- README section documenting the retriever, tool, and shared search filter parameters.
- Changeset marking `@langchain/perplexity` as a `minor` bump.

## Implementation notes

- The package uses the `openai` SDK pointed at the Perplexity base URL for chat completions; the official Perplexity TS SDK (`@perplexity-ai/perplexity_ai`) is not currently a dep. To avoid expanding the dep surface, the new classes call `/search` directly with `fetch` (this also keeps the auth flow — `Bearer \${apiKey}` — consistent with the rest of the package's HTTP shape).
- API parity with Python was verified against [`retrievers.py`](https://github.com/langchain-ai/langchain/blob/master/libs/partners/perplexity/langchain_perplexity/retrievers.py) and [`tools.py`](https://github.com/langchain-ai/langchain/blob/master/libs/partners/perplexity/langchain_perplexity/tools.py).

## Test plan

- [x] `pnpm --filter @langchain/perplexity build` (passes)
- [x] `pnpm --filter @langchain/perplexity test` — 67 unit tests pass, 1 integration test correctly skipped without an API key
- [x] `oxlint libs/providers/langchain-perplexity` (0 warnings, 0 errors)
- [ ] Integration tests (`pnpm --filter @langchain/perplexity test:int`) — gated on \`PERPLEXITY_API_KEY\`; left for maintainer secret

Fixes # (issue)