### PR TITLE
fix(google): restore withStructuredOutput includeRaw parsing with reasoning blocks

### DIFF
--- a/.changeset/strong-poems-rhyme.md
+++ b/.changeset/strong-poems-rhyme.md
@@ -1,0 +1,8 @@
+---
+"@langchain/core": patch
+"@langchain/google-common": patch
+---
+
+fix(google): restore structured output parsing with includeRaw and reasoning blocks
+
+Ensure structured output parsers read `BaseMessage` text content when `includeRaw: true`, so responses that include reasoning/thought blocks plus JSON text continue to parse correctly.

--- a/libs/langchain-core/src/output_parsers/standard_schema.ts
+++ b/libs/langchain-core/src/output_parsers/standard_schema.ts
@@ -1,6 +1,7 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 import { BaseOutputParser, OutputParserException } from "./base.js";
 import { parseJsonMarkdown } from "./json.js";
+import { BaseMessage } from "../messages/index.js";
 
 export class StandardSchemaOutputParser<
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,6 +41,10 @@ export class StandardSchemaOutputParser<
         text
       );
     }
+  }
+
+  protected override _baseMessageToString(message: BaseMessage): string {
+    return message.text;
   }
 
   getFormatInstructions(): string {

--- a/libs/langchain-core/src/output_parsers/structured.ts
+++ b/libs/langchain-core/src/output_parsers/structured.ts
@@ -4,6 +4,7 @@ import {
   FormatInstructionsOptions,
   OutputParserException,
 } from "./base.js";
+import { BaseMessage } from "../messages/index.js";
 import {
   type InteropZodType,
   type InferInteropZodOutput,
@@ -129,6 +130,10 @@ ${JSON.stringify(toJsonSchema(this.schema))}
         text
       );
     }
+  }
+
+  protected override _baseMessageToString(message: BaseMessage): string {
+    return message.text;
   }
 }
 

--- a/libs/langchain-core/src/output_parsers/tests/standard_schema.test.ts
+++ b/libs/langchain-core/src/output_parsers/tests/standard_schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { StandardSchemaV1 } from "@standard-schema/spec";
+import { AIMessage } from "../../messages/index.js";
 import { StandardSchemaOutputParser } from "../standard_schema.js";
 import { OutputParserException } from "../base.js";
 
@@ -94,6 +95,36 @@ describe("StandardSchemaOutputParser", () => {
         expect(e).toBeInstanceOf(OutputParserException);
         expect((e as OutputParserException).llmOutput).toBe('{"test": true}');
       }
+    });
+
+    it("invoke parses BaseMessage with reasoning blocks", async () => {
+      const schema = makeValidatingSchema<{ answer: string }>((v) => {
+        if (
+          typeof v === "object" &&
+          v !== null &&
+          "answer" in v &&
+          typeof v.answer === "string"
+        ) {
+          return { value: { answer: v.answer } };
+        }
+        return {
+          issues: [
+            { message: "answer is required", path: [{ key: "answer" }] },
+          ],
+        };
+      });
+      const parser = new StandardSchemaOutputParser(schema);
+
+      const result = await parser.invoke(
+        new AIMessage({
+          content: [
+            { type: "reasoning", reasoning: "Let me think..." },
+            { type: "text", text: '{"answer":"value"}' },
+          ],
+        })
+      );
+
+      expect(result).toEqual({ answer: "value" });
     });
   });
 

--- a/libs/langchain-core/src/output_parsers/tests/structured.test.ts
+++ b/libs/langchain-core/src/output_parsers/tests/structured.test.ts
@@ -3,6 +3,7 @@ import { z as z4 } from "zod/v4";
 
 import { describe, expect, test } from "vitest";
 
+import { AIMessage } from "../../messages/index.js";
 import { OutputParserException } from "../base.js";
 import { StructuredOutputParser } from "../structured.js";
 import { InteropZodObject, InteropZodType } from "../../utils/types/zod.js";
@@ -33,6 +34,25 @@ test("StructuredOutputParser.fromNamesAndDescriptions", async () => {
   \`\`\`
   "
   `);
+});
+
+test("StructuredOutputParser.invoke parses BaseMessage with reasoning blocks", async () => {
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({
+      answer: z.string(),
+    })
+  );
+
+  const result = await parser.invoke(
+    new AIMessage({
+      content: [
+        { type: "reasoning", reasoning: "Let me think..." },
+        { type: "text", text: '{"answer":"value"}' },
+      ],
+    })
+  );
+
+  expect(result).toEqual({ answer: "value" });
 });
 
 enum StateProvinceEnum {

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -2336,6 +2336,32 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(data.generationConfig.responseMimeType).toBe("application/json");
   });
 
+  test("4. Functions withStructuredOutput - includeRaw parses thought content blocks", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-json-schema-thinking-mock.json",
+    };
+
+    const schema = z.object({
+      testName: z.string().describe("The name of the test."),
+    });
+
+    const baseModel = new ChatGoogle({
+      authOptions,
+    });
+    const model = baseModel.withStructuredOutput(schema, {
+      includeRaw: true,
+    });
+
+    const result = await model.invoke("What is the test name?");
+
+    expect(result.raw).toBeDefined();
+    expect(result.parsed).toEqual({ testName: "cobalt" });
+  });
+
   test("4. Functions withStructuredOutput - functionCalling method request", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/providers/langchain-google-common/src/tests/data/chat-json-schema-thinking-mock.json
+++ b/libs/providers/langchain-google-common/src/tests/data/chat-json-schema-thinking-mock.json
@@ -1,0 +1,20 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Let me reason through this first.",
+            "thought": true
+          },
+          {
+            "text": "{\"testName\": \"cobalt\"}"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This fixes a regression in structured output parsing that surfaced for @langchain/google-vertexai users after 2.1.23.

When withStructuredOutput(..., { includeRaw: true }) parsed a BaseMessage whose content was ContentBlock[] (for example, reasoning/thought block + text JSON block), parsers could serialize the full block array instead of extracting text, causing parse failures (parsed: null).

### What changed
- Update StructuredOutputParser to parse BaseMessage via message.text.
- Update StandardSchemaOutputParser to parse BaseMessage via message.text.
- Add parser-level regression tests in @langchain/core for reasoning+text content arrays.
- Add @langchain/google-common regression test for withStructuredOutput(..., { includeRaw: true }) with thought content blocks.
- Add mock fixture chat-json-schema-thinking-mock.json.

## Testing
- pnpm test src/output_parsers/tests/structured.test.ts src/output_parsers/tests/standard_schema.test.ts --hookTimeout=60000 (in libs/langchain-core)
- pnpm test src/tests/chat_models.test.ts -t "includeRaw parses thought content blocks" (in libs/providers/langchain-google-common)
