### PR TITLE
feat(weaviate): create from json

### DIFF
--- a/.changeset/weaviate-json-schema-create-from-json.md
+++ b/.changeset/weaviate-json-schema-create-from-json.md
@@ -1,0 +1,5 @@
+---
+"@langchain/weaviate": minor
+---
+
+feat(weaviate): add jsonSchema support via createFromJson and upgrade client to v3.13.0

--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -1,6 +1,71 @@
-import { test, expect } from "vitest";
+import { test, expect, vi } from "vitest";
+import { FakeEmbeddings } from "@langchain/core/utils/testing";
 
-import { flattenObjectForWeaviate } from "../vectorstores.js";
+import { flattenObjectForWeaviate, WeaviateStore } from "../vectorstores.js";
+
+function makeMockClient({
+  collectionExists = false,
+}: { collectionExists?: boolean } = {}) {
+  const createFromJson = vi.fn().mockResolvedValue(undefined);
+  const create = vi.fn().mockResolvedValue(undefined);
+  const exists = vi.fn().mockResolvedValue(collectionExists);
+  const get = vi.fn().mockReturnValue({});
+
+  return {
+    client: {
+      collections: { createFromJson, create, exists, get },
+    } as any,
+    spies: { createFromJson, create, exists },
+  };
+}
+
+test("initialize with jsonSchema calls createFromJson", async () => {
+  const { client, spies } = makeMockClient();
+  const jsonSchema = { class: "MyCollection", properties: [] };
+
+  await WeaviateStore.initialize(new FakeEmbeddings(), { client, jsonSchema });
+
+  expect(spies.createFromJson).toHaveBeenCalledOnce();
+  expect(spies.createFromJson).toHaveBeenCalledWith(jsonSchema);
+  expect(spies.create).not.toHaveBeenCalled();
+});
+
+test("initialize with schema calls create", async () => {
+  const { client, spies } = makeMockClient();
+  const schema = { name: "MyCollection", properties: [] };
+
+  await WeaviateStore.initialize(new FakeEmbeddings(), { client, schema });
+
+  expect(spies.create).toHaveBeenCalledOnce();
+  expect(spies.create).toHaveBeenCalledWith(schema);
+  expect(spies.createFromJson).not.toHaveBeenCalled();
+});
+
+test("initialize with both jsonSchema and schema prefers jsonSchema", async () => {
+  const { client, spies } = makeMockClient();
+  const jsonSchema = { class: "MyCollection", properties: [] };
+  const schema = { name: "MyCollection", properties: [] };
+
+  await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    jsonSchema,
+    schema,
+  });
+
+  expect(spies.createFromJson).toHaveBeenCalledOnce();
+  expect(spies.createFromJson).toHaveBeenCalledWith(jsonSchema);
+  expect(spies.create).not.toHaveBeenCalled();
+});
+
+test("initialize skips creation when collection already exists", async () => {
+  const { client, spies } = makeMockClient({ collectionExists: true });
+  const jsonSchema = { class: "MyCollection", properties: [] };
+
+  await WeaviateStore.initialize(new FakeEmbeddings(), { client, jsonSchema });
+
+  expect(spies.createFromJson).not.toHaveBeenCalled();
+  expect(spies.create).not.toHaveBeenCalled();
+});
 
 test("flattenObjectForWeaviate", () => {
   expect(

--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -19,6 +19,28 @@ function makeMockClient({
   };
 }
 
+function makeSearchMockClient() {
+  const hybrid = vi.fn().mockResolvedValue({ objects: [] });
+  const generateHybrid = vi.fn().mockResolvedValue({ objects: [] });
+  const collection = {
+    query: { hybrid },
+    generate: { hybrid: generateHybrid },
+  };
+  const get = vi.fn().mockReturnValue(collection);
+
+  return {
+    client: {
+      collections: {
+        get,
+        exists: vi.fn().mockResolvedValue(true),
+        create: vi.fn(),
+        createFromJson: vi.fn(),
+      },
+    } as any,
+    spies: { hybrid, generateHybrid },
+  };
+}
+
 test("initialize with jsonSchema calls createFromJson", async () => {
   const { client, spies } = makeMockClient();
   const jsonSchema = { class: "MyCollection", properties: [] };
@@ -65,6 +87,116 @@ test("initialize skips creation when collection already exists", async () => {
 
   expect(spies.createFromJson).not.toHaveBeenCalled();
   expect(spies.create).not.toHaveBeenCalled();
+});
+
+test("hybridSearch forwards filters when provided", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filters = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  await store.hybridSearch("q", { filters, vector: [0.1, 0.2] });
+
+  expect(spies.hybrid).toHaveBeenCalledOnce();
+  const [, options] = spies.hybrid.mock.calls[0];
+  expect(options.filters).toBe(filters);
+});
+
+test("hybridSearch maps filter (singular) to filters and keeps both keys", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filter = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  await store.hybridSearch("q", { filter, vector: [0.1, 0.2] } as any);
+
+  expect(spies.hybrid).toHaveBeenCalledOnce();
+  const [, options] = spies.hybrid.mock.calls[0];
+  expect(options.filters).toBe(filter);
+  expect(options.filter).toBe(filter);
+});
+
+test("hybridSearch prefers filters over filter when both are provided", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filters = { operator: "Equal", path: ["a"], valueText: "1" } as any;
+  const filter = { operator: "Equal", path: ["b"], valueText: "2" } as any;
+  await store.hybridSearch("q", {
+    filters,
+    filter,
+    vector: [0.1, 0.2],
+  } as any);
+
+  expect(spies.hybrid).toHaveBeenCalledOnce();
+  const [, options] = spies.hybrid.mock.calls[0];
+  expect(options.filters).toBe(filters);
+});
+
+test("generate forwards filters when provided", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filters = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  await store.generate(
+    "q",
+    { singlePrompt: "summarize" },
+    { filters, vector: [0.1, 0.2] }
+  );
+
+  expect(spies.generateHybrid).toHaveBeenCalledOnce();
+  const [, , options] = spies.generateHybrid.mock.calls[0];
+  expect(options.filters).toBe(filters);
+});
+
+test("generate maps filter (singular) to filters and keeps both keys", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filter = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  await store.generate(
+    "q",
+    { singlePrompt: "summarize" },
+    { filter, vector: [0.1, 0.2] } as any
+  );
+
+  expect(spies.generateHybrid).toHaveBeenCalledOnce();
+  const [, , options] = spies.generateHybrid.mock.calls[0];
+  expect(options.filters).toBe(filter);
+  expect(options.filter).toBe(filter);
+});
+
+test("generate prefers filters over filter when both are provided", async () => {
+  const { client, spies } = makeSearchMockClient();
+  const store = await WeaviateStore.initialize(new FakeEmbeddings(), {
+    client,
+    indexName: "MyCollection",
+  });
+
+  const filters = { operator: "Equal", path: ["a"], valueText: "1" } as any;
+  const filter = { operator: "Equal", path: ["b"], valueText: "2" } as any;
+  await store.generate(
+    "q",
+    { singlePrompt: "summarize" },
+    { filters, filter, vector: [0.1, 0.2] } as any
+  );
+
+  expect(spies.generateHybrid).toHaveBeenCalledOnce();
+  const [, , options] = spies.generateHybrid.mock.calls[0];
+  expect(options.filters).toBe(filters);
 });
 
 test("flattenObjectForWeaviate", () => {

--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -167,11 +167,10 @@ test("generate maps filter (singular) to filters and keeps both keys", async () 
   });
 
   const filter = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
-  await store.generate(
-    "q",
-    { singlePrompt: "summarize" },
-    { filter, vector: [0.1, 0.2] } as any
-  );
+  await store.generate("q", { singlePrompt: "summarize" }, {
+    filter,
+    vector: [0.1, 0.2],
+  } as any);
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];
@@ -188,11 +187,11 @@ test("generate prefers filters over filter when both are provided", async () => 
 
   const filters = { operator: "Equal", path: ["a"], valueText: "1" } as any;
   const filter = { operator: "Equal", path: ["b"], valueText: "2" } as any;
-  await store.generate(
-    "q",
-    { singlePrompt: "summarize" },
-    { filters, filter, vector: [0.1, 0.2] } as any
-  );
+  await store.generate("q", { singlePrompt: "summarize" }, {
+    filters,
+    filter,
+    vector: [0.1, 0.2],
+  } as any);
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];

--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -180,10 +180,14 @@ test("generate maps filter (singular) to filters and keeps both keys", async () 
   });
 
   const filter = equalFilter("bar");
-  await store.generate("q", { singlePrompt: "summarize" }, {
-    filter,
-    vector: [0.1, 0.2],
-  });
+  await store.generate(
+    "q",
+    { singlePrompt: "summarize" },
+    {
+      filter,
+      vector: [0.1, 0.2],
+    }
+  );
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];
@@ -200,11 +204,15 @@ test("generate prefers filters over filter when both are provided", async () => 
 
   const filters = equalFilter("1");
   const filter = equalFilter("2");
-  await store.generate("q", { singlePrompt: "summarize" }, {
-    filters,
-    filter,
-    vector: [0.1, 0.2],
-  });
+  await store.generate(
+    "q",
+    { singlePrompt: "summarize" },
+    {
+      filters,
+      filter,
+      vector: [0.1, 0.2],
+    }
+  );
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];

--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -1,7 +1,24 @@
 import { test, expect, vi } from "vitest";
 import { FakeEmbeddings } from "@langchain/core/utils/testing";
+import type { FilterValue, WeaviateClient } from "weaviate-client";
 
 import { flattenObjectForWeaviate, WeaviateStore } from "../vectorstores.js";
+
+type MockCollections = Pick<
+  WeaviateClient["collections"],
+  "createFromJson" | "create" | "exists" | "get"
+>;
+
+function mockWeaviateClient(collections: MockCollections): WeaviateClient {
+  return { collections } as unknown as WeaviateClient;
+}
+
+function equalFilter(value: string): FilterValue {
+  return {
+    operator: "Equal",
+    value,
+  };
+}
 
 function makeMockClient({
   collectionExists = false,
@@ -12,9 +29,7 @@ function makeMockClient({
   const get = vi.fn().mockReturnValue({});
 
   return {
-    client: {
-      collections: { createFromJson, create, exists, get },
-    } as any,
+    client: mockWeaviateClient({ createFromJson, create, exists, get }),
     spies: { createFromJson, create, exists },
   };
 }
@@ -29,14 +44,12 @@ function makeSearchMockClient() {
   const get = vi.fn().mockReturnValue(collection);
 
   return {
-    client: {
-      collections: {
-        get,
-        exists: vi.fn().mockResolvedValue(true),
-        create: vi.fn(),
-        createFromJson: vi.fn(),
-      },
-    } as any,
+    client: mockWeaviateClient({
+      get,
+      exists: vi.fn().mockResolvedValue(true),
+      create: vi.fn(),
+      createFromJson: vi.fn(),
+    }),
     spies: { hybrid, generateHybrid },
   };
 }
@@ -96,7 +109,7 @@ test("hybridSearch forwards filters when provided", async () => {
     indexName: "MyCollection",
   });
 
-  const filters = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  const filters = equalFilter("bar");
   await store.hybridSearch("q", { filters, vector: [0.1, 0.2] });
 
   expect(spies.hybrid).toHaveBeenCalledOnce();
@@ -111,8 +124,8 @@ test("hybridSearch maps filter (singular) to filters and keeps both keys", async
     indexName: "MyCollection",
   });
 
-  const filter = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
-  await store.hybridSearch("q", { filter, vector: [0.1, 0.2] } as any);
+  const filter = equalFilter("bar");
+  await store.hybridSearch("q", { filter, vector: [0.1, 0.2] });
 
   expect(spies.hybrid).toHaveBeenCalledOnce();
   const [, options] = spies.hybrid.mock.calls[0];
@@ -127,13 +140,13 @@ test("hybridSearch prefers filters over filter when both are provided", async ()
     indexName: "MyCollection",
   });
 
-  const filters = { operator: "Equal", path: ["a"], valueText: "1" } as any;
-  const filter = { operator: "Equal", path: ["b"], valueText: "2" } as any;
+  const filters = equalFilter("1");
+  const filter = equalFilter("2");
   await store.hybridSearch("q", {
     filters,
     filter,
     vector: [0.1, 0.2],
-  } as any);
+  });
 
   expect(spies.hybrid).toHaveBeenCalledOnce();
   const [, options] = spies.hybrid.mock.calls[0];
@@ -147,7 +160,7 @@ test("generate forwards filters when provided", async () => {
     indexName: "MyCollection",
   });
 
-  const filters = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  const filters = equalFilter("bar");
   await store.generate(
     "q",
     { singlePrompt: "summarize" },
@@ -166,11 +179,11 @@ test("generate maps filter (singular) to filters and keeps both keys", async () 
     indexName: "MyCollection",
   });
 
-  const filter = { operator: "Equal", path: ["foo"], valueText: "bar" } as any;
+  const filter = equalFilter("bar");
   await store.generate("q", { singlePrompt: "summarize" }, {
     filter,
     vector: [0.1, 0.2],
-  } as any);
+  });
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];
@@ -185,13 +198,13 @@ test("generate prefers filters over filter when both are provided", async () => 
     indexName: "MyCollection",
   });
 
-  const filters = { operator: "Equal", path: ["a"], valueText: "1" } as any;
-  const filter = { operator: "Equal", path: ["b"], valueText: "2" } as any;
+  const filters = equalFilter("1");
+  const filter = equalFilter("2");
   await store.generate("q", { singlePrompt: "summarize" }, {
     filters,
     filter,
     vector: [0.1, 0.2],
-  } as any);
+  });
 
   expect(spies.generateHybrid).toHaveBeenCalledOnce();
   const [, , options] = spies.generateHybrid.mock.calls[0];

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -306,7 +306,9 @@ export class WeaviateStore extends VectorStore {
    */
   async hybridSearch(
     query: string,
-    options?: HybridOptions<undefined, undefined, undefined>
+    options?: HybridOptions<undefined, undefined, undefined> & {
+      filter?: FilterValue;
+    }
   ): Promise<Document[]> {
     const collection = this.client.collections.get(this.indexName);
     let query_vector: number[] | undefined;
@@ -314,8 +316,10 @@ export class WeaviateStore extends VectorStore {
       query_vector = await this.embeddings.embedQuery(query);
     }
 
+    const { filter, ...restOptions } = options ?? {};
     const options_with_vector = {
-      ...options,
+      ...restOptions,
+      filters: restOptions.filters ?? filter,
       vector: options?.vector || query_vector,
       returnMetadata: [
         "score",
@@ -364,23 +368,26 @@ export class WeaviateStore extends VectorStore {
   async generate(
     query: string,
     generate: GenerateOptions<undefined, GenerativeConfigRuntime | undefined>,
-    options?: BaseHybridOptions<undefined, undefined, undefined>
+    options?: BaseHybridOptions<undefined, undefined, undefined> & {
+      filter?: FilterValue;
+    }
   ): Promise<WeaviateDocument[]> {
     const collection = this.client.collections.get(this.indexName);
+    const { filter, ...restOptions } = options ?? {};
+    const hybridOptions = {
+      ...restOptions,
+      filters: restOptions.filters ?? filter,
+    };
     let result;
     if (this.tenant) {
       result = await collection
         .withTenant(this.tenant)
-        .generate.hybrid(
-          query,
-          { ...(generate || {}) },
-          { ...(options || {}) }
-        );
+        .generate.hybrid(query, { ...(generate || {}) }, hybridOptions);
     } else {
       result = await collection.generate.hybrid(
         query,
         { ...(generate || {}) },
-        { ...(options || {}) }
+        hybridOptions
       );
     }
     const documents = [];

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -12,6 +12,7 @@ import {
   type WeaviateField,
   BaseHybridOptions,
   MetadataKeys,
+  type WeaviateClass,
 } from "weaviate-client";
 import {
   type MaxMarginalRelevanceSearchOptions,
@@ -78,8 +79,12 @@ export interface WeaviateLibArgs {
   metadataKeys?: string[];
   tenant?: string;
   schema?: CollectionConfigCreate;
-  /** Raw Weaviate JSON schema passed to `client.collections.createFromJson()`. Takes precedence over `schema`. */
-  jsonSchema?: Record<string, unknown>;
+  /**
+   * Raw Weaviate JSON schema passed straight to `client.collections.createFromJson()`.
+   * This is the same shape returned by Weaviate's REST API and by `client.collections.exportToJson()`.
+   * Takes precedence over `schema` when both are provided.
+   */
+  jsonSchema?: WeaviateClass;
 }
 
 export class WeaviateDocument extends Document {
@@ -110,7 +115,7 @@ export class WeaviateStore extends VectorStore {
 
   private schema?: CollectionConfigCreate;
 
-  private jsonSchema?: Record<string, unknown>;
+  private jsonSchema?: WeaviateClass;
 
   _vectorstoreType(): string {
     return "weaviate";
@@ -123,10 +128,13 @@ export class WeaviateStore extends VectorStore {
     super(embeddings, args);
 
     this.client = args.client;
+    // `class` is Weaviate's legacy field name for the collection identifier in the
+    // raw REST/JSON schema — it is not the standard JSON Schema `class` keyword.
+    // See WeaviateClass in weaviate-client/openapi/types.
     this.indexName =
       args.indexName ||
       args.schema?.name ||
-      (args.jsonSchema?.["class"] as string | undefined) ||
+      args.jsonSchema?.class ||
       "";
     this.textKey = args.textKey || "text";
     this.queryAttrs = [this.textKey];
@@ -164,8 +172,9 @@ export class WeaviateStore extends VectorStore {
     );
     if (!collection) {
       if (weaviateStore.jsonSchema) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await weaviateStore.client.collections.createFromJson(weaviateStore.jsonSchema as any);
+        await weaviateStore.client.collections.createFromJson(
+          weaviateStore.jsonSchema
+        );
       } else if (weaviateStore.schema) {
         await weaviateStore.client.collections.create(weaviateStore.schema);
       } else {

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -1,4 +1,3 @@
-import * as uuid from "@langchain/core/utils/uuid";
 import {
   HybridOptions,
   CollectionConfigCreate,
@@ -79,6 +78,8 @@ export interface WeaviateLibArgs {
   metadataKeys?: string[];
   tenant?: string;
   schema?: CollectionConfigCreate;
+  /** Raw Weaviate JSON schema passed to `client.collections.createFromJson()`. Takes precedence over `schema`. */
+  jsonSchema?: Record<string, unknown>;
 }
 
 export class WeaviateDocument extends Document {
@@ -109,6 +110,8 @@ export class WeaviateStore extends VectorStore {
 
   private schema?: CollectionConfigCreate;
 
+  private jsonSchema?: Record<string, unknown>;
+
   _vectorstoreType(): string {
     return "weaviate";
   }
@@ -120,11 +123,16 @@ export class WeaviateStore extends VectorStore {
     super(embeddings, args);
 
     this.client = args.client;
-    this.indexName = args.indexName || args.schema?.name || "";
+    this.indexName =
+      args.indexName ||
+      args.schema?.name ||
+      (args.jsonSchema?.["class"] as string | undefined) ||
+      "";
     this.textKey = args.textKey || "text";
     this.queryAttrs = [this.textKey];
     this.tenant = args.tenant;
     this.schema = args.schema;
+    this.jsonSchema = args.jsonSchema;
 
     if (args.metadataKeys) {
       this.queryAttrs = [
@@ -155,7 +163,10 @@ export class WeaviateStore extends VectorStore {
       weaviateStore.indexName
     );
     if (!collection) {
-      if (weaviateStore.schema) {
+      if (weaviateStore.jsonSchema) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await weaviateStore.client.collections.createFromJson(weaviateStore.jsonSchema as any);
+      } else if (weaviateStore.schema) {
         await weaviateStore.client.collections.create(weaviateStore.schema);
       } else {
         if (config.tenant) {
@@ -189,7 +200,7 @@ export class WeaviateStore extends VectorStore {
     documents: Document[],
     options?: { ids?: string[] }
   ) {
-    const documentIds = options?.ids ?? documents.map((_) => uuid.v4());
+    const documentIds = options?.ids ?? documents.map((_) => crypto.randomUUID());
     const batch: DataObject<undefined>[] = documents.map((document, index) => {
       if (Object.hasOwn(document.metadata, "id"))
         throw new Error(
@@ -295,7 +306,7 @@ export class WeaviateStore extends VectorStore {
    */
   async hybridSearch(
     query: string,
-    options?: HybridOptions<undefined>
+    options?: HybridOptions<undefined, undefined, undefined>
   ): Promise<Document[]> {
     const collection = this.client.collections.get(this.indexName);
     let query_vector: number[] | undefined;
@@ -353,7 +364,7 @@ export class WeaviateStore extends VectorStore {
   async generate(
     query: string,
     generate: GenerateOptions<undefined, GenerativeConfigRuntime | undefined>,
-    options?: BaseHybridOptions<undefined>
+    options?: BaseHybridOptions<undefined, undefined, undefined>
   ): Promise<WeaviateDocument[]> {
     const collection = this.client.collections.get(this.indexName);
     let result;
@@ -472,7 +483,7 @@ export class WeaviateStore extends VectorStore {
           }),
           metadata?.distance ?? 0,
           metadata?.score ?? 0,
-          Object.values(data.vectors)[0],
+          Object.values(data.vectors)[0] as number[],
         ]);
       }
       return documents;

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -316,10 +316,9 @@ export class WeaviateStore extends VectorStore {
       query_vector = await this.embeddings.embedQuery(query);
     }
 
-    const { filter, ...restOptions } = options ?? {};
     const options_with_vector = {
-      ...restOptions,
-      filters: restOptions.filters ?? filter,
+      ...(options ?? {}),
+      filters: options?.filters ?? options?.filter,
       vector: options?.vector || query_vector,
       returnMetadata: [
         "score",
@@ -373,10 +372,9 @@ export class WeaviateStore extends VectorStore {
     }
   ): Promise<WeaviateDocument[]> {
     const collection = this.client.collections.get(this.indexName);
-    const { filter, ...restOptions } = options ?? {};
     const hybridOptions = {
-      ...restOptions,
-      filters: restOptions.filters ?? filter,
+      ...(options ?? {}),
+      filters: options?.filters ?? options?.filter,
     };
     let result;
     if (this.tenant) {

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -132,10 +132,7 @@ export class WeaviateStore extends VectorStore {
     // raw REST/JSON schema — it is not the standard JSON Schema `class` keyword.
     // See WeaviateClass in weaviate-client/openapi/types.
     this.indexName =
-      args.indexName ||
-      args.schema?.name ||
-      args.jsonSchema?.class ||
-      "";
+      args.indexName || args.schema?.name || args.jsonSchema?.class || "";
     this.textKey = args.textKey || "text";
     this.queryAttrs = [this.textKey];
     this.tenant = args.tenant;
@@ -209,7 +206,8 @@ export class WeaviateStore extends VectorStore {
     documents: Document[],
     options?: { ids?: string[] }
   ) {
-    const documentIds = options?.ids ?? documents.map((_) => crypto.randomUUID());
+    const documentIds =
+      options?.ids ?? documents.map((_) => crypto.randomUUID());
     const batch: DataObject<undefined>[] = documents.map((document, index) => {
       if (Object.hasOwn(document.metadata, "id"))
         throw new Error(


### PR DESCRIPTION
## Summary

This PR upgrades the `@langchain/weaviate` integration to `weaviate-client` v3.13.0 and adds support for creating collections from a raw JSON schema using the new `createFromJson` API.

It will allow more advanced usage, as you can now define the advanced collections options, such as dynamic index, quantization/compression, multi tenant, different property tokenization, etc.

It will also allow integrations such as n8n to pass a json schema along.

[You can use this online tool to design your collection schema](https://weaviate.github.io/weaviate-add-collection/)

## Changes

### `@langchain/weaviate`

- **New `jsonSchema` field** — `WeaviateLibArgs` now accepts a `jsonSchema?: Record<string, unknown>` property that maps directly to the raw Weaviate JSON schema format (as returned by the REST API or `client.collections.exportToJson()`). Internally it calls `client.collections.createFromJson()`, introduced in weaviate-client v3.13.0.
- **Backward compatible** — the existing `schema?: CollectionConfigCreate` field is fully preserved and continues to call `client.collections.create()`. When both fields are provided, `jsonSchema` takes precedence.
- **`crypto.randomUUID()`** — replaced the broken `@langchain/core/utils/uuid` import with the native `crypto.randomUUID()` (safe since Node ≥ 20 is already required by this package).
- **weaviate-client bumped to `^3.13.0`** — updated `package.json` and `pnpm-lock.yaml` (only the weaviate-client dependency and its transitive deps were changed in the lockfile).
- **Unit tests** — added four new tests covering all `initialize()` creation paths: `jsonSchema` only, `schema` only, `jsonSchema` takes precedence over `schema`, and skip creation when the collection already exists.
- Accept both `filter` and `filters` parameter for Hybrid Searches.

### `@langchain/core`

- Exports `./utils/uuid` as a public subpath in `package.json` and registers it in the import map, making UUID utilities available as `@langchain/core/utils/uuid`.

## Usage

```typescript
// New: create from a raw JSON schema (e.g. exported from Weaviate or the REST API)
const jsonSchema = {
  "class": "MyJsonCollection",
  "properties": [
    {
      "name": "text",
      "dataType": [
        "text"
      ],
      "indexFilterable": true,
      "indexSearchable": true,
      "tokenization": "word",
      "indexRangeFilters": false
    },
    {
      "name": "my_custom_id",
      "dataType": [
        "text"
      ],
      "indexFilterable": true,
      "indexSearchable": true,
      "tokenization": "field",
      "indexRangeFilters": false
    }
  ],
  "vectorConfig": {
    "default": {
      "vectorizer": {
        "text2vec-openai": {
          "properties": [
            "text"
          ]
        }
      },
      "vectorIndexType": "dynamic",
      "vectorIndexConfig": {
        "hnsw": {
          "rq": {
            "enabled": true
          }
        }
      }
    }
  },
  "multiTenancyConfig": {
    "enabled": true,
    "autoTenantCreation": true,
    "autoTenantActivation": true
  }
};

const store = await WeaviateStore.initialize(new OpenAIEmbeddings(), {
  client,
  jsonSchema,
  textKey: "text",
  metadataKeys: ["my_custom_id"],
});

// Existing: still works as before
const store = await WeaviateStore.initialize(embeddings, {
  client,
  schema: {
    name: "MyCollection",
    properties: [...],
  },
});
```

## Test plan

- [x] All existing unit tests pass (`pnpm test` in `libs/providers/langchain-weaviate`)
- [x] Four new unit tests added for `jsonSchema` / `schema` / precedence / skip-if-exists paths
- [x] TypeScript compiles with no errors in `vectorstores.ts`
- [ ] Integration tests against a live Weaviate instance (requires `WEAVIATE_URL` + credentials)
