### PR TITLE
feat(langchain): register stream transformers on middleware

### DIFF
--- a/.changeset/middleware-stream-transformers.md
+++ b/.changeset/middleware-stream-transformers.md
@@ -1,0 +1,9 @@
+---
+"langchain": patch
+---
+
+feat(langchain): register stream transformers on middleware
+
+`createMiddleware` accepts `streamTransformers` factories that are merged with
+`createAgent({ streamTransformers })` at compile time. Types flow through
+`CombineStreamTransformers` so `run.extensions` is inferred from both sources.

--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -69,6 +69,7 @@ import type { BuiltInState, JumpTo, UserInput } from "./types.js";
 import type { InvokeConfiguration, StreamConfiguration } from "./runtime.js";
 import type {
   AgentMiddleware,
+  AnyAgentMiddleware,
   InferMiddlewareContextInputs,
   InferMiddlewareStates,
   InferMiddlewareInputStates,
@@ -163,7 +164,7 @@ export class ReactAgent<
     Record<string, any>,
     undefined,
     AnyAnnotationRoot,
-    readonly AgentMiddleware[],
+    readonly AnyAgentMiddleware[],
     readonly (ClientTool | ServerTool)[],
     ReadonlyArray<() => StreamTransformer<any>>
   >,
@@ -671,8 +672,14 @@ export class ReactAgent<
     /**
      * compile the graph with native + user-defined stream transformers
      */
+    const middlewareStreamTransformers = (
+      this.options.middleware ?? []
+    ).flatMap((m) => m.streamTransformers ?? []);
     const compileTransformers = [
+      /* built-in stream transformers */
       createToolCallTransformer([]),
+      /* middleware stream transformers */
+      ...middlewareStreamTransformers,
       /* user-defined stream transformers */
       ...(this.options.streamTransformers ?? []),
     ];

--- a/libs/langchain/src/agents/annotation.ts
+++ b/libs/langchain/src/agents/annotation.ts
@@ -8,7 +8,7 @@ import {
 } from "@langchain/langgraph";
 import { schemaMetaRegistry } from "@langchain/langgraph/zod";
 
-import type { AgentMiddleware } from "./middleware/types.js";
+import type { AnyAgentMiddleware } from "./middleware/types.js";
 import {
   type InteropZodObject,
   isZodSchemaV4,
@@ -23,7 +23,7 @@ type JumpToTarget = "model_request" | "tools" | "end" | undefined;
 
 export function createAgentState<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
-  TMiddleware extends readonly AgentMiddleware<any, any, any>[] = [],
+  TMiddleware extends readonly AnyAgentMiddleware[] = [],
 >(
   hasStructuredResponse = true,
   stateSchema: TStateSchema,

--- a/libs/langchain/src/agents/index.ts
+++ b/libs/langchain/src/agents/index.ts
@@ -14,8 +14,12 @@ import type {
   CreateAgentParams,
   AgentTypeConfig,
   CombineTools,
+  CombineStreamTransformers,
 } from "./types.js";
-import type { AgentMiddleware, AnyAnnotationRoot } from "./middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  AnyAnnotationRoot,
+} from "./middleware/types.js";
 import type { ExtractZodArrayTypes } from "./types.js";
 import type { SerializableSchema } from "@langchain/core/utils/standard_schema";
 import type {
@@ -174,8 +178,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -202,7 +206,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -212,8 +216,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -244,7 +248,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -253,8 +257,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -281,7 +285,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -290,8 +294,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -318,7 +322,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -327,8 +331,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -355,7 +359,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -364,8 +368,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -392,7 +396,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -401,8 +405,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -429,7 +433,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -439,8 +443,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -467,7 +471,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -477,8 +481,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -505,7 +509,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -515,8 +519,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -543,7 +547,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -552,8 +556,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -582,7 +586,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -591,8 +595,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -622,7 +626,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -632,8 +636,8 @@ export function createAgent<
   TStateSchema extends StateDefinitionInit | undefined = undefined,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject =
     AnyAnnotationRoot,
-  const TMiddleware extends readonly AgentMiddleware[] =
-    readonly AgentMiddleware[],
+  const TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   const TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -660,7 +664,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 >;
 
@@ -669,7 +673,7 @@ export function createAgent<
   StructuredResponseFormat extends Record<string, any>,
   TStateSchema extends StateDefinitionInit,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[],
+  TMiddleware extends readonly AnyAgentMiddleware[] = readonly AnyAgentMiddleware[],
   TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -690,7 +694,7 @@ export function createAgent<
     ContextSchema,
     TMiddleware,
     CombineTools<TTools, TMiddleware>,
-    TStreamTransformers
+    CombineStreamTransformers<TStreamTransformers, TMiddleware>
   >
 > {
   return new ReactAgent(params);

--- a/libs/langchain/src/agents/index.ts
+++ b/libs/langchain/src/agents/index.ts
@@ -673,7 +673,8 @@ export function createAgent<
   StructuredResponseFormat extends Record<string, any>,
   TStateSchema extends StateDefinitionInit,
   ContextSchema extends AnyAnnotationRoot | InteropZodObject,
-  TMiddleware extends readonly AnyAgentMiddleware[] = readonly AnyAgentMiddleware[],
+  TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool

--- a/libs/langchain/src/agents/middleware.ts
+++ b/libs/langchain/src/agents/middleware.ts
@@ -2,7 +2,10 @@ import type {
   InteropZodObject,
   InferInteropZodOutput,
 } from "@langchain/core/utils/types";
-import type { StateDefinitionInit } from "@langchain/langgraph";
+import type {
+  StateDefinitionInit,
+  StreamTransformer,
+} from "@langchain/langgraph";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import {
@@ -29,6 +32,8 @@ import {
  * @param config.afterModel - The function to run after the model call
  * @param config.beforeAgent - The function to run before the agent execution starts
  * @param config.afterAgent - The function to run after the agent execution completes
+ * @param config.tools - Additional tools registered by the middleware
+ * @param config.streamTransformers - Stream transformer factories registered by the middleware
  * @returns A middleware instance
  *
  * @example Using Zod schema
@@ -75,6 +80,9 @@ export function createMiddleware<
     | ClientTool
     | ServerTool
   )[],
+  const TStreamTransformers extends ReadonlyArray<
+    () => StreamTransformer<any>
+  > = readonly [],
 >(config: {
   /**
    * The name of the middleware
@@ -100,6 +108,11 @@ export function createMiddleware<
    * Additional tools registered by the middleware.
    */
   tools?: TTools;
+  /**
+   * Stream transformer factories registered by the middleware.
+   * Merged with `createAgent({ streamTransformers })` when the agent compiles.
+   */
+  streamTransformers?: TStreamTransformers;
   /**
    * Wraps tool execution with custom logic. This allows you to:
    * - Modify tool call parameters before execution
@@ -236,13 +249,15 @@ export function createMiddleware<
   TSchema,
   TContextSchema,
   NormalizeContextSchema<TContextSchema>,
-  TTools
+  TTools,
+  TStreamTransformers
 > {
   const middleware: AgentMiddleware<
     TSchema,
     TContextSchema,
     NormalizeContextSchema<TContextSchema>,
-    TTools
+    TTools,
+    TStreamTransformers
   > = {
     [MIDDLEWARE_BRAND]: true as const,
     name: config.name,
@@ -255,6 +270,7 @@ export function createMiddleware<
     afterModel: config.afterModel,
     afterAgent: config.afterAgent,
     tools: config.tools,
+    streamTransformers: config.streamTransformers,
   };
 
   return middleware;

--- a/libs/langchain/src/agents/middleware.ts
+++ b/libs/langchain/src/agents/middleware.ts
@@ -81,6 +81,7 @@ export function createMiddleware<
     | ServerTool
   )[],
   const TStreamTransformers extends ReadonlyArray<
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     () => StreamTransformer<any>
   > = readonly [],
 >(config: {

--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -20,7 +20,7 @@ import type {
   ToolMessage,
 } from "@langchain/core/messages";
 import type { ToolCall } from "@langchain/core/messages/tool";
-import type { Command } from "@langchain/langgraph";
+import type { Command, StreamTransformer } from "@langchain/langgraph";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import type { JumpToTarget } from "../constants.js";
@@ -47,6 +47,9 @@ export type AnyAnnotationRoot = AnnotationRoot<any>;
  * @typeParam TFullContext - The full context type available to middleware hooks.
  *
  * @typeParam TTools - The tools array type registered by the middleware.
+ *
+ * @typeParam TStreamTransformers - The stream transformer factories registered
+ *   by the middleware.
  *
  * @example
  * ```typescript
@@ -77,6 +80,9 @@ export interface MiddlewareTypeConfig<
     | ClientTool
     | ServerTool
   )[],
+  TStreamTransformers extends ReadonlyArray<
+    () => StreamTransformer<any>
+  > = ReadonlyArray<() => StreamTransformer<any>>,
 > {
   /** The middleware state schema type */
   Schema: TSchema;
@@ -86,6 +92,8 @@ export interface MiddlewareTypeConfig<
   FullContext: TFullContext;
   /** The tools array type */
   Tools: TTools;
+  /** The stream transformer factories registered by the middleware */
+  StreamTransformers: TStreamTransformers;
 }
 
 /**
@@ -359,12 +367,30 @@ export type AfterAgentHook<
 export const MIDDLEWARE_BRAND: symbol = Symbol.for("AgentMiddleware");
 
 /**
+ * Widened middleware type for agent configuration arrays. Accepts middleware
+ * instances with any registered tools or stream transformers while preserving
+ * precise inference when middleware arrays are passed with `const`.
+ */
+export type AnyAgentMiddleware = AgentMiddleware<
+  StateDefinitionInit | undefined,
+  | InteropZodObject
+  | InteropZodDefault<InteropZodObject>
+  | InteropZodOptional<InteropZodObject>
+  | undefined,
+  any,
+  readonly (ClientTool | ServerTool)[],
+  ReadonlyArray<() => StreamTransformer<any>>
+>;
+
+/**
  * Base middleware interface.
  *
  * @typeParam TSchema - The middleware state schema type
  * @typeParam TContextSchema - The middleware context schema type
  * @typeParam TFullContext - The full context type available to hooks
  * @typeParam TTools - The tools array type registered by the middleware
+ * @typeParam TStreamTransformers - The stream transformer factories registered
+ *   by the middleware
  *
  * @example
  * ```typescript
@@ -387,6 +413,9 @@ export interface AgentMiddleware<
     | ClientTool
     | ServerTool
   )[],
+  TStreamTransformers extends ReadonlyArray<
+    () => StreamTransformer<any>
+  > = ReadonlyArray<() => StreamTransformer<any>>,
 > {
   /**
    * Brand property to distinguish middleware instances from plain objects or functions.
@@ -403,7 +432,8 @@ export interface AgentMiddleware<
     TSchema,
     TContextSchema,
     TFullContext,
-    TTools
+    TTools,
+    TStreamTransformers
   >;
 
   /**
@@ -433,6 +463,14 @@ export interface AgentMiddleware<
    * Additional tools registered by the middleware.
    */
   tools?: TTools;
+
+  /**
+   * Stream transformer factories registered by the middleware.
+   * These are merged with `createAgent({ streamTransformers })` when the agent
+   * is compiled.
+   */
+  streamTransformers?: TStreamTransformers;
+
   /**
    * Wraps tool execution with custom logic. This allows you to:
    * - Modify tool call parameters before execution
@@ -594,7 +632,7 @@ export type ResolveMiddlewareTypeConfig<T> = T extends {
  * Helper type to extract any property from a MiddlewareTypeConfig or AgentMiddleware.
  *
  * @typeParam T - The MiddlewareTypeConfig or AgentMiddleware to extract from
- * @typeParam K - The property key to extract ("Schema" | "ContextSchema" | "FullContext" | "Tools")
+ * @typeParam K - The property key to extract ("Schema" | "ContextSchema" | "FullContext" | "Tools" | "StreamTransformers")
  */
 export type InferMiddlewareType<
   T,
@@ -627,6 +665,14 @@ export type InferMiddlewareFullContext<T> = InferMiddlewareType<
  */
 export type InferMiddlewareToolsFromConfig<T> = InferMiddlewareType<T, "Tools">;
 
+/**
+ * Shorthand helper to extract the StreamTransformers type from a MiddlewareTypeConfig or AgentMiddleware.
+ */
+export type InferMiddlewareStreamTransformersFromConfig<T> = InferMiddlewareType<
+  T,
+  "StreamTransformers"
+>;
+
 export type InferChannelType<T extends AnyAnnotationRoot | InteropZodObject> =
   T extends AnyAnnotationRoot
     ? ToAnnotationRoot<T>["State"]
@@ -640,7 +686,7 @@ export type InferChannelType<T extends AnyAnnotationRoot | InteropZodObject> =
  * Supports both Zod schemas (InteropZodObject) and StateSchema from LangGraph
  */
 export type InferMiddlewareState<T extends AgentMiddleware> =
-  T extends AgentMiddleware<infer TSchema, any, any, any>
+  T extends AgentMiddleware<infer TSchema, any, any, any, any>
     ? TSchema extends StateSchema<infer TFields>
       ? FilterPrivateProps<InferStateSchemaValue<TFields>>
       : TSchema extends InteropZodObject
@@ -656,7 +702,7 @@ export type InferMiddlewareState<T extends AgentMiddleware> =
  * Supports both Zod schemas (InteropZodObject) and StateSchema from LangGraph
  */
 export type InferMiddlewareInputState<T extends AgentMiddleware> =
-  T extends AgentMiddleware<infer TSchema, any, any, any>
+  T extends AgentMiddleware<infer TSchema, any, any, any, any>
     ? TSchema extends StateSchema<infer TFields>
       ? FilterPrivateProps<InferStateSchemaUpdate<TFields>>
       : TSchema extends InteropZodObject
@@ -669,12 +715,12 @@ export type InferMiddlewareInputState<T extends AgentMiddleware> =
 /**
  * Helper type to infer merged state from an array of middleware (just the middleware states)
  */
-export type InferMiddlewareStates<T extends readonly AgentMiddleware[]> =
+export type InferMiddlewareStates<T extends readonly AnyAgentMiddleware[]> =
   T extends readonly []
     ? {}
     : T extends readonly [infer First, ...infer Rest]
       ? First extends AgentMiddleware
-        ? Rest extends readonly AgentMiddleware[]
+        ? Rest extends readonly AnyAgentMiddleware[]
           ? InferMiddlewareState<First> & InferMiddlewareStates<Rest>
           : InferMiddlewareState<First>
         : {}
@@ -683,12 +729,12 @@ export type InferMiddlewareStates<T extends readonly AgentMiddleware[]> =
 /**
  * Helper type to infer merged input state from an array of middleware (with optional defaults)
  */
-export type InferMiddlewareInputStates<T extends readonly AgentMiddleware[]> =
+export type InferMiddlewareInputStates<T extends readonly AnyAgentMiddleware[]> =
   T extends readonly []
     ? {}
     : T extends readonly [infer First, ...infer Rest]
       ? First extends AgentMiddleware
-        ? Rest extends readonly AgentMiddleware[]
+        ? Rest extends readonly AnyAgentMiddleware[]
           ? InferMiddlewareInputState<First> & InferMiddlewareInputStates<Rest>
           : InferMiddlewareInputState<First>
         : {}
@@ -697,20 +743,20 @@ export type InferMiddlewareInputStates<T extends readonly AgentMiddleware[]> =
 /**
  * Helper type to infer merged state from an array of middleware (includes built-in state)
  */
-export type InferMergedState<T extends readonly AgentMiddleware[]> =
+export type InferMergedState<T extends readonly AnyAgentMiddleware[]> =
   InferMiddlewareStates<T> & AgentBuiltInState;
 
 /**
  * Helper type to infer merged input state from an array of middleware (includes built-in state)
  */
-export type InferMergedInputState<T extends readonly AgentMiddleware[]> =
+export type InferMergedInputState<T extends readonly AnyAgentMiddleware[]> =
   InferMiddlewareInputStates<T> & AgentBuiltInState;
 
 /**
  * Helper type to infer the context schema type from a middleware
  */
 export type InferMiddlewareContext<T extends AgentMiddleware> =
-  T extends AgentMiddleware<any, infer TContextSchema, any, any>
+  T extends AgentMiddleware<any, infer TContextSchema, any, any, any>
     ? TContextSchema extends InteropZodObject
       ? InferInteropZodInput<TContextSchema>
       : {}
@@ -720,7 +766,7 @@ export type InferMiddlewareContext<T extends AgentMiddleware> =
  * Helper type to infer the input context schema type from a middleware (with optional defaults)
  */
 export type InferMiddlewareContextInput<T extends AgentMiddleware> =
-  T extends AgentMiddleware<any, infer TContextSchema, any, any>
+  T extends AgentMiddleware<any, infer TContextSchema, any, any, any>
     ? TContextSchema extends InteropZodOptional<infer Inner>
       ? InferInteropZodInput<Inner> | undefined
       : TContextSchema extends InteropZodObject
@@ -731,12 +777,12 @@ export type InferMiddlewareContextInput<T extends AgentMiddleware> =
 /**
  * Helper type to infer merged context from an array of middleware
  */
-export type InferMiddlewareContexts<T extends readonly AgentMiddleware[]> =
+export type InferMiddlewareContexts<T extends readonly AnyAgentMiddleware[]> =
   T extends readonly []
     ? {}
     : T extends readonly [infer First, ...infer Rest]
       ? First extends AgentMiddleware
-        ? Rest extends readonly AgentMiddleware[]
+        ? Rest extends readonly AnyAgentMiddleware[]
           ? InferMiddlewareContext<First> & InferMiddlewareContexts<Rest>
           : InferMiddlewareContext<First>
         : {}
@@ -760,12 +806,14 @@ type MergeContextTypes<A, B> = [A] extends [undefined]
 /**
  * Helper type to infer merged input context from an array of middleware (with optional defaults)
  */
-export type InferMiddlewareContextInputs<T extends readonly AgentMiddleware[]> =
+export type InferMiddlewareContextInputs<
+  T extends readonly AnyAgentMiddleware[],
+> =
   T extends readonly []
     ? {}
     : T extends readonly [infer First, ...infer Rest]
       ? First extends AgentMiddleware
-        ? Rest extends readonly AgentMiddleware[]
+        ? Rest extends readonly AnyAgentMiddleware[]
           ? MergeContextTypes<
               InferMiddlewareContextInput<First>,
               InferMiddlewareContextInputs<Rest>

--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -80,9 +80,8 @@ export interface MiddlewareTypeConfig<
     | ClientTool
     | ServerTool
   )[],
-  TStreamTransformers extends ReadonlyArray<
-    () => StreamTransformer<any>
-  > = ReadonlyArray<() => StreamTransformer<any>>,
+  TStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
+    ReadonlyArray<() => StreamTransformer<any>>,
 > {
   /** The middleware state schema type */
   Schema: TSchema;
@@ -413,9 +412,8 @@ export interface AgentMiddleware<
     | ClientTool
     | ServerTool
   )[],
-  TStreamTransformers extends ReadonlyArray<
-    () => StreamTransformer<any>
-  > = ReadonlyArray<() => StreamTransformer<any>>,
+  TStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
+    ReadonlyArray<() => StreamTransformer<any>>,
 > {
   /**
    * Brand property to distinguish middleware instances from plain objects or functions.
@@ -668,10 +666,8 @@ export type InferMiddlewareToolsFromConfig<T> = InferMiddlewareType<T, "Tools">;
 /**
  * Shorthand helper to extract the StreamTransformers type from a MiddlewareTypeConfig or AgentMiddleware.
  */
-export type InferMiddlewareStreamTransformersFromConfig<T> = InferMiddlewareType<
-  T,
-  "StreamTransformers"
->;
+export type InferMiddlewareStreamTransformersFromConfig<T> =
+  InferMiddlewareType<T, "StreamTransformers">;
 
 export type InferChannelType<T extends AnyAnnotationRoot | InteropZodObject> =
   T extends AnyAnnotationRoot
@@ -729,16 +725,17 @@ export type InferMiddlewareStates<T extends readonly AnyAgentMiddleware[]> =
 /**
  * Helper type to infer merged input state from an array of middleware (with optional defaults)
  */
-export type InferMiddlewareInputStates<T extends readonly AnyAgentMiddleware[]> =
-  T extends readonly []
-    ? {}
-    : T extends readonly [infer First, ...infer Rest]
-      ? First extends AgentMiddleware
-        ? Rest extends readonly AnyAgentMiddleware[]
-          ? InferMiddlewareInputState<First> & InferMiddlewareInputStates<Rest>
-          : InferMiddlewareInputState<First>
-        : {}
-      : {};
+export type InferMiddlewareInputStates<
+  T extends readonly AnyAgentMiddleware[],
+> = T extends readonly []
+  ? {}
+  : T extends readonly [infer First, ...infer Rest]
+    ? First extends AgentMiddleware
+      ? Rest extends readonly AnyAgentMiddleware[]
+        ? InferMiddlewareInputState<First> & InferMiddlewareInputStates<Rest>
+        : InferMiddlewareInputState<First>
+      : {}
+    : {};
 
 /**
  * Helper type to infer merged state from an array of middleware (includes built-in state)
@@ -808,19 +805,18 @@ type MergeContextTypes<A, B> = [A] extends [undefined]
  */
 export type InferMiddlewareContextInputs<
   T extends readonly AnyAgentMiddleware[],
-> =
-  T extends readonly []
-    ? {}
-    : T extends readonly [infer First, ...infer Rest]
-      ? First extends AgentMiddleware
-        ? Rest extends readonly AnyAgentMiddleware[]
-          ? MergeContextTypes<
-              InferMiddlewareContextInput<First>,
-              InferMiddlewareContextInputs<Rest>
-            >
-          : InferMiddlewareContextInput<First>
-        : {}
-      : {};
+> = T extends readonly []
+  ? {}
+  : T extends readonly [infer First, ...infer Rest]
+    ? First extends AgentMiddleware
+      ? Rest extends readonly AnyAgentMiddleware[]
+        ? MergeContextTypes<
+            InferMiddlewareContextInput<First>,
+            InferMiddlewareContextInputs<Rest>
+          >
+        : InferMiddlewareContextInput<First>
+      : {}
+    : {};
 
 /**
  * Helper type to extract input type from context schema (with optional defaults)

--- a/libs/langchain/src/agents/nodes/AfterAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterAgentNode.ts
@@ -1,6 +1,9 @@
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  MiddlewareResult,
+} from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -13,9 +16,7 @@ export class AfterAgentNode<
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "afterAgentNodes"];
 
-  constructor(
-    public middleware: AnyAgentMiddleware
-  ) {
+  constructor(public middleware: AnyAgentMiddleware) {
     super({
       name: `AfterAgentNode_${middleware.name}`,
       func: async (

--- a/libs/langchain/src/agents/nodes/AfterAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterAgentNode.ts
@@ -1,7 +1,6 @@
-import { z } from "zod/v4";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -15,10 +14,7 @@ export class AfterAgentNode<
   lc_namespace = ["langchain", "agents", "afterAgentNodes"];
 
   constructor(
-    public middleware: AgentMiddleware<
-      z.ZodObject<z.ZodRawShape>,
-      z.ZodObject<z.ZodRawShape>
-    >
+    public middleware: AnyAgentMiddleware
   ) {
     super({
       name: `AfterAgentNode_${middleware.name}`,

--- a/libs/langchain/src/agents/nodes/AfterModelNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterModelNode.ts
@@ -1,6 +1,9 @@
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  MiddlewareResult,
+} from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -13,9 +16,7 @@ export class AfterModelNode<
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "afterModelNodes"];
 
-  constructor(
-    public middleware: AnyAgentMiddleware
-  ) {
+  constructor(public middleware: AnyAgentMiddleware) {
     super({
       name: `AfterModelNode_${middleware.name}`,
       func: async (

--- a/libs/langchain/src/agents/nodes/AfterModelNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterModelNode.ts
@@ -1,7 +1,6 @@
-import { z } from "zod/v4";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -15,10 +14,7 @@ export class AfterModelNode<
   lc_namespace = ["langchain", "agents", "afterModelNodes"];
 
   constructor(
-    public middleware: AgentMiddleware<
-      z.ZodObject<z.ZodRawShape>,
-      z.ZodObject<z.ZodRawShape>
-    >
+    public middleware: AnyAgentMiddleware
   ) {
     super({
       name: `AfterModelNode_${middleware.name}`,

--- a/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
@@ -1,7 +1,6 @@
-import { z } from "zod/v4";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -15,10 +14,7 @@ export class BeforeAgentNode<
   lc_namespace = ["langchain", "agents", "beforeAgentNodes"];
 
   constructor(
-    public middleware: AgentMiddleware<
-      z.ZodObject<z.ZodRawShape>,
-      z.ZodObject<z.ZodRawShape>
-    >
+    public middleware: AnyAgentMiddleware
   ) {
     super({
       name: `BeforeAgentNode_${middleware.name}`,

--- a/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
@@ -1,6 +1,9 @@
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  MiddlewareResult,
+} from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -13,9 +16,7 @@ export class BeforeAgentNode<
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "beforeAgentNodes"];
 
-  constructor(
-    public middleware: AnyAgentMiddleware
-  ) {
+  constructor(public middleware: AnyAgentMiddleware) {
     super({
       name: `BeforeAgentNode_${middleware.name}`,
       func: async (

--- a/libs/langchain/src/agents/nodes/BeforeModelNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeModelNode.ts
@@ -1,7 +1,6 @@
-import { z } from "zod/v4";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -15,10 +14,7 @@ export class BeforeModelNode<
   lc_namespace = ["langchain", "agents", "beforeModelNodes"];
 
   constructor(
-    public middleware: AgentMiddleware<
-      z.ZodObject<z.ZodRawShape>,
-      z.ZodObject<z.ZodRawShape>
-    >
+    public middleware: AnyAgentMiddleware
   ) {
     super({
       name: `BeforeModelNode_${middleware.name}`,

--- a/libs/langchain/src/agents/nodes/BeforeModelNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeModelNode.ts
@@ -1,6 +1,9 @@
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MiddlewareNode } from "./middleware.js";
-import type { AnyAgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  MiddlewareResult,
+} from "../middleware/types.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import { getHookFunction } from "../middleware/utils.js";
 
@@ -13,9 +16,7 @@ export class BeforeModelNode<
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "beforeModelNodes"];
 
-  constructor(
-    public middleware: AnyAgentMiddleware
-  ) {
+  constructor(public middleware: AnyAgentMiddleware) {
     super({
       name: `BeforeModelNode_${middleware.name}`,
       func: async (

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -62,7 +62,9 @@ export abstract class MiddlewareNode<
       /**
        * Extract only the fields relevant to this middleware's schema
        */
-      const schemaShape = getInteropZodObjectShape(this.middleware.contextSchema);
+      const schemaShape = getInteropZodObjectShape(
+        this.middleware.contextSchema
+      );
       if (schemaShape) {
         const relevantContext: Record<string, unknown> = {};
         const invokeContext = config?.context || {};

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -1,12 +1,18 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
-import { z } from "zod/v4";
 import { LangGraphRunnableConfig, Command } from "@langchain/langgraph";
-import { interopParse } from "@langchain/core/utils/types";
+import {
+  getInteropZodObjectShape,
+  interopParse,
+  isInteropZodObject,
+} from "@langchain/core/utils/types";
 
 import { RunnableCallable, RunnableCallableArgs } from "../RunnableCallable.js";
 import type { JumpToTarget } from "../constants.js";
 import type { Runtime } from "../runtime.js";
-import type { AgentMiddleware, MiddlewareResult } from "../middleware/types.js";
+import type {
+  AnyAgentMiddleware,
+  MiddlewareResult,
+} from "../middleware/types.js";
 import { derivePrivateState } from "./utils.js";
 import { getHookConstraint } from "../middleware/utils.js";
 
@@ -25,10 +31,7 @@ export abstract class MiddlewareNode<
   TStateSchema extends Record<string, any>,
   TContextSchema extends Record<string, any>,
 > extends RunnableCallable<TStateSchema, NodeOutput<TStateSchema>> {
-  abstract middleware: AgentMiddleware<
-    z.ZodObject<z.ZodRawShape>,
-    z.ZodObject<z.ZodRawShape>
-  >;
+  abstract middleware: AnyAgentMiddleware;
 
   constructor(
     fields: RunnableCallableArgs<TStateSchema, NodeOutput<TStateSchema>>
@@ -52,11 +55,14 @@ export abstract class MiddlewareNode<
     /**
      * Parse context using middleware's contextSchema to apply defaults and validation
      */
-    if (this.middleware.contextSchema) {
+    if (
+      this.middleware.contextSchema &&
+      isInteropZodObject(this.middleware.contextSchema)
+    ) {
       /**
        * Extract only the fields relevant to this middleware's schema
        */
-      const schemaShape = this.middleware.contextSchema?.shape;
+      const schemaShape = getInteropZodObjectShape(this.middleware.contextSchema);
       if (schemaShape) {
         const relevantContext: Record<string, unknown> = {};
         const invokeContext = config?.context || {};

--- a/libs/langchain/src/agents/nodes/utils.ts
+++ b/libs/langchain/src/agents/nodes/utils.ts
@@ -14,7 +14,7 @@ import type { StateDefinitionInit } from "@langchain/langgraph";
 import { END, StateSchema, ReducedValue } from "@langchain/langgraph";
 
 import type { JumpTo } from "../types.js";
-import type { AgentMiddleware } from "../middleware/types.js";
+import type { AnyAgentMiddleware } from "../middleware/types.js";
 
 /**
  * Helper function to initialize middleware state defaults.
@@ -24,7 +24,7 @@ import type { AgentMiddleware } from "../middleware/types.js";
  * users cannot provide them when invoking the agent.
  */
 export async function initializeMiddlewareStates(
-  middlewareList: readonly AgentMiddleware[],
+  middlewareList: readonly AnyAgentMiddleware[],
   state: unknown
 ): Promise<Record<string, any>> {
   const middlewareStates: Record<string, any> = {};
@@ -38,7 +38,7 @@ export async function initializeMiddlewareStates(
     }
 
     // Convert StateSchema to Zod object if needed
-    let zodSchema = middleware.stateSchema;
+    let zodSchema: InteropZodObject;
     if (StateSchema.isInstance(middleware.stateSchema)) {
       const zodShape: Record<string, any> = {};
       for (const [key, field] of Object.entries(
@@ -52,6 +52,10 @@ export async function initializeMiddlewareStates(
         }
       }
       zodSchema = z.object(zodShape);
+    } else if (isInteropZodObject(middleware.stateSchema)) {
+      zodSchema = middleware.stateSchema;
+    } else {
+      continue;
     }
 
     // Create a modified schema where private properties are optional
@@ -106,7 +110,7 @@ export async function initializeMiddlewareStates(
  * @returns A new schema containing only the private properties (underscore-prefixed), all made optional
  */
 export function derivePrivateState(
-  stateSchema?: InteropZodObject | StateSchema<any>
+  stateSchema?: StateDefinitionInit
 ): InteropZodObject {
   const builtInStateSchema = {
     messages: z.custom<BaseMessage[]>(() => []),
@@ -131,8 +135,10 @@ export function derivePrivateState(
         shape[key] = field;
       }
     }
-  } else {
+  } else if (isInteropZodObject(stateSchema)) {
     shape = getInteropZodObjectShape(stateSchema);
+  } else {
+    return z.object(builtInStateSchema);
   }
 
   const privateShape: Record<string, any> = { ...builtInStateSchema };

--- a/libs/langchain/src/agents/state.ts
+++ b/libs/langchain/src/agents/state.ts
@@ -1,6 +1,5 @@
-import type { InteropZodObject } from "@langchain/core/utils/types";
 import type { RunnableCallable } from "./RunnableCallable.js";
-import type { AgentMiddleware } from "./middleware/types.js";
+import type { AnyAgentMiddleware } from "./middleware/types.js";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AgentNode = RunnableCallable<any, any>;
@@ -22,7 +21,7 @@ export class StateManager {
    * @param node - The node to add.
    */
   addNode(
-    middleware: AgentMiddleware<InteropZodObject | undefined>,
+    middleware: AnyAgentMiddleware,
     node: AgentNode
   ) {
     this.#nodes.set(middleware.name, [

--- a/libs/langchain/src/agents/state.ts
+++ b/libs/langchain/src/agents/state.ts
@@ -20,10 +20,7 @@ export class StateManager {
    * @param name - The name of the middleware group.
    * @param node - The node to add.
    */
-  addNode(
-    middleware: AnyAgentMiddleware,
-    node: AgentNode
-  ) {
+  addNode(middleware: AnyAgentMiddleware, node: AgentNode) {
     this.#nodes.set(middleware.name, [
       ...(this.#nodes.get(middleware.name) ?? []),
       node,

--- a/libs/langchain/src/agents/tests/middleware.stream.test-d.ts
+++ b/libs/langchain/src/agents/tests/middleware.stream.test-d.ts
@@ -1,0 +1,244 @@
+import { describe, it, expectTypeOf } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { fakeModel } from "@langchain/core/testing";
+import { StreamChannel, type StreamTransformer } from "@langchain/langgraph";
+
+import { createAgent, createMiddleware } from "../index.js";
+import type { InferMiddlewareType } from "../middleware/types.js";
+import type {
+  InferAgentStreamTransformers,
+  InferMiddlewareStreamTransformers,
+} from "../types.js";
+
+describe("middleware streamTransformers types", () => {
+  it("should infer stream transformers on createMiddleware", () => {
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    expectTypeOf<
+      InferMiddlewareType<typeof middleware, "StreamTransformers">
+    >().toEqualTypeOf<readonly [typeof eventCounter]>();
+
+    expectTypeOf<
+      InferMiddlewareStreamTransformers<typeof middleware>
+    >().toEqualTypeOf<readonly [typeof eventCounter]>();
+  });
+
+  it("should infer combined stream transformers on createAgent", () => {
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => ({
+      init: () => ({ methods: StreamChannel.remote<string>("methods") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const agent = createAgent({
+      model: "gpt-4",
+      tools: [],
+      middleware: [middleware],
+      streamTransformers: [methodTracker],
+    });
+
+    expectTypeOf<InferAgentStreamTransformers<typeof agent>[0]>().toEqualTypeOf<
+      typeof methodTracker
+    >();
+    expectTypeOf<InferAgentStreamTransformers<typeof agent>[1]>().toEqualTypeOf<
+      typeof eventCounter
+    >();
+  });
+
+  it("should infer stream transformers from multiple middleware on createAgent", () => {
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => ({
+      init: () => ({ methods: StreamChannel.remote<string>("methods") }),
+      process() {
+        return true;
+      },
+    });
+
+    const counterMiddleware = createMiddleware({
+      name: "CounterMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const trackerMiddleware = createMiddleware({
+      name: "TrackerMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model: "gpt-4",
+      tools: [],
+      middleware: [counterMiddleware, trackerMiddleware],
+    });
+
+    expectTypeOf<InferAgentStreamTransformers<typeof agent>[0]>().toEqualTypeOf<
+      typeof eventCounter
+    >();
+    expectTypeOf<InferAgentStreamTransformers<typeof agent>[1]>().toEqualTypeOf<
+      typeof methodTracker
+    >();
+  });
+
+  it("should type run.extensions from middleware-only streamTransformers", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<
+      StreamChannel<number>
+    >();
+  });
+
+  it("should type run.extensions from agent and middleware streamTransformers", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => ({
+      init: () => ({ methods: StreamChannel.remote<string>("methods") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+      streamTransformers: [eventCounter],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<
+      StreamChannel<number>
+    >();
+    expectTypeOf(run.extensions.methods).toEqualTypeOf<StreamChannel<string>>();
+  });
+
+  it("should type run.extensions from multiple middleware streamTransformers", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => ({
+      init: () => ({ methods: StreamChannel.remote<string>("methods") }),
+      process() {
+        return true;
+      },
+    });
+
+    const counterMiddleware = createMiddleware({
+      name: "CounterMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const trackerMiddleware = createMiddleware({
+      name: "TrackerMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [counterMiddleware, trackerMiddleware],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<
+      StreamChannel<number>
+    >();
+    expectTypeOf(run.extensions.methods).toEqualTypeOf<StreamChannel<string>>();
+  });
+});

--- a/libs/langchain/src/agents/tests/middleware.stream.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.stream.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { fakeModel } from "@langchain/core/testing";
+import { StreamChannel, type StreamTransformer } from "@langchain/langgraph";
+
+import { createAgent, createMiddleware } from "../index.js";
+
+describe("middleware streamTransformers", () => {
+  it("should expose streamTransformers on the middleware instance", () => {
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    expect(middleware.streamTransformers).toEqual([eventCounter]);
+  });
+
+  it("should stream event counts from a middleware-registered transformer", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => {
+      const eventCount = StreamChannel.remote<number>("eventCount");
+      let count = 0;
+
+      return {
+        init: () => ({ eventCount }),
+        process() {
+          count += 1;
+          eventCount.push(count);
+          return true;
+        },
+      };
+    };
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    const counts: number[] = [];
+    for await (const c of run.extensions.eventCount as AsyncIterable<number>) {
+      counts.push(c);
+    }
+
+    expect(counts.length).toBeGreaterThan(0);
+    expect(counts.every((c, i) => c === i + 1)).toBe(true);
+    expect(counts[counts.length - 1]).toBe(counts.length);
+  });
+
+  it("should stream protocol methods from a middleware-registered transformer", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => {
+      const methods = StreamChannel.remote<string>("methods");
+      return {
+        init: () => ({ methods }),
+        process(event) {
+          methods.push(event.method);
+          return true;
+        },
+      };
+    };
+
+    const middleware = createMiddleware({
+      name: "MethodMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    const seenMethods: string[] = [];
+    for await (const m of run.extensions.methods as AsyncIterable<string>) {
+      seenMethods.push(m);
+    }
+
+    expect(seenMethods.length).toBeGreaterThan(0);
+    expect(seenMethods).toContain("values");
+  });
+
+  it("should merge agent and middleware stream transformers", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => {
+      const eventCount = StreamChannel.remote<number>("eventCount");
+      let count = 0;
+      return {
+        init: () => ({ eventCount }),
+        process() {
+          count += 1;
+          eventCount.push(count);
+          return true;
+        },
+      };
+    };
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => {
+      const methods = StreamChannel.remote<string>("methods");
+      return {
+        init: () => ({ methods }),
+        process(event) {
+          methods.push(event.method);
+          return true;
+        },
+      };
+    };
+
+    const middleware = createMiddleware({
+      name: "MethodMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+      streamTransformers: [eventCounter],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    const counts: number[] = [];
+    for await (const c of run.extensions.eventCount as AsyncIterable<number>) {
+      counts.push(c);
+    }
+
+    const seenMethods: string[] = [];
+    for await (const m of run.extensions.methods as AsyncIterable<string>) {
+      seenMethods.push(m);
+    }
+
+    expect(counts.length).toBeGreaterThan(0);
+    expect(seenMethods.length).toBeGreaterThan(0);
+    expect(seenMethods).toContain("values");
+  });
+
+  it("should merge stream transformers from multiple middleware instances", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => {
+      const eventCount = StreamChannel.remote<number>("eventCount");
+      return {
+        init: () => ({ eventCount }),
+        process() {
+          eventCount.push(1);
+          return true;
+        },
+      };
+    };
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => {
+      const methods = StreamChannel.remote<string>("methods");
+      return {
+        init: () => ({ methods }),
+        process(event) {
+          methods.push(event.method);
+          return true;
+        },
+      };
+    };
+
+    const counterMiddleware = createMiddleware({
+      name: "CounterMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const trackerMiddleware = createMiddleware({
+      name: "TrackerMiddleware",
+      streamTransformers: [methodTracker],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [counterMiddleware, trackerMiddleware],
+    });
+
+    const run = await agent.streamEvents(
+      { messages: [new HumanMessage("hi")] },
+      { version: "v3" }
+    );
+
+    const counts: number[] = [];
+    for await (const c of run.extensions.eventCount as AsyncIterable<number>) {
+      counts.push(c);
+    }
+
+    const seenMethods: string[] = [];
+    for await (const m of run.extensions.methods as AsyncIterable<string>) {
+      seenMethods.push(m);
+    }
+
+    expect(counts.length).toBeGreaterThan(0);
+    expect(seenMethods.length).toBeGreaterThan(0);
+    expect(seenMethods).toContain("values");
+  });
+});

--- a/libs/langchain/src/agents/tests/middleware.test-d.ts
+++ b/libs/langchain/src/agents/tests/middleware.test-d.ts
@@ -4,6 +4,7 @@ import { HumanMessage, BaseMessage, AIMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import type { InferInteropZodInput } from "@langchain/core/utils/types";
 import type { ServerTool, ClientTool } from "@langchain/core/tools";
+import { StreamChannel, type StreamTransformer } from "@langchain/langgraph";
 
 import {
   createAgent,
@@ -14,6 +15,7 @@ import {
 import type { AgentBuiltInState } from "../runtime.js";
 import type { InferAgentState } from "../types.js";
 import type { InferMiddlewareType } from "../middleware/types.js";
+import type { InferAgentStreamTransformers } from "../types.js";
 import type { JsonSchemaFormat } from "../responses.js";
 
 describe("middleware types", () => {
@@ -474,5 +476,49 @@ describe("middleware types", () => {
     }>();
     type Tools = InferMiddlewareType<typeof middleware, "Tools">;
     expectTypeOf<Tools[0]>().toExtend<ClientTool>();
+  });
+
+  it("should infer stream transformers from middleware", () => {
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const methodTracker = (): StreamTransformer<{
+      methods: StreamChannel<string>;
+    }> => ({
+      init: () => ({ methods: StreamChannel.remote<string>("methods") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    expectTypeOf<
+      InferMiddlewareType<typeof middleware, "StreamTransformers">
+    >().toEqualTypeOf<readonly [typeof eventCounter]>();
+
+    const agent = createAgent({
+      model: "gpt-4",
+      tools: [],
+      middleware: [middleware],
+      streamTransformers: [methodTracker],
+    });
+
+    type AgentStreamTransformers = InferAgentStreamTransformers<typeof agent>;
+    expectTypeOf<AgentStreamTransformers[0]>().toEqualTypeOf<
+      typeof methodTracker
+    >();
+    expectTypeOf<AgentStreamTransformers[1]>().toEqualTypeOf<
+      typeof eventCounter
+    >();
   });
 });

--- a/libs/langchain/src/agents/tests/stream.test-d.ts
+++ b/libs/langchain/src/agents/tests/stream.test-d.ts
@@ -5,7 +5,7 @@ import { tool } from "@langchain/core/tools";
 import { fakeModel } from "@langchain/core/testing";
 import { StreamChannel, type StreamTransformer } from "@langchain/langgraph";
 
-import { createAgent } from "../index.js";
+import { createAgent, createMiddleware } from "../index.js";
 
 describe("streamEvents types", () => {
   it("should type tool calls as a discriminated union", async () => {
@@ -102,5 +102,40 @@ describe("streamEvents types", () => {
       StreamChannel<number>
     >();
     expectTypeOf(run.extensions.methods).toEqualTypeOf<StreamChannel<string>>();
+  });
+
+  it("should type run.extensions from middleware streamTransformers", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => ({
+      init: () => ({ eventCount: StreamChannel.remote<number>("eventCount") }),
+      process() {
+        return true;
+      },
+    });
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+    });
+
+    const run = await agent.streamEvents(
+      {
+        messages: [new HumanMessage("hi")],
+      },
+      { version: "v3" }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<
+      StreamChannel<number>
+    >();
   });
 });

--- a/libs/langchain/src/agents/tests/stream.test.ts
+++ b/libs/langchain/src/agents/tests/stream.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@langchain/langgraph";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
 
-import { createAgent } from "../index.js";
+import { createAgent, createMiddleware } from "../index.js";
 import { humanInTheLoopMiddleware } from "../middleware/hitl.js";
 import { createToolCallTransformer } from "../stream.js";
 
@@ -234,6 +234,52 @@ describe("streamEvents", () => {
       model,
       tools: [],
       streamTransformers: [eventCounter],
+    });
+
+    const run = await agent.streamEvents(
+      {
+        messages: [new HumanMessage("hi")],
+      },
+      { version: "v3" }
+    );
+
+    const counts: number[] = [];
+    for await (const c of run.extensions.eventCount as AsyncIterable<number>) {
+      counts.push(c);
+    }
+
+    expect(counts.length).toBeGreaterThan(0);
+    expect(counts[counts.length - 1]).toBe(counts.length);
+  });
+
+  it("should pass streamTransformers registered on middleware", async () => {
+    const model = fakeModel().respond(new AIMessage("ok"));
+
+    const eventCounter = (): StreamTransformer<{
+      eventCount: StreamChannel<number>;
+    }> => {
+      const eventCount = StreamChannel.remote<number>("eventCount");
+      let count = 0;
+
+      return {
+        init: () => ({ eventCount }),
+        process() {
+          count += 1;
+          eventCount.push(count);
+          return true;
+        },
+      };
+    };
+
+    const middleware = createMiddleware({
+      name: "StreamMiddleware",
+      streamTransformers: [eventCounter],
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
     });
 
     const run = await agent.streamEvents(

--- a/libs/langchain/src/agents/types.ts
+++ b/libs/langchain/src/agents/types.ts
@@ -35,6 +35,7 @@ import type {
 import type { AgentLanguageModelLike } from "./model.js";
 import type {
   AgentMiddleware,
+  AnyAgentMiddleware,
   AnyAnnotationRoot,
   InferSchemaInput,
   InferSchemaValue,
@@ -67,10 +68,10 @@ import type { JumpToTarget } from "./constants.js";
  * @typeParam TTools - The combined tools type from both `createAgent` tools parameter
  *   and middleware tools. This is a readonly array of `ClientTool | ServerTool`.
  *
- * @typeParam TStreamTransformers - The tuple of user-supplied stream transformer
- *   factories registered at `createAgent({ streamTransformers })`. Used to type
- *   `run.extensions` on the stream returned from
- *   `streamEvents(..., { version: "v3" })`.
+ * @typeParam TStreamTransformers - The combined tuple of stream transformer
+ *   factories from `createAgent({ streamTransformers })` and middleware
+ *   `streamTransformers`. Used to type `run.extensions` on the stream returned
+ *   from `streamEvents(..., { version: "v3" })`.
  *
  * @example
  * ```typescript
@@ -98,7 +99,7 @@ export interface AgentTypeConfig<
   TContext extends AnyAnnotationRoot | InteropZodObject =
     | AnyAnnotationRoot
     | InteropZodObject,
-  TMiddleware extends readonly AgentMiddleware[] = readonly AgentMiddleware[],
+  TMiddleware extends readonly AnyAgentMiddleware[] = readonly AnyAgentMiddleware[],
   TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool
@@ -133,7 +134,7 @@ export interface DefaultAgentTypeConfig extends AgentTypeConfig {
   Response: Record<string, any>;
   State: undefined;
   Context: AnyAnnotationRoot;
-  Middleware: readonly AgentMiddleware[];
+  Middleware: readonly AnyAgentMiddleware[];
   Tools: readonly (ClientTool | ServerTool)[];
   StreamTransformers: readonly [];
 }
@@ -143,22 +144,34 @@ export interface DefaultAgentTypeConfig extends AgentTypeConfig {
  * Extracts the TTools type parameter from AgentMiddleware.
  */
 export type InferMiddlewareTools<T extends AgentMiddleware> =
-  T extends AgentMiddleware<any, any, any, infer TTools>
+  T extends AgentMiddleware<any, any, any, infer TTools, any>
     ? TTools extends readonly (ClientTool | ServerTool)[]
       ? TTools
       : readonly []
     : readonly [];
 
 /**
+ * Helper type to infer stream transformers from a single middleware instance.
+ */
+export type InferMiddlewareStreamTransformers<T extends AgentMiddleware> =
+  T extends AgentMiddleware<any, any, any, any, infer TStreamTransformers>
+    ? [TStreamTransformers] extends [readonly []]
+      ? readonly []
+      : TStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>>
+        ? TStreamTransformers
+        : readonly []
+    : readonly [];
+
+/**
  * Helper type to infer and merge tools from an array of middleware.
  * Recursively extracts tools from each middleware and combines them into a single tuple.
  */
-export type InferMiddlewareToolsArray<T extends readonly AgentMiddleware[]> =
+export type InferMiddlewareToolsArray<T extends readonly AnyAgentMiddleware[]> =
   T extends readonly []
     ? readonly []
     : T extends readonly [infer First, ...infer Rest]
       ? First extends AgentMiddleware
-        ? Rest extends readonly AgentMiddleware[]
+        ? Rest extends readonly AnyAgentMiddleware[]
           ? readonly [
               ...InferMiddlewareTools<First>,
               ...InferMiddlewareToolsArray<Rest>,
@@ -172,8 +185,37 @@ export type InferMiddlewareToolsArray<T extends readonly AgentMiddleware[]> =
  */
 export type CombineTools<
   TAgentTools extends readonly (ClientTool | ServerTool)[],
-  TMiddleware extends readonly AgentMiddleware[],
+  TMiddleware extends readonly AnyAgentMiddleware[],
 > = readonly [...TAgentTools, ...InferMiddlewareToolsArray<TMiddleware>];
+
+/**
+ * Helper type to infer and merge stream transformers from an array of middleware.
+ */
+export type InferMiddlewareStreamTransformersArray<
+  T extends readonly AnyAgentMiddleware[],
+> = T extends readonly []
+  ? readonly []
+  : T extends readonly [infer First, ...infer Rest]
+    ? First extends AgentMiddleware
+      ? Rest extends readonly AnyAgentMiddleware[]
+        ? readonly [
+            ...InferMiddlewareStreamTransformers<First>,
+            ...InferMiddlewareStreamTransformersArray<Rest>,
+          ]
+        : InferMiddlewareStreamTransformers<First>
+      : readonly []
+    : readonly [];
+
+/**
+ * Helper type to combine agent stream transformers with middleware stream transformers.
+ */
+export type CombineStreamTransformers<
+  TAgentStreamTransformers extends ReadonlyArray<() => StreamTransformer<any>>,
+  TMiddleware extends readonly AnyAgentMiddleware[],
+> = readonly [
+  ...TAgentStreamTransformers,
+  ...InferMiddlewareStreamTransformersArray<TMiddleware>,
+];
 
 /**
  * Helper type to extract the tool name, input type, and output type from a tool.
@@ -795,7 +837,7 @@ export type CreateAgentParams<
    *
    * @see {@link https://docs.langchain.com/oss/javascript/langchain/middleware | Middleware}
    */
-  middleware?: readonly AgentMiddleware[];
+  middleware?: readonly AnyAgentMiddleware[];
 
   /**
    * An optional name for the agent.

--- a/libs/langchain/src/agents/types.ts
+++ b/libs/langchain/src/agents/types.ts
@@ -99,7 +99,8 @@ export interface AgentTypeConfig<
   TContext extends AnyAnnotationRoot | InteropZodObject =
     | AnyAnnotationRoot
     | InteropZodObject,
-  TMiddleware extends readonly AnyAgentMiddleware[] = readonly AnyAgentMiddleware[],
+  TMiddleware extends readonly AnyAgentMiddleware[] =
+    readonly AnyAgentMiddleware[],
   TTools extends readonly (ClientTool | ServerTool)[] = readonly (
     | ClientTool
     | ServerTool

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -547,9 +547,7 @@ function chainToolCallHandlers(
  * @param state state of the agent
  * @returns single wrap function
  */
-export function wrapToolCall(
-  middleware: readonly AnyAgentMiddleware[]
-) {
+export function wrapToolCall(middleware: readonly AnyAgentMiddleware[]) {
   const middlewareWithWrapToolCall = middleware.filter((m) => m.wrapToolCall);
 
   if (middlewareWithWrapToolCall.length === 0) {

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -36,7 +36,7 @@ import { MultipleToolsBoundError, MiddlewareError } from "./errors.js";
 import type { AgentBuiltInState } from "./runtime.js";
 import type {
   ToolCallHandler,
-  AgentMiddleware,
+  AnyAgentMiddleware,
   ToolCallRequest,
   WrapToolCallHook,
 } from "./middleware/types.js";
@@ -548,7 +548,7 @@ function chainToolCallHandlers(
  * @returns single wrap function
  */
 export function wrapToolCall(
-  middleware: readonly AgentMiddleware<InteropZodObject | undefined>[]
+  middleware: readonly AnyAgentMiddleware[]
 ) {
   const middlewareWithWrapToolCall = middleware.filter((m) => m.wrapToolCall);
 


### PR DESCRIPTION
## Summary

- Extend `createMiddleware` with an optional `streamTransformers` tuple, mirroring how middleware can register tools.
- Merge agent- and middleware-supplied transformers at graph compile time; propagate types via `CombineStreamTransformers` on `createAgent` / `ReactAgent`.
- Add `AnyAgentMiddleware` and widen middleware node utilities so middleware with stream transformers remains assignable without losing inference.
- Add focused unit and type tests in `middleware.stream.test.ts` and `middleware.stream.test-d.ts`.
