### PR TITLE
fix(core): surface helpful error when tool call arguments fail to JSON.parse

### DIFF
--- a/.changeset/fix-tool-call-parse-error.md
+++ b/.changeset/fix-tool-call-parse-error.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): surface helpful error when tool call arguments fail to JSON.parse

--- a/libs/langchain-core/src/messages/tests/message_utils.test.ts
+++ b/libs/langchain-core/src/messages/tests/message_utils.test.ts
@@ -12,6 +12,7 @@ import {
   trimMessages,
 } from "../transformers.js";
 import {
+  coerceMessageLikeToMessage,
   getBufferString,
   mapChatMessagesToStoredMessages,
   mapStoredMessagesToChatMessages,
@@ -767,6 +768,54 @@ test("getBufferString preserves non-text content block placeholders", () => {
   expect(getBufferString([mixedMsg])).toBe(
     "Human: Look at this: [image] and listen to this: [audio]"
   );
+});
+
+describe("coerceMessageLikeToMessage tool call argument parsing", () => {
+  it("throws a helpful error when OpenAI-format tool call arguments are malformed", () => {
+    // Models (especially during streaming) occasionally emit syntactically
+    // invalid JSON in tool call arguments. The bare SyntaxError from
+    // `JSON.parse` was very hard to diagnose because it surfaced no context
+    // about which tool call failed or what the offending payload was.
+    expect(() =>
+      coerceMessageLikeToMessage({
+        type: "ai",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_abc123",
+            type: "function",
+            function: {
+              name: "get_weather",
+              arguments: '{"city": "Paris",}', // trailing comma -> invalid JSON
+            },
+          },
+        ],
+      } as never)
+    ).toThrow(/Failed to parse tool call arguments for "get_weather".*call_abc123.*"city": "Paris"/s);
+  });
+
+  it("still parses valid OpenAI-format tool call arguments", () => {
+    const msg = coerceMessageLikeToMessage({
+      type: "ai",
+      content: "",
+      tool_calls: [
+        {
+          id: "call_ok",
+          type: "function",
+          function: {
+            name: "get_weather",
+            arguments: '{"city":"Paris"}',
+          },
+        },
+      ],
+    } as never) as AIMessage;
+    expect(msg.tool_calls?.[0]).toEqual({
+      id: "call_ok",
+      args: { city: "Paris" },
+      name: "get_weather",
+      type: "tool_call",
+    });
+  });
 });
 
 describe("chat message conversions", () => {

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -193,10 +193,28 @@ function _coerceToolCall(
     typeof toolCall.function.name === "string"
   ) {
     // Handle OpenAI tool call format
+    const name = toolCall.function.name;
+    const rawArgs = toolCall.function.arguments;
+    let args: Record<string, unknown>;
+    try {
+      args = JSON.parse(rawArgs);
+    } catch (cause) {
+      // Models occasionally emit malformed JSON in tool call arguments. A bare
+      // SyntaxError from JSON.parse gives no clue which tool call failed or
+      // what the offending payload was.
+      throw addLangChainErrorFields(
+        new Error(
+          `Failed to parse tool call arguments for "${name}" (id=${toolCall.id}): ${
+            (cause as Error)?.message ?? cause
+          }. Raw arguments: ${rawArgs}`
+        ),
+        "MESSAGE_COERCION_FAILURE"
+      );
+    }
     return {
       id: toolCall.id,
-      args: JSON.parse(toolCall.function.arguments),
-      name: toolCall.function.name,
+      args,
+      name,
       type: "tool_call",
     };
   } else {


### PR DESCRIPTION
## Summary

When \`coerceMessageLikeToMessage\` receives an OpenAI-style tool call whose \`function.arguments\` is malformed JSON, the bare \`JSON.parse\` call inside \`_coerceToolCall\` (libs/langchain-core/src/messages/utils.ts:198) throws a generic \`SyntaxError\` with no context: no tool name, no tool call ID, no raw payload. Models do occasionally emit malformed JSON in tool arguments (most commonly when streaming and a chunk is mishandled), so this surfaces as a hard-to-debug exception in user code.

The sibling helper \`defaultToolCallParser\` in \`messages/tool.ts:326\` already handles this case by catching \`JSON.parse\` failures and routing to \`invalid_tool_call\` — the divergence is only in this one code path.

## Fix

Wrap \`JSON.parse\` in \`_coerceToolCall\` with a try/catch that re-throws using \`addLangChainErrorFields\` and includes the tool name, the tool call id, and the raw arguments. Same \`MESSAGE_COERCION_FAILURE\` code as the sibling unrecognized-shape branch a few lines below.

Diff:

\`\`\`diff
-    return {
-      id: toolCall.id,
-      args: JSON.parse(toolCall.function.arguments),
-      name: toolCall.function.name,
-      type: \"tool_call\",
-    };
+    const name = toolCall.function.name;
+    const rawArgs = toolCall.function.arguments;
+    let args: Record<string, unknown>;
+    try {
+      args = JSON.parse(rawArgs);
+    } catch (cause) {
+      throw addLangChainErrorFields(
+        new Error(\`Failed to parse tool call arguments for \"\${name}\" (id=\${toolCall.id}): \${(cause as Error)?.message ?? cause}. Raw arguments: \${rawArgs}\`),
+        \"MESSAGE_COERCION_FAILURE\"
+      );
+    }
+    return { id: toolCall.id, args, name, type: \"tool_call\" };
\`\`\`

## Test

Two new vitest cases in \`libs/langchain-core/src/messages/tests/message_utils.test.ts\`:

1. \`throws a helpful error when OpenAI-format tool call arguments are malformed\` — passes a trailing-comma payload and asserts the error message contains the tool name, the id, and the raw JSON.
2. \`still parses valid OpenAI-format tool call arguments\` — regression guard.

\`npx vitest run src/messages/tests/message_utils.test.ts\` → 25 passed.

## Novelty

\`gh search prs --repo langchain-ai/langchainjs _coerceToolCall JSON.parse\` returns no matches. No open PR touches this block.