### PR TITLE
chore(core): deprecate `streamLog`, `streamEvents` v1, `RunnableWithMessageHistory` and improve threat model verbiage for `loads`

### DIFF
--- a/.changeset/perky-deer-nail.md
+++ b/.changeset/perky-deer-nail.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+chore(core): deprecate streamLog, streamEvents v1, RunnableWithMessageHistory and improve threat model verbiage for loads

--- a/libs/langchain-core/src/load/index.ts
+++ b/libs/langchain-core/src/load/index.ts
@@ -38,7 +38,7 @@
  * variables:
  *
  * - `false` (default): Secrets must be provided in `secretsMap`. If a secret is not
- *   found, an error is thrown.
+ *   found, `null` is returned instead of loading from environment variables.
  * - `true`: If a secret is not found in `secretsMap`, it will be loaded from
  *   environment variables. Use this only in trusted environments.
  *

--- a/libs/langchain-core/src/load/index.ts
+++ b/libs/langchain-core/src/load/index.ts
@@ -17,13 +17,28 @@
  *
  * When deserializing, the class path is validated against supported namespaces.
  *
+ * ## Threat model
+ *
+ * A serialized LangChain payload crosses a trust boundary because the manifest
+ * may contain serialized objects and configuration that affect runtime behavior.
+ * For example, a payload can configure a chat model with a custom `base_url`,
+ * custom headers, a different model name, or other constructor arguments. These
+ * are supported features, but they also mean the payload contents should be
+ * treated as executable configuration rather than plain text.
+ *
+ * Concretely, deserialization instantiates classes, so any constructor on an
+ * allowed class will run during `load()`. A crafted payload that is allowed to
+ * reach an unintended class — or an intended class with attacker-controlled
+ * kwargs — could cause network calls, file operations, or environment-variable
+ * access while the object is being built.
+ *
  * ## Security model
  *
  * The `secretsFromEnv` parameter controls whether secrets can be loaded from environment
  * variables:
  *
  * - `false` (default): Secrets must be provided in `secretsMap`. If a secret is not
- *   found, `null` is returned instead of loading from environment variables.
+ *   found, an error is thrown.
  * - `true`: If a secret is not found in `secretsMap`, it will be loaded from
  *   environment variables. Use this only in trusted environments.
  *
@@ -425,6 +440,10 @@ async function reviver(this: ReviverContext, value: unknown): Promise<unknown> {
  * originates from an untrusted source, an attacker can craft a payload that
  * instantiates arbitrary allowed classes with attacker-controlled arguments,
  * potentially causing secret exfiltration, SSRF, or other side effects.
+ *
+ * A serialized payload should be treated as executable configuration — it can
+ * configure models with custom endpoints, headers, or other constructor kwargs
+ * that execute during instantiation.
  *
  * Only call `load()` on data you have produced yourself or received from a
  * fully trusted origin (e.g., your own database). **Never deserialize

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -850,6 +850,42 @@ export abstract class Runnable<
    */
   streamEvents(
     input: RunInput,
+    options: Partial<CallOptions> & { version?: "v2" },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version?: "v2";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & { version: "v1" },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version: "v1";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  streamEvents(
+    input: RunInput,
     options: Partial<CallOptions> & { version: "v1" | "v2" },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
@@ -866,21 +902,25 @@ export abstract class Runnable<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version: "v1" | "v2";
+      version?: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent | Uint8Array> {
+    const version = options.version ?? "v2";
+    const resolvedOptions = { ...options, version };
+
     let stream;
-    if (options.version === "v1") {
-      stream = this._streamEventsV1(input, options, streamOptions);
-    } else if (options.version === "v2") {
-      stream = this._streamEventsV2(input, options, streamOptions);
+    if (version === "v1") {
+      stream = this._streamEventsV1(input, resolvedOptions, streamOptions);
+    } else if (version === "v2") {
+      stream = this._streamEventsV2(input, resolvedOptions, streamOptions);
     } else {
       throw new Error(
         `Only versions "v1" and "v2" of the schema are currently supported.`
       );
     }
+
     if (options.encoding === "text/event-stream") {
       return convertToHttpEventStream(stream);
     } else {
@@ -1418,6 +1458,42 @@ export class RunnableBinding<
 
   streamEvents(
     input: RunInput,
+    options: Partial<CallOptions> & { version?: "v2" },
+    streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version?: "v2";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & { version: "v1" },
+    streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version: "v1";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  streamEvents(
+    input: RunInput,
     options: Partial<CallOptions> & { version: "v1" | "v2" },
     streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
@@ -1434,12 +1510,13 @@ export class RunnableBinding<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version: "v1" | "v2";
+      version?: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent | Uint8Array> {
     const outerThis = this;
+    const version = options.version ?? "v2";
     const generator = async function* () {
       yield* outerThis.bound.streamEvents(
         input,
@@ -1448,7 +1525,7 @@ export class RunnableBinding<
             ensureConfig(options),
             outerThis.kwargs
           )),
-          version: options.version,
+          version,
         },
         streamOptions
       );

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -677,6 +677,9 @@ export abstract class Runnable<
    * jsonpatch ops that describe how the state of the run has changed in each
    * step, and the final state of the run.
    * The jsonpatch ops can be applied in order to construct state.
+   *
+   * @deprecated Use `.stream()` instead.
+   *
    * @param input
    * @param options
    * @param streamOptions

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -853,14 +853,14 @@ export abstract class Runnable<
    */
   streamEvents(
     input: RunInput,
-    options: Partial<CallOptions> & { version?: "v2" },
+    options: Partial<CallOptions> & { version: "v2" },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
 
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version?: "v2";
+      version: "v2";
       encoding: "text/event-stream";
     },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
@@ -905,19 +905,16 @@ export abstract class Runnable<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version?: "v1" | "v2";
+      version: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent | Uint8Array> {
-    const version = options.version ?? "v2";
-    const resolvedOptions = { ...options, version };
-
     let stream;
-    if (version === "v1") {
-      stream = this._streamEventsV1(input, resolvedOptions, streamOptions);
-    } else if (version === "v2") {
-      stream = this._streamEventsV2(input, resolvedOptions, streamOptions);
+    if (options.version === "v1") {
+      stream = this._streamEventsV1(input, options, streamOptions);
+    } else if (options.version === "v2") {
+      stream = this._streamEventsV2(input, options, streamOptions);
     } else {
       throw new Error(
         `Only versions "v1" and "v2" of the schema are currently supported.`
@@ -1461,14 +1458,14 @@ export class RunnableBinding<
 
   streamEvents(
     input: RunInput,
-    options: Partial<CallOptions> & { version?: "v2" },
+    options: Partial<CallOptions> & { version: "v2" },
     streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
 
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version?: "v2";
+      version: "v2";
       encoding: "text/event-stream";
     },
     streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
@@ -1513,13 +1510,12 @@ export class RunnableBinding<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version?: "v1" | "v2";
+      version: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<LogStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent | Uint8Array> {
     const outerThis = this;
-    const version = options.version ?? "v2";
     const generator = async function* () {
       yield* outerThis.bound.streamEvents(
         input,
@@ -1528,7 +1524,7 @@ export class RunnableBinding<
             ensureConfig(options),
             outerThis.kwargs
           )),
-          version,
+          version: options.version,
         },
         streamOptions
       );

--- a/libs/langchain-core/src/runnables/history.ts
+++ b/libs/langchain-core/src/runnables/history.ts
@@ -42,6 +42,9 @@ export interface RunnableWithMessageHistoryInputs<
  * Wraps a LCEL chain and manages history. It appends input messages
  * and chain outputs as history, and adds the current history messages to
  * the chain input.
+ *
+ * @deprecated Use LangGraph's built-in persistence instead.
+ *
  * @example
  * ```typescript
  * // pnpm install @langchain/anthropic @langchain/classic

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -602,6 +602,42 @@ export class ConfigurableModel<
 
   streamEvents(
     input: RunInput,
+    options: Partial<CallOptions> & { version?: "v2" },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version?: "v2";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & { version: "v1" },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<StreamEvent>;
+
+  /**
+   * @deprecated Use version "v2" or `.stream()` instead.
+   */
+  streamEvents(
+    input: RunInput,
+    options: Partial<CallOptions> & {
+      version: "v1";
+      encoding: "text/event-stream";
+    },
+    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
+  ): IterableReadableStream<Uint8Array>;
+
+  streamEvents(
+    input: RunInput,
     options: Partial<CallOptions> & { version: "v1" | "v2" },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
@@ -618,7 +654,7 @@ export class ConfigurableModel<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version: "v1" | "v2";
+      version?: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
@@ -626,7 +662,8 @@ export class ConfigurableModel<
     const outerThis = this;
     async function* wrappedGenerator() {
       const model = await outerThis._getModelInstance(options);
-      const config = ensureConfig(options);
+      const version = options.version ?? "v2";
+      const config = ensureConfig({ ...options, version });
       const eventStream = model.streamEvents(input, config, streamOptions);
 
       for await (const chunk of eventStream) {

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -602,42 +602,6 @@ export class ConfigurableModel<
 
   streamEvents(
     input: RunInput,
-    options: Partial<CallOptions> & { version?: "v2" },
-    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
-  ): IterableReadableStream<StreamEvent>;
-
-  streamEvents(
-    input: RunInput,
-    options: Partial<CallOptions> & {
-      version?: "v2";
-      encoding: "text/event-stream";
-    },
-    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
-  ): IterableReadableStream<Uint8Array>;
-
-  /**
-   * @deprecated Use version "v2" or `.stream()` instead.
-   */
-  streamEvents(
-    input: RunInput,
-    options: Partial<CallOptions> & { version: "v1" },
-    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
-  ): IterableReadableStream<StreamEvent>;
-
-  /**
-   * @deprecated Use version "v2" or `.stream()` instead.
-   */
-  streamEvents(
-    input: RunInput,
-    options: Partial<CallOptions> & {
-      version: "v1";
-      encoding: "text/event-stream";
-    },
-    streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
-  ): IterableReadableStream<Uint8Array>;
-
-  streamEvents(
-    input: RunInput,
     options: Partial<CallOptions> & { version: "v1" | "v2" },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
   ): IterableReadableStream<StreamEvent>;
@@ -654,7 +618,7 @@ export class ConfigurableModel<
   streamEvents(
     input: RunInput,
     options: Partial<CallOptions> & {
-      version?: "v1" | "v2";
+      version: "v1" | "v2";
       encoding?: "text/event-stream" | undefined;
     },
     streamOptions?: Omit<EventStreamCallbackHandlerInput, "autoClose">
@@ -662,8 +626,7 @@ export class ConfigurableModel<
     const outerThis = this;
     async function* wrappedGenerator() {
       const model = await outerThis._getModelInstance(options);
-      const version = options.version ?? "v2";
-      const config = ensureConfig({ ...options, version });
+      const config = ensureConfig(options);
       const eventStream = model.streamEvents(input, config, streamOptions);
 
       for await (const chunk of eventStream) {


### PR DESCRIPTION
### Summary

- Deprecate `streamEvents` v1 in favor of v2 (v1 callers see IDE strikethrough; version remains required for backwards compatibility)
- Deprecate `streamLog` in favor of `.stream()`
- Deprecate `RunnableWithMessageHistory` in favor of langgraph
- Add threat model documentation to `load` module and function docstrings