### PR TITLE
fix: handle undefined agent state schema

### DIFF
--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -793,19 +793,23 @@ export type ToAnnotationRoot<A extends StateDefinitionInit> =
       : never;
 
 export type InferSchemaValue<A extends StateDefinitionInit | undefined> =
-  A extends StateSchema<infer TFields>
-    ? InferStateSchemaValue<TFields>
-    : A extends InteropZodObject
-      ? InferInteropZodOutput<A>
-      : A extends AnyAnnotationRoot
-        ? A["State"]
-        : {};
+  A extends undefined
+    ? {}
+    : A extends StateSchema<infer TFields>
+      ? InferStateSchemaValue<TFields>
+      : A extends InteropZodObject
+        ? InferInteropZodOutput<A>
+        : A extends AnyAnnotationRoot
+          ? A["State"]
+          : {};
 
 export type InferSchemaInput<A extends StateDefinitionInit | undefined> =
-  A extends StateSchema<infer TFields>
-    ? InferStateSchemaUpdate<TFields>
-    : A extends InteropZodObject
-      ? InferInteropZodInput<A>
-      : A extends AnyAnnotationRoot
-        ? A["Update"]
-        : {};
+  A extends undefined
+    ? {}
+    : A extends StateSchema<infer TFields>
+      ? InferStateSchemaUpdate<TFields>
+      : A extends InteropZodObject
+        ? InferInteropZodInput<A>
+        : A extends AnyAnnotationRoot
+          ? A["Update"]
+          : {};

--- a/libs/langchain/src/agents/tests/reactAgent.test-d.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.test-d.ts
@@ -8,7 +8,14 @@ import { describe, it, expectTypeOf } from "vitest";
 import type { IterableReadableStream } from "@langchain/core/utils/stream";
 import type { RunnableInterface } from "@langchain/core/runnables";
 
-import { type BuiltInState, createAgent, createMiddleware } from "../index.js";
+import {
+  type AgentTypeConfig,
+  type BuiltInState,
+  createAgent,
+  createMiddleware,
+  type ReactAgent,
+  type ResponseFormatUndefined,
+} from "../index.js";
 import type { StreamOutputMap } from "@langchain/langgraph";
 
 describe("reactAgent", () => {
@@ -77,6 +84,16 @@ describe("reactAgent", () => {
     });
     await agent.invoke({
       messages: [new HumanMessage("Hello, world!")],
+    });
+  });
+
+  it("should accept messages for explicitly unstructured agents", async () => {
+    const agent = createAgent({
+      model: "openai:gpt-4",
+    }) as ReactAgent<AgentTypeConfig<ResponseFormatUndefined, undefined>>;
+
+    await agent.invoke({
+      messages: [{ role: "user", content: "Hello, world!" }],
     });
   });
 


### PR DESCRIPTION
## Summary
- Treat `undefined` agent state schemas as no custom state before checking LangGraph schema branches.
- Add a type regression for an explicitly unstructured `ReactAgent<AgentTypeConfig<ResponseFormatUndefined, undefined>>` accepting `messages` input.

Fixes #10888.

## Testing
- `npx --yes pnpm@10.14.0 exec oxfmt --check libs/langchain/src/agents/middleware/types.ts libs/langchain/src/agents/tests/reactAgent.test-d.ts`
- `git diff --check`
- `npx --yes pnpm@10.14.0 exec tsdown` from `libs/langchain-core`, `libs/providers/langchain-openai`, and `libs/providers/langchain-anthropic` to generate local declarations for type tests
- `npx --yes pnpm@10.14.0 --dir libs/langchain exec vitest run src/agents/tests/reactAgent.test-d.ts --typecheck.only`