### PR TITLE
fix(openai): preserve v1 assistant tool calls

### DIFF
--- a/.changeset/gold-rivers-love.md
+++ b/.changeset/gold-rivers-love.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): preserve v1 assistant tool calls

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -660,10 +660,20 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       content: message.contentBlocks.filter((block) => block.type === "text"),
     };
   } else if (role === "assistant") {
-    return {
-      role: "assistant",
-      content: message.contentBlocks.filter((block) => block.type === "text"),
-    };
+    const completionParam: OpenAIClient.Chat.Completions.ChatCompletionAssistantMessageParam =
+      {
+        role: "assistant",
+        content: message.contentBlocks.filter((block) => block.type === "text"),
+      };
+    if (AIMessage.isInstance(message) && !!message.tool_calls?.length) {
+      completionParam.tool_calls = message.tool_calls.map(
+        convertLangChainToolCallToOpenAI
+      ) as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
+    } else if (message.additional_kwargs.tool_calls != null) {
+      completionParam.tool_calls = message.additional_kwargs
+        .tool_calls as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
+    }
+    return completionParam;
   } else if (role === "tool" && ToolMessage.isInstance(message)) {
     return {
       role: "tool",

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -320,6 +320,49 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
+    it("should preserve tool_calls for output_version v1 assistant messages", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "tool_call",
+            id: "call_123",
+            name: "someFunction",
+            args: { key: "value" },
+          },
+        ],
+        tool_calls: [
+          {
+            id: "call_123",
+            name: "someFunction",
+            args: { key: "value" },
+          },
+        ],
+        response_metadata: {
+          output_version: "v1",
+        },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        role: "assistant",
+        content: [],
+        tool_calls: [
+          {
+            id: "call_123",
+            type: "function",
+            function: {
+              name: "someFunction",
+              arguments: '{"key":"value"}',
+            },
+          },
+        ],
+      });
+    });
+
     it("should preserve content with function_call in additional_kwargs", () => {
       const message = new AIMessage({
         content: "Let me call a function for you.",


### PR DESCRIPTION
## Summary
- Preserve `tool_calls` when converting `output_version: "v1"` assistant messages to OpenAI chat completions params.
- Prevent OpenAI from receiving tool-role messages without the preceding assistant `tool_calls`, which addresses the `INVALID_TOOL_RESULTS` 400 from langchain-ai/deepagentsjs#534.
- Keep the tool-result streaming leak fix separate in langchain-ai/langchainjs#10900.
