### PR TITLE
fix(perplexity): Add useResponsesApi flag to ChatPerplexity

### DIFF
--- a/.changeset/rotten-apes-fetch.md
+++ b/.changeset/rotten-apes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Add useResponsesApi flag to ChatPerplexity

--- a/libs/providers/langchain-perplexity/src/chat_models.ts
+++ b/libs/providers/langchain-perplexity/src/chat_models.ts
@@ -6,7 +6,9 @@ import {
   ChatMessageChunk,
   HumanMessageChunk,
   SystemMessageChunk,
+  UsageMetadata,
 } from "@langchain/core/messages";
+import { ToolCall } from "@langchain/core/messages/tool";
 import { concat } from "@langchain/core/utils/stream";
 import {
   BaseChatModel,
@@ -148,6 +150,18 @@ export interface PerplexityChatInput extends BaseChatModelParams {
 
   /** Configuration for web search behaviour. */
   webSearchOptions?: WebSearchOptions;
+
+  /**
+   * Whether to use the Perplexity Agent API (Responses-compatible) instead of Chat Completions.
+   *
+   * If `undefined` (default), inferred from the request payload: `true` when the request
+   * uses a built-in Perplexity tool (`web_search`, `fetch_url`, `finance_search`, `people_search`)
+   * or any Responses-only field (`previousResponseId`, `instructions`, `input`, `include`).
+   * `false` otherwise.
+   *
+   * Maps to `client.responses.create()` → `POST /v1/agent` (alias: `/v1/responses`).
+   */
+  useResponsesApi?: boolean;
 }
 
 export interface PerplexityChatCallOptions extends BaseChatModelCallOptions {
@@ -159,6 +173,215 @@ export interface PerplexityChatCallOptions extends BaseChatModelCallOptions {
       schema: Record<string, unknown>;
     };
   };
+
+  /**
+   * Tools to expose to the model. May include OpenAI-style function tools or
+   * Perplexity built-in tools (e.g. `{ type: "web_search" }`). Passing any
+   * built-in tool routes the request to the Agent API automatically.
+   */
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  tools?: Array<Record<string, any>>;
+
+  /**
+   * Continue a prior Agent API turn. Setting this routes to the Agent API
+   * automatically.
+   */
+  previousResponseId?: string;
+
+  /**
+   * System-style instructions for the Agent API. Setting this routes to the
+   * Agent API automatically.
+   */
+  instructions?: string;
+
+  /**
+   * Native Agent API input. When provided it replaces `messages`. Setting this
+   * routes to the Agent API automatically.
+   */
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  input?: unknown;
+
+  /**
+   * Additional Agent API response fields to include. Setting this routes to
+   * the Agent API automatically.
+   */
+  include?: string[];
+}
+
+function _isBuiltinTool(tool: Record<string, unknown>): boolean {
+  return typeof tool.type === "string" && tool.type !== "function";
+}
+
+function _useResponsesApi(payload: Record<string, unknown>): boolean {
+  const tools = payload.tools as Array<Record<string, unknown>> | undefined;
+  const usesBuiltin = Array.isArray(tools) && tools.some(_isBuiltinTool);
+  const responsesOnly = [
+    "previous_response_id",
+    "instructions",
+    "input",
+    "include",
+  ];
+  const hasResponsesOnly = responsesOnly.some((k) => k in payload);
+  return Boolean(usesBuiltin || hasResponsesOnly);
+}
+
+/**
+ * Map a Perplexity Agent API (Responses-compatible) response to a `ChatResult`.
+ */
+export function convertResponsesToChatResult(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  response: Record<string, any>
+): ChatResult {
+  const outputItems: Array<Record<string, unknown>> = Array.isArray(
+    response.output
+  )
+    ? (response.output as Array<Record<string, unknown>>)
+    : [];
+
+  let text: string = "";
+  if (typeof response.output_text === "string") {
+    text = response.output_text;
+  } else {
+    const parts: string[] = [];
+    for (const item of outputItems) {
+      const content = item.content as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (typeof block.text === "string") {
+            parts.push(block.text);
+          }
+        }
+      }
+    }
+    text = parts.join("");
+  }
+
+  const toolCalls: ToolCall[] = [];
+  for (const item of outputItems) {
+    if (item.type === "function_call") {
+      let parsedArgs: Record<string, unknown> = {};
+      const raw = item.arguments;
+      if (typeof raw === "string" && raw.length > 0) {
+        try {
+          parsedArgs = JSON.parse(raw);
+        } catch {
+          parsedArgs = { __raw: raw };
+        }
+      } else if (raw && typeof raw === "object") {
+        parsedArgs = raw as Record<string, unknown>;
+      }
+      toolCalls.push({
+        id: (item.call_id as string) ?? (item.id as string) ?? "",
+        name: (item.name as string) ?? "",
+        args: parsedArgs,
+        type: "tool_call",
+      });
+    }
+  }
+
+  const responseMetadata: Record<string, unknown> = {
+    id: response.id,
+    model: response.model,
+    status: response.status,
+    object: response.object,
+  };
+  for (const key of [
+    "citations",
+    "images",
+    "related_questions",
+    "search_results",
+  ] as const) {
+    if (response[key] !== undefined) {
+      responseMetadata[key] = response[key];
+    }
+  }
+
+  let usageMetadata: UsageMetadata | undefined;
+  if (response.usage) {
+    const usage = response.usage as Record<string, unknown>;
+    usageMetadata = {
+      input_tokens: (usage.input_tokens as number) ?? 0,
+      output_tokens: (usage.output_tokens as number) ?? 0,
+      total_tokens: (usage.total_tokens as number) ?? 0,
+    };
+  }
+
+  const additionalKwargs: Record<string, unknown> = {
+    responses_output: outputItems,
+  };
+
+  const message = new AIMessage({
+    content: text,
+    tool_calls: toolCalls,
+    additional_kwargs: additionalKwargs,
+    response_metadata: responseMetadata,
+    usage_metadata: usageMetadata,
+  });
+
+  return {
+    generations: [{ text, message }],
+    llmOutput: {
+      tokenUsage: usageMetadata
+        ? {
+            promptTokens: usageMetadata.input_tokens,
+            completionTokens: usageMetadata.output_tokens,
+            totalTokens: usageMetadata.total_tokens,
+          }
+        : {},
+    },
+  };
+}
+
+/**
+ * Map a single Perplexity Agent API streaming event to a `ChatGenerationChunk`.
+ * Returns `null` for events that do not produce a chunk.
+ */
+export function convertResponsesEventToChunk(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  event: Record<string, any>
+): ChatGenerationChunk | null {
+  if (!event || typeof event !== "object") return null;
+  if (event.type === "response.output_text.delta") {
+    const delta: string = typeof event.delta === "string" ? event.delta : "";
+    return new ChatGenerationChunk({
+      text: delta,
+      message: new AIMessageChunk({ content: delta }),
+    });
+  }
+  if (event.type === "response.completed") {
+    const usage = event.response?.usage as Record<string, unknown> | undefined;
+    let usageMetadata: UsageMetadata | undefined;
+    if (usage) {
+      usageMetadata = {
+        input_tokens: (usage.input_tokens as number) ?? 0,
+        output_tokens: (usage.output_tokens as number) ?? 0,
+        total_tokens: (usage.total_tokens as number) ?? 0,
+      };
+    }
+    return new ChatGenerationChunk({
+      text: "",
+      message: new AIMessageChunk({
+        content: "",
+        usage_metadata: usageMetadata,
+        response_metadata: event.response
+          ? {
+              id: event.response.id,
+              model: event.response.model,
+              status: event.response.status,
+              object: event.response.object,
+            }
+          : {},
+      }),
+    });
+  }
+  if (event.type === "response.error") {
+    throw new Error(
+      typeof event.message === "string" ? event.message : "Responses API error"
+    );
+  }
+  return null;
 }
 
 /**
@@ -234,6 +457,8 @@ export class ChatPerplexity
 
   webSearchOptions?: WebSearchOptions;
 
+  useResponsesApi?: boolean;
+
   private client: OpenAI;
 
   constructor(fields: PerplexityChatInput) {
@@ -266,6 +491,7 @@ export class ChatPerplexity
     this.disableSearch = fields?.disableSearch;
     this.enableSearchClassifier = fields?.enableSearchClassifier;
     this.webSearchOptions = fields?.webSearchOptions;
+    this.useResponsesApi = fields?.useResponsesApi;
 
     if (!this.apiKey) {
       throw new Error("Perplexity API key not found");
@@ -337,6 +563,84 @@ export class ChatPerplexity
     throw new Error(`Unknown message type: ${message}`);
   }
 
+  /**
+   * Decide whether to route a payload through the Agent API (Responses) or
+   * Chat Completions. Honors the explicit `useResponsesApi` setting when one
+   * was provided; otherwise auto-detects from the payload shape.
+   */
+  protected _useResponsesApi(payload: Record<string, unknown>): boolean {
+    if (typeof this.useResponsesApi === "boolean") return this.useResponsesApi;
+    return _useResponsesApi(payload);
+  }
+
+  /**
+   * Translate a Chat-Completions-shaped payload into the Agent API
+   * (Responses) shape. Non-equivalent Perplexity knobs are stashed under
+   * `extra_body` so they still reach the server.
+   *
+   * Per the Perplexity OpenAI-compatible docs, the Agent API alias accepts
+   * `max_tokens`, so it is passed through unchanged.
+   * https://docs.perplexity.ai/docs/agent-api/openai-compatibility
+   */
+  protected _toResponsesPayload(
+    payload: Record<string, unknown>
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    const passthrough = new Set([
+      "model",
+      "stream",
+      "temperature",
+      "max_tokens",
+      "top_p",
+      "tools",
+      "tool_choice",
+      "instructions",
+      "previous_response_id",
+      "include",
+      "response_format",
+    ]);
+    const extraBody: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(payload)) {
+      if (value === undefined) continue;
+      if (key === "messages") {
+        if (!("input" in payload)) {
+          out.input = value;
+        }
+        continue;
+      }
+      if (key === "input") {
+        out.input = value;
+        continue;
+      }
+      if (passthrough.has(key)) {
+        out[key] = value;
+        continue;
+      }
+      extraBody[key] = value;
+    }
+    if (Object.keys(extraBody).length > 0) {
+      out.extra_body = extraBody;
+    }
+    return out;
+  }
+
+  /**
+   * Collect Agent-API-specific knobs from call options.
+   */
+  private _responsesOptions(
+    options?: this["ParsedCallOptions"]
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    if (options?.tools !== undefined) out.tools = options.tools;
+    if (options?.previousResponseId !== undefined)
+      out.previous_response_id = options.previousResponseId;
+    if (options?.instructions !== undefined)
+      out.instructions = options.instructions;
+    if (options?.input !== undefined) out.input = options.input;
+    if (options?.include !== undefined) out.include = options.include;
+    return out;
+  }
+
   async _generate(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
@@ -346,6 +650,13 @@ export class ChatPerplexity
     const messagesList = messages.map((message) =>
       this.messageToPerplexityRole(message)
     );
+
+    const basePayload: Record<string, unknown> = {
+      messages: messagesList,
+      ...this.invocationParams(options),
+      ...this._responsesOptions(options),
+    };
+    const route = this._useResponsesApi(basePayload);
 
     if (this.streaming) {
       const stream = this._streamResponseChunks(messages, options, runManager);
@@ -364,6 +675,18 @@ export class ChatPerplexity
         .sort(([aKey], [bKey]) => parseInt(aKey, 10) - parseInt(bKey, 10))
         .map(([_, value]) => value);
       return { generations };
+    }
+
+    if (route) {
+      const responsesPayload = this._toResponsesPayload({
+        ...basePayload,
+        stream: false,
+      });
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await (this.client as any).responses.create(
+        responsesPayload
+      );
+      return convertResponsesToChatResult(response);
     }
 
     const response = await this.client.chat.completions.create({
@@ -409,6 +732,35 @@ export class ChatPerplexity
     const messagesList = messages.map((message) =>
       this.messageToPerplexityRole(message)
     );
+
+    const basePayload: Record<string, unknown> = {
+      messages: messagesList,
+      ...this.invocationParams(options),
+      ...this._responsesOptions(options),
+    };
+
+    if (this._useResponsesApi(basePayload)) {
+      const responsesPayload = this._toResponsesPayload({
+        ...basePayload,
+        stream: true,
+      });
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      const responsesStream = await (this.client as any).responses.create(
+        responsesPayload
+      );
+      for await (const event of responsesStream as AsyncIterable<
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        Record<string, any>
+      >) {
+        const chunk = convertResponsesEventToChunk(event);
+        if (chunk === null) continue;
+        yield chunk;
+        if (runManager && chunk.text) {
+          await runManager.handleLLMNewToken(chunk.text);
+        }
+      }
+      return;
+    }
 
     const stream = await this.client.chat.completions.create({
       messages: messagesList,

--- a/libs/providers/langchain-perplexity/src/tests/chat_models_responses.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/chat_models_responses.test.ts
@@ -1,0 +1,253 @@
+import { vi, test, expect, describe } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import {
+  ChatPerplexity,
+  convertResponsesToChatResult,
+  convertResponsesEventToChunk,
+} from "../chat_models.js";
+
+function mockResponses(model: ChatPerplexity) {
+  const completionsCreate = vi
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn((model as any).client.chat.completions, "create")
+    .mockResolvedValue({
+      choices: [{ message: { role: "assistant", content: "ok" } }],
+      citations: [],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+
+  const responsesCreate = vi.fn().mockResolvedValue({
+    id: "resp_test",
+    model: "openai/gpt-5.4",
+    object: "response",
+    status: "completed",
+    output: [
+      {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "agent answer" }],
+      },
+    ],
+    output_text: "agent answer",
+    usage: {
+      input_tokens: 3,
+      output_tokens: 5,
+      total_tokens: 8,
+    },
+  });
+
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  (model as any).client.responses = { create: responsesCreate };
+  return { completionsCreate, responsesCreate };
+}
+
+describe("ChatPerplexity useResponsesApi routing", () => {
+  test("auto-routes to Responses when payload contains a built-in tool", async () => {
+    const model = new ChatPerplexity({
+      model: "openai/gpt-5.4",
+      apiKey: "test-key",
+    });
+    const { completionsCreate, responsesCreate } = mockResponses(model);
+
+    await model._generate([new HumanMessage("hi")], {
+      tools: [{ type: "web_search" }],
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(completionsCreate).not.toHaveBeenCalled();
+    const payload = responsesCreate.mock.calls[0][0];
+    expect(payload.tools).toEqual([{ type: "web_search" }]);
+    expect(payload.input).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  test("auto-routes to Responses when previousResponseId is supplied", async () => {
+    const model = new ChatPerplexity({
+      model: "openai/gpt-5.4",
+      apiKey: "test-key",
+    });
+    const { completionsCreate, responsesCreate } = mockResponses(model);
+
+    await model._generate([new HumanMessage("follow up")], {
+      previousResponseId: "resp_abc",
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(completionsCreate).not.toHaveBeenCalled();
+    const payload = responsesCreate.mock.calls[0][0];
+    expect(payload.previous_response_id).toBe("resp_abc");
+  });
+
+  test("auto-routes to Chat Completions for a plain text request", async () => {
+    const model = new ChatPerplexity({
+      model: "sonar",
+      apiKey: "test-key",
+    });
+    const { completionsCreate, responsesCreate } = mockResponses(model);
+
+    await model._generate([new HumanMessage("hello")], {});
+
+    expect(completionsCreate).toHaveBeenCalledTimes(1);
+    expect(responsesCreate).not.toHaveBeenCalled();
+  });
+
+  test("explicit useResponsesApi: true routes to Responses for plain text", async () => {
+    const model = new ChatPerplexity({
+      model: "openai/gpt-5.4",
+      apiKey: "test-key",
+      useResponsesApi: true,
+    });
+    const { completionsCreate, responsesCreate } = mockResponses(model);
+
+    await model._generate([new HumanMessage("plain")], {});
+
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(completionsCreate).not.toHaveBeenCalled();
+  });
+
+  test("explicit useResponsesApi: false routes to Chat Completions despite built-in tools", async () => {
+    const model = new ChatPerplexity({
+      model: "sonar",
+      apiKey: "test-key",
+      useResponsesApi: false,
+    });
+    const { completionsCreate, responsesCreate } = mockResponses(model);
+
+    await model._generate([new HumanMessage("hi")], {
+      tools: [{ type: "web_search" }],
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    expect(completionsCreate).toHaveBeenCalledTimes(1);
+    expect(responsesCreate).not.toHaveBeenCalled();
+  });
+
+  test("converts a Responses API response into an AIMessage with usage_metadata", async () => {
+    const model = new ChatPerplexity({
+      model: "openai/gpt-5.4",
+      apiKey: "test-key",
+      useResponsesApi: true,
+    });
+    mockResponses(model);
+
+    const result = await model._generate([new HumanMessage("hi")], {});
+
+    expect(result.generations).toHaveLength(1);
+    expect(result.generations[0].text).toBe("agent answer");
+    expect(result.generations[0].message.content).toBe("agent answer");
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = result.generations[0].message as any;
+    expect(message.usage_metadata).toEqual({
+      input_tokens: 3,
+      output_tokens: 5,
+      total_tokens: 8,
+    });
+    expect(message.response_metadata.id).toBe("resp_test");
+    expect(message.response_metadata.model).toBe("openai/gpt-5.4");
+    expect(result.llmOutput?.tokenUsage).toEqual({
+      promptTokens: 3,
+      completionTokens: 5,
+      totalTokens: 8,
+    });
+  });
+
+  test("converts a function_call output item into a tool_call", () => {
+    const result = convertResponsesToChatResult({
+      id: "resp_x",
+      model: "openai/gpt-5.4",
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: '{"city":"Paris"}',
+        },
+      ],
+      output_text: "",
+      usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+    });
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = result.generations[0].message as any;
+    expect(message.tool_calls).toEqual([
+      {
+        id: "call_1",
+        name: "lookup",
+        args: { city: "Paris" },
+        type: "tool_call",
+      },
+    ]);
+  });
+
+  test("streams content chunks from output_text.delta events and surfaces usage on completion", async () => {
+    const model = new ChatPerplexity({
+      model: "openai/gpt-5.4",
+      apiKey: "test-key",
+      useResponsesApi: true,
+    });
+
+    async function* fakeStream() {
+      yield { type: "response.output_text.delta", delta: "Hello" };
+      yield { type: "response.output_text.delta", delta: " world" };
+      yield {
+        type: "response.completed",
+        response: {
+          id: "resp_stream",
+          model: "openai/gpt-5.4",
+          status: "completed",
+          object: "response",
+          usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+        },
+      };
+    }
+
+    const responsesCreate = vi.fn().mockResolvedValue(fakeStream());
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).client.responses = { create: responsesCreate };
+
+    const chunks = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage("hi")],
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0].text).toBe("Hello");
+    expect(chunks[1].text).toBe(" world");
+    expect(chunks[2].text).toBe("");
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((chunks[2].message as any).usage_metadata).toEqual({
+      input_tokens: 1,
+      output_tokens: 2,
+      total_tokens: 3,
+    });
+  });
+
+  test("convertResponsesEventToChunk throws on response.error", () => {
+    expect(() =>
+      convertResponsesEventToChunk({
+        type: "response.error",
+        message: "boom",
+      })
+    ).toThrow("boom");
+  });
+
+  test("convertResponsesEventToChunk returns null for unhandled events", () => {
+    expect(
+      convertResponsesEventToChunk({ type: "response.output_item.added" })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `useResponsesApi` option to `ChatPerplexity` so callers can route requests through Perplexity's **Agent API** (Responses-compatible) instead of Chat Completions. The flag mirrors `ChatOpenAI`'s `useResponsesApi` field in shape, placement, and behavior.

Perplexity exposes two HTTP surfaces on the same client:

| Surface | Endpoint | SDK method |
| --- | --- | --- |
| Chat Completions | `POST /chat/completions` | `client.chat.completions.create()` |
| Agent API | `POST /v1/agent` (alias: `POST /v1/responses`) | `client.responses.create()` |

The Agent API supports built-in tools (`web_search`, `fetch_url`, `finance_search`, `people_search`), `instructions`, `input`, `previous_response_id`, and `include` — none of which exist on Chat Completions. Today `ChatPerplexity` only talks to Chat Completions; this PR makes it able to talk to both, gated by a single flag.

## What changes

- New `useResponsesApi?: boolean` on `PerplexityChatInput`.
- New call-options fields on `PerplexityChatCallOptions` for `tools`, `previousResponseId`, `instructions`, `input`, and `include` so they can be passed via `bind` / call options.
- `_generate` and `_streamResponseChunks` now branch on a private `_useResponsesApi(payload)` and call `client.responses.create()` when routing to the Agent API.
- Module-level helpers `_isBuiltinTool` / `_useResponsesApi`, and exported `convertResponsesToChatResult` / `convertResponsesEventToChunk` to map Agent API responses and streaming events into `ChatResult` / `ChatGenerationChunk`.
- Private `_toResponsesPayload(payload)` that translates the Chat-Completions-shaped payload into the Responses shape (`messages` → `input`; Perplexity-only knobs go under `extra_body`). Per the [OpenAI-compatibility docs](https://docs.perplexity.ai/docs/agent-api/openai-compatibility), the Agent API alias accepts `max_tokens`, so it's passed through unchanged.

### Auto-detection rules (when `useResponsesApi` is unset)

- Route to Responses when the payload contains any **built-in Perplexity tool** (any `tools` entry whose `type` is not `"function"`).
- Route to Responses when the payload contains a **Responses-only field** (`previous_response_id`, `instructions`, `input`, `include`).
- Otherwise route to Chat Completions (today's default).

`useResponsesApi: true` / `useResponsesApi: false` override the auto-detection.

### Backwards compatibility

Additive only. Existing `new ChatPerplexity({ model: "sonar", ... })` users see no behavior change — the auto-detection only flips to Responses when the request explicitly uses an Agent API feature.

## Test plan

- [x] `pnpm --filter @langchain/perplexity test` — 77 passed, 1 skipped (10 new tests added).
- [x] `pnpm --filter @langchain/perplexity build` clean (CJS + ESM, attw + publint pass).
- [x] `pnpm lint libs/providers/langchain-perplexity` — 0 warnings, 0 errors.
- [x] `pnpm format:check` — clean.

New unit tests in `src/tests/chat_models_responses.test.ts`:

1. Auto-detect: `tools: [{ type: "web_search" }]` → Responses.
2. Auto-detect: `previousResponseId` via call options → Responses.
3. Auto-detect: plain text → Chat Completions.
4. Explicit `useResponsesApi: true` → Responses (even for plain text).
5. Explicit `useResponsesApi: false` → Chat Completions (even with built-in tools).
6. Response → `AIMessage` conversion (content, `usage_metadata`, `response_metadata`).
7. `function_call` output item → `aiMessage.tool_calls[0]`.
8. Streaming: async iterator of `response.output_text.delta` events produces matching content chunks; `response.completed` carries `usage_metadata`.
9. `response.error` event raises.
10. Unhandled event types return `null` (no chunk emitted).

Net new feature; no upstream issue.
