### PR TITLE
fix(openai): preserve top-level Responses API message ids

### DIFF
--- a/.changeset/thin-vans-bow.md
+++ b/.changeset/thin-vans-bow.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): preserve top-level Responses API ids on AI messages

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
@@ -831,7 +831,8 @@ describe("reasoning summaries", () => {
       aiMessage = await llm.invoke(prompt);
     }
 
-    expect(aiMessage.id).toMatch(/^msg_[a-f0-9]+$/);
+    expect(aiMessage.id).toMatch(/^resp_[a-f0-9]+$/);
+    expect(aiMessage.id).toBe(aiMessage.response_metadata.id);
 
     // Check the final aggregated message
     const reasoning = aiMessage?.additional_kwargs

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -336,7 +336,6 @@ export const convertResponsesMessageToAIMessage: Converter<
     throw error;
   }
 
-  let messageId: string | undefined;
   const content: MessageContent = [];
   const tool_calls: ToolCall[] = [];
   const invalid_tool_calls: InvalidToolCall[] = [];
@@ -380,7 +379,6 @@ export const convertResponsesMessageToAIMessage: Converter<
 
   for (const item of response.output) {
     if (item.type === "message") {
-      messageId = item.id;
       content.push(
         ...item.content.flatMap((part) => {
           if (part.type === "output_text") {
@@ -485,7 +483,7 @@ export const convertResponsesMessageToAIMessage: Converter<
   }
 
   return new AIMessage({
-    id: messageId,
+    id: response.id,
     content,
     tool_calls,
     invalid_tool_calls,

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -595,7 +595,7 @@ export const convertReasoningSummaryToResponsesReasoningItem: Converter<
  * @returns A ChatGenerationChunk containing:
  *   - `text`: Concatenated text content from all text parts in the event
  *   - `message`: An AIMessageChunk with:
- *     - `id`: Message ID (set when a message output item is added)
+ *     - `id`: Response ID (set on `response.created` / `response.completed`)
  *     - `content`: Array of content blocks (text with optional annotations)
  *     - `tool_call_chunks`: Incremental tool call data (name, args, id)
  *     - `usage_metadata`: Token usage information (only in completion events)
@@ -676,7 +676,6 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     event.type === "response.output_item.added" &&
     event.item.type === "message"
   ) {
-    id = event.item.id;
     const phase = "phase" in event.item ? event.item.phase : undefined;
     if (phase) {
       content.push({
@@ -751,10 +750,15 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
   ) {
     additional_kwargs.tool_outputs = [event.item];
   } else if (event.type === "response.created") {
+    id = event.response.id;
     response_metadata.id = event.response.id;
     response_metadata.model_name = event.response.model;
     response_metadata.model = event.response.model;
-  } else if (event.type === "response.completed") {
+  } else if (
+    event.type === "response.completed" ||
+    event.type === "response.incomplete"
+  ) {
+    id = event.response.id;
     const msg = convertResponsesMessageToAIMessage(event.response);
 
     usage_metadata = convertResponsesUsageToUsageMetadata(event.response.usage);

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -229,6 +229,34 @@ describe("convertResponsesMessageToAIMessage", () => {
     expect(reasoningBlocks.length).toBe(0);
   });
 
+  it("uses the top-level response id for the AIMessage id", () => {
+    const response = {
+      id: "resp_top_level",
+      model: "gpt-4o",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_nested",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello!", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    expect(result.id).toBe("resp_top_level");
+    expect(result.response_metadata.id).toBe("resp_top_level");
+  });
+
   it("should store output in response_metadata", () => {
     const output = [
       {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -317,6 +317,71 @@ describe("convertResponsesMessageToAIMessage", () => {
 });
 
 describe("convertResponsesDeltaToChatGenerationChunk", () => {
+  it("uses the top-level response id when streaming", () => {
+    const created = convertResponsesDeltaToChatGenerationChunk({
+      type: "response.created",
+      response: {
+        id: "resp_top_level",
+        model: "gpt-4o",
+        object: "response",
+        status: "in_progress",
+        output: [],
+      },
+    } as any);
+    const messageAdded = convertResponsesDeltaToChatGenerationChunk({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "msg_nested",
+        role: "assistant",
+        content: [],
+        status: "in_progress",
+      },
+    } as any);
+    const textDelta = convertResponsesDeltaToChatGenerationChunk({
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: "Hello!",
+    } as any);
+    const completed = convertResponsesDeltaToChatGenerationChunk({
+      type: "response.completed",
+      response: {
+        id: "resp_top_level",
+        model: "gpt-4o",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg_nested",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hello!", annotations: [] }],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      },
+    } as any);
+
+    expect(created?.message.id).toBe("resp_top_level");
+    expect(messageAdded?.message.id).toBeUndefined();
+    expect(textDelta?.message.id).toBeUndefined();
+
+    const aggregated = [created!, messageAdded!, textDelta!, completed!].reduce(
+      (acc, chunk) => acc.concat(chunk.message as AIMessageChunk),
+      created!.message as AIMessageChunk
+    );
+
+    expect(aggregated.id).toBe("resp_top_level");
+    expect(aggregated.response_metadata.id).toBe("resp_top_level");
+  });
+
   describe("custom tool streaming delta handling", () => {
     it("should handle response.custom_tool_call_input.delta events", () => {
       // Test custom tool delta event


### PR DESCRIPTION
Fixes #10499.

## Summary

- Use the top-level OpenAI Responses API `response.id` as the resulting `AIMessage.id`.
- Stop overwriting the message id with the nested `message` output item id while still preserving the full raw output in `response_metadata.output`.
- Add a regression test that distinguishes the top-level response id from the nested output message id.

## Validation

- `pnpm install --frozen-lockfile`
- `nvm use 24.5.0 && cd libs/langchain-core && pnpm build:compile`
- `pnpm --filter @langchain/openai exec vitest run src/converters/tests/responses.test.ts --typecheck.enabled false`
- `pnpm exec oxfmt --check libs/providers/langchain-openai/src/converters/responses.ts libs/providers/langchain-openai/src/converters/tests/responses.test.ts .changeset/thin-vans-bow.md`
- `pnpm exec oxlint libs/providers/langchain-openai/src/converters/responses.ts libs/providers/langchain-openai/src/converters/tests/responses.test.ts`
- `nvm use 24.5.0 && cd libs/providers/langchain-openai && pnpm build:compile`
- `git diff --check`

I also tried `pnpm --filter @langchain/openai test -- src/converters/tests/responses.test.ts`; the runtime tests passed, but the package script exited non-zero because Vitest type-checking scanned unrelated existing test files with type errors outside this patch.
