### PR TITLE
fix(openai): re-emit reasoning_content on outbound completions requests

### DIFF
--- a/.changeset/deepseek-reasoning-content-outbound.md
+++ b/.changeset/deepseek-reasoning-content-outbound.md
@@ -1,0 +1,16 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): re-emit `reasoning_content` on outbound completions requests
+
+The OpenAI Chat Completions converter already preserved `reasoning_content`
+from responses into `additional_kwargs.reasoning_content` on the inbound
+path, but the outbound path (`convertMessagesToCompletionsMessageParams`
+and `convertStandardContentMessageToCompletionsMessage`) dropped the field
+when converting an `AIMessage` back into a request payload. OpenAI-compatible
+reasoning providers such as DeepSeek require the `reasoning_content` to be
+echoed back on follow-up turns; without this roundtrip, multi-turn tool-call
+loops fail with `400 The reasoning_content in the thinking mode must be
+passed back to the API.`. OpenAI's own endpoints do not populate this field,
+so passthrough is naturally provider-scoped.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -82,7 +82,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
     }
 
     throw new Error(
-      `Image content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`
+      `Image content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`,
     );
   },
 
@@ -91,7 +91,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
       const data = parseBase64DataUrl({ dataUrl: block.url });
       if (!data) {
         throw new Error(
-          `URL audio blocks with source_type ${block.source_type} must be formatted as a data URL for ChatOpenAI`
+          `URL audio blocks with source_type ${block.source_type} must be formatted as a data URL for ChatOpenAI`,
         );
       }
 
@@ -102,7 +102,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
         mimeType = parseMimeType(rawMimeType);
       } catch {
         throw new Error(
-          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`
+          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`,
         );
       }
 
@@ -111,7 +111,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
         (mimeType.subtype !== "wav" && mimeType.subtype !== "mp3")
       ) {
         throw new Error(
-          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`
+          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`,
         );
       }
 
@@ -131,7 +131,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
         mimeType = parseMimeType(block.mime_type ?? "");
       } catch {
         throw new Error(
-          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`
+          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`,
         );
       }
 
@@ -140,7 +140,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
         (mimeType.subtype !== "wav" && mimeType.subtype !== "mp3")
       ) {
         throw new Error(
-          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`
+          `Audio blocks with source_type ${block.source_type} must have mime type of audio/wav or audio/mp3`,
         );
       }
 
@@ -154,7 +154,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
     }
 
     throw new Error(
-      `Audio content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`
+      `Audio content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`,
     );
   },
 
@@ -166,7 +166,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
 
       if (!data) {
         throw new Error(
-          `URL file blocks with source_type ${block.source_type} must be formatted as a data URL for ChatOpenAI`
+          `URL file blocks with source_type ${block.source_type} must be formatted as a data URL for ChatOpenAI`,
         );
       }
 
@@ -201,7 +201,7 @@ export const completionsApiContentBlockConverter: StandardContentBlockConverter<
     }
 
     throw new Error(
-      `File content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`
+      `File content blocks with source_type ${block.source_type} are not supported for ChatOpenAI`,
     );
   },
 };
@@ -314,7 +314,7 @@ export const convertCompletionsMessageToBaseMessage: Converter<
 
       const content = handleMultiModalOutput(
         message.content || "",
-        rawResponse.choices?.[0]?.message
+        rawResponse.choices?.[0]?.message,
       );
       return new AIMessage({
         content,
@@ -660,10 +660,17 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       content: message.contentBlocks.filter((block) => block.type === "text"),
     };
   } else if (role === "assistant") {
-    return {
-      role: "assistant",
-      content: message.contentBlocks.filter((block) => block.type === "text"),
-    };
+    const assistantParam: OpenAIClient.Chat.Completions.ChatCompletionMessageParam =
+      {
+        role: "assistant",
+        content: message.contentBlocks.filter((block) => block.type === "text"),
+      };
+    const reasoningContent = message.additional_kwargs?.reasoning_content;
+    if (reasoningContent != null) {
+      (assistantParam as { reasoning_content?: unknown }).reasoning_content =
+        reasoningContent;
+    }
+    return assistantParam;
   } else if (role === "tool" && ToolMessage.isInstance(message)) {
     return {
       role: "tool",
@@ -794,7 +801,7 @@ export const convertMessagesToCompletionsMessageParams: Converter<
             if (isDataContentBlock(m)) {
               return convertToProviderContentBlock(
                 m,
-                completionsApiContentBlockConverter
+                completionsApiContentBlockConverter,
               );
             }
             // Drop Anthropic tool_use blocks from content — these are
@@ -823,7 +830,7 @@ export const convertMessagesToCompletionsMessageParams: Converter<
     }
     if (AIMessage.isInstance(message) && !!message.tool_calls?.length) {
       completionParam.tool_calls = message.tool_calls.map(
-        convertLangChainToolCallToOpenAI
+        convertLangChainToolCallToOpenAI,
       );
     } else {
       if (message.additional_kwargs.tool_calls != null) {
@@ -832,6 +839,13 @@ export const convertMessagesToCompletionsMessageParams: Converter<
       if (ToolMessage.isInstance(message) && message.tool_call_id != null) {
         completionParam.tool_call_id = message.tool_call_id;
       }
+    }
+    if (
+      role === "assistant" &&
+      message.additional_kwargs.reasoning_content != null
+    ) {
+      completionParam.reasoning_content =
+        message.additional_kwargs.reasoning_content;
     }
 
     if (

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -673,6 +673,11 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       completionParam.tool_calls = message.additional_kwargs
         .tool_calls as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
     }
+    const reasoningContent = message.additional_kwargs?.reasoning_content;
+    if (reasoningContent != null) {
+      (completionParam as { reasoning_content?: unknown }).reasoning_content =
+        reasoningContent;
+    }
     return completionParam;
   } else if (role === "tool" && ToolMessage.isInstance(message)) {
     return {
@@ -842,6 +847,13 @@ export const convertMessagesToCompletionsMessageParams: Converter<
       if (ToolMessage.isInstance(message) && message.tool_call_id != null) {
         completionParam.tool_call_id = message.tool_call_id;
       }
+    }
+    if (
+      role === "assistant" &&
+      message.additional_kwargs.reasoning_content != null
+    ) {
+      completionParam.reasoning_content =
+        message.additional_kwargs.reasoning_content;
     }
 
     if (

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -35,7 +35,7 @@ describe("convertCompletionsMessageToBaseMessage", () => {
     }) as AIMessage;
 
     expect(result.additional_kwargs.reasoning_content).toBe(
-      "The user asked 1+1."
+      "The user asked 1+1.",
     );
   });
 
@@ -345,6 +345,57 @@ describe("convertCompletionsMessageToBaseMessage", () => {
         },
       });
     });
+
+    it("re-emits assistant reasoning_content on outbound legacy request", () => {
+      const message = new AIMessage({
+        content: "2",
+        additional_kwargs: {
+          reasoning_content: "The user asked 1+1.",
+        },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: "assistant",
+        content: "2",
+        reasoning_content: "The user asked 1+1.",
+      });
+    });
+
+    it("re-emits assistant reasoning_content on outbound v1 standard request", () => {
+      const message = new AIMessage({
+        content: [{ type: "text", text: "2" }],
+        additional_kwargs: {
+          reasoning_content: "The user asked 1+1.",
+        },
+        response_metadata: { output_version: "v1" },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: "assistant",
+        reasoning_content: "The user asked 1+1.",
+      });
+    });
+
+    it("omits reasoning_content when AIMessage has none (no false-positive field)", () => {
+      const message = new AIMessage({ content: "hello" });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty("reasoning_content");
+    });
   });
 
   describe("completionsApiContentBlockConverter.fromStandardFileBlock", () => {
@@ -432,9 +483,9 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       } as any;
 
       expect(() =>
-        completionsApiContentBlockConverter.fromStandardFileBlock!(block)
+        completionsApiContentBlockConverter.fromStandardFileBlock!(block),
       ).toThrowError(
-        `URL file blocks with source_type url must be formatted as a data URL for ChatOpenAI`
+        `URL file blocks with source_type url must be formatted as a data URL for ChatOpenAI`,
       );
     });
   });

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -388,6 +388,57 @@ describe("convertCompletionsMessageToBaseMessage", () => {
         },
       });
     });
+
+    it("re-emits assistant reasoning_content on outbound legacy request", () => {
+      const message = new AIMessage({
+        content: "2",
+        additional_kwargs: {
+          reasoning_content: "The user asked 1+1.",
+        },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: "assistant",
+        content: "2",
+        reasoning_content: "The user asked 1+1.",
+      });
+    });
+
+    it("re-emits assistant reasoning_content on outbound v1 standard request", () => {
+      const message = new AIMessage({
+        content: [{ type: "text", text: "2" }],
+        additional_kwargs: {
+          reasoning_content: "The user asked 1+1.",
+        },
+        response_metadata: { output_version: "v1" },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        role: "assistant",
+        reasoning_content: "The user asked 1+1.",
+      });
+    });
+
+    it("omits reasoning_content when AIMessage has none (no false-positive field)", () => {
+      const message = new AIMessage({ content: "hello" });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty("reasoning_content");
+    });
   });
 
   describe("completionsApiContentBlockConverter.fromStandardFileBlock", () => {


### PR DESCRIPTION
## Summary

Fixes #10883.

The `@langchain/openai` Chat Completions converter already preserved `reasoning_content` from API responses into `additional_kwargs.reasoning_content` (see `converters/completions.ts:276-298` for response messages, and `:419-420` for streaming deltas). The outbound direction was missing: `convertMessagesToCompletionsMessageParams` and `convertStandardContentMessageToCompletionsMessage` dropped the field when converting an `AIMessage` back into a request payload.

OpenAI-compatible reasoning providers — DeepSeek being the headline case — require `reasoning_content` to be echoed back on the next turn after a tool call. Without the roundtrip, the second model call fails with:

```
BadRequestError: 400 The `reasoning_content` in the thinking mode must be passed back to the API.
```

`ChatDeepSeek` extends `ChatOpenAICompletions`, so it walks through the same converter path and benefits automatically. OpenAI's own endpoints do not populate `reasoning_content` on responses, so passthrough is naturally provider-scoped — no risk to vanilla OpenAI traffic.

## Changes

- `converters/completions.ts`: re-emit `reasoning_content` in both the v1/standard assistant branch and the legacy assistant branch of the outbound converter.
- `converters/tests/completions.test.ts`: three new unit tests — legacy path, v1 path, and a negative test asserting the field is absent when the source `AIMessage` has none.
- `.changeset/deepseek-reasoning-content-outbound.md`: patch bump for `@langchain/openai`.

## Test plan

- [x] `npx vitest run src/converters/tests/completions.test.ts` — 21/21 passing (3 new + 18 existing)
- [x] `npx prettier --check` clean on touched files
- [x] `npx tsc --noEmit` introduces no new diagnostics on touched files (pre-existing baseline noise in other test files unchanged)
- [x] Reverse-direction test asserts that a stripped-fix copy of the converter would fail, confirming the test exercises the new code path

## AI Disclosure

This bug was identified and triaged with AI assistance; the fix and tests were drafted with AI assistance and reviewed manually. Path-sensitive reasoning (response_metadata.output_version="v1" routing through the standard converter vs. legacy) was verified against existing roundtrip tests before submission.