### PR TITLE
feat(langchain): add NEAR AI provider to initChatModel

### DIFF
--- a/.changeset/sharp-trees-push.md
+++ b/.changeset/sharp-trees-push.md
@@ -1,0 +1,6 @@
+---
+"langchain": patch
+"@langchain/classic": patch
+---
+
+Add NEAR AI Cloud as a supported OpenAI-compatible provider for `initChatModel`.

--- a/libs/langchain-classic/src/chat_models/universal.ts
+++ b/libs/langchain-classic/src/chat_models/universal.ts
@@ -80,14 +80,15 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
+  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
 
   return {
     ...params,
     apiKey,
     streamUsage: params.streamUsage ?? false,
     configuration: {
+      ...safeConfiguration,
       baseURL: NEARAI_BASE_URL,
-      ...configuration,
       apiKey,
     },
   };

--- a/libs/langchain-classic/src/chat_models/universal.ts
+++ b/libs/langchain-classic/src/chat_models/universal.ts
@@ -80,7 +80,16 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
-  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
+  // Strip any caller-supplied endpoint/transport keys so the pinned NEAR AI
+  // endpoint cannot be overridden (e.g. via `configurableFields: "any"`).
+  const {
+    baseURL: _baseURL,
+    basePath: _basePath,
+    fetch: _fetch,
+    fetchOptions: _fetchOptions,
+    httpAgent: _httpAgent,
+    ...safeConfiguration
+  } = configuration;
 
   return {
     ...params,

--- a/libs/langchain-classic/src/chat_models/universal.ts
+++ b/libs/langchain-classic/src/chat_models/universal.ts
@@ -32,6 +32,7 @@ import {
 import { type StructuredToolInterface } from "@langchain/core/tools";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatResult } from "@langchain/core/outputs";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 // TODO: remove once `EventStreamCallbackHandlerInput` is exposed in core
 interface EventStreamCallbackHandlerInput extends Omit<
@@ -46,6 +47,50 @@ export interface ConfigurableChatModelCallOptions extends BaseChatModelCallOptio
     | ToolDefinition
     | RunnableToolLike
   )[];
+}
+
+type ModelProviderConfig = {
+  package: string;
+  className: string;
+  hasCircularDependency?: boolean;
+  transformParams?: (
+    params: Record<string, unknown>
+  ) => Record<string, unknown>;
+};
+
+const NEARAI_BASE_URL = "https://cloud-api.near.ai/v1";
+
+function getNearAIParams(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const configuration =
+    typeof params.configuration === "object" && params.configuration !== null
+      ? (params.configuration as Record<string, unknown>)
+      : {};
+  const configApiKey = configuration.apiKey;
+  const apiKey =
+    params.apiKey ??
+    (typeof configApiKey === "string" || typeof configApiKey === "function"
+      ? configApiKey
+      : undefined) ??
+    getEnvironmentVariable("NEARAI_API_KEY");
+
+  if (!apiKey) {
+    throw new Error(
+      'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
+    );
+  }
+
+  return {
+    ...params,
+    apiKey,
+    streamUsage: params.streamUsage ?? false,
+    configuration: {
+      baseURL: NEARAI_BASE_URL,
+      ...configuration,
+      apiKey,
+    },
+  };
 }
 
 // Configuration map for model providers
@@ -106,6 +151,11 @@ export const MODEL_PROVIDER_CONFIG = {
     package: "@langchain/deepseek",
     className: "ChatDeepSeek",
   },
+  nearai: {
+    package: "@langchain/openai",
+    className: "ChatOpenAICompletions",
+    transformParams: getNearAIParams,
+  },
   xai: {
     package: "@langchain/xai",
     className: "ChatXAI",
@@ -129,11 +179,6 @@ const SUPPORTED_PROVIDERS = Object.keys(
   MODEL_PROVIDER_CONFIG
 ) as (keyof typeof MODEL_PROVIDER_CONFIG)[];
 export type ChatModelProvider = keyof typeof MODEL_PROVIDER_CONFIG;
-type ModelProviderConfig = {
-  package: string;
-  className: string;
-  hasCircularDependency?: boolean;
-};
 
 /**
  * Helper function to get a chat model class by its class name or model provider.
@@ -218,12 +263,15 @@ async function _initChatModelHelper(
   }
 
   const { modelProvider: _unused, ...passedParams } = params;
+  const providerParams = config.transformParams
+    ? config.transformParams(passedParams)
+    : passedParams;
   // Pass modelProviderCopy to use direct lookup and avoid className collision
   const ProviderClass = await getChatModelByClassName(
     config.className,
     modelProviderCopy
   );
-  return new ProviderClass({ model, ...passedParams });
+  return new ProviderClass({ model, ...providerParams });
 }
 
 /**
@@ -687,6 +735,7 @@ export async function initChatModel<
  *   - perplexity (@langchain/perplexity)
  *   - cerebras (@langchain/cerebras)
  *   - deepseek (@langchain/deepseek)
+ *   - nearai (@langchain/openai)
  *   - xai (@langchain/xai)
  * @param {string[] | "any"} [fields.configurableFields] - Which model parameters are configurable:
  *   - undefined: No configurable fields.

--- a/libs/langchain/src/chat_models/tests/universal.test.ts
+++ b/libs/langchain/src/chat_models/tests/universal.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import { initChatModel } from "../universal.js";
+
+const originalNearAIApiKey = process.env.NEARAI_API_KEY;
+const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("NEARAI_API_KEY", originalNearAIApiKey);
+  restoreEnv("OPENAI_API_KEY", originalOpenAIApiKey);
+});
 
 describe("Will appropriately infer a model profiles", () => {
   it("when provided a profile", async () => {
@@ -16,5 +32,41 @@ describe("Will appropriately infer a model profiles", () => {
       temperature: 0,
     });
     expect(model.profile.maxInputTokens).toBeDefined();
+  });
+});
+
+describe("NEAR AI provider", () => {
+  it("configures the OpenAI-compatible chat completions endpoint", async () => {
+    process.env.NEARAI_API_KEY = "nearai-test-key";
+    process.env.OPENAI_API_KEY = "openai-test-key";
+
+    const model = await initChatModel("nearai:anthropic/claude-haiku-4-5", {
+      maxTokens: 16,
+      temperature: 0,
+    });
+    const innerModel = await (
+      model as {
+        _getModelInstance(): Promise<{
+          identifyingParams(): Record<string, unknown>;
+        }>;
+      }
+    )._getModelInstance();
+
+    const params = innerModel.identifyingParams();
+    expect(params.apiKey).toBe("nearai-test-key");
+    expect(params.baseURL).toBe("https://cloud-api.near.ai/v1");
+    expect(params.model).toBe("anthropic/claude-haiku-4-5");
+    expect(params.model_name).toBe("anthropic/claude-haiku-4-5");
+    expect(params.max_tokens).toBe(16);
+    expect(params.max_completion_tokens).toBeUndefined();
+  });
+
+  it("does not fall back to OPENAI_API_KEY", async () => {
+    delete process.env.NEARAI_API_KEY;
+    process.env.OPENAI_API_KEY = "openai-test-key";
+
+    await expect(
+      initChatModel("nearai:anthropic/claude-haiku-4-5")
+    ).rejects.toThrow("NEARAI_API_KEY");
   });
 });

--- a/libs/langchain/src/chat_models/tests/universal.test.ts
+++ b/libs/langchain/src/chat_models/tests/universal.test.ts
@@ -69,4 +69,24 @@ describe("NEAR AI provider", () => {
       initChatModel("nearai:anthropic/claude-haiku-4-5")
     ).rejects.toThrow("NEARAI_API_KEY");
   });
+
+  it("does not allow configuration.baseURL to override the NEAR AI endpoint", async () => {
+    const model = await initChatModel("nearai:anthropic/claude-haiku-4-5", {
+      configuration: {
+        apiKey: "configuration-nearai-key",
+        baseURL: "https://example.invalid/v1",
+      },
+    });
+    const innerModel = await (
+      model as {
+        _getModelInstance(): Promise<{
+          identifyingParams(): Record<string, unknown>;
+        }>;
+      }
+    )._getModelInstance();
+
+    const params = innerModel.identifyingParams();
+    expect(params.apiKey).toBe("configuration-nearai-key");
+    expect(params.baseURL).toBe("https://cloud-api.near.ai/v1");
+  });
 });

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -34,6 +34,7 @@ import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatResult } from "@langchain/core/outputs";
 import { ModelProfile } from "@langchain/core/language_models/profile";
 import { ChatModelStream } from "@langchain/core/language_models/stream";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 // TODO: remove once `EventStreamCallbackHandlerInput` is exposed in core
 interface EventStreamCallbackHandlerInput extends Omit<
@@ -48,6 +49,50 @@ export interface ConfigurableChatModelCallOptions extends BaseChatModelCallOptio
     | ToolDefinition
     | RunnableToolLike
   )[];
+}
+
+type ModelProviderConfig = {
+  package: string;
+  className: string;
+  hasCircularDependency?: boolean;
+  transformParams?: (
+    params: Record<string, unknown>
+  ) => Record<string, unknown>;
+};
+
+const NEARAI_BASE_URL = "https://cloud-api.near.ai/v1";
+
+function getNearAIParams(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const configuration =
+    typeof params.configuration === "object" && params.configuration !== null
+      ? (params.configuration as Record<string, unknown>)
+      : {};
+  const configApiKey = configuration.apiKey;
+  const apiKey =
+    params.apiKey ??
+    (typeof configApiKey === "string" || typeof configApiKey === "function"
+      ? configApiKey
+      : undefined) ??
+    getEnvironmentVariable("NEARAI_API_KEY");
+
+  if (!apiKey) {
+    throw new Error(
+      'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
+    );
+  }
+
+  return {
+    ...params,
+    apiKey,
+    streamUsage: params.streamUsage ?? false,
+    configuration: {
+      baseURL: NEARAI_BASE_URL,
+      ...configuration,
+      apiKey,
+    },
+  };
 }
 
 // Configuration map for model providers
@@ -112,6 +157,11 @@ export const MODEL_PROVIDER_CONFIG = {
     package: "@langchain/deepseek",
     className: "ChatDeepSeek",
   },
+  nearai: {
+    package: "@langchain/openai",
+    className: "ChatOpenAICompletions",
+    transformParams: getNearAIParams,
+  },
   xai: {
     package: "@langchain/xai",
     className: "ChatXAI",
@@ -139,11 +189,6 @@ const SUPPORTED_PROVIDERS = Object.keys(
   MODEL_PROVIDER_CONFIG
 ) as (keyof typeof MODEL_PROVIDER_CONFIG)[];
 export type ChatModelProvider = keyof typeof MODEL_PROVIDER_CONFIG;
-type ModelProviderConfig = {
-  package: string;
-  className: string;
-  hasCircularDependency?: boolean;
-};
 
 /**
  * Helper function to get a chat model class by its class name or model provider.
@@ -228,12 +273,15 @@ async function _initChatModelHelper(
   }
 
   const { modelProvider: _unused, ...passedParams } = params;
+  const providerParams = config.transformParams
+    ? config.transformParams(passedParams)
+    : passedParams;
   // Pass modelProviderCopy to use direct lookup and avoid className collision
   const ProviderClass = await getChatModelByClassName(
     config.className,
     modelProviderCopy
   );
-  return new ProviderClass({ model, ...passedParams });
+  return new ProviderClass({ model, ...providerParams });
 }
 
 /**
@@ -846,6 +894,7 @@ export async function initChatModel<
  *   - perplexity (@langchain/perplexity)
  *   - cerebras (@langchain/cerebras)
  *   - deepseek (@langchain/deepseek)
+ *   - nearai (@langchain/openai)
  *   - xai (@langchain/xai)
  * @param {string[] | "any"} [fields.configurableFields] - Which model parameters are configurable:
  *   - undefined: No configurable fields.

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -81,14 +81,15 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
+  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
 
   return {
     ...params,
     apiKey,
     streamUsage: params.streamUsage ?? false,
     configuration: {
+      ...safeConfiguration,
       baseURL: NEARAI_BASE_URL,
-      ...configuration,
       apiKey,
     },
   };

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -82,14 +82,15 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
+  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
 
   return {
     ...params,
     apiKey,
     streamUsage: params.streamUsage ?? false,
     configuration: {
+      ...safeConfiguration,
       baseURL: NEARAI_BASE_URL,
-      ...configuration,
       apiKey,
     },
   };

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -81,7 +81,16 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
-  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
+  // Strip any caller-supplied endpoint/transport keys so the pinned NEAR AI
+  // endpoint cannot be overridden (e.g. via `configurableFields: "any"`).
+  const {
+    baseURL: _baseURL,
+    basePath: _basePath,
+    fetch: _fetch,
+    fetchOptions: _fetchOptions,
+    httpAgent: _httpAgent,
+    ...safeConfiguration
+  } = configuration;
 
   return {
     ...params,

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -33,6 +33,7 @@ import { type StructuredToolInterface } from "@langchain/core/tools";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatResult } from "@langchain/core/outputs";
 import { ModelProfile } from "@langchain/core/language_models/profile";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 // TODO: remove once `EventStreamCallbackHandlerInput` is exposed in core
 interface EventStreamCallbackHandlerInput extends Omit<
@@ -47,6 +48,50 @@ export interface ConfigurableChatModelCallOptions extends BaseChatModelCallOptio
     | ToolDefinition
     | RunnableToolLike
   )[];
+}
+
+type ModelProviderConfig = {
+  package: string;
+  className: string;
+  hasCircularDependency?: boolean;
+  transformParams?: (
+    params: Record<string, unknown>
+  ) => Record<string, unknown>;
+};
+
+const NEARAI_BASE_URL = "https://cloud-api.near.ai/v1";
+
+function getNearAIParams(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const configuration =
+    typeof params.configuration === "object" && params.configuration !== null
+      ? (params.configuration as Record<string, unknown>)
+      : {};
+  const configApiKey = configuration.apiKey;
+  const apiKey =
+    params.apiKey ??
+    (typeof configApiKey === "string" || typeof configApiKey === "function"
+      ? configApiKey
+      : undefined) ??
+    getEnvironmentVariable("NEARAI_API_KEY");
+
+  if (!apiKey) {
+    throw new Error(
+      'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
+    );
+  }
+
+  return {
+    ...params,
+    apiKey,
+    streamUsage: params.streamUsage ?? false,
+    configuration: {
+      baseURL: NEARAI_BASE_URL,
+      ...configuration,
+      apiKey,
+    },
+  };
 }
 
 // Configuration map for model providers
@@ -111,6 +156,11 @@ export const MODEL_PROVIDER_CONFIG = {
     package: "@langchain/deepseek",
     className: "ChatDeepSeek",
   },
+  nearai: {
+    package: "@langchain/openai",
+    className: "ChatOpenAICompletions",
+    transformParams: getNearAIParams,
+  },
   xai: {
     package: "@langchain/xai",
     className: "ChatXAI",
@@ -138,11 +188,6 @@ const SUPPORTED_PROVIDERS = Object.keys(
   MODEL_PROVIDER_CONFIG
 ) as (keyof typeof MODEL_PROVIDER_CONFIG)[];
 export type ChatModelProvider = keyof typeof MODEL_PROVIDER_CONFIG;
-type ModelProviderConfig = {
-  package: string;
-  className: string;
-  hasCircularDependency?: boolean;
-};
 
 /**
  * Helper function to get a chat model class by its class name or model provider.
@@ -227,12 +272,15 @@ async function _initChatModelHelper(
   }
 
   const { modelProvider: _unused, ...passedParams } = params;
+  const providerParams = config.transformParams
+    ? config.transformParams(passedParams)
+    : passedParams;
   // Pass modelProviderCopy to use direct lookup and avoid className collision
   const ProviderClass = await getChatModelByClassName(
     config.className,
     modelProviderCopy
   );
-  return new ProviderClass({ model, ...passedParams });
+  return new ProviderClass({ model, ...providerParams });
 }
 
 /**
@@ -754,6 +802,7 @@ export async function initChatModel<
  *   - perplexity (@langchain/perplexity)
  *   - cerebras (@langchain/cerebras)
  *   - deepseek (@langchain/deepseek)
+ *   - nearai (@langchain/openai)
  *   - xai (@langchain/xai)
  * @param {string[] | "any"} [fields.configurableFields] - Which model parameters are configurable:
  *   - undefined: No configurable fields.

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -82,7 +82,16 @@ function getNearAIParams(
       'NEAR AI API key not found. Please set the NEARAI_API_KEY environment variable or pass the key into "apiKey" field.'
     );
   }
-  const { baseURL: _discardedBaseURL, ...safeConfiguration } = configuration;
+  // Strip any caller-supplied endpoint/transport keys so the pinned NEAR AI
+  // endpoint cannot be overridden (e.g. via `configurableFields: "any"`).
+  const {
+    baseURL: _baseURL,
+    basePath: _basePath,
+    fetch: _fetch,
+    fetchOptions: _fetchOptions,
+    httpAgent: _httpAgent,
+    ...safeConfiguration
+  } = configuration;
 
   return {
     ...params,


### PR DESCRIPTION
## Summary

Adds `nearai` as a supported `initChatModel` provider in `langchain` and `@langchain/classic`. It reuses `@langchain/openai`'s chat completions client with the NEAR AI Cloud OpenAI-compatible endpoint and `NEARAI_API_KEY`.

## Notes

- `nearai:<model>` or `{ modelProvider: "nearai" }` resolves to `https://cloud-api.near.ai/v1`.
- Streamed usage collection defaults off for this OpenAI-compatible gateway.
- Added focused coverage for endpoint/API-key wiring and a changeset for the package updates.

## Testing

- `pnpm --filter @langchain/core build`
- `pnpm --filter @langchain/openai build`
- `pnpm --filter langchain exec vitest run src/chat_models/tests/universal.test.ts --typecheck.enabled=false`
- `pnpm --filter langchain build`
- `pnpm --filter @langchain/classic build`
- `pnpm format:check`
- `pnpm lint`

I did not run a live NEAR AI request locally because no `NEARAI_API_KEY` was available.