### PR TITLE
fix: support agent invoke without strict null checks

### DIFF
--- a/.changeset/tiny-llamas-type.md
+++ b/.changeset/tiny-llamas-type.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): support agent invoke messages when strictNullChecks is disabled

--- a/environment_tests/test-exports-tsc/main.ts
+++ b/environment_tests/test-exports-tsc/main.ts
@@ -1,5 +1,6 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { createAgent } from "langchain";
 
 const model = new ChatOpenAI({
   openAIApiKey: "sk-XXXX",
@@ -11,3 +12,21 @@ const prompt = ChatPromptTemplate.fromMessages([
   ["human", "{input}"],
   ["placeholder", "{agent_scratchpad}"],
 ]);
+
+// Regression for #10888: this package's tsconfig disables strictNullChecks.
+export async function invokeAgentWithMessages() {
+  const agent = createAgent({
+    model: "openai:gpt-4o-mini",
+    tools: [],
+    systemPrompt: "You are a helpful assistant.",
+  });
+
+  await agent.invoke({
+    messages: [
+      {
+        role: "human",
+        content: "Please generate a greeting message.",
+      },
+    ],
+  });
+}

--- a/environment_tests/test-exports-tsc/package.json
+++ b/environment_tests/test-exports-tsc/package.json
@@ -6,7 +6,7 @@
   "description": "TSC Tests for the things exported by the langchain package",
   "main": "./index.mjs",
   "scripts": {
-    "build": "tsc -m nodenext main.ts",
+    "build": "tsc -p tsconfig.json",
     "test": "node ./main.js"
   },
   "author": "LangChain",
@@ -15,6 +15,7 @@
     "@langchain/core": "workspace:^",
     "@langchain/openai": "workspace:*",
     "@types/node": "^24.3.0",
+    "langchain": "workspace:*",
     "typescript": "^5.9.3"
   },
   "pnpm": {

--- a/environment_tests/test-exports-tsc/tsconfig.json
+++ b/environment_tests/test-exports-tsc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": false,
+    "strictNullChecks": false
+  },
+  "include": ["main.ts"]
+}

--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -792,8 +792,11 @@ export type ToAnnotationRoot<A extends StateDefinitionInit> =
       ? InteropZodToStateDefinition<A>
       : never;
 
-export type InferSchemaValue<A extends StateDefinitionInit | undefined> =
-  A extends StateSchema<infer TFields>
+export type InferSchemaValue<A extends StateDefinitionInit | undefined> = [
+  A,
+] extends [undefined]
+  ? {}
+  : A extends StateSchema<infer TFields>
     ? InferStateSchemaValue<TFields>
     : A extends InteropZodObject
       ? InferInteropZodOutput<A>
@@ -801,8 +804,11 @@ export type InferSchemaValue<A extends StateDefinitionInit | undefined> =
         ? A["State"]
         : {};
 
-export type InferSchemaInput<A extends StateDefinitionInit | undefined> =
-  A extends StateSchema<infer TFields>
+export type InferSchemaInput<A extends StateDefinitionInit | undefined> = [
+  A,
+] extends [undefined]
+  ? {}
+  : A extends StateSchema<infer TFields>
     ? InferStateSchemaUpdate<TFields>
     : A extends InteropZodObject
       ? InferInteropZodInput<A>


### PR DESCRIPTION
Fixes #10888.

I checked this after #10904 got closed. Missing bit was `strictNullChecks: false`; without that the test is too weak and passes even on main.

This handles missing agent state schema before LangGraph schema branches, so `agent.invoke({ messages })` doesn't collapse into `messages: never` in non-strict TS. Added small export TSC fixture for that config.
