### PR TITLE
docs: fix typos in generative agent comments

### DIFF
--- a/libs/langchain-classic/src/experimental/generative_agents/generative_agent.ts
+++ b/libs/langchain-classic/src/experimental/generative_agents/generative_agent.ts
@@ -127,7 +127,7 @@ export class GenerativeAgent extends BaseChain {
    * @returns An array of strings parsed from the input text.
    */
   parseList(text: string): string[] {
-    // parse a newline-seperated string into a list of strings
+    // parse a newline-separated string into a list of strings
     const lines: string[] = text.trim().split("\n");
     const result: string[] = lines.map((line: string) =>
       line.replace(/^\s*\d+\.\s*/, "").trim()

--- a/libs/langchain-classic/src/experimental/generative_agents/generative_agent_memory.ts
+++ b/libs/langchain-classic/src/experimental/generative_agents/generative_agent_memory.ts
@@ -263,7 +263,7 @@ class GenerativeAgentMemoryChain extends BaseChain {
    * @returns An array of strings.
    */
   static parseList(text: string): string[] {
-    // parse a newine seperates string into a list of strings
+    // parse a newline-separated string into a list of strings
     return text.split("\n").map((s) => s.trim());
   }
 


### PR DESCRIPTION
Fixes two comment typos in the experimental generative agents code.

No runtime behavior changes.