### PR TITLE
fix(pinecone): support Pinecone JS SDK v7 upsert/deleteMany APIs

### DIFF
--- a/.changeset/pinecone-sdk-v7.md
+++ b/.changeset/pinecone-sdk-v7.md
@@ -1,0 +1,11 @@
+---
+"@langchain/pinecone": minor
+---
+
+fix(pinecone): support Pinecone JS SDK v7 upsert/deleteMany APIs
+
+Align `@langchain/pinecone` with `@pinecone-database/pinecone` v7 option-object APIs for `upsert` and `deleteMany`, and construct `Index` via v7 `IndexOptions` when using `pineconeConfig`.
+
+**BREAKING CHANGE**: The `@pinecone-database/pinecone` peer dependency now requires v7 (`^7.0.0`). Upgrade from v5/v6 before updating `@langchain/pinecone`.
+
+Fixes #10890

--- a/libs/providers/langchain-pinecone/CHANGELOG.md
+++ b/libs/providers/langchain-pinecone/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @langchain/pinecone
 
+## 1.1.0
+
+### Minor Changes
+
+- Support `@pinecone-database/pinecone` v7 by using the SDK's options-object APIs for `upsert` and `deleteMany`, and constructing `Index` with v7 `IndexOptions`.
+
+### BREAKING CHANGES
+
+- The `@pinecone-database/pinecone` peer dependency now requires v7 (`^7.0.0`). Upgrade from v5/v6 before updating `@langchain/pinecone`.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/libs/providers/langchain-pinecone/package.json
+++ b/libs/providers/langchain-pinecone/package.json
@@ -32,13 +32,13 @@
   },
   "peerDependencies": {
     "@langchain/core": "workspace:^",
-    "@pinecone-database/pinecone": "^5.0.2"
+    "@pinecone-database/pinecone": "^7.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.3.1",
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
-    "@pinecone-database/pinecone": "^5.0.2",
+    "@pinecone-database/pinecone": "^7.0.0",
     "@langchain/tsconfig": "workspace:*",
     "@tsconfig/recommended": "^1.0.3",
     "@types/flat": "^5.0.5",

--- a/libs/providers/langchain-pinecone/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-pinecone/src/tests/vectorstores.test.ts
@@ -30,13 +30,15 @@ test("PineconeStore with external ids", async () => {
     ["id1"]
   );
   expect(upsert).toHaveBeenCalledTimes(1);
-  expect(upsert).toHaveBeenCalledWith([
-    {
-      id: "id1",
-      metadata: { a: 1, "b.nested.0": 1, "b.nested.1.a": 4, text: "hello" },
-      values: [0.1, 0.2, 0.3, 0.4],
-    },
-  ]);
+  expect(upsert).toHaveBeenCalledWith({
+    records: [
+      {
+        id: "id1",
+        metadata: { a: 1, "b.nested.0": 1, "b.nested.1.a": 4, text: "hello" },
+        values: [0.1, 0.2, 0.3, 0.4],
+      },
+    ],
+  });
 
   const results = await store.similaritySearch("hello", 1);
   expect(results).toHaveLength(0);
@@ -92,22 +94,58 @@ test("PineconeStore with string arrays", async () => {
     ["id1"]
   );
 
-  expect(upsert).toHaveBeenCalledWith([
-    {
-      id: "id1",
-      metadata: {
-        a: 1,
-        "b.nested.0": 1,
-        "b.nested.1.a": 4,
-        c: ["some", "string", "array"],
-        "d.0": 1,
-        "d.1.nested": 2,
-        "d.2": "string",
-        text: "hello",
+  expect(upsert).toHaveBeenCalledWith({
+    records: [
+      {
+        id: "id1",
+        metadata: {
+          a: 1,
+          "b.nested.0": 1,
+          "b.nested.1.a": 4,
+          c: ["some", "string", "array"],
+          "d.0": 1,
+          "d.1.nested": 2,
+          "d.2": "string",
+          text: "hello",
+        },
+        values: [0.1, 0.2, 0.3, 0.4],
       },
-      values: [0.1, 0.2, 0.3, 0.4],
-    },
-  ]);
+    ],
+  });
+});
+
+test("PineconeStore delete by ids uses v7 deleteMany options", async () => {
+  const deleteMany = vi.fn();
+  const client = {
+    namespace: vi.fn().mockReturnValue({
+      upsert: vi.fn(),
+      deleteMany,
+      query: vi.fn().mockResolvedValue({ matches: [] }),
+    }),
+  };
+  const embeddings = new FakeEmbeddings();
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  await store.delete({ ids: ["id1", "id2"] });
+
+  expect(deleteMany).toHaveBeenCalledWith({ ids: ["id1", "id2"] });
+});
+
+test("PineconeStore delete by filter uses v7 deleteMany options", async () => {
+  const deleteMany = vi.fn();
+  const client = {
+    namespace: vi.fn().mockReturnValue({
+      upsert: vi.fn(),
+      deleteMany,
+      query: vi.fn().mockResolvedValue({ matches: [] }),
+    }),
+  };
+  const embeddings = new FakeEmbeddings();
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  await store.delete({ filter: { genre: "classical" } });
+
+  expect(deleteMany).toHaveBeenCalledWith({ filter: { genre: "classical" } });
 });
 
 describe("PineconeStore with null pageContent", () => {

--- a/libs/providers/langchain-pinecone/src/vectorstores.ts
+++ b/libs/providers/langchain-pinecone/src/vectorstores.ts
@@ -6,6 +6,7 @@ import {
   PineconeRecord,
   Index as PineconeIndex,
   ScoredPineconeRecord,
+  type PineconeConfiguration,
 } from "@pinecone-database/pinecone";
 
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
@@ -45,8 +46,8 @@ export interface PineconeStoreParams extends AsyncCallerParams {
    * Either this or pineconeIndex must be provided.
    */
   pineconeConfig?: {
-    indexName: ConstructorParameters<typeof PineconeIndex>[0];
-    config: ConstructorParameters<typeof PineconeIndex>[1];
+    indexName: string;
+    config: PineconeConfiguration;
     namespace?: string;
     indexHostUrl?: string;
     additionalHeaders?: HTTPHeaders;
@@ -240,14 +241,16 @@ export class PineconeStore extends VectorStore {
       this.pineconeIndex = pineconeIndex;
     } else if (pineconeConfig) {
       this.pineconeIndex = new PineconeIndex(
-        pineconeConfig.indexName,
+        {
+          name: pineconeConfig.indexName,
+          namespace: pineconeConfig.namespace,
+          host: pineconeConfig.indexHostUrl,
+          additionalHeaders: pineconeConfig.additionalHeaders,
+        },
         {
           ...pineconeConfig.config,
           sourceTag: "langchainjs",
-        },
-        pineconeConfig.namespace,
-        pineconeConfig.indexHostUrl,
-        pineconeConfig.additionalHeaders
+        }
       );
     }
 
@@ -341,7 +344,7 @@ export class PineconeStore extends VectorStore {
     const batchRequests = chunkedVectors.map((chunk) =>
       this.caller.call(async () => {
         try {
-          await namespace.upsert(chunk);
+          await namespace.upsert({ records: chunk });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {
           if (e.message.includes("404")) {
@@ -373,10 +376,10 @@ export class PineconeStore extends VectorStore {
       const batchSize = 1000;
       for (let i = 0; i < ids.length; i += batchSize) {
         const batchIds = ids.slice(i, i + batchSize);
-        await namespace.deleteMany(batchIds);
+        await namespace.deleteMany({ ids: batchIds });
       }
     } else if (filter) {
-      await namespace.deleteMany(filter);
+      await namespace.deleteMany({ filter });
     } else {
       throw new Error("Either ids or delete_all must be provided.");
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2171,8 +2171,8 @@ importers:
         specifier: workspace:*
         version: link:../../../internal/tsconfig
       '@pinecone-database/pinecone':
-        specifier: ^5.0.2
-        version: 5.1.2
+        specifier: ^7.0.0
+        version: 7.2.0
       '@tsconfig/recommended':
         specifier: ^1.0.3
         version: 1.0.13


### PR DESCRIPTION
Fixes #10890

## Problem
`@langchain/pinecone` called Pinecone v5/v6-style APIs (`namespace.upsert(array)`, `deleteMany(ids[])`). With `@pinecone-database/pinecone` v7, upsert expects `{ records: [...] }`, so the SDK saw no records and threw: *"Must pass in at least 1 record to upsert."*

## Solution
- `upsert({ records: chunk })`
- `deleteMany({ ids })` / `deleteMany({ filter })`
- Construct `Index` via v7 `IndexOptions` when using `pineconeConfig`

## Breaking change
Peer dependency now requires `@pinecone-database/pinecone` `^7.0.0`. Upgrade Pinecone SDK before upgrading `@langchain/pinecone`.

## Test plan
- [x] Updated unit tests for upsert/deleteMany call shapes
- [x] `pnpm --filter @langchain/pinecone build`
- [x] `pnpm --filter @langchain/pinecone test`