### PR TITLE
fix(core, openrouter): make CJS default re-exports callable

### DIFF
--- a/.changeset/fix-cjs-default-reexports.md
+++ b/.changeset/fix-cjs-default-reexports.md
@@ -1,0 +1,6 @@
+---
+"@langchain/core": patch
+"@langchain/openrouter": patch
+---
+
+fix(core, openrouter): make CJS default re-exports callable

--- a/environment_tests/test-exports-cjs/src/require.js
+++ b/environment_tests/test-exports-cjs/src/require.js
@@ -4,6 +4,7 @@ const { ChatOllama } = require("@langchain/ollama");
 const { ChatGoogle } = require("@langchain/google-gauth");
 const { ChatPromptTemplate } = require("@langchain/core/prompts");
 const { RunnableLambda } = require("@langchain/core/runnables");
+const uuid = require("@langchain/core/utils/uuid");
 
 async function test() {
   // Test exports
@@ -13,6 +14,19 @@ async function test() {
   assert(typeof ChatGoogle === "function");
 
   assert(typeof RunnableLambda === "function");
+
+  assert(typeof uuid.v1 === "function");
+  assert(typeof uuid.v4 === "function");
+  assert(typeof uuid.v5 === "function");
+  assert(typeof uuid.v6 === "function");
+  assert(typeof uuid.v7 === "function");
+  assert(typeof uuid.parse === "function");
+  assert(typeof uuid.stringify === "function");
+  assert(typeof uuid.validate === "function");
+  assert(typeof uuid.version === "function");
+  assert(typeof uuid.MAX === "string");
+  assert(typeof uuid.NIL === "string");
+  assert(/^[0-9a-f-]{36}$/.test(uuid.v4()));
   let attemptCount = 0;
   const flakyRunnable = new RunnableLambda({
     func: () => {

--- a/libs/langchain-core/src/utils/uuid/index.ts
+++ b/libs/langchain-core/src/utils/uuid/index.ts
@@ -1,12 +1,25 @@
-export { default as MAX } from "./max.js";
-export { default as NIL } from "./nil.js";
-export { default as parse } from "./parse.js";
-export { default as stringify } from "./stringify.js";
+import _MAX from "./max.js";
+import _NIL from "./nil.js";
+import _parse from "./parse.js";
+import _stringify from "./stringify.js";
+import _v1 from "./v1.js";
+import _v4 from "./v4.js";
+import _v5 from "./v5.js";
+import _v6 from "./v6.js";
+import _v7 from "./v7.js";
+import _validate from "./validate.js";
+import _version from "./version.js";
+
 export type * from "./types.js";
-export { default as v1 } from "./v1.js";
-export { default as v4 } from "./v4.js";
-export { default as v5 } from "./v5.js";
-export { default as v6 } from "./v6.js";
-export { default as v7 } from "./v7.js";
-export { default as validate } from "./validate.js";
-export { default as version } from "./version.js";
+
+export const MAX = _MAX;
+export const NIL = _NIL;
+export const parse = _parse;
+export const stringify = _stringify;
+export const v1 = _v1;
+export const v4 = _v4;
+export const v5 = _v5;
+export const v6 = _v6;
+export const v7 = _v7;
+export const validate = _validate;
+export const version = _version;

--- a/libs/providers/langchain-openrouter/src/index.ts
+++ b/libs/providers/langchain-openrouter/src/index.ts
@@ -12,4 +12,6 @@ export {
   OpenRouterAuthError,
   OpenRouterRateLimitError,
 } from "./utils/errors.js";
-export { default as OPENROUTER_MODEL_PROFILES } from "./profiles.js";
+import _OPENROUTER_MODEL_PROFILES from "./profiles.js";
+
+export const OPENROUTER_MODEL_PROFILES = _OPENROUTER_MODEL_PROFILES;


### PR DESCRIPTION
Fixes #10827

`require("@langchain/core/utils/uuid").v4` resolves to `{ default: [Function v4] }` instead of the function, so `uuid.v4()` throws `TypeError: v4 is not a function`. ESM is unaffected; CJS consumers like `@langchain/google-common`'s `gemini.cjs` crash.

Cause: rolldown emits `export { default as v4 } from "./v4.js"` as `exports.v4 = require_v4` (the namespace object) instead of `exports.v4 = require_v4.default`.

Fix: bind each default import to a local const before re-exporting — semantically identical TS, but rolldown emits this form correctly. Two files used the broken pattern; both updated.