### PR TITLE
feat(langchain): add registerProviderForBundling for bundler support

### DIFF
--- a/.changeset/init-chat-model-bundling-registry.md
+++ b/.changeset/init-chat-model-bundling-registry.md
@@ -1,0 +1,5 @@
+---
+"langchain": minor
+---
+
+Add `registerProviderForBundling` to make `initChatModel` work with bundlers (esbuild, rollup, webpack). Without it, the lib's runtime `import(packageName)` cannot be statically analyzed and provider packages are dropped from production bundles. Call once at app entry with the provider key and the imported package namespace. Without the call, behavior is unchanged.

--- a/libs/langchain/src/chat_models/tests/universal.test.ts
+++ b/libs/langchain/src/chat_models/tests/universal.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { initChatModel } from "../universal.js";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { ChatOpenAI } from "@langchain/openai";
+import {
+  getChatModelByClassName,
+  initChatModel,
+  registerProviderForBundling,
+} from "../universal.js";
 
 describe("Will appropriately infer a model profiles", () => {
   it("when provided a profile", async () => {
@@ -16,5 +21,89 @@ describe("Will appropriately infer a model profiles", () => {
       temperature: 0,
     });
     expect(model.profile.maxInputTokens).toBeDefined();
+  });
+});
+
+describe("registerProviderForBundling", () => {
+  afterEach(() => {
+    globalThis.lc_chat_model_provider_registry.clear();
+  });
+
+  it("returns the registered class for the given provider", async () => {
+    class DummyOpenAI {
+      constructor(public fields: Record<string, unknown>) {}
+    }
+
+    registerProviderForBundling("openai", { ChatOpenAI: DummyOpenAI });
+
+    const chatModelClass = await getChatModelByClassName(
+      "ChatOpenAI",
+      "openai"
+    );
+
+    expect(chatModelClass).toBe(DummyOpenAI);
+  });
+
+  it("falls through to dynamic import when no registration exists", async () => {
+    // No registerProviderForBundling call. Must hit the dynamic-import branch
+    // and resolve the real class from @langchain/openai.
+    const chatModelClass = await getChatModelByClassName(
+      "ChatOpenAI",
+      "openai"
+    );
+
+    expect(chatModelClass).toBe(ChatOpenAI);
+  });
+
+  it("overwrites a prior registration for the same provider key", async () => {
+    class DummyOpenAI {
+      constructor(public fields: Record<string, unknown>) {}
+    }
+
+    class AnotherDummyOpenAI {
+      constructor(public fields: Record<string, unknown>) {}
+    }
+
+    registerProviderForBundling("openai", { ChatOpenAI: DummyOpenAI });
+    registerProviderForBundling("openai", {
+      ChatOpenAI: AnotherDummyOpenAI,
+    });
+
+    const chatModelClass = await getChatModelByClassName(
+      "ChatOpenAI",
+      "openai"
+    );
+
+    expect(chatModelClass).toBe(AnotherDummyOpenAI);
+  });
+
+  it("throws when the registered module is missing the expected class", async () => {
+    registerProviderForBundling("openai", {});
+
+    await expect(
+      getChatModelByClassName("ChatOpenAI", "openai")
+    ).rejects.toThrow(
+      `Module registered for "openai" must export "ChatOpenAI".`
+    );
+  });
+
+  it("initChatModel uses the registered class", async () => {
+    const constructorSpy = vi.fn();
+    class TrackedDummyOpenAI {
+      constructor(public fields: Record<string, unknown>) {
+        constructorSpy(fields);
+      }
+    }
+    registerProviderForBundling("openai", {
+      ChatOpenAI: TrackedDummyOpenAI,
+    });
+
+    await initChatModel("openai:gpt-4o-mini", { temperature: 0.5 });
+
+    expect(constructorSpy).toHaveBeenCalledOnce();
+    expect(constructorSpy).toHaveBeenCalledWith({
+      model: "gpt-4o-mini",
+      temperature: 0.5,
+    });
   });
 });

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -144,6 +144,16 @@ type ModelProviderConfig = {
   hasCircularDependency?: boolean;
 };
 
+declare global {
+  // oxlint-disable-next-line vars-on-top, no-var
+  var lc_chat_model_provider_registry: Map<
+    ChatModelProvider,
+    Record<string, unknown>
+  >;
+}
+
+globalThis.lc_chat_model_provider_registry ??= new Map();
+
 /**
  * Helper function to get a chat model class by its class name or model provider.
  * @param className The class name (e.g., "ChatOpenAI", "ChatAnthropic")
@@ -175,6 +185,23 @@ export async function getChatModelByClassName(
 
   if (!config) {
     return undefined;
+  }
+
+  const registeredModule =
+    modelProvider !== undefined
+      ? globalThis.lc_chat_model_provider_registry.get(
+          modelProvider as ChatModelProvider
+        )
+      : undefined;
+
+  if (registeredModule) {
+    const chatModelClass = registeredModule[config.className];
+    if (!chatModelClass) {
+      throw new Error(
+        `Module registered for "${modelProvider}" must export "${config.className}".`
+      );
+    }
+    return chatModelClass;
   }
 
   try {
@@ -273,6 +300,34 @@ export function _inferModelProvider(modelName: string): string | undefined {
   } else {
     return undefined;
   }
+}
+
+/**
+ * Register a provider package module so bundlers
+ * (esbuild, rollup, webpack)
+ * include it in production bundles.
+ *
+ * Without this call,
+ * `initChatModel` resolves provider packages via runtime `import(packageName)`,
+ * which bundlers cannot statically analyze.
+ * This causes `Cannot find module '@langchain/X'` errors
+ * in single-file bundles (lambdas, browser bundles).
+ *
+ * Pass the namespace import of the provider package.
+ * Call once per provider key at app entry,
+ * before any `initChatModel` invocation.
+ *
+ * @example
+ *   import * as aws from "@langchain/aws";
+ *   import { registerProviderForBundling } from "langchain/chat_models/universal";
+ *
+ *   registerProviderForBundling("bedrock", aws);
+ */
+export function registerProviderForBundling(
+  provider: ChatModelProvider,
+  packageModule: Record<string, unknown>
+): void {
+  globalThis.lc_chat_model_provider_registry.set(provider, packageModule);
 }
 
 interface ConfigurableModelFields extends BaseChatModelParams {


### PR DESCRIPTION
## Summary

Adds `registerProviderForBundling` so `initChatModel` works with esbuild-bundled apps. Without it, the lib's runtime `import(config.package)` cannot be statically analyzed, and provider integration packages are dropped from production bundles.

Fixes #10818

## Problem

`getChatModelByClassName` resolves provider packages via:

```ts
const module = await import(config.package);
```

`config.package` is a runtime variable from `MODEL_PROVIDER_CONFIG`. esbuild cannot statically analyze a non-literal `import()` argument and excludes the target package from the bundle. Single-file deploys then fail at runtime:

```
Error: Unable to import @langchain/aws. Please install with `npm install @langchain/aws` or `pnpm install @langchain/aws`
```

The package was installed in the project, but esbuild did not bundle it.

## Solution

A globally-scoped registry mapped by provider key. Users register a package namespace at app entry; the lib consults the registry before falling back to the existing dynamic import, avoiding `import(config.package)` for registered providers.

```ts
// app entry — runs once at boot
import * as aws from "@langchain/aws";
import { registerProviderForBundling } from "langchain/chat_models/universal";

registerProviderForBundling("bedrock", aws);
```

Anywhere later, unchanged:

```ts
const model = await initChatModel("bedrock:claude-3-5-sonnet-20241022");
```

## Notes

Without `registerProviderForBundling` the registry is empty; every lookup misses; existing dynamic-import path runs unchanged. No behavioral change for current users.
