### PR TITLE
docs: fix duplicate-word typos in source comments

### DIFF
--- a/libs/langchain-core/src/prompts/prompt.ts
+++ b/libs/langchain-core/src/prompts/prompt.ts
@@ -183,7 +183,7 @@ export class PromptTemplate<
   /**
    * Take examples in list format with prefix and suffix to create a prompt.
    *
-   * Intended to be used a a way to dynamically create a prompt from examples.
+   * Intended to be used as a way to dynamically create a prompt from examples.
    *
    * @param examples - List of examples to use in the prompt.
    * @param suffix - String to go after the list of examples. Should generally set up the user's input.

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -164,7 +164,7 @@ export class AgentNode<
    * If the user selects a tool output:
    * - return a record of tools to extract structured output from the model's response
    *
-   * if the the user selects a native schema output or if the model supports JSON schema output:
+   * if the user selects a native schema output or if the model supports JSON schema output:
    * - return a provider strategy to extract structured output from the model's response
    *
    * @param model - The model to get the response format for.

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -566,7 +566,7 @@ export const convertReasoningSummaryToResponsesReasoningItem: Converter<
   ChatOpenAIReasoningSummary,
   OpenAIClient.Responses.ResponseReasoningItem
 > = (reasoning) => {
-  // combine summary parts that have the the same index and then remove the indexes
+  // combine summary parts that have the same index and then remove the indexes
   const summary = (
     reasoning.summary.length > 1
       ? reasoning.summary.reduce(


### PR DESCRIPTION
## Summary

Three duplicate-word typos in source comments, no code changes:

| File:Line | Fix |
|---|---|
| \`libs/langchain-core/src/prompts/prompt.ts:186\` | \`used a a way\` → \`used as a way\` |
| \`libs/langchain/src/agents/nodes/AgentNode.ts:167\` | \`if the the user\` → \`if the user\` |
| \`libs/providers/langchain-openai/src/converters/responses.ts:569\` | \`have the the same index\` → \`have the same index\` |

Diff is exactly 3 lines, all in JSDoc / inline comments.

## Novelty check

\`gh pr list --search\` against each of the three file paths returned no open PR overlapping these lines. \`grep -rn \"the the \\| a a way\"\` across the repo turns up only these three sites.

## Test plan

- [x] No runtime behavior changes — comment-only edits.
- [x] \`grep -rn 'the the\\|a a way' libs/\` (excluding node_modules / dist) returns no matches after the fix.