### PR TITLE
fix(deepseek): make <think> tag parsing opt-in via enableThinkTagParsing

### DIFF
--- a/.changeset/fix-deepseek-think-tag-parsing.md
+++ b/.changeset/fix-deepseek-think-tag-parsing.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/deepseek": patch
+"@langchain/deepseek": minor
 ---
 
 fix(deepseek): disable <think> tag parsing by default, add enableThinkTagParsing option

--- a/.changeset/fix-deepseek-think-tag-parsing.md
+++ b/.changeset/fix-deepseek-think-tag-parsing.md
@@ -1,0 +1,15 @@
+---
+"@langchain/deepseek": patch
+---
+
+fix(deepseek): disable <think> tag parsing by default, add enableThinkTagParsing option
+
+`<think>...</think>` tag parsing in `_streamResponseChunks` (added in #9726) is
+now disabled by default and opt-in via `enableThinkTagParsing: true`. The
+official DeepSeek API (`api.deepseek.com`) returns reasoning content in the
+dedicated `reasoning_content` field (already handled by `ChatOpenAICompletions`). When this parsing is enabled by default, it
+incorrectly strips `<think>` tags from normal content produced by non-reasoning
+models like `deepseek-chat` (`deepseek-v4-flash` with thinking disabled), or deepseek-v4-flash/deepseek-v4-pro with thinking disabled, moving that content into `reasoning_content` and leaving the response content corrupted.
+
+When using third-party proxies or older API endpoints that embed reasoning in
+`<think>` tags, set `enableThinkTagParsing: true`.

--- a/libs/providers/langchain-deepseek/src/chat_models.ts
+++ b/libs/providers/langchain-deepseek/src/chat_models.ts
@@ -56,6 +56,13 @@ export interface ChatDeepSeekInput extends ChatOpenAIFields {
    * This limits ensures computational efficiency and resource management.
    */
   maxTokens?: number;
+  /**
+   * Parse `<think>` tags in content into reasoning_content.
+   * Disabled by default — only needed for third-party proxies
+   * or older endpoints.
+   * @default false
+   */
+  enableThinkTagParsing?: boolean;
 }
 
 /**
@@ -452,8 +459,16 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
         ...fields.configuration,
       },
     });
+    this.enableThinkTagParsing = fields.enableThinkTagParsing ?? false;
     this._addVersion("@langchain/deepseek", __PKG_VERSION__);
   }
+
+  /**
+   * Whether to parse `<think>...</think>` tags from the content stream.
+   * Controlled by the constructor option of the same name.
+   * @internal
+   */
+  private enableThinkTagParsing: boolean = false;
 
   protected override _convertCompletionsDeltaToBaseMessageChunk(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -485,6 +500,23 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
     options: this["ParsedCallOptions"],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    // When think tag parsing is disabled (default), pass through chunks
+    // directly from the parent stream. This avoids incorrectly stripping
+    // <think> tags from normal content produced by non-reasoning models.
+    if (!this.enableThinkTagParsing) {
+      for await (const chunk of super._streamResponseChunks(
+        messages,
+        options,
+        runManager
+      )) {
+        if (options.signal?.aborted) {
+          return;
+        }
+        yield chunk;
+      }
+      return;
+    }
+
     const stream = super._streamResponseChunks(messages, options, runManager);
 
     // State for parsing <think> tags

--- a/libs/providers/langchain-deepseek/src/chat_models.ts
+++ b/libs/providers/langchain-deepseek/src/chat_models.ts
@@ -468,7 +468,9 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
    * Controlled by the constructor option of the same name.
    * @internal
    */
-  private enableThinkTagParsing: boolean = false;
+  private enableThinkTagParsing: boolean;
+
+  private warnedAboutDisabledThinkTagParsing = false;
 
   protected override _convertCompletionsDeltaToBaseMessageChunk(
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -504,6 +506,7 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
     // directly from the parent stream. This avoids incorrectly stripping
     // <think> tags from normal content produced by non-reasoning models.
     if (!this.enableThinkTagParsing) {
+      let tagDetectionBuffer = "";
       for await (const chunk of super._streamResponseChunks(
         messages,
         options,
@@ -511,6 +514,22 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
       )) {
         if (options.signal?.aborted) {
           return;
+        }
+        if (
+          !this.warnedAboutDisabledThinkTagParsing &&
+          typeof chunk.text === "string"
+        ) {
+          const detectionText = tagDetectionBuffer + chunk.text;
+          if (
+            detectionText.includes("<think>") ||
+            detectionText.includes("</think>")
+          ) {
+            console.warn(
+              "DeepSeek: <think> tags detected in streamed content while enableThinkTagParsing is false. They will be returned as normal message content. Only set enableThinkTagParsing: true if your endpoint embeds reasoning in <think>...</think> tags instead of using reasoning_content."
+            );
+            this.warnedAboutDisabledThinkTagParsing = true;
+          }
+          tagDetectionBuffer = detectionText.slice(-"</think>".length + 1);
         }
         yield chunk;
       }

--- a/libs/providers/langchain-deepseek/src/tests/chat_models_reasoning.test.ts
+++ b/libs/providers/langchain-deepseek/src/tests/chat_models_reasoning.test.ts
@@ -86,6 +86,7 @@ test("ChatDeepSeek should separate <think> tags into reasoning_content", async (
 
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: {
       fetch: mockFetch as any,
     },
@@ -143,6 +144,7 @@ test("ChatDeepSeek should handle multiple think blocks and content before/after"
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -188,6 +190,7 @@ test("ChatDeepSeek should handle unclosed think tags (flush at end)", async () =
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -230,6 +233,7 @@ test("ChatDeepSeek should handle split tags across chunks", async () => {
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -272,6 +276,7 @@ test("ChatDeepSeek should handle empty think blocks", async () => {
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -320,6 +325,7 @@ test("ChatDeepSeek should handle nested think tags (treat inner as content)", as
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -367,6 +373,7 @@ test("ChatDeepSeek should handle malformed tags gracefully", async () => {
     new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
   const model = new ChatDeepSeek({
     apiKey: "test",
+    enableThinkTagParsing: true,
     configuration: { fetch: mockFetch as any },
   });
 
@@ -379,4 +386,98 @@ test("ChatDeepSeek should handle malformed tags gracefully", async () => {
 
   // Orphan </think> and incomplete <think should just be treated as content
   expect(fullContent).toContain("Text");
+});
+
+test("ChatDeepSeek should NOT parse <think> tags by default (enableThinkTagParsing=false)", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const chunks = [
+        { choices: [{ delta: { content: "<think>" } }] },
+        { choices: [{ delta: { content: "internal thought" } }] },
+        { choices: [{ delta: { content: "</think>" } }] },
+        { choices: [{ delta: { content: " visible content" } }] },
+        { choices: [{ finish_reason: "stop" }] },
+      ];
+
+      for (const chunk of chunks) {
+        const str = `data: ${JSON.stringify({
+          ...chunk,
+          model: "deepseek-chat",
+        })}\n\n`;
+        controller.enqueue(encoder.encode(str));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  const mockFetch = async () =>
+    new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+  // enableThinkTagParsing is NOT set — default is false
+  const model = new ChatDeepSeek({
+    apiKey: "test",
+    configuration: { fetch: mockFetch as any },
+  });
+
+  const chunks: AIMessageChunk[] = [];
+  for await (const chunk of await model.stream("hi")) {
+    chunks.push(chunk);
+  }
+
+  const fullContent = chunks.map((c) => c.content).join("");
+  const fullReasoning = chunks
+    .map((c) => c.additional_kwargs.reasoning_content || "")
+    .join("");
+
+  // Tags should remain in content, NOT extracted to reasoning_content
+  expect(fullContent).toBe("<think>internal thought</think> visible content");
+  expect(fullReasoning).toBe("");
+});
+
+test("ChatDeepSeek should parse <think> tags when enableThinkTagParsing=true", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const chunks = [
+        { choices: [{ delta: { content: "<think>" } }] },
+        { choices: [{ delta: { content: "thinking..." } }] },
+        { choices: [{ delta: { content: "</think>" } }] },
+        { choices: [{ delta: { content: "result" } }] },
+        { choices: [{ finish_reason: "stop" }] },
+      ];
+
+      for (const chunk of chunks) {
+        const str = `data: ${JSON.stringify({
+          ...chunk,
+          model: "deepseek-chat",
+        })}\n\n`;
+        controller.enqueue(encoder.encode(str));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  const mockFetch = async () =>
+    new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+  const model = new ChatDeepSeek({
+    apiKey: "test",
+    enableThinkTagParsing: true,
+    configuration: { fetch: mockFetch as any },
+  });
+
+  const chunks: AIMessageChunk[] = [];
+  for await (const chunk of await model.stream("hi")) {
+    chunks.push(chunk);
+  }
+
+  const fullContent = chunks.map((c) => c.content).join("");
+  const fullReasoning = chunks
+    .map((c) => c.additional_kwargs.reasoning_content || "")
+    .join("");
+
+  // Tags should be stripped from content and moved to reasoning_content
+  expect(fullContent).toBe("result");
+  expect(fullReasoning).toBe("thinking...");
 });

--- a/libs/providers/langchain-deepseek/src/tests/chat_models_reasoning.test.ts
+++ b/libs/providers/langchain-deepseek/src/tests/chat_models_reasoning.test.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
-import { test, expect } from "vitest";
+import { test, expect, vi } from "vitest";
 import { ChatDeepSeek } from "../chat_models.js";
 import { AIMessageChunk } from "@langchain/core/messages";
 
@@ -433,6 +433,148 @@ test("ChatDeepSeek should NOT parse <think> tags by default (enableThinkTagParsi
   // Tags should remain in content, NOT extracted to reasoning_content
   expect(fullContent).toBe("<think>internal thought</think> visible content");
   expect(fullReasoning).toBe("");
+});
+
+test("ChatDeepSeek should preserve native reasoning_content when think tag parsing is disabled", async () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const chunks = [
+        {
+          choices: [
+            {
+              delta: {
+                role: "assistant",
+                content: "",
+                reasoning_content: "native reasoning",
+              },
+            },
+          ],
+        },
+        {
+          choices: [
+            {
+              delta: {
+                content: "visible content",
+              },
+            },
+          ],
+        },
+        { choices: [{ finish_reason: "stop" }] },
+      ];
+
+      for (const chunk of chunks) {
+        const str = `data: ${JSON.stringify({
+          ...chunk,
+          model: "deepseek-reasoner",
+        })}\n\n`;
+        controller.enqueue(encoder.encode(str));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  const mockFetch = async () =>
+    new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+  const model = new ChatDeepSeek({
+    apiKey: "test",
+    configuration: { fetch: mockFetch as any },
+  });
+
+  const chunks: AIMessageChunk[] = [];
+  for await (const chunk of await model.stream("hi")) {
+    chunks.push(chunk);
+  }
+
+  const fullContent = chunks.map((c) => c.content).join("");
+  const fullReasoning = chunks
+    .map((c) => c.additional_kwargs.reasoning_content || "")
+    .join("");
+
+  expect(fullContent).toBe("visible content");
+  expect(fullReasoning).toBe("native reasoning");
+});
+
+test("ChatDeepSeek should preserve native reasoning_content in non-streaming responses", async () => {
+  const mockFetch = async () =>
+    new Response(
+      JSON.stringify({
+        id: "chatcmpl-123",
+        object: "chat.completion",
+        created: 1694268190,
+        model: "deepseek-reasoner",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "visible content",
+              reasoning_content: "native reasoning",
+            },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  const model = new ChatDeepSeek({
+    apiKey: "test",
+    configuration: { fetch: mockFetch as any },
+  });
+
+  const message = await model.invoke("hi");
+
+  expect(message.content).toBe("visible content");
+  expect(message.additional_kwargs.reasoning_content).toBe("native reasoning");
+});
+
+test("ChatDeepSeek should warn once when think tags are detected with parsing disabled", async () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const chunks = [
+        { choices: [{ delta: { content: "<th" } }] },
+        { choices: [{ delta: { content: "ink>internal" } }] },
+        { choices: [{ delta: { content: "</think>" } }] },
+        { choices: [{ delta: { content: " visible" } }] },
+        { choices: [{ finish_reason: "stop" }] },
+      ];
+
+      for (const chunk of chunks) {
+        const str = `data: ${JSON.stringify({
+          ...chunk,
+          model: "deepseek-chat",
+        })}\n\n`;
+        controller.enqueue(encoder.encode(str));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  const mockFetch = async () =>
+    new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+  const model = new ChatDeepSeek({
+    apiKey: "test",
+    configuration: { fetch: mockFetch as any },
+  });
+
+  const chunks: AIMessageChunk[] = [];
+  for await (const chunk of await model.stream("hi")) {
+    chunks.push(chunk);
+  }
+
+  expect(chunks.map((c) => c.content).join("")).toBe(
+    "<think>internal</think> visible"
+  );
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+  expect(warnSpy).toHaveBeenCalledWith(
+    "DeepSeek: <think> tags detected in streamed content while enableThinkTagParsing is false. They will be returned as normal message content. Only set enableThinkTagParsing: true if your endpoint embeds reasoning in <think>...</think> tags instead of using reasoning_content."
+  );
+
+  warnSpy.mockRestore();
 });
 
 test("ChatDeepSeek should parse <think> tags when enableThinkTagParsing=true", async () => {


### PR DESCRIPTION
## Summary

`<think>` tag parsing in `_streamResponseChunks` (added in #9726)
is now **disabled by default** and opt-in via `enableThinkTagParsing: true`.

The official DeepSeek API now returns reasoning content in
the dedicated `reasoning_content` field, which `ChatOpenAICompletions` already
handles. The `<think>` tag parser was only needed for older/third-party
endpoints, but when enabled by default it incorrectly strips `<think>` tags
from normal content produced by non-reasoning models like `deepseek-chat` or `deepseek-v4-flash`/`deepseek-v4-pro` with thinking disabled.

## Changes

- Added `enableThinkTagParsing?: boolean` option to `ChatDeepSeekInput`
  (default `false`)
- Added pass-through path in `_streamResponseChunks` that skips `<think>`
  tag parsing when the option is disabled
- Updated existing tests to pass `enableThinkTagParsing: true`
- Added two new tests: default behavior (no parsing) and opt-in behavior
- Added changeset

## Test plan

- [x] `pnpm --filter @langchain/deepseek test` — 18/18 pass
- [x] `pnpm --filter @langchain/deepseek build`
- [x] `pnpm format`



<img width="841" height="416" alt="image" src="https://github.com/user-attachments/assets/5e415b5a-1f8e-492e-ba28-d6666bb96c61" />

**Thanks for reviewing.**