### PR TITLE
fix(aws): ignore empty Bedrock Converse text blocks

### DIFF
--- a/.changeset/empty-bedrock-text-blocks.md
+++ b/.changeset/empty-bedrock-text-blocks.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): ignore empty Bedrock Converse AI text content blocks

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -110,6 +110,51 @@ describe("convertToConverseMessages", () => {
       },
     },
     {
+      name: "AI message with empty text content block and tool call",
+      input: [
+        new HumanMessage("Use the retriever."),
+        new AIMessage({
+          content: [{ type: "text", text: "" }],
+          tool_calls: [
+            {
+              name: "retrieverTool",
+              args: {
+                query: "weather",
+              },
+              id: "123_retriever_tool",
+            },
+          ],
+        }),
+      ],
+      output: {
+        converseMessages: [
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "Use the retriever.",
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.ASSISTANT,
+            content: [
+              {
+                toolUse: {
+                  name: "retrieverTool",
+                  toolUseId: "123_retriever_tool",
+                  input: {
+                    query: "weather",
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        converseSystem: [],
+      },
+    },
+    {
       name: "prompt caching",
       input: [
         new SystemMessage({

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -501,7 +501,10 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
     const concatenatedBlocks = concatenateLangchainReasoningBlocks(msg.content);
     const contentBlocks: Bedrock.ContentBlock[] = [];
     concatenatedBlocks.forEach((block) => {
-      if (block.type === "text" && block.text !== "") {
+      if (block.type === "text") {
+        if (block.text === "") {
+          return;
+        }
         // Merge whitespace/newlines with previous text blocks to avoid validation errors.
         const cleanedText = block.text?.replace(/\n/g, "").trim();
         if (cleanedText === "") {


### PR DESCRIPTION
Fixes #10782

## Summary
- ignore truly empty AI text content blocks before Bedrock Converse block conversion falls through to the unsupported-block error
- preserve existing whitespace-only text cleanup/merge behavior
- add a regression case for an AI message with an empty text content block plus a tool call
- add a patch changeset for @langchain/aws

## Validation
- pnpm exec oxfmt --check libs/providers/langchain-aws/src/utils/message_inputs.ts libs/providers/langchain-aws/src/tests/chat_models.test.ts .changeset/empty-bedrock-text-blocks.md
- pnpm exec oxlint libs/providers/langchain-aws/src/utils/message_inputs.ts libs/providers/langchain-aws/src/tests/chat_models.test.ts
- pnpm --filter @langchain/aws test -- src/tests/chat_models.test.ts
- pnpm build:compile (from libs/providers/langchain-aws, Node 24.5.0)
- git diff --check