### PR TITLE
fix(anthropic): drop empty thinking blocks on replay

### DIFF
--- a/.changeset/tall-lamps-cross.md
+++ b/.changeset/tall-lamps-cross.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Filter malformed empty thinking blocks before replaying Anthropic streamed messages.

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -314,6 +314,12 @@ function* _formatContentBlocks(
         ...(cacheControl ? { cache_control: cacheControl } : {}),
       } as Anthropic.Messages.DocumentBlockParam;
     } else if (_isAnthropicThinkingBlock(contentPart)) {
+      if (
+        typeof contentPart.thinking !== "string" ||
+        contentPart.thinking.length === 0
+      ) {
+        continue;
+      }
       const block: AnthropicThinkingBlockParam = {
         type: "thinking" as const, // Explicitly setting the type as "thinking"
         thinking: contentPart.thinking,

--- a/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
@@ -1,4 +1,10 @@
 import { test, expect, describe } from "vitest";
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from "@langchain/core/messages";
+import { _convertMessagesToAnthropicPayload } from "../message_inputs.js";
 import { _makeMessageChunkFromAnthropicEvent } from "../message_outputs.js";
 
 const fields = { streamUsage: true, coerceContentToString: false };
@@ -57,5 +63,110 @@ describe("_makeMessageChunkFromAnthropicEvent", () => {
     expect(usage.input_tokens).toBe(0);
     expect(usage.input_token_details?.cache_creation).toBeUndefined();
     expect(usage.input_token_details?.cache_read).toBeUndefined();
+  });
+
+  test("drops empty thinking blocks when replaying streamed content", () => {
+    const events = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_01",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-opus-4-7-20260101",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+          },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "thinking",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "signature_delta",
+          signature: "signature-1",
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 1,
+        content_block: {
+          type: "text",
+          text: "",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: {
+          type: "text_delta",
+          text: "done",
+        },
+      },
+    ];
+
+    let full: AIMessageChunk | undefined;
+    for (const event of events) {
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = _makeMessageChunkFromAnthropicEvent(event as any, fields);
+      if (result) {
+        full = full ? full.concat(result.chunk) : result.chunk;
+      }
+    }
+
+    expect(full).toBeDefined();
+    const payload = _convertMessagesToAnthropicPayload([
+      new HumanMessage("hello"),
+      full!,
+      new HumanMessage("again"),
+    ]);
+    const assistant = payload.messages.find(
+      (message) => message.role === "assistant"
+    );
+
+    expect(assistant).toBeDefined();
+    expect(Array.isArray(assistant!.content)).toBe(true);
+    expect(assistant!.content).toEqual([{ type: "text", text: "done" }]);
+  });
+
+  test("preserves complete thinking blocks when replaying messages", () => {
+    const payload = _convertMessagesToAnthropicPayload([
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: [
+          {
+            type: "thinking",
+            thinking: "reasoned answer",
+            signature: "signature-1",
+          },
+          { type: "text", text: "done" },
+        ],
+      }),
+      new HumanMessage("again"),
+    ]);
+    const assistant = payload.messages.find(
+      (message) => message.role === "assistant"
+    );
+
+    expect(assistant).toBeDefined();
+    expect(assistant!.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "reasoned answer",
+        signature: "signature-1",
+      },
+      { type: "text", text: "done" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- skip malformed Anthropic thinking blocks whose streamed content has a signature but no thinking text
- add a regression test that reconstructs streamed chunks and reserializes them for a follow-up request
- add a guard test proving complete thinking blocks are still replayed unchanged

Fixes #10744.

## Tests
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm --filter @langchain/core build
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm --dir libs/providers/langchain-anthropic exec vitest run src/utils/tests/message_outputs.test.ts
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm --filter @langchain/anthropic test
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm exec oxfmt --check libs/providers/langchain-anthropic/src/utils/message_inputs.ts libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts .changeset/tall-lamps-cross.md
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm exec oxlint libs/providers/langchain-anthropic/src/utils/message_inputs.ts libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
- PATH="/Users/joeyroth/.nvm/versions/node/v24.5.0/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/joeyroth/.codex/tmp/arg0/codex-arg0iCD331:/Users/joeyroth/Library/pnpm:/Users/joeyroth/bin:/Users/joeyroth/.antigravity/antigravity/bin:/Users/joeyroth/.elan/bin:/Users/joeyroth/.local/share/solana/install/active_release/bin:/Users/joeyroth/.nvm/versions/node/v22.17.0/bin:/Users/joeyroth/.cargo/bin:/Users/joeyroth/.foundry/bin:/Users/joeyroth/.local/bin:/Applications/Codex.app/Contents/Resources:/Users/joeyroth/.local/bin" corepack pnpm --filter @langchain/anthropic build
- git diff --check