### PR TITLE
fix(core): deno re-declaration in LangSmith is causing unit test failures

### DIFF
--- a/.changeset/rare-lands-decide.md
+++ b/.changeset/rare-lands-decide.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): deno re-declaration in LangSmith is causing unit test failures

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -1,6 +1,6 @@
 // Inlined from https://github.com/flexdinesh/browser-or-node
 declare global {
-  // @ts-ignore Conflicts with langsmith's ambient Deno declaration
+  // @ts-expect-error Conflicts with langsmith's ambient Deno declaration
   const Deno:
     | {
         version: {
@@ -84,7 +84,7 @@ export function getEnvironmentVariable(name: string): string | undefined {
       // oxlint-disable-next-line no-process-env
       return process.env?.[name];
     } else if (isDeno()) {
-      // @ts-ignore Langsmith's Deno declaration is missing `env`
+      // @ts-expect-error Langsmith's Deno declaration is missing `env`
       return Deno?.env.get(name);
     } else {
       return undefined;

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -1,9 +1,17 @@
-type Deno = {
-  version?: { deno: string };
-  env?: { get: (name: string) => string | undefined };
-};
-
-const global = globalThis as typeof globalThis & { Deno?: Deno };
+// Inlined from https://github.com/flexdinesh/browser-or-node
+declare global {
+  // @ts-ignore Conflicts with langsmith's ambient Deno declaration
+  const Deno:
+    | {
+        version: {
+          deno: string;
+        };
+        env: {
+          get: (name: string) => string | undefined;
+        };
+      }
+    | undefined;
+}
 
 export const isBrowser = () =>
   typeof window !== "undefined" && typeof window.document !== "undefined";
@@ -19,7 +27,7 @@ export const isJsDom = () =>
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property
-export const isDeno = () => typeof global.Deno !== "undefined";
+export const isDeno = () => typeof Deno !== "undefined";
 
 // Mark not-as-node if in Supabase Edge Function
 export const isNode = () =>
@@ -76,7 +84,8 @@ export function getEnvironmentVariable(name: string): string | undefined {
       // oxlint-disable-next-line no-process-env
       return process.env?.[name];
     } else if (isDeno()) {
-      return global.Deno?.env?.get(name);
+      // @ts-ignore Langsmith's Deno declaration is missing `env`
+      return Deno?.env.get(name);
     } else {
       return undefined;
     }

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -3,6 +3,8 @@ type Deno = {
   env?: { get: (name: string) => string | undefined };
 };
 
+const global = globalThis as typeof globalThis & { Deno?: Deno };
+
 export const isBrowser = () =>
   typeof window !== "undefined" && typeof window.document !== "undefined";
 
@@ -17,9 +19,7 @@ export const isJsDom = () =>
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property
-export const isDeno = () =>
-  typeof (globalThis as typeof globalThis & { Deno?: Deno }).Deno !==
-  "undefined";
+export const isDeno = () => typeof global.Deno !== "undefined";
 
 // Mark not-as-node if in Supabase Edge Function
 export const isNode = () =>
@@ -76,9 +76,7 @@ export function getEnvironmentVariable(name: string): string | undefined {
       // oxlint-disable-next-line no-process-env
       return process.env?.[name];
     } else if (isDeno()) {
-      return (globalThis as typeof globalThis & { Deno?: Deno }).Deno?.env?.get(
-        name
-      );
+      return global.Deno?.env?.get(name);
     } else {
       return undefined;
     }

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -1,5 +1,3 @@
-// Inlined from https://github.com/flexdinesh/browser-or-node
-
 type Deno = {
   version?: { deno: string };
   env?: { get: (name: string) => string | undefined };

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -1,6 +1,6 @@
 // Inlined from https://github.com/flexdinesh/browser-or-node
 
-type DenoGlobal = {
+type Deno = {
   version?: { deno: string };
   env?: { get: (name: string) => string | undefined };
 };
@@ -20,7 +20,7 @@ export const isJsDom = () =>
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property
 export const isDeno = () =>
-  typeof (globalThis as typeof globalThis & { Deno?: DenoGlobal }).Deno !==
+  typeof (globalThis as typeof globalThis & { Deno?: Deno }).Deno !==
   "undefined";
 
 // Mark not-as-node if in Supabase Edge Function
@@ -78,9 +78,9 @@ export function getEnvironmentVariable(name: string): string | undefined {
       // oxlint-disable-next-line no-process-env
       return process.env?.[name];
     } else if (isDeno()) {
-      return (
-        globalThis as typeof globalThis & { Deno?: DenoGlobal }
-      ).Deno?.env?.get(name);
+      return (globalThis as typeof globalThis & { Deno?: Deno }).Deno?.env?.get(
+        name
+      );
     } else {
       return undefined;
     }

--- a/libs/langchain-core/src/utils/env.ts
+++ b/libs/langchain-core/src/utils/env.ts
@@ -1,16 +1,9 @@
 // Inlined from https://github.com/flexdinesh/browser-or-node
-declare global {
-  const Deno:
-    | {
-        version: {
-          deno: string;
-        };
-        env: {
-          get: (name: string) => string | undefined;
-        };
-      }
-    | undefined;
-}
+
+type DenoGlobal = {
+  version?: { deno: string };
+  env?: { get: (name: string) => string | undefined };
+};
 
 export const isBrowser = () =>
   typeof window !== "undefined" && typeof window.document !== "undefined";
@@ -26,7 +19,9 @@ export const isJsDom = () =>
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property
-export const isDeno = () => typeof Deno !== "undefined";
+export const isDeno = () =>
+  typeof (globalThis as typeof globalThis & { Deno?: DenoGlobal }).Deno !==
+  "undefined";
 
 // Mark not-as-node if in Supabase Edge Function
 export const isNode = () =>
@@ -83,7 +78,9 @@ export function getEnvironmentVariable(name: string): string | undefined {
       // oxlint-disable-next-line no-process-env
       return process.env?.[name];
     } else if (isDeno()) {
-      return Deno?.env.get(name);
+      return (
+        globalThis as typeof globalThis & { Deno?: DenoGlobal }
+      ).Deno?.env?.get(name);
     } else {
       return undefined;
     }


### PR DESCRIPTION
### Summary

Unit tests are failing due to the following:
```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 2 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯ Unhandled Source Error ⎯⎯⎯
TypeCheckError: Cannot redeclare block-scoped variable 'Deno'.
 ❯ src/utils/env.ts:3:9
      1| // Inlined from https://github.com/flexdinesh/browser-or-node
      2| declare global {
      3|   const Deno:
       |         ^
      4|     | {
      5|         version: {


⎯⎯⎯ Unhandled Source Error ⎯⎯⎯
TypeCheckError: Property 'env' does not exist on type '{ version { deno string; }; }'.
 ❯ src/utils/env.ts:86:20
     84|       return process.env?.[name];
     85|     } else if (isDeno()) {
     86|       return Deno?.env.get(name);
       |                    ^
     87|     } else {
     88|       return undefined;

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

### Root Cause
The langsmith 0.5.21 → 0.6.0 bump introduced a conflicting declare global { const Deno } declaration.

@langchain/core and langsmith both declare const Deno in a declare global block. Since const is block-scoped, TypeScript treats the second declaration as a redeclaration error. LangSmith's declaration only includes version (no env), and the conflict causes TypeScript to resolve to the narrower type.

This adds @ts-expect-error directives to suppress both errors. The conflict is environment-dependent and it only surfaces when LangSmith types are in the typecheck scope (e.g. in CI).
