### PR TITLE
fix(community): route Atlas Voyage keys to MongoDB endpoint

### DIFF
--- a/.changeset/lucky-trains-serve.md
+++ b/.changeset/lucky-trains-serve.md
@@ -1,0 +1,5 @@
+---
+"@langchain/community": patch
+---
+
+Default Voyage embeddings with MongoDB Atlas API keys to the MongoDB AI endpoint.

--- a/libs/langchain-community/src/embeddings/tests/voyage.test.ts
+++ b/libs/langchain-community/src/embeddings/tests/voyage.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@jest/globals";
+import { VoyageEmbeddings } from "../voyage.js";
+
+test("VoyageEmbeddings defaults native keys to the Voyage AI endpoint", () => {
+  const embeddings = new VoyageEmbeddings({
+    apiKey: "pa-test-key",
+  });
+
+  expect(embeddings.apiUrl).toBe("https://api.voyageai.com/v1/embeddings");
+});
+
+test("VoyageEmbeddings defaults Atlas keys to the MongoDB AI endpoint", () => {
+  const embeddings = new VoyageEmbeddings({
+    apiKey: "al-test-key",
+  });
+
+  expect(embeddings.apiUrl).toBe("https://ai.mongodb.com/v1/embeddings");
+});
+
+test("VoyageEmbeddings uses the provided basePath when set", () => {
+  const embeddings = new VoyageEmbeddings({
+    apiKey: "al-test-key",
+    basePath: "https://example.test/v1",
+  });
+
+  expect(embeddings.apiUrl).toBe("https://example.test/v1/embeddings");
+});

--- a/libs/langchain-community/src/embeddings/voyage.ts
+++ b/libs/langchain-community/src/embeddings/voyage.ts
@@ -2,6 +2,15 @@ import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import { Embeddings, type EmbeddingsParams } from "@langchain/core/embeddings";
 import { chunkArray } from "@langchain/core/utils/chunk_array";
 
+const VOYAGE_API_BASE_PATH = "https://api.voyageai.com/v1";
+const MONGODB_ATLAS_VOYAGE_API_BASE_PATH = "https://ai.mongodb.com/v1";
+
+function getDefaultVoyageBasePath(apiKey: string): string {
+  return apiKey.startsWith("al-")
+    ? MONGODB_ATLAS_VOYAGE_API_BASE_PATH
+    : VOYAGE_API_BASE_PATH;
+}
+
 /**
  * Interface that extends EmbeddingsParams and defines additional
  * parameters specific to the VoyageEmbeddings class.
@@ -39,6 +48,11 @@ export interface VoyageEmbeddingsParams extends EmbeddingsParams {
    * The format of the output embeddings. Can be "float", "base64", or "ubinary".
    */
   encodingFormat?: string;
+
+  /**
+   * Base URL for the embeddings API.
+   */
+  basePath?: string;
 }
 
 /**
@@ -97,7 +111,7 @@ export class VoyageEmbeddings
 
   private apiKey: string;
 
-  basePath?: string = "https://api.voyageai.com/v1";
+  basePath?: string = VOYAGE_API_BASE_PATH;
 
   apiUrl: string;
 
@@ -138,6 +152,8 @@ export class VoyageEmbeddings
     this.modelName = fieldsWithDefaults?.modelName ?? this.modelName;
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.apiKey = apiKey;
+    this.basePath =
+      fieldsWithDefaults?.basePath ?? getDefaultVoyageBasePath(apiKey);
     this.apiUrl = `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
     this.truncation = fieldsWithDefaults?.truncation;


### PR DESCRIPTION
## Summary

Fixes #10778 by matching the official Voyage Python SDK's default endpoint selection for MongoDB Atlas-provisioned Voyage keys.

When `VoyageEmbeddings` receives an API key starting with `al-`, it now defaults to `https://ai.mongodb.com/v1`. Other keys continue to use `https://api.voyageai.com/v1`. Passing `basePath` explicitly still takes precedence.

## Validation

- `corepack yarn install --immutable`
- `corepack yarn workspace @langchain/core build`
- `corepack yarn workspace @langchain/community test:single src/embeddings/tests/voyage.test.ts --runInBand`
- `corepack yarn workspace @langchain/community format:check --ignore-path ../../.gitignore src/embeddings/voyage.ts src/embeddings/tests/voyage.test.ts`
- `corepack yarn workspace @langchain/community lint:eslint --no-cache src/embeddings/voyage.ts src/embeddings/tests/voyage.test.ts` (0 errors; existing repo warnings outside touched files)
- `corepack yarn workspace @langchain/community build` (exited 0; existing tree-shaking warnings outside touched files)
- `git diff --check`
