### PR TITLE
fix(aws): add cache_control request mapping and cache-token parity

### DIFF
--- a/.changeset/hunter-aws-cache-control-parity.md
+++ b/.changeset/hunter-aws-cache-control-parity.md
@@ -1,0 +1,9 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): align Bedrock prompt caching with Python behavior
+
+Add `cache_control` request handling for `ChatBedrockConverse` so cache points
+are applied at request time, and align Bedrock usage accounting by including
+cache read/write input tokens in `usage_metadata.input_tokens`.

--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -43,6 +43,7 @@ import {
   ChatBedrockConverseToolType,
   ConverseCommandParams,
   CredentialType,
+  BedrockPromptCacheControl,
 } from "./types.js";
 import {
   BedrockConverseToolChoice,
@@ -50,7 +51,10 @@ import {
   convertToConverseTools,
   supportedToolChoiceValuesForModel,
 } from "./utils/tools.js";
-import { convertToConverseMessages } from "./utils/message_inputs.js";
+import {
+  applyCachePointsToConversePayload,
+  convertToConverseMessages,
+} from "./utils/message_inputs.js";
 import {
   convertConverseMessageToLangChainMessage,
   handleConverseStreamContentBlockDelta,
@@ -262,6 +266,15 @@ export interface ChatBedrockConverseCallOptions
    * Key-value pairs that you can use to filter invocation logs.
    */
   requestMetadata?: ConverseRequest["requestMetadata"];
+
+  /**
+   * Prompt cache-control settings.
+   *
+   * When provided, cache points are applied at request-build time for
+   * Bedrock Converse payloads (system, last message, and tools where
+   * applicable), matching Python ChatBedrockConverse behavior.
+   */
+  cache_control?: BedrockPromptCacheControl;
 }
 
 /**
@@ -1013,6 +1026,13 @@ export class ChatBedrockConverse
       const { converseMessages, converseSystem } =
         convertToConverseMessages(messages);
       const params = this.invocationParams(options);
+      applyCachePointsToConversePayload({
+        cacheControl: options.cache_control,
+        system: converseSystem,
+        messages: converseMessages,
+        params,
+        modelId: this.applicationInferenceProfile ?? this.model,
+      });
 
       const command = new ConverseCommand({
         modelId: this.applicationInferenceProfile ?? this.model,
@@ -1057,6 +1077,13 @@ export class ChatBedrockConverse
       const { converseMessages, converseSystem } =
         convertToConverseMessages(messages);
       const params = this.invocationParams(options);
+      applyCachePointsToConversePayload({
+        cacheControl: options.cache_control,
+        system: converseSystem,
+        messages: converseMessages,
+        params,
+        modelId: this.applicationInferenceProfile ?? this.model,
+      });
       let { streamUsage } = this;
       if (options.streamUsage !== undefined) {
         streamUsage = options.streamUsage;

--- a/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
@@ -307,6 +307,82 @@ describe("ChatBedrockConverse invocationParams", () => {
     );
   });
 
+  describe("prompt caching request mapping", () => {
+    test("invoke maps cache_control to system, messages, and tools", async () => {
+      const model = new ChatBedrockConverse(baseConstructorArgs);
+      await model.invoke(
+        [new SystemMessage("System prompt"), new HumanMessage("Hello")],
+        {
+          cache_control: { type: "ephemeral", ttl: "1h" },
+          tools: [
+            {
+              toolSpec: {
+                name: "get_weather",
+                description: "Get weather",
+                inputSchema: {
+                  json: { type: "object", properties: {} },
+                },
+              },
+            },
+          ],
+        }
+      );
+
+      const input = Reflect.get(
+        ConverseCommand,
+        "lastInput"
+      ) as ConverseCommandInput;
+
+      expect(input.system).toEqual([
+        { text: "System prompt" },
+        { cachePoint: { type: "default", ttl: "1h" } },
+      ]);
+      expect(input.messages?.[0].content).toEqual([
+        { text: "Hello" },
+        { cachePoint: { type: "default", ttl: "1h" } },
+      ]);
+      expect(input.toolConfig?.tools).toEqual([
+        {
+          toolSpec: {
+            name: "get_weather",
+            description: "Get weather",
+            inputSchema: {
+              json: { type: "object", properties: {} },
+            },
+          },
+        },
+        { cachePoint: { type: "default", ttl: "1h" } },
+      ]);
+    });
+
+    test("stream maps cache_control to system and last message", async () => {
+      const model = new ChatBedrockConverse(baseConstructorArgs);
+      const stream = await model.stream(
+        [new SystemMessage("System prompt"), new HumanMessage("Hello")],
+        {
+          cache_control: { type: "ephemeral" },
+        }
+      );
+      for await (const _chunk of stream) {
+        // Fully consume stream so command is executed.
+      }
+
+      const input = Reflect.get(
+        ConverseStreamCommand,
+        "lastInput"
+      ) as ConverseStreamCommandInput;
+
+      expect(input.system).toEqual([
+        { text: "System prompt" },
+        { cachePoint: { type: "default" } },
+      ]);
+      expect(input.messages?.[0].content).toEqual([
+        { text: "Hello" },
+        { cachePoint: { type: "default" } },
+      ]);
+    });
+  });
+
   describe("defaultHeaders middleware", () => {
     test("registers middleware on client when defaultHeaders are provided", () => {
       const model = new ChatBedrockConverse({

--- a/libs/providers/langchain-aws/src/types.ts
+++ b/libs/providers/langchain-aws/src/types.ts
@@ -20,6 +20,18 @@ export type BedrockToolChoice =
   | ToolChoice.ToolMember;
 export type ChatBedrockConverseToolType = BindToolsInput | BedrockTool;
 
+/**
+ * Prompt cache control settings for Bedrock Converse.
+ *
+ * Mirrors Python `cache_control` model settings for ChatBedrockConverse.
+ * `type` is accepted for parity but Converse cache points always use
+ * `cachePoint.type = "default"`.
+ */
+export type BedrockPromptCacheControl = {
+  type?: "ephemeral";
+  ttl?: "5m" | "1h";
+};
+
 export type MessageContentReasoningBlockReasoningText = {
   type: "reasoning_content";
   reasoningText: {

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -18,6 +18,8 @@ import {
 import type * as Bedrock from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType as __DocumentType } from "@smithy/types";
 import {
+  BedrockPromptCacheControl,
+  ConverseCommandParams,
   MessageContentReasoningBlock,
   MessageContentReasoningBlockReasoningText,
   MessageContentReasoningBlockRedacted,
@@ -35,6 +37,85 @@ function isDefaultCachePoint(block: unknown): boolean {
     "type" in block.cachePoint &&
     block.cachePoint.type === "default"
   );
+}
+
+function isConverseCachePoint(block: unknown): boolean {
+  return Boolean(
+    typeof block === "object" &&
+    block !== null &&
+    "cachePoint" in block &&
+    block.cachePoint &&
+    typeof block.cachePoint === "object" &&
+    block.cachePoint !== null &&
+    "type" in block.cachePoint
+  );
+}
+
+function createConverseCachePointBlock(
+  cacheControl: BedrockPromptCacheControl,
+  isNovaModel: boolean
+): { cachePoint: { type: "default"; ttl?: "1h" } } {
+  const ttl =
+    !isNovaModel && cacheControl.ttl && cacheControl.ttl !== "5m"
+      ? cacheControl.ttl
+      : undefined;
+  return {
+    cachePoint: {
+      type: "default",
+      ...(ttl ? { ttl } : {}),
+    },
+  };
+}
+
+export function applyCachePointsToConversePayload(fields: {
+  cacheControl?: BedrockPromptCacheControl;
+  system: Bedrock.SystemContentBlock[];
+  messages: Bedrock.Message[];
+  params?: Partial<ConverseCommandParams>;
+  modelId: string;
+}): void {
+  const { cacheControl, system, messages, params, modelId } = fields;
+  if (!cacheControl) {
+    return;
+  }
+
+  const isNovaModel = modelId.toLowerCase().includes("amazon.nova");
+  const cacheBlock = createConverseCachePointBlock(cacheControl, isNovaModel);
+
+  if (
+    system.length > 0 &&
+    !system.some((block) => isConverseCachePoint(block))
+  ) {
+    system.push(cacheBlock);
+  }
+
+  const lastMessage = messages[messages.length - 1];
+  const lastContent = lastMessage?.content;
+  if (Array.isArray(lastContent)) {
+    const hasNovaToolBlock =
+      isNovaModel &&
+      lastContent.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          ("toolResult" in block || "toolUse" in block)
+      );
+    if (
+      !hasNovaToolBlock &&
+      !lastContent.some((block) => isConverseCachePoint(block))
+    ) {
+      lastContent.push(cacheBlock);
+    }
+  }
+
+  const tools = params?.toolConfig?.tools;
+  if (
+    !isNovaModel &&
+    Array.isArray(tools) &&
+    !tools.some((tool) => isConverseCachePoint(tool))
+  ) {
+    tools.push(cacheBlock as unknown as Bedrock.Tool);
+  }
 }
 
 export function extractImageInfo(

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -33,6 +33,10 @@ export function convertConverseMessageToLangChainMessage(
   }
   let tokenUsage: UsageMetadata | undefined;
   if (responseMetadata.usage) {
+    const cacheReadInputTokens =
+      responseMetadata.usage.cacheReadInputTokens ?? 0;
+    const cacheWriteInputTokens =
+      responseMetadata.usage.cacheWriteInputTokens ?? 0;
     const inputTokenDetails = {
       ...(responseMetadata.usage.cacheReadInputTokens !== undefined && {
         cache_read: responseMetadata.usage.cacheReadInputTokens,
@@ -41,7 +45,10 @@ export function convertConverseMessageToLangChainMessage(
         cache_creation: responseMetadata.usage.cacheWriteInputTokens,
       }),
     };
-    const input_tokens = responseMetadata.usage.inputTokens ?? 0;
+    const input_tokens =
+      (responseMetadata.usage.inputTokens ?? 0) +
+      cacheReadInputTokens +
+      cacheWriteInputTokens;
     const output_tokens = responseMetadata.usage.outputTokens ?? 0;
     tokenUsage = {
       input_tokens,
@@ -204,6 +211,8 @@ export function handleConverseStreamMetadata(
     streamUsage: boolean;
   }
 ): ChatGenerationChunk {
+  const cacheReadInputTokens = metadata.usage?.cacheReadInputTokens ?? 0;
+  const cacheWriteInputTokens = metadata.usage?.cacheWriteInputTokens ?? 0;
   const inputTokenDetails = {
     ...(metadata.usage?.cacheReadInputTokens !== undefined && {
       cache_read: metadata.usage.cacheReadInputTokens,
@@ -212,7 +221,10 @@ export function handleConverseStreamMetadata(
       cache_creation: metadata.usage.cacheWriteInputTokens,
     }),
   };
-  const inputTokens = metadata.usage?.inputTokens ?? 0;
+  const inputTokens =
+    (metadata.usage?.inputTokens ?? 0) +
+    cacheReadInputTokens +
+    cacheWriteInputTokens;
   const outputTokens = metadata.usage?.outputTokens ?? 0;
   const usage_metadata: UsageMetadata = {
     input_tokens: inputTokens,

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -15,7 +15,7 @@ describe("message output usage metadata conversion", () => {
       usage: {
         inputTokens: 10,
         outputTokens: 5,
-        totalTokens: 15,
+        totalTokens: 25,
         cacheReadInputTokens: 7,
         cacheWriteInputTokens: 3,
       },
@@ -27,9 +27,9 @@ describe("message output usage metadata conversion", () => {
     );
 
     expect(result.usage_metadata).toEqual({
-      input_tokens: 10,
+      input_tokens: 20,
       output_tokens: 5,
-      total_tokens: 15,
+      total_tokens: 25,
       input_token_details: {
         cache_read: 7,
         cache_creation: 3,
@@ -64,7 +64,7 @@ describe("message output usage metadata conversion", () => {
         usage: {
           inputTokens: 20,
           outputTokens: 4,
-          totalTokens: 24,
+          totalTokens: 39,
           cacheReadInputTokens: 9,
           cacheWriteInputTokens: 6,
         },
@@ -73,9 +73,9 @@ describe("message output usage metadata conversion", () => {
     );
 
     expect(result.message.usage_metadata).toEqual({
-      input_tokens: 20,
+      input_tokens: 35,
       output_tokens: 4,
-      total_tokens: 24,
+      total_tokens: 39,
       input_token_details: {
         cache_read: 9,
         cache_creation: 6,


### PR DESCRIPTION
## Summary

`ChatBedrockConverse` in `@langchain/aws` had two prompt-caching parity gaps vs Python:
- request-side `cache_control` was not translated into Bedrock Converse `cachePoint` blocks, so caching could silently no-op unless users manually crafted cache blocks
- `usage_metadata.input_tokens` did not include Bedrock cached input token counts

This PR closes both gaps by applying cache points at request-build time and aligning Bedrock usage accounting with Python behavior.

## Changes

- `@langchain/aws`
- Added `cache_control` call option support on `ChatBedrockConverse`.
- Added `applyCachePointsToConversePayload` helper to apply cache points to:
  - system blocks
  - last message content block list
  - tool config entries (non-Nova models)
- Updated invoke + stream request building to apply cache points when `cache_control` is provided.
- Updated usage metadata conversion so:
  - `input_tokens = inputTokens + cacheReadInputTokens + cacheWriteInputTokens`
  - `input_token_details.cache_read/cache_creation` continue to be populated.
- Added/updated unit tests for:
  - cache-control request mapping in invoke and stream paths
  - summed cached input token accounting in usage metadata
- Added a changeset for `@langchain/aws` patch bump.
