### PR TITLE
feat(core): add uuid v6 support to core utils

### DIFF
--- a/.changeset/hunter-core-uuid-v6-support.md
+++ b/.changeset/hunter-core-uuid-v6-support.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": minor
+---
+
+feat(core): add uuid v6 utility support
+
+Add `v6` UUID generation support to `@langchain/core/utils/uuid` by vendoring the upstream uuidjs `v6` implementation and its `v1ToV6` helper, exporting `v6` from the UUID utils index, and adding tests for deterministic generation, buffer/offset behavior, validation/versioning, and ordering.

--- a/libs/langchain-core/src/utils/tests/uuid.test.ts
+++ b/libs/langchain-core/src/utils/tests/uuid.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import { v6, validate, version } from "../uuid/index.js";
+import v1ToV6 from "../uuid/v1ToV6.js";
+
+describe("uuid v6", () => {
+  const v1Id = "f1207660-21d2-11ef-8c4f-419efbd44d48";
+  const v6Id = "1ef21d2f-1207-6660-8c4f-419efbd44d48";
+
+  const fullOptions = {
+    msecs: 0x133b891f705,
+    nsecs: 0x1538,
+    clockseq: 0x385c,
+    node: Uint8Array.of(0x61, 0xcd, 0x3c, 0xbb, 0x32, 0x10),
+  };
+
+  const expectedBytes = Uint8Array.of(
+    0x1e,
+    0x11,
+    0x22,
+    0xbd,
+    0x94,
+    0x28,
+    0x68,
+    0x88,
+    0xb8,
+    0x5c,
+    0x61,
+    0xcd,
+    0x3c,
+    0xbb,
+    0x32,
+    0x10
+  );
+
+  test("generates a valid v6 uuid", () => {
+    const id = v6();
+    expect(validate(id)).toBe(true);
+    expect(version(id)).toBe(6);
+  });
+
+  test("supports all options deterministically", () => {
+    const id = v6(fullOptions);
+    expect(id).toBe("1e1122bd-9428-6888-b85c-61cd3cbb3210");
+  });
+
+  test("supports writing to an output buffer", () => {
+    const buffer = new Uint8Array(16);
+    const result = v6(fullOptions, buffer);
+
+    expect(buffer).toEqual(expectedBytes);
+    expect(result).toBe(buffer);
+  });
+
+  test("supports writing at an offset", () => {
+    const buffer = new Uint8Array(32);
+    v6(fullOptions, buffer, 0);
+    v6(fullOptions, buffer, 16);
+
+    const expectedBuffer = new Uint8Array(32);
+    expectedBuffer.set(expectedBytes, 0);
+    expectedBuffer.set(expectedBytes, 16);
+
+    expect(buffer).toEqual(expectedBuffer);
+  });
+
+  test("throws for out-of-range buffer offsets", () => {
+    const buf15 = new Uint8Array(15);
+    const buf30 = new Uint8Array(30);
+
+    expect(() => v6({}, buf15)).toThrow(RangeError);
+    expect(() => v6({}, buf30, -1)).toThrow(RangeError);
+    expect(() => v6({}, buf30, 15)).toThrow(RangeError);
+  });
+
+  test("converts v1 to v6 correctly", () => {
+    expect(v1ToV6(v1Id)).toBe(v6Id);
+  });
+
+  test("sorts lexicographically by creation time", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      ids.push(v6({ msecs: i * 1000 }));
+    }
+
+    expect(ids).toEqual([...ids].sort());
+  });
+});

--- a/libs/langchain-core/src/utils/uuid/index.ts
+++ b/libs/langchain-core/src/utils/uuid/index.ts
@@ -6,6 +6,7 @@ export type * from "./types.js";
 export { default as v1 } from "./v1.js";
 export { default as v4 } from "./v4.js";
 export { default as v5 } from "./v5.js";
+export { default as v6 } from "./v6.js";
 export { default as v7 } from "./v7.js";
 export { default as validate } from "./validate.js";
 export { default as version } from "./version.js";

--- a/libs/langchain-core/src/utils/uuid/v1ToV6.ts
+++ b/libs/langchain-core/src/utils/uuid/v1ToV6.ts
@@ -1,0 +1,47 @@
+import parse from "./parse.js";
+import { unsafeStringify } from "./stringify.js";
+import type { NonSharedArrayBuffer, UUIDTypes } from "./types.js";
+
+/**
+ * Convert a v1 UUID to a v6 UUID
+ *
+ * @param {string|Uint8Array} uuid - The v1 UUID to convert to v6
+ * @returns {string|Uint8Array} The v6 UUID as the same type as the `uuid` arg
+ * (string or Uint8Array)
+ */
+export default function v1ToV6(uuid: string): string;
+export default function v1ToV6(uuid: Uint8Array): NonSharedArrayBuffer;
+export default function v1ToV6(
+  uuid: string | Uint8Array
+): UUIDTypes<NonSharedArrayBuffer> {
+  const v1Bytes = typeof uuid === "string" ? parse(uuid) : uuid;
+
+  const v6Bytes = _v1ToV6(v1Bytes);
+
+  return typeof uuid === "string" ? unsafeStringify(v6Bytes) : v6Bytes;
+}
+
+// Do the field transformation needed for v1 -> v6
+function _v1ToV6(v1Bytes: Uint8Array): NonSharedArrayBuffer {
+  return Uint8Array.of(
+    ((v1Bytes[6] & 0x0f) << 4) | ((v1Bytes[7] >> 4) & 0x0f),
+    ((v1Bytes[7] & 0x0f) << 4) | ((v1Bytes[4] & 0xf0) >> 4),
+    ((v1Bytes[4] & 0x0f) << 4) | ((v1Bytes[5] & 0xf0) >> 4),
+    ((v1Bytes[5] & 0x0f) << 4) | ((v1Bytes[0] & 0xf0) >> 4),
+
+    ((v1Bytes[0] & 0x0f) << 4) | ((v1Bytes[1] & 0xf0) >> 4),
+    ((v1Bytes[1] & 0x0f) << 4) | ((v1Bytes[2] & 0xf0) >> 4),
+
+    0x60 | (v1Bytes[2] & 0x0f),
+    v1Bytes[3],
+
+    v1Bytes[8],
+    v1Bytes[9],
+    v1Bytes[10],
+    v1Bytes[11],
+    v1Bytes[12],
+    v1Bytes[13],
+    v1Bytes[14],
+    v1Bytes[15]
+  );
+}

--- a/libs/langchain-core/src/utils/uuid/v6.ts
+++ b/libs/langchain-core/src/utils/uuid/v6.ts
@@ -1,0 +1,49 @@
+import { unsafeStringify } from "./stringify.js";
+import type { UUIDTypes, Version6Options } from "./types.js";
+import v1 from "./v1.js";
+import v1ToV6 from "./v1ToV6.js";
+
+function v6(
+  options?: Version6Options,
+  buf?: undefined,
+  offset?: number
+): string;
+function v6<TBuf extends Uint8Array = Uint8Array>(
+  options: Version6Options | undefined,
+  buf: TBuf,
+  offset?: number
+): TBuf;
+function v6<TBuf extends Uint8Array = Uint8Array>(
+  options?: Version6Options,
+  buf?: TBuf,
+  offset?: number
+): UUIDTypes<TBuf> {
+  options ??= {};
+  offset ??= 0;
+
+  // v6 is v1 with different field layout, so we start with a v1 UUID, albeit
+  // with slightly different behavior around how the clock_seq and node fields
+  // are randomized, which is why we call v1 with _v6: true.
+  let bytes = v1({ ...options, _v6: true }, new Uint8Array(16));
+
+  // Reorder the fields to v6 layout.
+  bytes = v1ToV6(bytes);
+
+  // Return as a byte array if requested
+  if (buf) {
+    if (offset < 0 || offset + 16 > buf.length) {
+      throw new RangeError(
+        `UUID byte range ${offset}:${offset + 15} is out of buffer bounds`
+      );
+    }
+
+    for (let i = 0; i < 16; i++) {
+      buf[offset + i] = bytes[i];
+    }
+    return buf;
+  }
+
+  return unsafeStringify(bytes);
+}
+
+export default v6;


### PR DESCRIPTION
## Summary

This PR adds UUID v6 support to `@langchain/core`'s vendored UUID utilities so callers can generate RFC 9562 version-6 identifiers without taking a direct `uuid` dependency. The implementation mirrors the upstream uuidjs `v6` behavior, including conversion from v1 layout and buffer/offset output handling.

## Changes

- `@langchain/core` UUID utils:
  - Add `v6` generator at `src/utils/uuid/v6.ts`.
  - Add `v1ToV6` conversion helper at `src/utils/uuid/v1ToV6.ts`.
  - Export `v6` from `src/utils/uuid/index.ts`.
- `@langchain/core` tests:
  - Add `src/utils/tests/uuid.test.ts` coverage for v6 validity/version detection, deterministic output with options, buffer writes with offsets, range errors, v1->v6 conversion fixture, and lexicographic ordering by time.
- Release metadata:
  - Add `.changeset/hunter-core-uuid-v6-support.md` with a `minor` bump for `@langchain/core`.
