### PR TITLE
fix(core): translate content block delta for other models

### DIFF
--- a/.changeset/sour-glasses-join.md
+++ b/.changeset/sour-glasses-join.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): translate content block delta for other models

--- a/libs/langchain-core/src/language_models/stream.ts
+++ b/libs/langchain-core/src/language_models/stream.ts
@@ -127,11 +127,46 @@ function applyDelta(
   }
 }
 
+/**
+ * Returns the typed delta carried by a content-block delta event.
+ *
+ * Stream protocol compliant language models store incremental updates in
+ * `event.delta`, e.g. `{ type: "text-delta", text: "hello" }`. Some models and
+ * adapters still emit the older content-shaped form on `event.content`, e.g.
+ * `{ type: "text", text: "hello" }`, which predates explicit delta event
+ * variants.
+ *
+ * Keep accepting that content-shaped form here so {@link ChatModelStream}
+ * remains a tolerant consumer while producers migrate to protocol compliant
+ * typed deltas.
+ *
+ * @internal
+ */
 function getEventDelta(
   event: ChatModelStreamEvent
 ): ContentBlockDelta | undefined {
   if (event.event !== "content-block-delta") return undefined;
-  return event.delta;
+  if ("delta" in event && event.delta) return event.delta;
+
+  const content = (event as { content?: unknown }).content;
+  if (content == null || typeof content !== "object") return undefined;
+  const block = content as { type?: string } & Record<string, unknown>;
+  if (block.type === "text" && typeof block.text === "string") {
+    return { type: "text-delta", text: block.text };
+  }
+  if (block.type === "reasoning" && typeof block.reasoning === "string") {
+    return { type: "reasoning-delta", reasoning: block.reasoning };
+  }
+  if (block.type === "thinking" && typeof block.thinking === "string") {
+    return { type: "reasoning-delta", reasoning: block.thinking };
+  }
+  if (typeof block.data === "string") {
+    return { type: "data-delta", data: block.data, encoding: "base64" };
+  }
+  if (typeof block.type === "string") {
+    return { type: "block-delta", fields: { ...block, type: block.type } };
+  }
+  return undefined;
 }
 
 function getReasoningDelta(content: unknown): string | undefined {

--- a/libs/langchain-core/src/language_models/tests/stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream.test.ts
@@ -251,6 +251,32 @@ describe("ChatModelStream", () => {
       expect(fullText).toBe("Hello world");
     });
 
+    test("accepts legacy content-shaped text deltas", async () => {
+      const stream = new ChatModelStream(
+        iterEvents([
+          { event: "message-start", id: "msg_legacy_content_delta" },
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "text", text: "" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            content: { type: "text", text: "Hello" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            content: { type: "text", text: " world" },
+          },
+          { event: "message-finish", reason: "stop" },
+        ] as unknown as ChatModelStreamEvent[])
+      );
+
+      await expect(stream.text).resolves.toBe("Hello world");
+    });
+
     test(".full yields running concatenation", async () => {
       const stream = new ChatModelStream(iterEvents(textStreamEvents()));
 


### PR DESCRIPTION
## Summary

Fixes a regression in `ChatModelStream` where content-shaped `content-block-delta` events were no longer reflected in derived streams like `.text`.

Some language models and adapters still emit incremental updates on `event.content`, for example:

```ts
{ event: "content-block-delta", content: { type: "text", text: "hello" } }
```

The newer protocol-compliant shape uses typed deltas on event.delta:

```ts
{ event: "content-block-delta", delta: { type: "text-delta", text: "hello" } }
```

This PR restores Core’s transitional runtime tolerance for the content-shaped form so ChatModelStream remains compatible while producers migrate to explicit typed deltas.