### PR TITLE
fix(openai): use response id for AIMessage

### DIFF
--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -336,7 +336,6 @@ export const convertResponsesMessageToAIMessage: Converter<
     throw error;
   }
 
-  let messageId: string | undefined;
   const content: MessageContent = [];
   const tool_calls: ToolCall[] = [];
   const invalid_tool_calls: InvalidToolCall[] = [];
@@ -380,7 +379,6 @@ export const convertResponsesMessageToAIMessage: Converter<
 
   for (const item of response.output) {
     if (item.type === "message") {
-      messageId = item.id;
       content.push(
         ...item.content.flatMap((part) => {
           if (part.type === "output_text") {
@@ -485,7 +483,7 @@ export const convertResponsesMessageToAIMessage: Converter<
   }
 
   return new AIMessage({
-    id: messageId,
+    id: response.id,
     content,
     tool_calls,
     invalid_tool_calls,

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -82,6 +82,33 @@ describe("convertResponsesUsageToUsageMetadata", () => {
 });
 
 describe("convertResponsesMessageToAIMessage", () => {
+  it("should use the top-level response id for the AIMessage id", () => {
+    const response = {
+      id: "resp_123",
+      model: "gpt-4",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_123",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello!", annotations: [] }],
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    expect(result.id).toBe("resp_123");
+  });
+
   it("should elevate reasoning to content array", () => {
     const response = {
       id: "resp_123",


### PR DESCRIPTION
## Summary
- set `AIMessage.id` from the top-level Responses API `response.id` instead of a nested message output item id
- keep nested output ids available through `response_metadata.output` for multi-turn replay
- add regression coverage for the response id mapping

Fixes #10499.

## Tests
- `pnpm --filter @langchain/core build`
- `CI=1 pnpm --dir libs/providers/langchain-openai exec vitest run src/converters/tests/responses.test.ts`
- `pnpm exec oxfmt --check libs/providers/langchain-openai/src/converters/responses.ts libs/providers/langchain-openai/src/converters/tests/responses.test.ts`
- `pnpm --filter @langchain/openai build`

Note: `pnpm --dir libs/providers/langchain-openai exec prettier --check ...` is not a valid formatter check on this checkout because the installed Prettier 2.3.2 cannot parse existing `import { type ... }` syntax; the repo-level formatter is `oxfmt`.