### PR TITLE
fix(core): preserve caller-supplied tool_calls on AIMessageChunk when chunks are present

### DIFF
--- a/.changeset/tasty-toys-share.md
+++ b/.changeset/tasty-toys-share.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+preserve caller-supplied tool_calls on AIMessageChunk when chunks are present

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -58,9 +58,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
   }
 
   constructor(
-    fields:
-      | $InferMessageContent<TStructure, "ai">
-      | AIMessageFields<TStructure>,
+    fields: $InferMessageContent<TStructure, "ai"> | AIMessageFields<TStructure>
   ) {
     let initParams: AIMessageFields<TStructure>;
     if (typeof fields === "string" || Array.isArray(fields)) {
@@ -85,7 +83,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
             "tool calling.\n\nPlease upgrade your packages to versions that set",
             "message tool calls. e.g., `pnpm install @langchain/anthropic`,",
             "pnpm install @langchain/openai`, etc.",
-          ].join(" "),
+          ].join(" ")
         );
       }
       try {
@@ -126,8 +124,8 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
                 (block) =>
                   block.type === "tool_call" &&
                   block.id === toolCall.id &&
-                  block.name === toolCall.name,
-              ),
+                  block.name === toolCall.name
+              )
           );
           initParams.contentBlocks.push(
             ...missingContentBlockToolCalls.map((toolCall) => ({
@@ -135,21 +133,21 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
               id: toolCall.id,
               name: toolCall.name,
               args: toolCall.args,
-            })),
+            }))
           );
         }
         // Add content block tool calls that aren't in the constructor tool calls
         const missingToolCalls = initParams.contentBlocks
           .filter<ContentBlock.Tools.ToolCall>(
             (block): block is ContentBlock.Tools.ToolCall =>
-              block.type === "tool_call",
+              block.type === "tool_call"
           )
           .filter(
             (block) =>
               !initParams.tool_calls?.some(
                 (toolCall) =>
-                  toolCall.id === block.id && toolCall.name === block.name,
-              ),
+                  toolCall.id === block.id && toolCall.name === block.name
+              )
           );
         if (missingToolCalls.length > 0) {
           initParams.tool_calls = [
@@ -204,7 +202,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
     if (this.tool_calls) {
       const missingToolCalls = this.tool_calls.filter(
         (block) =>
-          !blocks.some((b) => b.id === block.id && b.name === block.name),
+          !blocks.some((b) => b.id === block.id && b.name === block.name)
       );
       blocks.push(
         ...(missingToolCalls.map((block) => ({
@@ -212,7 +210,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
           id: block.id,
           name: block.name,
           args: block.args,
-        })) as ContentBlock.Tools.ToolCall[]),
+        })) as ContentBlock.Tools.ToolCall[])
       );
     }
 
@@ -234,7 +232,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
    * @overload When called with a typed BaseMessage, preserves the TStructure type
    */
   static isInstance<T extends MessageStructure>(
-    obj: BaseMessage<T>,
+    obj: BaseMessage<T>
   ): obj is BaseMessage<T> & AIMessage<T>;
   /**
    * Type guard to check if an object is an AIMessage.
@@ -242,7 +240,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
    */
   static isInstance(obj: unknown): obj is AIMessage;
   static isInstance<T extends MessageStructure = MessageStructure>(
-    obj: BaseMessage<T> | unknown,
+    obj: BaseMessage<T> | unknown
   ): obj is AIMessage<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
   }
@@ -252,7 +250,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
  * @deprecated Use {@link AIMessage.isInstance} instead
  */
 export function isAIMessage<TStructure extends MessageStructure>(
-  x: BaseMessage,
+  x: BaseMessage
 ): x is AIMessage<TStructure> {
   return x._getType() === "ai";
 }
@@ -261,7 +259,7 @@ export function isAIMessage<TStructure extends MessageStructure>(
  * @deprecated Use {@link AIMessageChunk.isInstance} instead
  */
 export function isAIMessageChunk<TStructure extends MessageStructure>(
-  x: BaseMessageChunk,
+  x: BaseMessageChunk
 ): x is AIMessageChunk<TStructure> {
   return x._getType() === "ai";
 }
@@ -295,7 +293,7 @@ export class AIMessageChunk<
   constructor(
     fields:
       | $InferMessageContent<TStructure, "ai">
-      | AIMessageChunkFields<TStructure>,
+      | AIMessageChunkFields<TStructure>
   ) {
     let initParams: AIMessageChunkFields<TStructure>;
     if (typeof fields === "string" || Array.isArray(fields)) {
@@ -433,11 +431,11 @@ export class AIMessageChunk<
       content: mergeContent(this.content, chunk.content),
       additional_kwargs: _mergeDicts(
         this.additional_kwargs,
-        chunk.additional_kwargs,
+        chunk.additional_kwargs
       ),
       response_metadata: mergeResponseMetadata(
         this.response_metadata,
-        chunk.response_metadata,
+        chunk.response_metadata
       ),
       tool_call_chunks: [],
       tool_calls: [],
@@ -449,7 +447,7 @@ export class AIMessageChunk<
     ) {
       const rawToolCalls = _mergeLists(
         this.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[],
-        chunk.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[],
+        chunk.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[]
       );
       if (rawToolCalls !== undefined && rawToolCalls.length > 0) {
         combinedFields.tool_call_chunks = rawToolCalls as ToolCallChunk[];
@@ -458,7 +456,7 @@ export class AIMessageChunk<
     if (this.tool_calls !== undefined || chunk.tool_calls !== undefined) {
       const rawToolCalls = _mergeLists(
         this.tool_calls as ContentBlock.Tools.ToolCall[],
-        chunk.tool_calls as ContentBlock.Tools.ToolCall[],
+        chunk.tool_calls as ContentBlock.Tools.ToolCall[]
       );
       if (rawToolCalls !== undefined && rawToolCalls.length > 0) {
         combinedFields.tool_calls =
@@ -471,7 +469,7 @@ export class AIMessageChunk<
     ) {
       combinedFields.usage_metadata = mergeUsageMetadata(
         this.usage_metadata,
-        chunk.usage_metadata,
+        chunk.usage_metadata
       );
     }
     const Cls = this.constructor as Constructor<this>;
@@ -484,7 +482,7 @@ export class AIMessageChunk<
    * @overload When called with a typed BaseMessage, preserves the TStructure type
    */
   static isInstance<T extends MessageStructure>(
-    obj: BaseMessage<T>,
+    obj: BaseMessage<T>
   ): obj is BaseMessage<T> & AIMessageChunk<T>;
   /**
    * Type guard to check if an object is an AIMessageChunk.
@@ -492,7 +490,7 @@ export class AIMessageChunk<
    */
   static isInstance(obj: unknown): obj is AIMessageChunk;
   static isInstance<T extends MessageStructure = MessageStructure>(
-    obj: BaseMessage<T> | unknown,
+    obj: BaseMessage<T> | unknown
   ): obj is AIMessageChunk<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
   }

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -20,7 +20,12 @@ import {
   ToolCallChunk,
   defaultToolCallParser,
 } from "./tool.js";
-import { collapseToolCallChunks, Constructor } from "./utils.js";
+import {
+  collapseToolCallChunks,
+  collectCollapsedToolCallIds,
+  Constructor,
+  mergeProvidedByCollapsedIds,
+} from "./utils.js";
 
 export interface AIMessageFields<
   TStructure extends MessageStructure = MessageStructure,
@@ -53,7 +58,9 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
   }
 
   constructor(
-    fields: $InferMessageContent<TStructure, "ai"> | AIMessageFields<TStructure>
+    fields:
+      | $InferMessageContent<TStructure, "ai">
+      | AIMessageFields<TStructure>,
   ) {
     let initParams: AIMessageFields<TStructure>;
     if (typeof fields === "string" || Array.isArray(fields)) {
@@ -78,7 +85,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
             "tool calling.\n\nPlease upgrade your packages to versions that set",
             "message tool calls. e.g., `pnpm install @langchain/anthropic`,",
             "pnpm install @langchain/openai`, etc.",
-          ].join(" ")
+          ].join(" "),
         );
       }
       try {
@@ -119,8 +126,8 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
                 (block) =>
                   block.type === "tool_call" &&
                   block.id === toolCall.id &&
-                  block.name === toolCall.name
-              )
+                  block.name === toolCall.name,
+              ),
           );
           initParams.contentBlocks.push(
             ...missingContentBlockToolCalls.map((toolCall) => ({
@@ -128,21 +135,21 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
               id: toolCall.id,
               name: toolCall.name,
               args: toolCall.args,
-            }))
+            })),
           );
         }
         // Add content block tool calls that aren't in the constructor tool calls
         const missingToolCalls = initParams.contentBlocks
           .filter<ContentBlock.Tools.ToolCall>(
             (block): block is ContentBlock.Tools.ToolCall =>
-              block.type === "tool_call"
+              block.type === "tool_call",
           )
           .filter(
             (block) =>
               !initParams.tool_calls?.some(
                 (toolCall) =>
-                  toolCall.id === block.id && toolCall.name === block.name
-              )
+                  toolCall.id === block.id && toolCall.name === block.name,
+              ),
           );
         if (missingToolCalls.length > 0) {
           initParams.tool_calls = [
@@ -197,7 +204,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
     if (this.tool_calls) {
       const missingToolCalls = this.tool_calls.filter(
         (block) =>
-          !blocks.some((b) => b.id === block.id && b.name === block.name)
+          !blocks.some((b) => b.id === block.id && b.name === block.name),
       );
       blocks.push(
         ...(missingToolCalls.map((block) => ({
@@ -205,7 +212,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
           id: block.id,
           name: block.name,
           args: block.args,
-        })) as ContentBlock.Tools.ToolCall[])
+        })) as ContentBlock.Tools.ToolCall[]),
       );
     }
 
@@ -227,7 +234,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
    * @overload When called with a typed BaseMessage, preserves the TStructure type
    */
   static isInstance<T extends MessageStructure>(
-    obj: BaseMessage<T>
+    obj: BaseMessage<T>,
   ): obj is BaseMessage<T> & AIMessage<T>;
   /**
    * Type guard to check if an object is an AIMessage.
@@ -235,7 +242,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
    */
   static isInstance(obj: unknown): obj is AIMessage;
   static isInstance<T extends MessageStructure = MessageStructure>(
-    obj: BaseMessage<T> | unknown
+    obj: BaseMessage<T> | unknown,
   ): obj is AIMessage<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
   }
@@ -245,7 +252,7 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
  * @deprecated Use {@link AIMessage.isInstance} instead
  */
 export function isAIMessage<TStructure extends MessageStructure>(
-  x: BaseMessage
+  x: BaseMessage,
 ): x is AIMessage<TStructure> {
   return x._getType() === "ai";
 }
@@ -254,7 +261,7 @@ export function isAIMessage<TStructure extends MessageStructure>(
  * @deprecated Use {@link AIMessageChunk.isInstance} instead
  */
 export function isAIMessageChunk<TStructure extends MessageStructure>(
-  x: BaseMessageChunk
+  x: BaseMessageChunk,
 ): x is AIMessageChunk<TStructure> {
   return x._getType() === "ai";
 }
@@ -288,7 +295,7 @@ export class AIMessageChunk<
   constructor(
     fields:
       | $InferMessageContent<TStructure, "ai">
-      | AIMessageChunkFields<TStructure>
+      | AIMessageChunkFields<TStructure>,
   ) {
     let initParams: AIMessageChunkFields<TStructure>;
     if (typeof fields === "string" || Array.isArray(fields)) {
@@ -314,37 +321,22 @@ export class AIMessageChunk<
       };
     } else {
       const collapsed = collapseToolCallChunks(fields.tool_call_chunks ?? []);
-      // Preserve caller-supplied tool_calls / invalid_tool_calls that
-      // are NOT also represented in the collapsed chunks (deduped by
-      // id). Collapsed entries win on collision because they reflect
-      // the freshest assembled state — `concat()` forwards the prior
-      // chunk's stale `tool_calls` field alongside merged
-      // `tool_call_chunks`, and we must not let the stale snapshot
-      // override the freshly merged args. The caller-fill path keeps
-      // finalized tool_calls visible when callers supply both arrays
-      // for *different* ids (e.g. one tool call finalized while
-      // siblings are still streaming — common with parallel tool
-      // calls landing sequentially within a single message).
-      const collapsedIds = new Set<string>();
-      for (const tc of collapsed.tool_calls)
-        if (tc.id !== undefined) collapsedIds.add(tc.id);
-      for (const tc of collapsed.invalid_tool_calls)
-        if (tc.id !== undefined) collapsedIds.add(tc.id);
-      const callerToolCalls = (fields.tool_calls ??
-        []) as $InferToolCalls<TStructure>[];
-      const callerInvalidToolCalls = fields.invalid_tool_calls ?? [];
-      const mergedToolCalls = [
-        ...(collapsed.tool_calls as $InferToolCalls<TStructure>[]),
-        ...callerToolCalls.filter(
-          (tc) => tc.id === undefined || !collapsedIds.has(tc.id)
-        ),
-      ];
-      const mergedInvalidToolCalls = [
-        ...collapsed.invalid_tool_calls,
-        ...callerInvalidToolCalls.filter(
-          (tc) => tc.id === undefined || !collapsedIds.has(tc.id)
-        ),
-      ];
+      const collapsedIds = collectCollapsedToolCallIds({
+        collapsedToolCalls: collapsed.tool_calls,
+        collapsedInvalidToolCalls: collapsed.invalid_tool_calls,
+      });
+      const mergedToolCalls = mergeProvidedByCollapsedIds<
+        $InferToolCalls<TStructure>
+      >({
+        collapsed: collapsed.tool_calls as $InferToolCalls<TStructure>[],
+        provided: fields.tool_calls as $InferToolCalls<TStructure>[],
+        collapsedIds,
+      });
+      const mergedInvalidToolCalls = mergeProvidedByCollapsedIds({
+        collapsed: collapsed.invalid_tool_calls,
+        provided: fields.invalid_tool_calls,
+        collapsedIds,
+      });
       initParams = {
         ...fields,
         tool_call_chunks: collapsed.tool_call_chunks,
@@ -441,11 +433,11 @@ export class AIMessageChunk<
       content: mergeContent(this.content, chunk.content),
       additional_kwargs: _mergeDicts(
         this.additional_kwargs,
-        chunk.additional_kwargs
+        chunk.additional_kwargs,
       ),
       response_metadata: mergeResponseMetadata(
         this.response_metadata,
-        chunk.response_metadata
+        chunk.response_metadata,
       ),
       tool_call_chunks: [],
       tool_calls: [],
@@ -457,7 +449,7 @@ export class AIMessageChunk<
     ) {
       const rawToolCalls = _mergeLists(
         this.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[],
-        chunk.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[]
+        chunk.tool_call_chunks as ContentBlock.Tools.ToolCallChunk[],
       );
       if (rawToolCalls !== undefined && rawToolCalls.length > 0) {
         combinedFields.tool_call_chunks = rawToolCalls as ToolCallChunk[];
@@ -466,7 +458,7 @@ export class AIMessageChunk<
     if (this.tool_calls !== undefined || chunk.tool_calls !== undefined) {
       const rawToolCalls = _mergeLists(
         this.tool_calls as ContentBlock.Tools.ToolCall[],
-        chunk.tool_calls as ContentBlock.Tools.ToolCall[]
+        chunk.tool_calls as ContentBlock.Tools.ToolCall[],
       );
       if (rawToolCalls !== undefined && rawToolCalls.length > 0) {
         combinedFields.tool_calls =
@@ -479,7 +471,7 @@ export class AIMessageChunk<
     ) {
       combinedFields.usage_metadata = mergeUsageMetadata(
         this.usage_metadata,
-        chunk.usage_metadata
+        chunk.usage_metadata,
       );
     }
     const Cls = this.constructor as Constructor<this>;
@@ -492,7 +484,7 @@ export class AIMessageChunk<
    * @overload When called with a typed BaseMessage, preserves the TStructure type
    */
   static isInstance<T extends MessageStructure>(
-    obj: BaseMessage<T>
+    obj: BaseMessage<T>,
   ): obj is BaseMessage<T> & AIMessageChunk<T>;
   /**
    * Type guard to check if an object is an AIMessageChunk.
@@ -500,7 +492,7 @@ export class AIMessageChunk<
    */
   static isInstance(obj: unknown): obj is AIMessageChunk;
   static isInstance<T extends MessageStructure = MessageStructure>(
-    obj: BaseMessage<T> | unknown
+    obj: BaseMessage<T> | unknown,
   ): obj is AIMessageChunk<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
   }

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -314,11 +314,42 @@ export class AIMessageChunk<
       };
     } else {
       const collapsed = collapseToolCallChunks(fields.tool_call_chunks ?? []);
+      // Preserve caller-supplied tool_calls / invalid_tool_calls that
+      // are NOT also represented in the collapsed chunks (deduped by
+      // id). Collapsed entries win on collision because they reflect
+      // the freshest assembled state — `concat()` forwards the prior
+      // chunk's stale `tool_calls` field alongside merged
+      // `tool_call_chunks`, and we must not let the stale snapshot
+      // override the freshly merged args. The caller-fill path keeps
+      // finalized tool_calls visible when callers supply both arrays
+      // for *different* ids (e.g. one tool call finalized while
+      // siblings are still streaming — common with parallel tool
+      // calls landing sequentially within a single message).
+      const collapsedIds = new Set<string>();
+      for (const tc of collapsed.tool_calls)
+        if (tc.id !== undefined) collapsedIds.add(tc.id);
+      for (const tc of collapsed.invalid_tool_calls)
+        if (tc.id !== undefined) collapsedIds.add(tc.id);
+      const callerToolCalls = (fields.tool_calls ??
+        []) as $InferToolCalls<TStructure>[];
+      const callerInvalidToolCalls = fields.invalid_tool_calls ?? [];
+      const mergedToolCalls = [
+        ...(collapsed.tool_calls as $InferToolCalls<TStructure>[]),
+        ...callerToolCalls.filter(
+          (tc) => tc.id === undefined || !collapsedIds.has(tc.id)
+        ),
+      ];
+      const mergedInvalidToolCalls = [
+        ...collapsed.invalid_tool_calls,
+        ...callerInvalidToolCalls.filter(
+          (tc) => tc.id === undefined || !collapsedIds.has(tc.id)
+        ),
+      ];
       initParams = {
         ...fields,
         tool_call_chunks: collapsed.tool_call_chunks,
-        tool_calls: collapsed.tool_calls as $InferToolCalls<TStructure>[],
-        invalid_tool_calls: collapsed.invalid_tool_calls,
+        tool_calls: mergedToolCalls,
+        invalid_tool_calls: mergedInvalidToolCalls,
         usage_metadata:
           fields.usage_metadata !== undefined
             ? fields.usage_metadata

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -340,6 +340,87 @@ describe("AIMessageChunk", () => {
         },
       ]);
     });
+
+    // Regression: when a streamed AI message contains both finalized
+    // tool_calls and still-streaming tool_call_chunks (common with
+    // parallel tool calls that land sequentially within one message),
+    // the constructor should preserve the caller-supplied tool_calls
+    // rather than rebuilding the field solely from chunks.
+    //
+    // Symptom in langgraph-sdk: only the in-flight tool call is visible
+    // on `message.tool_calls` during streaming; finished calls
+    // disappear until `message-finish` flips the message to a plain
+    // AIMessage. See langchain-ai/langgraphjs#2380.
+    it("preserves caller-supplied tool_calls when tool_call_chunks is non-empty", () => {
+      const chunk = new AIMessageChunk({
+        content: "",
+        // Tool A is finished: fully parsed args, no chunk to collapse.
+        tool_calls: [
+          {
+            id: "A",
+            name: "search",
+            args: { q: "weather" },
+            type: "tool_call",
+          },
+        ],
+        // Tool B is mid-stream: partial JSON in chunk form.
+        tool_call_chunks: [
+          {
+            id: "B",
+            name: "search",
+            args: '{"q":"',
+            index: 1,
+            type: "tool_call_chunk",
+          },
+        ],
+      });
+
+      const callA = chunk.tool_calls?.find((tc) => tc.id === "A");
+      expect(callA).toMatchObject({
+        id: "A",
+        name: "search",
+        args: { q: "weather" },
+      });
+      expect(chunk.tool_call_chunks).toHaveLength(1);
+      expect(chunk.tool_call_chunks?.[0]).toMatchObject({
+        id: "B",
+        args: '{"q":"',
+      });
+    });
+
+    // concat() already merges this.tool_calls with chunk.tool_calls
+    // and hands the result to the constructor. Today that merge is
+    // dead code: the constructor discards it whenever
+    // tool_call_chunks is also non-empty. This test pins the intended
+    // behavior so the merge in concat() stays load-bearing.
+    it("concat preserves merged tool_calls across both sides", () => {
+      const left = new AIMessageChunk({
+        content: "",
+        tool_calls: [
+          { id: "A", name: "search", args: { q: "x" }, type: "tool_call" },
+        ],
+      });
+      const right = new AIMessageChunk({
+        content: "",
+        tool_call_chunks: [
+          {
+            id: "B",
+            name: "search",
+            args: '{"q":"',
+            index: 1,
+            type: "tool_call_chunk",
+          },
+        ],
+      });
+
+      const merged = left.concat(right);
+      const callA = merged.tool_calls?.find((tc) => tc.id === "A");
+      expect(callA).toMatchObject({
+        id: "A",
+        name: "search",
+        args: { q: "x" },
+      });
+    });
   });
 
   it("should properly merge tool call chunks that have matching indices and ids", () => {

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -344,14 +344,14 @@ describe("AIMessageChunk", () => {
     // Regression: when a streamed AI message contains both finalized
     // tool_calls and still-streaming tool_call_chunks (common with
     // parallel tool calls that land sequentially within one message),
-    // the constructor should preserve the caller-supplied tool_calls
+    // the constructor should preserve the provided tool_calls
     // rather than rebuilding the field solely from chunks.
     //
     // Symptom in langgraph-sdk: only the in-flight tool call is visible
     // on `message.tool_calls` during streaming; finished calls
     // disappear until `message-finish` flips the message to a plain
     // AIMessage. See langchain-ai/langgraphjs#2380.
-    it("preserves caller-supplied tool_calls when tool_call_chunks is non-empty", () => {
+    it("preserves provided tool_calls when tool_call_chunks is non-empty", () => {
       const chunk = new AIMessageChunk({
         content: "",
         // Tool A is finished: fully parsed args, no chunk to collapse.
@@ -419,6 +419,36 @@ describe("AIMessageChunk", () => {
         id: "A",
         name: "search",
         args: { q: "x" },
+      });
+    });
+
+    it("prefers collapsed tool_calls over provided snapshot on id collision", () => {
+      const chunk = new AIMessageChunk({
+        content: "",
+        tool_calls: [
+          {
+            id: "A",
+            name: "search",
+            args: { q: "stale" },
+            type: "tool_call",
+          },
+        ],
+        tool_call_chunks: [
+          {
+            id: "A",
+            name: "search",
+            args: '{"q":"fresh"}',
+            index: 0,
+            type: "tool_call_chunk",
+          },
+        ],
+      });
+
+      const callA = chunk.tool_calls?.find((tc) => tc.id === "A");
+      expect(callA).toMatchObject({
+        id: "A",
+        name: "search",
+        args: { q: "fresh" },
       });
     });
   });

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -626,3 +626,55 @@ export function collapseToolCallChunks(chunks: ToolCallChunk[]): {
     invalid_tool_calls: invalidToolCalls,
   };
 }
+
+export interface CollectCollapsedToolCallIdsParams {
+  collapsedToolCalls: ToolCall[];
+  collapsedInvalidToolCalls: InvalidToolCall[];
+}
+
+/**
+ * Collects ids from chunk-collapsed valid and invalid tool call arrays.
+ */
+export function collectCollapsedToolCallIds({
+  collapsedToolCalls,
+  collapsedInvalidToolCalls,
+}: CollectCollapsedToolCallIdsParams): Set<string> {
+  const collapsedIds = new Set<string>();
+  for (const tc of collapsedToolCalls) {
+    if (tc.id !== undefined) collapsedIds.add(tc.id);
+  }
+  for (const tc of collapsedInvalidToolCalls) {
+    if (tc.id !== undefined) collapsedIds.add(tc.id);
+  }
+  return collapsedIds;
+}
+
+export interface MergeProvidedByCollapsedIdsParams<
+  T extends {
+    id?: string;
+  },
+> {
+  collapsed: T[];
+  provided?: T[];
+  collapsedIds: Set<string>;
+}
+
+/**
+ * Merges provided entries with collapsed entries, deduping by collapsed ids.
+ *
+ * Collapsed entries are kept first and win on `id` collisions.
+ */
+export function mergeProvidedByCollapsedIds<
+  T extends {
+    id?: string;
+  },
+>({
+  collapsed,
+  provided = [],
+  collapsedIds,
+}: MergeProvidedByCollapsedIdsParams<T>): T[] {
+  return [
+    ...collapsed,
+    ...provided.filter((tc) => tc.id === undefined || !collapsedIds.has(tc.id)),
+  ];
+}


### PR DESCRIPTION
## Summary

`AIMessageChunk`'s constructor discards caller-supplied `tool_calls` when `tool_call_chunks` is non-empty, rebuilding the field solely from `collapseToolCallChunks`. This drops finalized tool calls mid-stream whenever an AI message contains a mix of finalized and still-streaming tool calls — common with parallel tool calls landing sequentially within one message.

`AIMessageChunk.concat()` already merges `tool_calls` from both sides and forwards them to the constructor, so the discard makes that merge dead code today: a concatenated chunk silently loses every tool_call the prior side had finalized.

This PR replaces the overwrite with a dedupe-by-id merge:

- **Collapsed entries win on id collision.** `concat()` forwards the prior chunk's snapshot `tool_calls` alongside freshly merged `tool_call_chunks`; the chunks are the freshest assembled state and must not be overridden by a stale snapshot.
- **Caller-supplied entries with non-colliding ids are appended.** This keeps finalized tool_calls visible when callers supply both arrays for different ids (e.g. one tool call finalized while siblings are still streaming).

