### PR TITLE
fix(agents): resolve generic type inference for createAgent state parameters

### DIFF
--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -670,9 +670,9 @@ export type InferMiddlewareInputState<T extends AgentMiddleware> =
  * Helper type to infer merged state from an array of middleware (just the middleware states)
  */
 export type InferMiddlewareStates<T extends readonly AgentMiddleware[]> =
-  T extends readonly []
+  [T] extends [readonly []]
     ? {}
-    : T extends readonly [infer First, ...infer Rest]
+    : [T] extends [readonly [infer First, ...infer Rest]]
       ? First extends AgentMiddleware
         ? Rest extends readonly AgentMiddleware[]
           ? InferMiddlewareState<First> & InferMiddlewareStates<Rest>
@@ -684,9 +684,9 @@ export type InferMiddlewareStates<T extends readonly AgentMiddleware[]> =
  * Helper type to infer merged input state from an array of middleware (with optional defaults)
  */
 export type InferMiddlewareInputStates<T extends readonly AgentMiddleware[]> =
-  T extends readonly []
+  [T] extends [readonly []]
     ? {}
-    : T extends readonly [infer First, ...infer Rest]
+    : [T] extends [readonly [infer First, ...infer Rest]]
       ? First extends AgentMiddleware
         ? Rest extends readonly AgentMiddleware[]
           ? InferMiddlewareInputState<First> & InferMiddlewareInputStates<Rest>
@@ -732,9 +732,9 @@ export type InferMiddlewareContextInput<T extends AgentMiddleware> =
  * Helper type to infer merged context from an array of middleware
  */
 export type InferMiddlewareContexts<T extends readonly AgentMiddleware[]> =
-  T extends readonly []
+  [T] extends [readonly []]
     ? {}
-    : T extends readonly [infer First, ...infer Rest]
+    : [T] extends [readonly [infer First, ...infer Rest]]
       ? First extends AgentMiddleware
         ? Rest extends readonly AgentMiddleware[]
           ? InferMiddlewareContext<First> & InferMiddlewareContexts<Rest>
@@ -761,9 +761,9 @@ type MergeContextTypes<A, B> = [A] extends [undefined]
  * Helper type to infer merged input context from an array of middleware (with optional defaults)
  */
 export type InferMiddlewareContextInputs<T extends readonly AgentMiddleware[]> =
-  T extends readonly []
+  [T] extends [readonly []]
     ? {}
-    : T extends readonly [infer First, ...infer Rest]
+    : [T] extends [readonly [infer First, ...infer Rest]]
       ? First extends AgentMiddleware
         ? Rest extends readonly AgentMiddleware[]
           ? MergeContextTypes<
@@ -802,10 +802,10 @@ export type InferSchemaValue<A extends StateDefinitionInit | undefined> =
         : {};
 
 export type InferSchemaInput<A extends StateDefinitionInit | undefined> =
-  A extends StateSchema<infer TFields>
+  [A] extends [StateSchema<infer TFields>]
     ? InferStateSchemaUpdate<TFields>
-    : A extends InteropZodObject
+    : [A] extends [InteropZodObject]
       ? InferInteropZodInput<A>
-      : A extends AnyAnnotationRoot
+      : [A] extends [AnyAnnotationRoot]
         ? A["Update"]
         : {};

--- a/libs/langchain/src/agents/types.ts
+++ b/libs/langchain/src/agents/types.ts
@@ -137,9 +137,9 @@ export type InferMiddlewareTools<T extends AgentMiddleware> =
  * Recursively extracts tools from each middleware and combines them into a single tuple.
  */
 export type InferMiddlewareToolsArray<T extends readonly AgentMiddleware[]> =
-  T extends readonly []
+  [T] extends [readonly []]
     ? readonly []
-    : T extends readonly [infer First, ...infer Rest]
+    : [T] extends [readonly [infer First, ...infer Rest]]
       ? First extends AgentMiddleware
         ? Rest extends readonly AgentMiddleware[]
           ? readonly [


### PR DESCRIPTION
## Description
This PR fixes a TypeScript inference bug in `createAgent` where the `invoke` parameter type fails to resolve correctly when options like `middleware` or `stateSchema` are omitted and the agent is assigned implicitly. 

## Reproduction
In an implicit assignment, TypeScript throws an error on `.invoke()`:

```typescript
import { createAgent, tool } from "langchain";

const agent = createAgent({
  model: "openai:gpt-4",
  tools: [/* tools */],
  systemPrompt: '...',
});

// ❌ TypeScript Error:
// Argument of type '{ messages: { role: string; content: string; }[]; }' is not assignable to parameter of type 'never'.
await agent.invoke({
  messages: [{ role: 'user', content: "message" }],
});
```

## The Issue
When `Types["State"]` or `Types["Middleware"]` are inferred as broad default bounds (e.g., `readonly AgentMiddleware[]`), TypeScript delays the evaluation of distributive conditional types (like `T extends readonly [] ? ...`). This deferred evaluation results in an unresolved cross-type for `.invoke()`, causing valid inputs (e.g., `{ messages: [...] }`) to be incorrectly flagged as type errors.

## The Fix
Disabled the distributive behavior in the internal middleware and schema type helpers by wrapping the conditional parameters in tuples (e.g., `[T] extends [readonly []] ? ...`). This forces eager evaluation of the types, fully resolving the `InvokeStateParameter` even when explicit bounds are omitted.