### PR TITLE
fix(langchain): swallow unhandled rejection on tool-call output promises

### DIFF
--- a/libs/langchain/src/agents/stream.ts
+++ b/libs/langchain/src/agents/stream.ts
@@ -240,6 +240,16 @@ export function createToolCallTransformer(
         resolveOutput = res;
         rejectOutput = rej;
       });
+      // Attach a no-op catch so that a rejection occurring before any
+      // user-space consumer has had a chance to `await call.output`
+      // does not trigger Node's `unhandledRejection` and crash the
+      // process. This can happen, for example, when an HITL middleware
+      // interrupt rejects the output while the consumer is iterating
+      // `run.interrupts` instead of `run.toolCalls`. Each downstream
+      // `await` / `.then` still observes the rejection independently,
+      // so this only swallows the *unhandled* signal — not the error
+      // itself.
+      output.catch(() => {});
       const status = new Promise<ToolCallStatus>((res) => {
         resolveStatus = res;
       });

--- a/libs/langchain/src/agents/tests/stream.test.ts
+++ b/libs/langchain/src/agents/tests/stream.test.ts
@@ -552,4 +552,87 @@ describe("streamEvents", () => {
     expect(await pendingCall.value.output).toBe("serialized result");
     expect(await iterator.next()).toEqual({ done: true, value: undefined });
   });
+
+  it("does not emit an unhandledRejection when tool-error fires before the consumer awaits output", async () => {
+    const transformer = createToolCallTransformer([])();
+    const projection = transformer.init();
+    const toolEvent = (data: Record<string, unknown>): ProtocolEvent =>
+      ({
+        method: "tools",
+        params: {
+          namespace: ["tools"],
+          data,
+        },
+      }) as ProtocolEvent;
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      transformer.process(
+        toolEvent({
+          event: "tool-started",
+          tool_call_id: "call_1",
+          tool_name: "write_file",
+          input: '{"filename":"test.txt","content":"hello"}',
+        })
+      );
+
+      const iterator = projection.toolCalls[Symbol.asyncIterator]();
+      const pendingCall = await iterator.next();
+      expect(pendingCall.done).toBe(false);
+
+      // Simulate an HITL interrupt surfaced as a tool-error whose payload
+      // does NOT match the headless `type: "tool"` interrupt shape. This
+      // is what `humanInTheLoopMiddleware` emits — a JSON-encoded array
+      // of `{ id, value: { actionRequests, reviewConfigs } }`. The
+      // transformer falls through to `rejectOutput`, and the consumer
+      // (iterating `run.interrupts` rather than `call.output`) never
+      // attaches a handler. Prior to the fix this crashed the process.
+      transformer.process(
+        toolEvent({
+          event: "tool-error",
+          tool_call_id: "call_1",
+          message: JSON.stringify([
+            {
+              id: "interrupt_1",
+              value: {
+                actionRequests: [
+                  {
+                    args: { filename: "test.txt", content: "hello" },
+                    description: "Tool execution requires approval: write_file",
+                    name: "write_file",
+                  },
+                ],
+                reviewConfigs: [
+                  {
+                    actionName: "write_file",
+                    allowedDecisions: ["approve"],
+                  },
+                ],
+              },
+            },
+          ]),
+        })
+      );
+
+      // Give microtasks + the unhandledRejection task a chance to fire.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+
+      // The rejection is still observable when the consumer eventually
+      // awaits `call.output` — the no-op catch only suppresses the
+      // unhandled-rejection signal, it does not swallow the error.
+      await expect(pendingCall.value.output).rejects.toThrow();
+
+      transformer.finalize?.();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #10933.

`createToolCallTransformer` creates an `output: Promise<unknown>` for each tool call at `tool-started` time and pushes it onto the `toolCalls` stream channel. If `rejectOutput` is invoked before any consumer attaches a handler, Node fires `unhandledRejection` and crashes the process — even when the caller is correctly handling the underlying condition through a different surface (e.g. `run.interrupts`).

This reproduces deterministically when a `humanInTheLoopMiddleware` interrupt is delivered as a `tool-error` payload of the shape `[{ id, value: { actionRequests, reviewConfigs } }]`. The existing `isHeadlessToolInterruptError` guard only matches the headless `value.type === "tool"` shape, so the HITL payload falls through to `rejectOutput`, and a consumer iterating `streamEvents({ version: "v3" })` via `run.interrupts` never awaits `call.output`.

## Fix

Attach a no-op `.catch(() => {})` to the `output` promise immediately after creation. This marks the promise as "handled" for Node's unhandled-rejection detector. Each downstream `await call.output` / `.then(...)` still observes the rejection independently, so this only suppresses the unhandled signal — not the error itself.

This is the smallest correct change: it addresses the promise-lifecycle gap directly rather than special-casing one more interrupt payload shape, so it is robust to future interrupt schemas.

## Test plan

- [x] New unit test in `libs/langchain/src/agents/tests/stream.test.ts`: subscribes to `process.on('unhandledRejection')`, drives the transformer through `tool-started` → HITL-shaped `tool-error`, asserts no unhandled rejection is emitted, and verifies the rejection is still observable when the consumer eventually awaits `call.output`.
- [x] Verified the test fails on `main` and passes with this change.
- [x] `pnpm test src/agents/tests` — 24 files, 383 tests pass.
- [x] `pnpm lint` clean.
- [x] `pnpm format:check` clean.

## Alternatives considered

- **Defer `rejectOutput` by a microtask** so consumers have time to attach. Rejected: the unhandled-rejection task can still fire first under load; fragile.
- **Track handler attachment** and only reject synchronously if attached. Rejected: more invasive, requires wrapping the Promise type, no upside over the no-op-catch idiom.
- **Broaden `isHeadlessToolInterruptError`** to match HITL payloads. Rejected: that would silently swallow rejections that consumers may expect to see when they DO `await call.output`. The lifecycle fix is correct regardless of which interrupt shapes are emitted today or in the future.
