### PR TITLE
chore(environment-tests): audit and trim fixture dependencies

### DIFF
--- a/.github/workflows/test-exports.yml
+++ b/.github/workflows/test-exports.yml
@@ -9,6 +9,7 @@ on:
       - "libs/langchain-classic/**"
       - "libs/providers/langchain-anthropic/**"
       - "libs/providers/langchain-openai/**"
+      - "environment_tests/**"
       - ".github/workflows/test-exports.yml"
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 

--- a/environment_tests/scripts/test-runner.ts
+++ b/environment_tests/scripts/test-runner.ts
@@ -193,6 +193,13 @@ class EnvironmentTestRunner {
     // Enable corepack for pnpm
     if (!this.isBun) {
       await this.execCommand("corepack", ["enable"]);
+      // Keep environment tests on the repo's pinned pnpm major to avoid
+      // strict build-script policy changes from floating Corepack downloads.
+      await this.execCommand("corepack", [
+        "prepare",
+        "pnpm@10.14.0",
+        "--activate",
+      ]);
     }
   }
 

--- a/environment_tests/test-exports-bun/package.json
+++ b/environment_tests/test-exports-bun/package.json
@@ -17,13 +17,9 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
-    "d3-dsv": "2",
-    "hnswlib-node": "^3.0.0",
-    "langchain": "workspace:*",
-    "zod": "^3.25.76 || ^4"
+    "langchain": "workspace:*"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",

--- a/environment_tests/test-exports-cf/package.json
+++ b/environment_tests/test-exports-cf/package.json
@@ -5,16 +5,11 @@
     "@cloudflare/workers-types": "^4.20230321.0"
   },
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
-    "@tsconfig/recommended": "^1.0.2",
-    "cheerio": "^1.1.2",
     "langchain": "workspace:*",
     "wrangler": "^3.19.0",
     "vitest": "0.34.3",
-    "typeorm": "^0.3.25",
-    "reflect-metadata": "^0.1.13",
     "typescript": "^5.0.3"
   },
   "private": true,
@@ -24,5 +19,12 @@
     "build": "wrangler deploy --dry-run --outdir=dist",
     "test": "vitest run **/*.unit.test.ts",
     "test:integration": "vitest run **/*.int.test.ts"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "workerd"
+    ]
   }
 }

--- a/environment_tests/test-exports-cjs/package.json
+++ b/environment_tests/test-exports-cjs/package.json
@@ -16,20 +16,18 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@langchain/ollama": "workspace:*",
     "@langchain/google-gauth": "workspace:*",
     "@tsconfig/recommended": "^1.0.10",
     "@types/node": "^24.3.0",
-    "@xenova/transformers": "^2.17.2",
-    "cheerio": "^1.1.2",
-    "typeorm": "^0.3.25",
     "langchain": "workspace:*",
     "typescript": "^5.0.0"
   },
-  "devDependencies": {
-    "@types/node": "^18.15.11"
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/environment_tests/test-exports-esbuild/package.json
+++ b/environment_tests/test-exports-esbuild/package.json
@@ -14,18 +14,17 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@tsconfig/recommended": "^1.0.2",
     "@types/node": "^18.15.11",
-    "cheerio": "^1.1.2",
     "esbuild": "^0.25.0",
     "langchain": "workspace:*",
-    "typeorm": "^0.3.25",
     "typescript": "^5.0.0"
   },
-  "devDependencies": {
-    "prettier": "^3.5.0"
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/environment_tests/test-exports-esm/package.json
+++ b/environment_tests/test-exports-esm/package.json
@@ -17,19 +17,16 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@tsconfig/recommended": "^1.0.2",
     "@types/node": "^24.3.0",
-    "@xenova/transformers": "^2.17.2",
-    "cheerio": "^1.1.2",
     "langchain": "workspace:*",
-    "typeorm": "^0.3.25",
-    "reflect-metadata": "^0.1.13",
     "typescript": "^5.0.0"
   },
-  "devDependencies": {
-    "@types/node": "^18.15.11"
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/environment_tests/test-exports-node-classic/package.json
+++ b/environment_tests/test-exports-node-classic/package.json
@@ -17,7 +17,9 @@
     "langchain": "workspace:*",
     "typescript": "^5.0.0"
   },
-  "devDependencies": {
-    "prettier": "^3.5.0"
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/environment_tests/test-exports-tsc/package.json
+++ b/environment_tests/test-exports-tsc/package.json
@@ -12,14 +12,14 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@types/node": "^24.3.0",
-    "langchain": "workspace:*",
     "typescript": "^5.9.3"
   },
-  "devDependencies": {
-    "@types/node": "^18.15.11"
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/environment_tests/test-exports-vercel/package.json
+++ b/environment_tests/test-exports-vercel/package.json
@@ -9,20 +9,21 @@
     "test": "next build"
   },
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@types/node": "18.15.11",
     "@types/react": "18.0.33",
     "@types/react-dom": "18.0.11",
-    "cheerio": "^1.1.2",
     "langchain": "workspace:*",
     "next": "^16.1.7",
-    "peggy": "^5.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "reflect-metadata": "^0.2.2",
-    "typeorm": "^0.3.25",
     "typescript": "^5.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/environment_tests/test-exports-vite/package.json
+++ b/environment_tests/test-exports-vite/package.json
@@ -10,11 +10,15 @@
     "test": "tsc"
   },
   "dependencies": {
-    "@langchain/anthropic": "workspace:*",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "langchain": "workspace:*",
     "typescript": "^5.0.0",
     "vite": "^6.4.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

This PR audits and trims dependencies across `environment_tests/test-exports-*` fixture packages.

The goal is to keep each fixture manifest aligned with what the fixture code and scripts actually use, reduce transitive install surface area, and keep environment tests stable under newer pnpm behavior.

## Changes

### Environment test fixture dependency cleanup

- Removed unused fixture dependencies across Bun/CF/CJS/ESBuild/ESM/Node Classic/TSC/Vercel/Vite test packages.
- Removed stale duplicate `@types/node` devDependency entries where a dependency entry already existed.
- Removed unused `prettier` devDependencies from fixtures that do not invoke it.

### pnpm build-script allowlist tightening

- Added or retained `pnpm.onlyBuiltDependencies` in fixture package manifests used by environment tests.
- Tightened CJS/ESM allowlists to `esbuild` after removing the transitive path that previously required additional built deps.

### Notable fixture-specific adjustments

- Removed `@xenova/transformers` from CJS/ESM fixture manifests because fixture source does not import it.
- Removed additional transitive-only fixture deps that were no longer exercised by test code/scripts.

## Changeset

No changeset was added. These edits are limited to private `environment_tests` fixture manifests and do not change publishable package source or public API surface.

## CI Note

The `Environment tests` workflow currently uses path filters that do not include `environment_tests/**`, so fixture-only manifest changes in this PR do not automatically execute the corresponding environment test jobs in CI.
