### PR TITLE
fix(core): share fakeModel invocation state across bindTools instances

### DIFF
--- a/.changeset/stupid-tables-help.md
+++ b/.changeset/stupid-tables-help.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(testing): share fakeModel invocation state across bindTools instances

--- a/libs/langchain-core/src/testing/fake_model_builder.ts
+++ b/libs/langchain-core/src/testing/fake_model_builder.ts
@@ -30,6 +30,11 @@ interface FakeModelCall {
   options: any;
 }
 
+interface FakeModelState {
+  callIndex: number;
+  calls: FakeModelCall[];
+}
+
 function deriveContent(messages: BaseMessage[]): string {
   return messages
     .map((m) => m.text)
@@ -60,9 +65,7 @@ export class FakeBuiltModel extends BaseChatModel {
 
   private _tools: (StructuredTool | ToolSpec)[] = [];
 
-  private _callIndex = 0;
-
-  private _calls: FakeModelCall[] = [];
+  private _state: FakeModelState = { callIndex: 0, calls: [] };
 
   /**
    * All invocations recorded by this model, in order.
@@ -70,14 +73,14 @@ export class FakeBuiltModel extends BaseChatModel {
    * passed to `invoke()`.
    */
   get calls(): FakeModelCall[] {
-    return this._calls;
+    return this._state.calls;
   }
 
   /**
    * The number of times this model has been invoked.
    */
   get callCount(): number {
-    return this._calls.length;
+    return this._state.calls.length;
   }
 
   constructor() {
@@ -165,8 +168,7 @@ export class FakeBuiltModel extends BaseChatModel {
     next._alwaysThrowError = this._alwaysThrowError;
     next._structuredResponseValue = this._structuredResponseValue;
     next._tools = merged;
-    next._calls = this._calls;
-    next._callIndex = this._callIndex;
+    next._state = this._state;
 
     return next.withConfig({} as BaseChatModelCallOptions);
   }
@@ -203,10 +205,10 @@ export class FakeBuiltModel extends BaseChatModel {
     options?: this["ParsedCallOptions"],
     _runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
-    this._calls.push({ messages: [...messages], options });
+    this._state.calls.push({ messages: [...messages], options });
 
-    const currentCallIndex = this._callIndex;
-    this._callIndex += 1;
+    const currentCallIndex = this._state.callIndex;
+    this._state.callIndex += 1;
 
     if (this._alwaysThrowError) {
       throw this._alwaysThrowError;

--- a/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
+++ b/libs/langchain-core/src/testing/tests/fake_model_builder.test.ts
@@ -269,6 +269,22 @@ describe("fakeModel", () => {
       expect(r2.content).toBe("done");
     });
 
+    test("preserves response sequence across multiple bound instances", async () => {
+      const model = fakeModel()
+        .respondWithTools([{ name: "search", args: {}, id: "1" }])
+        .respond(new AIMessage("done"));
+
+      const firstBound = model.bindTools([dummyTool]);
+      const secondBound = model.bindTools([dummyTool]);
+
+      const r1 = await firstBound.invoke([new HumanMessage("a")]);
+      expect(r1.tool_calls?.[0]?.name).toBe("search");
+
+      const r2 = await secondBound.invoke([new HumanMessage("b")]);
+      expect(r2.content).toBe("done");
+      expect(r2.tool_calls ?? []).toHaveLength(0);
+    });
+
     test("shares call recording across bindTools", async () => {
       const model = fakeModel().respond(new AIMessage("hi"));
       const bound = model.bindTools([dummyTool]);


### PR DESCRIPTION
## Summary
- Fix `fakeModel()` / `FakeBuiltModel.bindTools()` so every bound model shares one invocation cursor and call log, matching the intended “one queued response per `invoke()`” semantics across separate bindings (as `createAgent` does).
- Add a unit test for two different `bindTools()` instances consuming the same queue in order.
- Tighten the agent v3 streaming test to assert the full post-tool message list ends with a final assistant reply.
