### PR TITLE
fix(openai): guard bare JSON.parse in Responses API converter against trailing characters

### DIFF
--- a/.changeset/openai-responses-bare-json-parse-10894.md
+++ b/.changeset/openai-responses-bare-json-parse-10894.md
@@ -2,6 +2,6 @@
 "@langchain/openai": patch
 ---
 
-fix(openai): guard bare `JSON.parse` in Responses API converter against trailing characters
+fix(openai): guard bare `JSON.parse` in Responses API converter against trailing non-whitespace characters
 
-`convertResponsesDeltaToChatGenerationChunk` previously called `JSON.parse(msg.text)` directly when `response.text.format.type === "json_schema"`. Some models (observed with `gpt-5-mini` on `service_tier: "auto"`) intermittently emit trailing characters after a valid JSON object, causing a `SyntaxError` that propagates as an unhandled exception and kills the entire streaming response. The parse is now wrapped in a `try`/`catch`: on failure, `additional_kwargs.parsed` is left undefined, the rest of the message converts normally, and the caller can fall back to `msg.text` or retry. Closes #10894.
+`convertResponsesDeltaToChatGenerationChunk` previously called `JSON.parse(msg.text)` directly when `response.text.format.type === "json_schema"`. Some models (observed with `gpt-5-mini` on `service_tier: "auto"`) intermittently emit trailing non-whitespace characters (extra tokens, control characters) after a valid JSON object, causing a `SyntaxError` that propagates as an unhandled exception and kills the entire streaming response mid-flight. The parse is now wrapped in a `try`/`catch`: on failure, `additional_kwargs.parsed` is left undefined, the stream completes normally, and the existing `withStructuredOutput` pipeline handles the typed failure — `includeRaw: true` returns `{ raw, parsed: null }` via its `withFallbacks` wrapper, `includeRaw: false` throws a typed `OutputParserException` that the caller can catch and retry. Closes #10894.

--- a/.changeset/openai-responses-bare-json-parse-10894.md
+++ b/.changeset/openai-responses-bare-json-parse-10894.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): guard bare `JSON.parse` in Responses API converter against trailing characters
+
+`convertResponsesDeltaToChatGenerationChunk` previously called `JSON.parse(msg.text)` directly when `response.text.format.type === "json_schema"`. Some models (observed with `gpt-5-mini` on `service_tier: "auto"`) intermittently emit trailing characters after a valid JSON object, causing a `SyntaxError` that propagates as an unhandled exception and kills the entire streaming response. The parse is now wrapped in a `try`/`catch`: on failure, `additional_kwargs.parsed` is left undefined, the rest of the message converts normally, and the caller can fall back to `msg.text` or retry. Closes #10894.

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -1684,4 +1684,204 @@ describe("ChatOpenAI", () => {
       expect(result.text).toEqual("Foo bar");
     });
   });
+
+  describe("withStructuredOutput streaming with malformed structured output (#10894)", () => {
+    // Helper: builds a Response that streams a single response.completed event
+    // whose output_text contains the given JSON text. The mock targets the
+    // Responses API surface, which is where #10894 was reported.
+    const buildMalformedStream = (outputText: string) => {
+      const mockResponseDefaults = {
+        object: "response",
+        background: false,
+        created_at: Math.floor(Date.now() / 1000),
+        completed_at: Math.floor(Date.now() / 1000),
+        error: null,
+        frequency_penalty: 0.0,
+        incomplete_details: null,
+        instructions: null,
+        max_output_tokens: null,
+        max_tool_calls: null,
+        output: [],
+        parallel_tool_calls: true,
+        presence_penalty: 0.0,
+        previous_response_id: null,
+        prompt_cache_key: null,
+        prompt_cache_retention: null,
+        reasoning: { effort: null, summary: null },
+        safety_identifier: null,
+        service_tier: "auto",
+        store: true,
+        temperature: 1.0,
+        text: {
+          format: {
+            type: "json_schema" as const,
+            name: "Plan",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["status", "plan"],
+              properties: {
+                status: { type: "string" },
+                plan: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["steps"],
+                  properties: {
+                    steps: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+          verbosity: "medium",
+        },
+        tool_choice: "auto",
+        tools: [],
+        top_logprobs: 0,
+        top_p: 1.0,
+        truncation: "disabled",
+        usage: {
+          input_tokens: 10,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 12,
+          output_tokens_details: { reasoning_tokens: 0 },
+          total_tokens: 22,
+        },
+        user: null,
+        metadata: {},
+      };
+
+      const events = [
+        {
+          type: "response.created",
+          response: {
+            ...mockResponseDefaults,
+            id: "resp_10894",
+            status: "in_progress",
+          },
+          sequence_number: 0,
+        },
+        {
+          type: "response.completed",
+          response: {
+            ...mockResponseDefaults,
+            id: "resp_10894",
+            status: "completed",
+            output: [
+              {
+                id: "msg_10894",
+                type: "message",
+                status: "completed",
+                role: "assistant",
+                content: [
+                  {
+                    type: "output_text",
+                    annotations: [],
+                    logprobs: [],
+                    text: outputText,
+                  },
+                ],
+              },
+            ],
+          },
+          sequence_number: 1,
+        },
+      ]
+        .map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n`)
+        .join("\n");
+
+      const mockFetch =
+        vi.fn<(url: string | URL | Request, options?: any) => Promise<any>>();
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(`${events}\n`, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          })
+        )
+      );
+      return mockFetch;
+    };
+
+    // Trailing non-whitespace token after a valid JSON object: matches the
+    // production failure mode reported in the issue (extra tokens emitted by
+    // gpt-5-mini on service_tier: "auto"). JSON.parse rejects this with
+    // 'Unexpected non-whitespace character after JSON at position N'.
+    const malformed = '{"status":"ok","plan":{"steps":[]}}x';
+
+    const planSchema = z.object({
+      status: z.string(),
+      plan: z.object({
+        steps: z.array(z.string()),
+      }),
+    });
+
+    it("returns { parsed: null } when invoked with includeRaw: true on a malformed structured response", async () => {
+      const model = new ChatOpenAI({
+        model: "gpt-5-mini",
+        apiKey: "test-key",
+        useResponsesApi: true,
+        streaming: true,
+        configuration: { fetch: buildMalformedStream(malformed) },
+      });
+
+      const structured = model.withStructuredOutput(planSchema, {
+        method: "jsonSchema",
+        includeRaw: true,
+      });
+
+      const result = (await structured.invoke("plan something")) as {
+        raw: unknown;
+        parsed: unknown;
+      };
+
+      // includeRaw fallback path: raw message survives, parsed degrades to
+      // null instead of bubbling a SyntaxError up to the caller.
+      expect(result.parsed).toBeNull();
+      expect(result.raw).toBeDefined();
+    });
+
+    it("throws a typed OutputParserException when invoked with includeRaw: false on a malformed structured response", async () => {
+      const model = new ChatOpenAI({
+        model: "gpt-5-mini",
+        apiKey: "test-key",
+        useResponsesApi: true,
+        streaming: true,
+        configuration: { fetch: buildMalformedStream(malformed) },
+      });
+
+      const structured = model.withStructuredOutput(planSchema, {
+        method: "jsonSchema",
+      });
+
+      // Non-includeRaw path: the StructuredOutputParser fallback throws a
+      // typed OutputParserException (not a raw SyntaxError that would have
+      // killed the stream mid-flight before the converter-level fix). The
+      // caller can catch it normally and retry.
+      await expect(structured.invoke("plan something")).rejects.toThrow(
+        /Failed to parse/i
+      );
+    });
+
+    it("returns the parsed object when the structured response is well-formed", async () => {
+      // Regression guard: the lambda + altParser combo must still hand back
+      // the parsed result on the happy path.
+      const wellFormed = '{"status":"ok","plan":{"steps":["a","b"]}}';
+      const model = new ChatOpenAI({
+        model: "gpt-5-mini",
+        apiKey: "test-key",
+        useResponsesApi: true,
+        streaming: true,
+        configuration: { fetch: buildMalformedStream(wellFormed) },
+      });
+
+      const structured = model.withStructuredOutput(planSchema, {
+        method: "jsonSchema",
+      });
+
+      const result = await structured.invoke("plan something");
+      expect(result).toEqual({ status: "ok", plan: { steps: ["a", "b"] } });
+    });
+  });
 });

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -762,7 +762,15 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     usage_metadata = convertResponsesUsageToUsageMetadata(event.response.usage);
 
     if (event.response.text?.format?.type === "json_schema" && msg.text) {
-      additional_kwargs.parsed ??= JSON.parse(msg.text);
+      try {
+        additional_kwargs.parsed ??= JSON.parse(msg.text);
+      } catch {
+        // Some models (observed with gpt-5-mini on service_tier: "auto")
+        // intermittently emit trailing characters after a valid JSON object
+        // in the Responses API path. Throw-on-parse kills the entire stream
+        // even though msg.text is otherwise usable. Leave parsed undefined
+        // and let the caller fall back to msg.text or retry. See #10894.
+      }
     }
     for (const [key, value] of Object.entries(event.response)) {
       if (key === "id") continue;

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -2224,10 +2224,12 @@ describe("convertResponsesDeltaToChatGenerationChunk - json_schema with tool cal
   });
 });
 
-describe("convertResponsesDeltaToChatGenerationChunk - json_schema with trailing characters (#10894)", () => {
-  it("should not throw when response text contains valid JSON followed by trailing characters", () => {
+describe("convertResponsesDeltaToChatGenerationChunk - json_schema with trailing non-whitespace characters (#10894)", () => {
+  it("should not throw when response text contains valid JSON followed by a trailing non-whitespace character", () => {
     // gpt-5-mini on service_tier: "auto" intermittently emits trailing
-    // characters after a valid JSON object on the Responses API. Previously
+    // characters after a valid JSON object on the Responses API. JSON.parse
+    // accepts trailing whitespace, so the failure mode is specifically
+    // trailing non-whitespace (extra tokens, control characters). Previously
     // the bare JSON.parse threw SyntaxError and killed the stream. The
     // conversion should now degrade gracefully: additional_kwargs.parsed is
     // left undefined, the rest of the message converts normally, and the
@@ -2253,7 +2255,7 @@ describe("convertResponsesDeltaToChatGenerationChunk - json_schema with trailing
             content: [
               {
                 type: "output_text",
-                text: '{"status":"ok","plan":{"steps":[]}} ',
+                text: '{"status":"ok","plan":{"steps":[]}}x',
                 annotations: [],
               },
             ],

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -2224,6 +2224,149 @@ describe("convertResponsesDeltaToChatGenerationChunk - json_schema with tool cal
   });
 });
 
+describe("convertResponsesDeltaToChatGenerationChunk - json_schema with trailing characters (#10894)", () => {
+  it("should not throw when response text contains valid JSON followed by trailing characters", () => {
+    // gpt-5-mini on service_tier: "auto" intermittently emits trailing
+    // characters after a valid JSON object on the Responses API. Previously
+    // the bare JSON.parse threw SyntaxError and killed the stream. The
+    // conversion should now degrade gracefully: additional_kwargs.parsed is
+    // left undefined, the rest of the message converts normally, and the
+    // caller can fall back to msg.text or retry.
+    const event = {
+      type: "response.completed",
+      response: {
+        id: "resp_test_10894",
+        model: "gpt-5-mini",
+        object: "response",
+        created_at: 1700000000,
+        status: "completed",
+        incomplete_details: null,
+        metadata: {},
+        user: null,
+        service_tier: "auto",
+        output: [
+          {
+            type: "message",
+            id: "msg_001",
+            role: "assistant",
+            status: "completed",
+            content: [
+              {
+                type: "output_text",
+                text: '{"status":"ok","plan":{"steps":[]}} ',
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        text: {
+          format: {
+            type: "json_schema",
+            name: "response",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["status", "plan"],
+              properties: {
+                status: { type: "string" },
+                plan: { type: "object" },
+              },
+            },
+          },
+        },
+        usage: {
+          input_tokens: 30,
+          output_tokens: 12,
+          total_tokens: 42,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      },
+    };
+
+    expect(() =>
+      convertResponsesDeltaToChatGenerationChunk(event as any)
+    ).not.toThrow();
+
+    const result = convertResponsesDeltaToChatGenerationChunk(event as any);
+    expect(result).not.toBeNull();
+
+    const message = result!.message as AIMessageChunk;
+    // Parsing failed, so parsed should not be populated.
+    expect(message.additional_kwargs.parsed).toBeUndefined();
+    // Usage metadata should still flow through so the caller can account
+    // for the tokens that were spent on the bad payload.
+    expect(result!.message.usage_metadata).toBeDefined();
+    expect(result!.message.usage_metadata!.input_tokens).toBe(30);
+  });
+
+  it("should still parse cleanly when response text is well-formed JSON", () => {
+    // Regression guard: the try/catch must not change the well-formed path.
+    const event = {
+      type: "response.completed",
+      response: {
+        id: "resp_test_10894_b",
+        model: "gpt-5-mini",
+        object: "response",
+        created_at: 1700000000,
+        status: "completed",
+        incomplete_details: null,
+        metadata: {},
+        user: null,
+        service_tier: "auto",
+        output: [
+          {
+            type: "message",
+            id: "msg_002",
+            role: "assistant",
+            status: "completed",
+            content: [
+              {
+                type: "output_text",
+                text: '{"status":"ok","plan":{"steps":[]}}',
+                annotations: [],
+              },
+            ],
+          },
+        ],
+        text: {
+          format: {
+            type: "json_schema",
+            name: "response",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              required: ["status", "plan"],
+              properties: {
+                status: { type: "string" },
+                plan: { type: "object" },
+              },
+            },
+          },
+        },
+        usage: {
+          input_tokens: 30,
+          output_tokens: 12,
+          total_tokens: 42,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      },
+    };
+
+    const result = convertResponsesDeltaToChatGenerationChunk(event as any);
+    expect(result).not.toBeNull();
+
+    const message = result!.message as AIMessageChunk;
+    expect(message.additional_kwargs.parsed).toEqual({
+      status: "ok",
+      plan: { steps: [] },
+    });
+  });
+});
+
 describe("phase parameter support", () => {
   describe("convertResponsesMessageToAIMessage", () => {
     it("should include phase on text content blocks when present on message output", () => {


### PR DESCRIPTION
## Summary

`convertResponsesDeltaToChatGenerationChunk` in `libs/providers/langchain-openai/src/converters/responses.ts` calls `JSON.parse(msg.text)` directly when `response.text.format.type === "json_schema"`. Some models (observed with `gpt-5-mini` on `service_tier: "auto"`) intermittently emit **trailing non-whitespace characters** (extra tokens, control characters) after a valid JSON object on the Responses API. `JSON.parse` accepts trailing whitespace but rejects trailing non-whitespace, so the bare parse throws `SyntaxError` and kills the entire streaming response mid-flight.

This PR wraps the call in a `try`/`catch`:

```ts
if (event.response.text?.format?.type === "json_schema" && msg.text) {
  try {
    additional_kwargs.parsed ??= JSON.parse(msg.text);
  } catch {
    // graceful degradation; leave parsed undefined, caller can fall back
    // to msg.text or retry. See #10894.
  }
}
```

On failure `additional_kwargs.parsed` is left `undefined`, the rest of the message converts normally, the stream completes, and `usage_metadata` still flows through.

The downstream `withStructuredOutput(zodSchema)` pipeline already gives the right semantics from there:

- The `RunnableLambda` at `base.ts:1089` falls through to `altParser.invoke(content)` when `additional_kwargs.parsed` is absent.
- For Zod schemas, `createContentParser` returns `StructuredOutputParser`, whose `.parse()` already wraps `JSON.parse(...)` in try/catch and throws a typed `OutputParserException` (`libs/langchain-core/src/output_parsers/structured.ts:126-131`).
- `assembleStructuredOutputPipeline` already routes `includeRaw: true` through `withFallbacks`, so a typed throw becomes `parsed: null`. `includeRaw: false` passes the typed throw to the caller.

Net effect for the user reporting #10894: streams no longer die mid-flight; `includeRaw: true` degrades to `{ raw, parsed: null }`; `includeRaw: false` throws a typed `OutputParserException` the caller can catch and retry.

Closes #10894.

## Test plan

Converter-level unit tests in `libs/providers/langchain-openai/src/converters/tests/responses.test.ts`:

1. **Trailing non-whitespace case** — `msg.text = '{"status":"ok","plan":{"steps":[]}}x'` (valid JSON + trailing `x`). The conversion does not throw, `additional_kwargs.parsed` is `undefined`, `usage_metadata` is populated.
2. **Well-formed regression guard** — `msg.text` contains valid JSON with no trailing characters. The conversion parses cleanly into `additional_kwargs.parsed`.

End-to-end `withStructuredOutput(zodSchema)` streaming tests in `libs/providers/langchain-openai/src/chat_models/tests/index.test.ts`:

3. **`includeRaw: true` + malformed structured output** — returns `{ raw, parsed: null }`.
4. **`includeRaw: false` (default) + malformed structured output** — throws `OutputParserException` matching `/Failed to parse/i` (post-stream, not the mid-stream `SyntaxError` that originally killed the call).
5. **Well-formed structured output regression guard** — `withStructuredOutput(zodSchema)` returns the parsed object.

```
pnpm vitest run src/converters/tests/responses.test.ts src/chat_models/tests/index.test.ts
→ PASS (126) FAIL (0)
pnpm build → clean
```

## Notes

- Follows the same shape as the prior fix for #10505 (empty `msg.text` case, also in this file).
- Changeset under `.changeset/openai-responses-bare-json-parse-10894.md` as `patch` on `@langchain/openai`.
- Review feedback from @christian-bromann addressed in follow-up commit `4b35a2f` (NUL byte in test literal swapped for explicit non-whitespace `x`; E2E coverage added for both `includeRaw` modes).