### PR TITLE
fix(openai): preserve reasoning_content in completions requests

### DIFF
--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -821,6 +821,13 @@ export const convertMessagesToCompletionsMessageParams: Converter<
     if (message.additional_kwargs.function_call != null) {
       completionParam.function_call = message.additional_kwargs.function_call;
     }
+    if (
+      role === "assistant" &&
+      typeof message.additional_kwargs.reasoning_content === "string"
+    ) {
+      completionParam.reasoning_content =
+        message.additional_kwargs.reasoning_content;
+    }
     if (AIMessage.isInstance(message) && !!message.tool_calls?.length) {
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToOpenAI

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -345,6 +345,43 @@ describe("convertCompletionsMessageToBaseMessage", () => {
         },
       });
     });
+
+    it("should preserve DeepSeek reasoning_content when resending assistant tool calls", () => {
+      const message = new AIMessage({
+        content: "",
+        additional_kwargs: {
+          reasoning_content: "Need the current time, so call get_current_time.",
+        },
+        tool_calls: [
+          {
+            id: "call_deepseek_time",
+            name: "get_current_time",
+            args: {},
+          },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        role: "assistant",
+        content: "",
+        reasoning_content: "Need the current time, so call get_current_time.",
+        tool_calls: [
+          {
+            id: "call_deepseek_time",
+            type: "function",
+            function: {
+              name: "get_current_time",
+              arguments: "{}",
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe("completionsApiContentBlockConverter.fromStandardFileBlock", () => {


### PR DESCRIPTION
## Summary
- pass assistant `reasoning_content` back through chat completions request conversion
- keep the field scoped to assistant messages where providers such as DeepSeek require it
- add regression coverage for assistant tool-call messages with reasoning content

Fixes #10883.

## Tests
- `pnpm --filter @langchain/core build`
- `CI=1 pnpm --dir libs/providers/langchain-openai exec vitest run src/converters/tests/completions.test.ts`
- `pnpm --dir libs/providers/langchain-openai exec prettier --check src/converters/completions.ts src/converters/tests/completions.test.ts`
- `pnpm --filter @langchain/openai build`