### PR TITLE
feat(mongodb): add $rerank support to MongoDBAtlasVectorSearch

### DIFF
--- a/.changeset/mongodb-rerank-support.md
+++ b/.changeset/mongodb-rerank-support.md
@@ -1,0 +1,7 @@
+---
+"@langchain/mongodb": minor
+---
+
+feat(mongodb): add `$rerank` aggregation pipeline support to `MongoDBAtlasVectorSearch`
+
+Adds an optional `rerankOptions` constructor parameter that appends a `$rerank` stage after `$vectorSearch` to reorder results by semantic relevance using a MongoDB Atlas reranking model. The rerank score is returned as the numeric score in the `[Document, number]` tuple and copied to `document.metadata.relevanceScore`.

--- a/.changeset/mongodb-rerank-support.md
+++ b/.changeset/mongodb-rerank-support.md
@@ -1,7 +1,0 @@
----
-"@langchain/mongodb": minor
----
-
-feat(mongodb): add `$rerank` aggregation pipeline support to `MongoDBAtlasVectorSearch`
-
-Adds an optional `rerankOptions` constructor parameter that appends a `$rerank` stage after `$vectorSearch` to reorder results by semantic relevance using a MongoDB Atlas reranking model. The rerank score is returned as the numeric score in the `[Document, number]` tuple and copied to `document.metadata.relevanceScore`.

--- a/libs/providers/langchain-mongodb/CHANGELOG.md
+++ b/libs/providers/langchain-mongodb/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @langchain/mongodb
 
-## 1.3.0
-
-### Minor Changes
-
-- feat(mongodb): add `$rerank` aggregation pipeline support to `MongoDBAtlasVectorSearch`
-
-  Pass `rerankOptions: { model: string, path?: string | string[] }` to the constructor to enable MongoDB Atlas reranking. When set, `similaritySearchWithScore` appends a `$rerank` stage after `$vectorSearch`, returning results ordered by semantic relevance score. The rerank score is exposed as the numeric score in the returned tuple and as `metadata.relevanceScore` on each document. Works with both manual embeddings and auto-embedding mode.
-
 
 ### Patch Changes
 

--- a/libs/providers/langchain-mongodb/CHANGELOG.md
+++ b/libs/providers/langchain-mongodb/CHANGELOG.md
@@ -1,6 +1,5 @@
 # @langchain/mongodb
 
-
 ### Patch Changes
 
 - [#10872](https://github.com/langchain-ai/langchainjs/pull/10872) [`a640079`](https://github.com/langchain-ai/langchainjs/commit/a64007997a4940f51bba3c1c83dae89d1ccfb692) Thanks [@hntrl](https://github.com/hntrl)! - chore(deps): remove redundant @types/uuid declarations

--- a/libs/providers/langchain-mongodb/CHANGELOG.md
+++ b/libs/providers/langchain-mongodb/CHANGELOG.md
@@ -1,6 +1,13 @@
 # @langchain/mongodb
 
-## 1.2.1
+## 1.3.0
+
+### Minor Changes
+
+- feat(mongodb): add `$rerank` aggregation pipeline support to `MongoDBAtlasVectorSearch`
+
+  Pass `rerankOptions: { model: string, path?: string | string[] }` to the constructor to enable MongoDB Atlas reranking. When set, `similaritySearchWithScore` appends a `$rerank` stage after `$vectorSearch`, returning results ordered by semantic relevance score. The rerank score is exposed as the numeric score in the returned tuple and as `metadata.relevanceScore` on each document. Works with both manual embeddings and auto-embedding mode.
+
 
 ### Patch Changes
 

--- a/libs/providers/langchain-mongodb/src/tests/cache.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/cache.int.test.ts
@@ -4,6 +4,21 @@ import { Generation } from "@langchain/core/outputs";
 import { MongoDBCache, MongoDBAtlasSemanticCache } from "../cache.js";
 import { uri, waitForIndexToBeQueryable } from "./utils.js";
 
+async function waitForCacheIndexed(
+  cache: MongoDBAtlasSemanticCache,
+  prompt: string,
+  llmKey: string,
+  maxWaitMs = 30_000
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    const result = await cache.lookup(prompt, llmKey);
+    if (result !== null) return;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`Semantic cache entry not indexed after ${maxWaitMs}ms`);
+}
+
 class TestEmbeddings {
   async embedQuery(text: string): Promise<number[]> {
     if (text === "What is the capital of France?") {
@@ -84,7 +99,6 @@ test("MongoDBAtlasSemanticCache: caches and retrieves a prompt", async () => {
   const embeddings = new TestEmbeddings();
   const cache = new MongoDBAtlasSemanticCache(semanticCollection, embeddings, {
     scoreThreshold: 0.99,
-    waitUntilReady: 1,
   });
 
   const prompt = "What is the capital of France?";
@@ -92,7 +106,7 @@ test("MongoDBAtlasSemanticCache: caches and retrieves a prompt", async () => {
   const gen = [{ text: "Paris" }];
 
   await cache.update(prompt, llmKey, gen);
-  await waitForIndexToBeQueryable(semanticCollection, "default");
+  await waitForCacheIndexed(cache, prompt, llmKey);
   const result = await cache.lookup(prompt, llmKey);
   expect(result?.[0].text).toBe("Paris");
 });
@@ -101,7 +115,6 @@ test("MongoDBAtlasSemanticCache: similar prompts share cache", async () => {
   const embeddings = new TestEmbeddings();
   const cache = new MongoDBAtlasSemanticCache(semanticCollection, embeddings, {
     scoreThreshold: 0.99,
-    waitUntilReady: 1,
   });
 
   const prompt1 = "What is the capital of France?";
@@ -110,7 +123,7 @@ test("MongoDBAtlasSemanticCache: similar prompts share cache", async () => {
   const gen = [{ text: "Paris" }];
 
   await cache.update(prompt1, llmKey, gen);
-  await waitForIndexToBeQueryable(semanticCollection, "default");
+  await waitForCacheIndexed(cache, prompt1, llmKey);
   const result = await cache.lookup(prompt2, llmKey);
   expect(result?.[0].text).toBe("Paris");
 });
@@ -119,7 +132,6 @@ test("MongoDBAtlasSemanticCache: dissimilar prompts do not share cache", async (
   const embeddings = new TestEmbeddings();
   const cache = new MongoDBAtlasSemanticCache(semanticCollection, embeddings, {
     scoreThreshold: 0.99,
-    waitUntilReady: 1,
   });
 
   const prompt1 = "What is the capital of France?";
@@ -130,7 +142,7 @@ test("MongoDBAtlasSemanticCache: dissimilar prompts do not share cache", async (
 
   await cache.update(prompt1, llmKey, gen1);
   await cache.update(prompt3, llmKey, gen3);
-  await waitForIndexToBeQueryable(semanticCollection, "default");
+  await waitForCacheIndexed(cache, prompt3, llmKey);
   const result = await cache.lookup(prompt3, llmKey);
   expect(result?.[0].text).toBe("Mount Everest");
 });

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -72,7 +72,7 @@ export default async function setup() {
   let container: StartedTestContainer;
   try {
     container = await new GenericContainer("mongodb/mongodb-atlas-local:preview")
-      .withExposedPorts({ host: 27017, container: 27017 })
+      .withExposedPorts(27017)
       .withEnvironment({
         // oxlint-disable-next-line no-process-env
         VOYAGE_API_KEY: process.env.VOYAGE_API_KEY ?? "",
@@ -107,4 +107,5 @@ export default async function setup() {
   // context between setup and teardown modules.
   // See https://jestjs.io/docs/configuration#globalsetup-string.
   globalThis.__container = container;
+  globalThis.__mongoPort = container.getMappedPort(27017);
 }

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -119,9 +119,10 @@ export default async function setup() {
     }
     throw error;
   }
-  // @ts-expect-error Assigning properties on the globalThis object is Jest's recommended practice of sharing
-  // context between setup and teardown modules.
-  // See https://jestjs.io/docs/configuration#globalsetup-string.
+  // Store container for teardown. Set MONGODB_URI so test workers inherit
+  // the correct port — globalThis is not shared across Vitest worker threads.
+  // @ts-expect-error globalThis.__container shared between setup and teardown
   globalThis.__container = container;
-  globalThis.__mongoPort = container.getMappedPort(27017);
+  // oxlint-disable-next-line no-process-env
+  process.env.MONGODB_URI = `mongodb://localhost:${container.getMappedPort(27017)}?directConnection=true`;
 }

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -74,8 +74,9 @@ export default async function setup() {
     container = await new GenericContainer("mongodb/mongodb-atlas-local:preview")
       .withExposedPorts({ host: 27017, container: 27017 })
       .withEnvironment({
-        // oxlint-disable-next-line no-process-env
-        VOYAGEAI_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
+        // The :preview image reads VOYAGE_API_KEY internally. Accept either
+        // name from the host so both CI (VOYAGEAI_API_KEY) and local (.env
+        // with VOYAGE_API_KEY) work without changes.
         // oxlint-disable-next-line no-process-env
         VOYAGE_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
         EMBEDDING_PROVIDER_ENDPOINT:

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -71,14 +71,17 @@ export default async function setup() {
 
   let container: Awaited<ReturnType<GenericContainer["start"]>>;
   try {
-    container = await new GenericContainer("mongodb/mongodb-atlas-local:preview")
+    container = await new GenericContainer(
+      "mongodb/mongodb-atlas-local:preview"
+    )
       .withExposedPorts({ host: 27017, container: 27017 })
       .withEnvironment({
         // The :preview image reads VOYAGE_API_KEY internally. Accept either
         // name from the host so both CI (VOYAGEAI_API_KEY) and local (.env
         // with VOYAGE_API_KEY) work without changes.
         // oxlint-disable-next-line no-process-env
-        VOYAGE_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
+        VOYAGE_API_KEY:
+          process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
         EMBEDDING_PROVIDER_ENDPOINT:
           // oxlint-disable-next-line no-process-env
           process.env.EMBEDDING_PROVIDER_ENDPOINT ??

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -75,7 +75,7 @@ export default async function setup() {
       .withExposedPorts(27017)
       .withEnvironment({
         // oxlint-disable-next-line no-process-env
-        VOYAGE_API_KEY: process.env.VOYAGE_API_KEY ?? "",
+        VOYAGEAI_API_KEY: process.env.VOYAGEAI_API_KEY ?? "",
         EMBEDDING_PROVIDER_ENDPOINT:
           // oxlint-disable-next-line no-process-env
           process.env.EMBEDDING_PROVIDER_ENDPOINT ??

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -17,6 +17,13 @@ import { isUsingLocalAtlas, uri } from "./utils.ts";
  * a search index is successfully created, indicating that the mongot process is up and running.
  */
 class ReadyWhenMongotEstablished extends StartupCheckStrategy {
+  private port = 27017;
+
+  override async waitUntilReady(container: StartedTestContainer): Promise<void> {
+    this.port = container.getMappedPort(27017);
+    return super.waitUntilReady(container);
+  }
+
   public async checkStartupState(): Promise<StartupStatus> {
     try {
       await this.tryCreateSearchIndex();
@@ -33,7 +40,10 @@ class ReadyWhenMongotEstablished extends StartupCheckStrategy {
   private async tryCreateSearchIndex() {
     let client;
     try {
-      client = new MongoClient(uri(), { serverSelectionTimeoutMS: 1_000 });
+      client = new MongoClient(
+        `mongodb://localhost:${this.port}?directConnection=true`,
+        { serverSelectionTimeoutMS: 1_000 }
+      );
       await client.connect();
 
       const namespace = "vectorstore.test";

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -71,10 +71,19 @@ export default async function setup() {
 
   let container: StartedTestContainer;
   try {
-    container = await new GenericContainer("mongodb/mongodb-atlas-local")
+    container = await new GenericContainer("mongodb/mongodb-atlas-local:preview")
       .withExposedPorts({ host: 27017, container: 27017 })
+      .withEnvironment({
+        // oxlint-disable-next-line no-process-env
+        VOYAGE_API_KEY: process.env.VOYAGE_API_KEY ?? "",
+        EMBEDDING_PROVIDER_ENDPOINT:
+          // oxlint-disable-next-line no-process-env
+          process.env.EMBEDDING_PROVIDER_ENDPOINT ??
+          "https://api.voyageai.com/v1/embeddings",
+        MONGODB_ATLAS_LOCAL_PREVIEW: "true",
+      })
       .withWaitStrategy(new ReadyWhenMongotEstablished())
-      .withStartupTimeout(30_000)
+      .withStartupTimeout(120_000)
       .start();
   } catch (error: Error | unknown) {
     const hasMessage = (err: unknown): err is { message: string } =>

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -19,9 +19,12 @@ import { isUsingLocalAtlas, uri } from "./utils.ts";
 class ReadyWhenMongotEstablished extends StartupCheckStrategy {
   private port = 27017;
 
-  override async waitUntilReady(container: StartedTestContainer): Promise<void> {
-    this.port = container.getMappedPort(27017);
-    return super.waitUntilReady(container);
+  // boundPorts is the second argument testcontainers passes internally —
+  // it maps container ports to host ports before start() returns.
+  override async waitUntilReady(container: unknown, boundPorts?: { getBinding: (port: number) => number }): Promise<void> {
+    if (boundPorts) this.port = boundPorts.getBinding(27017);
+    // @ts-expect-error super.waitUntilReady signature varies by testcontainers version
+    return super.waitUntilReady(container, boundPorts);
   }
 
   public async checkStartupState(): Promise<StartupStatus> {

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -67,7 +67,8 @@ class ReadyWhenMongotEstablished extends StartupCheckStrategy {
 }
 
 export default async function setup() {
-  if (!isUsingLocalAtlas()) return;
+  // oxlint-disable-next-line no-process-env
+  if (process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI) return;
 
   let container: StartedTestContainer;
   try {
@@ -75,7 +76,9 @@ export default async function setup() {
       .withExposedPorts(27017)
       .withEnvironment({
         // oxlint-disable-next-line no-process-env
-        VOYAGEAI_API_KEY: process.env.VOYAGEAI_API_KEY ?? "",
+        VOYAGEAI_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
+        // oxlint-disable-next-line no-process-env
+        VOYAGE_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
         EMBEDDING_PROVIDER_ENDPOINT:
           // oxlint-disable-next-line no-process-env
           process.env.EMBEDDING_PROVIDER_ENDPOINT ??

--- a/libs/providers/langchain-mongodb/src/tests/setup.ts
+++ b/libs/providers/langchain-mongodb/src/tests/setup.ts
@@ -1,6 +1,5 @@
 import {
   GenericContainer,
-  StartedTestContainer,
   StartupCheckStrategy,
   StartupStatus,
 } from "testcontainers";
@@ -8,7 +7,7 @@ import { MongoClient } from "mongodb";
 
 // @ts-expect-error In order for jest to succesfully load this file, we need the TS extension
 // instead of the JS extension.  This errors because `allowImportingTsExtensions` is
-// not set but this is okay because this file isn't not technically a part of the project
+// not set but this is okay because this file isn't technically a part of the project
 // (not imported by any code in the project).
 import { isUsingLocalAtlas, uri } from "./utils.ts";
 
@@ -17,16 +16,6 @@ import { isUsingLocalAtlas, uri } from "./utils.ts";
  * a search index is successfully created, indicating that the mongot process is up and running.
  */
 class ReadyWhenMongotEstablished extends StartupCheckStrategy {
-  private port = 27017;
-
-  // boundPorts is the second argument testcontainers passes internally —
-  // it maps container ports to host ports before start() returns.
-  override async waitUntilReady(container: unknown, boundPorts?: { getBinding: (port: number) => number }): Promise<void> {
-    if (boundPorts) this.port = boundPorts.getBinding(27017);
-    // @ts-expect-error super.waitUntilReady signature varies by testcontainers version
-    return super.waitUntilReady(container, boundPorts);
-  }
-
   public async checkStartupState(): Promise<StartupStatus> {
     try {
       await this.tryCreateSearchIndex();
@@ -43,10 +32,7 @@ class ReadyWhenMongotEstablished extends StartupCheckStrategy {
   private async tryCreateSearchIndex() {
     let client;
     try {
-      client = new MongoClient(
-        `mongodb://localhost:${this.port}?directConnection=true`,
-        { serverSelectionTimeoutMS: 1_000 }
-      );
+      client = new MongoClient(uri(), { serverSelectionTimeoutMS: 1_000 });
       await client.connect();
 
       const namespace = "vectorstore.test";
@@ -83,10 +69,10 @@ export default async function setup() {
   // oxlint-disable-next-line no-process-env
   if (process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI) return;
 
-  let container: StartedTestContainer;
+  let container: Awaited<ReturnType<GenericContainer["start"]>>;
   try {
     container = await new GenericContainer("mongodb/mongodb-atlas-local:preview")
-      .withExposedPorts(27017)
+      .withExposedPorts({ host: 27017, container: 27017 })
       .withEnvironment({
         // oxlint-disable-next-line no-process-env
         VOYAGEAI_API_KEY: process.env.VOYAGEAI_API_KEY ?? process.env.VOYAGE_API_KEY ?? "",
@@ -119,10 +105,8 @@ export default async function setup() {
     }
     throw error;
   }
-  // Store container for teardown. Set MONGODB_URI so test workers inherit
-  // the correct port — globalThis is not shared across Vitest worker threads.
-  // @ts-expect-error globalThis.__container shared between setup and teardown
+  // @ts-expect-error Assigning properties on the globalThis object is Jest's recommended practice of sharing
+  // context between setup and teardown modules.
+  // See https://jestjs.io/docs/configuration#globalsetup-string.
   globalThis.__container = container;
-  // oxlint-disable-next-line no-process-env
-  process.env.MONGODB_URI = `mongodb://localhost:${container.getMappedPort(27017)}?directConnection=true`;
 }

--- a/libs/providers/langchain-mongodb/src/tests/teardown.ts
+++ b/libs/providers/langchain-mongodb/src/tests/teardown.ts
@@ -20,6 +20,9 @@ export default async function teardown() {
     }
     await client.close();
   }
+  // Only stop the container if testcontainers started it (no URI was pre-provided)
+  // oxlint-disable-next-line no-process-env
+  if (process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI) return;
   // @ts-expect-error No __container on globalThis
   // however, this is the recommended way to share context between setup and teardown modules
   // https://jestjs.io/docs/configuration#globalsetup-string

--- a/libs/providers/langchain-mongodb/src/tests/teardown.ts
+++ b/libs/providers/langchain-mongodb/src/tests/teardown.ts
@@ -20,9 +20,6 @@ export default async function teardown() {
     }
     await client.close();
   }
-  // Only stop the container if testcontainers started it (no URI was pre-provided)
-  // oxlint-disable-next-line no-process-env
-  if (process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI) return;
   // @ts-expect-error No __container on globalThis
   // however, this is the recommended way to share context between setup and teardown modules
   // https://jestjs.io/docs/configuration#globalsetup-string

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,7 +5,8 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  return !process.env.MONGODB_ATLAS_URI;
+  const atlasUri = process.env.MONGODB_ATLAS_URI || process.env.MONGODB_URI || "";
+  return !atlasUri.startsWith("mongodb+srv://");
 }
 export function uri() {
   // oxlint-disable-next-line no-process-env

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,7 +5,7 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  return !process.env.MONGODB_ATLAS_URI;
+  return !process.env.MONGODB_ATLAS_URI && !process.env.MONGODB_URI;
 }
 export function uri() {
   return (

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,7 +5,7 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  return !process.env.MONGODB_ATLAS_URI && !process.env.MONGODB_URI;
+  return !process.env.MONGODB_ATLAS_URI;
 }
 export function uri() {
   return (

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,8 +5,7 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  const uri = process.env.MONGODB_ATLAS_URI || process.env.MONGODB_URI || "";
-  return !uri.startsWith("mongodb+srv://");
+  return !process.env.MONGODB_ATLAS_URI && !process.env.MONGODB_URI;
 }
 export function uri() {
   return (

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,10 +5,12 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  const atlasUri = process.env.MONGODB_ATLAS_URI || process.env.MONGODB_URI || "";
-  return !atlasUri.startsWith("mongodb+srv://");
+  const mongoUri = process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI || "";
+  return !mongoUri.startsWith("mongodb+srv://");
 }
 export function uri() {
+  // oxlint-disable-next-line no-process-env
+  if (process.env.MONGODB_URI) return process.env.MONGODB_URI;
   // oxlint-disable-next-line no-process-env
   if (process.env.MONGODB_ATLAS_URI) return process.env.MONGODB_ATLAS_URI;
   // @ts-expect-error __mongoPort is set by the global test setup

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,7 +5,8 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  return !process.env.MONGODB_ATLAS_URI && !process.env.MONGODB_URI;
+  const uri = process.env.MONGODB_ATLAS_URI || process.env.MONGODB_URI || "";
+  return !uri.startsWith("mongodb+srv://");
 }
 export function uri() {
   return (

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -5,7 +5,8 @@ import type { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 
 export function isUsingLocalAtlas() {
   // oxlint-disable-next-line no-process-env
-  const mongoUri = process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI || "";
+  const mongoUri =
+    process.env.MONGODB_URI || process.env.MONGODB_ATLAS_URI || "";
   return !mongoUri.startsWith("mongodb+srv://");
 }
 export function uri() {

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -8,11 +8,11 @@ export function isUsingLocalAtlas() {
   return !process.env.MONGODB_ATLAS_URI;
 }
 export function uri() {
-  return (
-    // oxlint-disable-next-line no-process-env
-    process.env.MONGODB_ATLAS_URI ||
-    "mongodb://localhost:27017?directConnection=true"
-  );
+  // oxlint-disable-next-line no-process-env
+  if (process.env.MONGODB_ATLAS_URI) return process.env.MONGODB_ATLAS_URI;
+  // @ts-expect-error __mongoPort is set by the global test setup
+  const port: number = globalThis.__mongoPort ?? 27017;
+  return `mongodb://localhost:${port}?directConnection=true`;
 }
 
 /**

--- a/libs/providers/langchain-mongodb/src/tests/utils.ts
+++ b/libs/providers/langchain-mongodb/src/tests/utils.ts
@@ -13,9 +13,7 @@ export function uri() {
   if (process.env.MONGODB_URI) return process.env.MONGODB_URI;
   // oxlint-disable-next-line no-process-env
   if (process.env.MONGODB_ATLAS_URI) return process.env.MONGODB_ATLAS_URI;
-  // @ts-expect-error __mongoPort is set by the global test setup
-  const port: number = globalThis.__mongoPort ?? 27017;
-  return `mongodb://localhost:${port}?directConnection=true`;
+  return "mongodb://localhost:27017?directConnection=true";
 }
 
 /**

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores.int.test.ts
@@ -18,24 +18,6 @@ import { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { MongoDBAtlasVectorSearch } from "../vectorstores.js";
 import { isUsingLocalAtlas, uri, waitForIndexToBeQueryable } from "./utils.js";
 
-/**
- * The following json can be used to create an index in atlas for Cohere embeddings.
- * Use "langchain.test" for the namespace and "default" for the index name.
-
-{
-  "mappings": {
-    "fields": {
-      "e": { "type": "number" },
-      "embedding": {
-        "dimensions": 1536,
-        "similarity": "euclidean",
-        "type": "knnVector"
-      }
-    }
-  }
-}
-*/
-
 let client: MongoClient;
 let collection: Collection;
 beforeAll(async () => {

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_auto_embed.int.test.ts
@@ -19,24 +19,6 @@ import {
   waitForDocumentsIndexed,
 } from "./utils.js";
 
-/**
- * The following json can be used to create an index in atlas for Cohere embeddings.
- * Use "langchain.test" for the namespace and "default" for the index name.
-
-{
-  "mappings": {
-    "fields": {
-      "e": { "type": "number" },
-      "embedding": {
-        "dimensions": 1536,
-        "similarity": "euclidean",
-        "type": "knnVector"
-      }
-    }
-  }
-}
-*/
-
 const tempClient = new MongoClient(uri());
 await tempClient.connect();
 const admin = tempClient.db().admin();

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
@@ -21,7 +21,8 @@ const skipRerankTests = isUsingLocalAtlas();
 
 // oxlint-disable-next-line no-process-env
 const skipAutoEmbedRerankTests =
-  isUsingLocalAtlas() || (!process.env.VOYAGEAI_API_KEY && !process.env.VOYAGE_API_KEY);
+  isUsingLocalAtlas() ||
+  (!process.env.VOYAGEAI_API_KEY && !process.env.VOYAGE_API_KEY);
 
 function getEmbeddings() {
   if (process.env.AZURE_OPENAI_API_KEY) {
@@ -45,7 +46,10 @@ class PatchedVectorStore extends MongoDBAtlasVectorSearch {
     const ids = await super.addDocuments(documents, options);
     const queryEmbedding = await this.embeddings.embedQuery("sandwich");
     for (;;) {
-      const results = await this.similaritySearchVectorWithScore(queryEmbedding, documents.length);
+      const results = await this.similaritySearchVectorWithScore(
+        queryEmbedding,
+        documents.length
+      );
       if (results.length === documents.length) return ids;
       await setTimeout(1000);
     }
@@ -188,8 +192,7 @@ describe.skipIf(skipAutoEmbedRerankTests)(
       client = new MongoClient(uri(), { monitorCommands: true });
       await client.connect();
 
-      const namespace =
-        "langchain_test_db.langchain_auto_embed_rerank_test";
+      const namespace = "langchain_test_db.langchain_auto_embed_rerank_test";
       const [dbName, collectionName] = namespace.split(".");
       const db = client.db(dbName);
 

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
@@ -21,7 +21,7 @@ const skipRerankTests = isUsingLocalAtlas();
 
 // oxlint-disable-next-line no-process-env
 const skipAutoEmbedRerankTests =
-  isUsingLocalAtlas() || !process.env.VOYAGE_API_KEY;
+  isUsingLocalAtlas() || !process.env.VOYAGEAI_API_KEY;
 
 function getEmbeddings() {
   if (process.env.AZURE_OPENAI_API_KEY) {

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
@@ -21,7 +21,7 @@ const skipRerankTests = isUsingLocalAtlas();
 
 // oxlint-disable-next-line no-process-env
 const skipAutoEmbedRerankTests =
-  isUsingLocalAtlas() || !process.env.VOYAGEAI_API_KEY;
+  isUsingLocalAtlas() || (!process.env.VOYAGEAI_API_KEY && !process.env.VOYAGE_API_KEY);
 
 function getEmbeddings() {
   if (process.env.AZURE_OPENAI_API_KEY) {

--- a/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/vectorstores_rerank.int.test.ts
@@ -1,0 +1,262 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { Collection, MongoClient } from "mongodb";
+import { setTimeout } from "timers/promises";
+import { OpenAIEmbeddings, AzureOpenAIEmbeddings } from "@langchain/openai";
+import { Document } from "@langchain/core/documents";
+
+import { MongoDBAtlasVectorSearch } from "../vectorstores.js";
+import { isUsingLocalAtlas, uri, waitForIndexToBeQueryable } from "./utils.js";
+
+const RERANK_MODEL = "rerank-2.5";
+
+// $rerank requires a real Atlas cluster — skip when running against local Docker
+const skipRerankTests = isUsingLocalAtlas();
+
+// oxlint-disable-next-line no-process-env
+const skipAutoEmbedRerankTests =
+  isUsingLocalAtlas() || !process.env.VOYAGE_API_KEY;
+
+function getEmbeddings() {
+  if (process.env.AZURE_OPENAI_API_KEY) {
+    return new AzureOpenAIEmbeddings({
+      model: "text-embedding-3-small",
+      azureOpenAIApiDeploymentName: "openai/deployments/text-embedding-3-small",
+    });
+  }
+  return new OpenAIEmbeddings();
+}
+
+/**
+ * Patches addDocuments to poll until all inserted docs are returned by
+ * similaritySearch, so tests don't race the search index.
+ */
+class PatchedVectorStore extends MongoDBAtlasVectorSearch {
+  async addDocuments(
+    documents: Document[],
+    options?: { ids?: string[] }
+  ): Promise<string[]> {
+    const ids = await super.addDocuments(documents, options);
+    const queryEmbedding = await this.embeddings.embedQuery("sandwich");
+    for (;;) {
+      const results = await this.similaritySearchVectorWithScore(queryEmbedding, documents.length);
+      if (results.length === documents.length) return ids;
+      await setTimeout(1000);
+    }
+  }
+}
+
+describe.skipIf(skipRerankTests)("Rerank Tests (manual embeddings)", () => {
+  let client: MongoClient;
+  let collection: Collection;
+
+  beforeAll(async () => {
+    client = new MongoClient(uri(), { monitorCommands: true });
+    await client.connect();
+
+    const namespace = "langchain_test_db.langchain_rerank_test";
+    const [dbName, collectionName] = namespace.split(".");
+    const db = client.db(dbName);
+
+    try {
+      await db.dropCollection(collectionName);
+    } catch {
+      // collection may not exist yet
+    }
+
+    collection = await db.createCollection(collectionName);
+
+    await collection.createSearchIndex({
+      name: "default",
+      type: "vectorSearch",
+      definition: {
+        fields: [
+          {
+            type: "vector",
+            path: "embedding",
+            numDimensions: 1536,
+            similarity: "cosine",
+          },
+        ],
+      },
+    });
+
+    await waitForIndexToBeQueryable(collection, "default");
+  });
+
+  beforeEach(async () => {
+    await collection.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  test("similaritySearchWithScore returns rerankScore as a numeric score", async () => {
+    const vectorStore = new PatchedVectorStore(getEmbeddings(), {
+      collection,
+      rerankOptions: { model: RERANK_MODEL },
+    });
+
+    await vectorStore.addDocuments([
+      { pageContent: "Dogs are tough.", metadata: { a: 1 } },
+      { pageContent: "Cats have fluff.", metadata: { b: 1 } },
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+      { pageContent: "That fence is purple.", metadata: { d: 1 } },
+    ]);
+
+    const results = await vectorStore.similaritySearchWithScore("Sandwich", 2);
+
+    expect(results.length).toEqual(2);
+    expect(typeof results[0][1]).toBe("number");
+    expect(results[0][1]).toBeGreaterThan(0);
+  });
+
+  test("rerankScore is attached to document metadata as relevanceScore", async () => {
+    const vectorStore = new PatchedVectorStore(getEmbeddings(), {
+      collection,
+      rerankOptions: { model: RERANK_MODEL },
+    });
+
+    await vectorStore.addDocuments([
+      { pageContent: "Dogs are tough.", metadata: { a: 1 } },
+      { pageContent: "Cats have fluff.", metadata: { b: 1 } },
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+      { pageContent: "That fence is purple.", metadata: { d: 1 } },
+    ]);
+
+    const results = await vectorStore.similaritySearchWithScore("Sandwich", 2);
+
+    for (const [doc, score] of results) {
+      expect(doc.metadata.relevanceScore).toBeDefined();
+      expect(doc.metadata.relevanceScore).toBe(score);
+    }
+  });
+
+  test("k limits the number of results returned", async () => {
+    const vectorStore = new PatchedVectorStore(getEmbeddings(), {
+      collection,
+      rerankOptions: { model: RERANK_MODEL },
+    });
+
+    await vectorStore.addDocuments([
+      { pageContent: "Dogs are tough.", metadata: { a: 1 } },
+      { pageContent: "Cats have fluff.", metadata: { b: 1 } },
+      { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+      { pageContent: "That fence is purple.", metadata: { d: 1 } },
+    ]);
+
+    const results = await vectorStore.similaritySearch("Sandwich", 1);
+
+    expect(results.length).toEqual(1);
+  });
+
+  test("reranking improves result ordering for an ambiguous query", async () => {
+    const vectorStore = new PatchedVectorStore(getEmbeddings(), {
+      collection,
+      rerankOptions: { model: RERANK_MODEL },
+    });
+
+    await vectorStore.addDocuments([
+      { pageContent: "Dogs are tough.", metadata: {} },
+      { pageContent: "Cats have fluff.", metadata: {} },
+      { pageContent: "What is a sandwich?", metadata: {} },
+      { pageContent: "That fence is purple.", metadata: {} },
+    ]);
+
+    const results = await vectorStore.similaritySearch("food between bread", 1);
+
+    expect(results[0].pageContent).toEqual("What is a sandwich?");
+  });
+});
+
+describe.skipIf(skipAutoEmbedRerankTests)(
+  "Rerank Tests (auto-embedding + rerank)",
+  () => {
+    const autoEmbedModel = "voyage-4";
+
+    let client: MongoClient;
+    let collection: Collection;
+
+    beforeAll(async () => {
+      client = new MongoClient(uri(), { monitorCommands: true });
+      await client.connect();
+
+      const namespace =
+        "langchain_test_db.langchain_auto_embed_rerank_test";
+      const [dbName, collectionName] = namespace.split(".");
+      const db = client.db(dbName);
+
+      try {
+        await db.dropCollection(collectionName);
+      } catch {
+        // collection may not exist yet
+      }
+
+      collection = await db.createCollection(collectionName);
+
+      await collection.createSearchIndex({
+        name: "default",
+        type: "vectorSearch",
+        definition: {
+          fields: [
+            {
+              type: "autoEmbed",
+              modality: "text",
+              path: "text",
+              model: autoEmbedModel,
+            },
+          ],
+        },
+      });
+
+      await waitForIndexToBeQueryable(collection, "default");
+    });
+
+    beforeEach(async () => {
+      await collection.deleteMany({});
+    });
+
+    afterAll(async () => {
+      await client.close();
+    });
+
+    test("auto-embedding with rerank returns rerankScore in metadata", async () => {
+      const vectorStore = new MongoDBAtlasVectorSearch({
+        collection,
+        rerankOptions: { model: RERANK_MODEL },
+      });
+
+      await vectorStore.addDocuments([
+        { pageContent: "Dogs are tough.", metadata: { a: 1 } },
+        { pageContent: "Cats have fluff.", metadata: { b: 1 } },
+        { pageContent: "What is a sandwich?", metadata: { c: 1 } },
+        { pageContent: "That fence is purple.", metadata: { d: 1 } },
+      ]);
+
+      // Poll until the auto-embed index picks up the new documents
+      for (;;) {
+        const probe = await vectorStore.similaritySearch("Sandwich", 4);
+        if (probe.length === 4) break;
+        await setTimeout(2000);
+      }
+
+      const results = await vectorStore.similaritySearchWithScore(
+        "Sandwich",
+        2
+      );
+
+      expect(results.length).toEqual(2);
+      for (const [doc, score] of results) {
+        expect(typeof score).toBe("number");
+        expect(doc.metadata.relevanceScore).toBe(score);
+      }
+    });
+  }
+);

--- a/libs/providers/langchain-mongodb/src/vectorstores.ts
+++ b/libs/providers/langchain-mongodb/src/vectorstores.ts
@@ -41,12 +41,25 @@ class AutoEmbeddingStub implements EmbeddingsInterface {
  * @param embeddingKey Key to store the embedding under.
  * @param primaryKey The Key to use for upserting documents.
  */
+export interface MongoDBRerankOptions {
+  /**
+   * Reranking model (e.g. "rerank-2.5", "rerank-2.5-lite", "rerank-2", "rerank-2-lite").
+   */
+  model: string;
+  /**
+   * Field path(s) in the collection to rerank on. Defaults to the textKey
+   * ("text" unless overridden).
+   */
+  path?: string | string[];
+}
+
 export interface MongoDBAtlasVectorSearchLibArgs extends AsyncCallerParams {
   readonly collection: Collection<MongoDBDocument>;
   readonly indexName?: string;
   readonly textKey?: string;
   readonly embeddingKey?: string;
   readonly primaryKey?: string;
+  readonly rerankOptions?: MongoDBRerankOptions;
 }
 
 /**
@@ -83,6 +96,8 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
   private caller: AsyncCaller;
 
   private readonly useAutoEmbedding: boolean;
+
+  private readonly rerankOptions?: MongoDBRerankOptions;
 
   _vectorstoreType(): string {
     return "mongodb_atlas";
@@ -126,6 +141,7 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     this.primaryKey = libArgs.primaryKey ?? "_id";
     this.caller = new AsyncCaller(libArgs);
     this.useAutoEmbedding = useAutoEmbedding;
+    this.rerankOptions = libArgs.rerankOptions;
     this.collection.db.client.appendMetadata({
       name: "langchainjs_vector",
     });
@@ -308,8 +324,15 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     filter: this["FilterType"] | undefined = undefined
   ): Promise<[Document, number][]> {
     if (this.useAutoEmbedding) {
+      if (this.rerankOptions) {
+        return this.textBasedRerankSearchWithScore(query, k, filter);
+      }
       // Auto-embed mode: use text-based $vectorSearch query
       return this.textBasedSearchWithScore(query, k, filter);
+    }
+
+    if (this.rerankOptions) {
+      return this.rerankSearchWithScore(query, k, filter);
     }
 
     // Manual embedding mode: embed query client-side
@@ -387,6 +410,118 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       .map<[Document, number]>((result) => {
         const { score, [this.textKey]: text, ...metadata } = result;
         return [new Document({ pageContent: text, metadata }), score];
+      });
+
+    return results.toArray();
+  }
+
+  private async textBasedRerankSearchWithScore(
+    query: string,
+    k: number,
+    filter?: MongoDBAtlasFilter
+  ): Promise<[Document, number][]> {
+    const { model, path } = this.rerankOptions!;
+    const rerankPath = path ?? this.textKey;
+
+    const postFilterPipeline = filter?.postFilterPipeline ?? [];
+    const preFilter: MongoDBDocument | undefined =
+      filter?.preFilter ||
+      filter?.postFilterPipeline ||
+      filter?.includeEmbeddings
+        ? filter.preFilter
+        : filter;
+    const removeEmbeddingsPipeline = !filter?.includeEmbeddings
+      ? [{ $project: { [this.embeddingKey]: 0 } }]
+      : [];
+
+    const pipeline: MongoDBDocument[] = [
+      {
+        $vectorSearch: {
+          query: { text: query },
+          index: this.indexName,
+          path: this.textKey,
+          limit: k,
+          numCandidates: 10 * k,
+          ...(preFilter && { filter: preFilter }),
+        },
+      },
+      {
+        $rerank: {
+          query: { text: query },
+          path: rerankPath,
+          numDocsToRerank: k,
+          model,
+        },
+      },
+      { $addFields: { rerankScore: { $meta: "score" } } },
+      ...removeEmbeddingsPipeline,
+      ...postFilterPipeline,
+      { $limit: k },
+    ];
+
+    const results = this.collection
+      .aggregate(pipeline)
+      .map<[Document, number]>((result) => {
+        const { rerankScore, [this.textKey]: text, ...metadata } = result;
+        metadata.relevanceScore = rerankScore;
+        return [new Document({ pageContent: text, metadata }), rerankScore];
+      });
+
+    return results.toArray();
+  }
+
+  private async rerankSearchWithScore(
+    query: string,
+    k: number,
+    filter?: MongoDBAtlasFilter
+  ): Promise<[Document, number][]> {
+    const { model, path } = this.rerankOptions!;
+    const rerankPath = path ?? this.textKey;
+
+    const queryEmbedding = await this.embeddings.embedQuery(query);
+
+    const postFilterPipeline = filter?.postFilterPipeline ?? [];
+    const preFilter: MongoDBDocument | undefined =
+      filter?.preFilter ||
+      filter?.postFilterPipeline ||
+      filter?.includeEmbeddings
+        ? filter.preFilter
+        : filter;
+    const removeEmbeddingsPipeline = !filter?.includeEmbeddings
+      ? [{ $project: { [this.embeddingKey]: 0 } }]
+      : [];
+
+    const pipeline: MongoDBDocument[] = [
+      {
+        $vectorSearch: {
+          queryVector: MongoDBAtlasVectorSearch.fixArrayPrecision(queryEmbedding),
+          index: this.indexName,
+          path: this.embeddingKey,
+          limit: k,
+          numCandidates: 10 * k,
+          ...(preFilter && { filter: preFilter }),
+        },
+      },
+      {
+        $rerank: {
+          query: { text: query },
+          path: rerankPath,
+          numDocsToRerank: k,
+          model,
+        },
+      },
+      { $addFields: { rerankScore: { $meta: "score" } } },
+      ...removeEmbeddingsPipeline,
+      ...postFilterPipeline,
+      { $limit: k },
+    ];
+
+    const results = this.collection
+      .aggregate(pipeline)
+      .map<[Document, number]>((result) => {
+        const { rerankScore, [this.textKey]: text, ...metadata } = result;
+        metadata.relevanceScore = rerankScore;
+        return [new Document({ pageContent: text, metadata }), rerankScore];
       });
 
     return results.toArray();

--- a/libs/providers/langchain-mongodb/src/vectorstores.ts
+++ b/libs/providers/langchain-mongodb/src/vectorstores.ts
@@ -494,7 +494,8 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     const pipeline: MongoDBDocument[] = [
       {
         $vectorSearch: {
-          queryVector: MongoDBAtlasVectorSearch.fixArrayPrecision(queryEmbedding),
+          queryVector:
+            MongoDBAtlasVectorSearch.fixArrayPrecision(queryEmbedding),
           index: this.indexName,
           path: this.embeddingKey,
           limit: k,


### PR DESCRIPTION
# feat(mongodb): add `$rerank` support to `MongoDBAtlasVectorSearch`

This PR adds MongoDB Atlas `$rerank` aggregation pipeline support to `MongoDBAtlasVectorSearch`, fixes flaky `MongoDBAtlasSemanticCache` integration tests, and updates the auto-embedding test infrastructure to use the `mongodb/mongodb-atlas-local:preview` Docker image.

---

Adds an optional `rerankOptions` constructor parameter that, when set, appends a `$rerank` stage after `$vectorSearch` to reorder results by semantic relevance using a MongoDB Atlas reranking model.

**New interface:**

```typescript
export interface MongoDBRerankOptions {
  model: string;               // e.g. "rerank-2.5", "rerank-2.5-lite", "rerank-2", "rerank-2-lite"
  path?: string | string[];    // field(s) to rerank on; defaults to textKey ("text")
}
```

**Usage:**

```typescript
const vectorStore = new MongoDBAtlasVectorSearch(embeddings, {
  collection,
  rerankOptions: {
    model: "rerank-2.5",
    path: "text",           // single field; omit to use textKey default
    // path: ["text", "title"],  // or multiple fields
  },
});
const results = await vectorStore.similaritySearchWithScore("query", 4);
// results[0][1] === rerankScore, results[0][0].metadata.relevanceScore === rerankScore
```

**Behaviour:**
- Works with both manual embeddings and auto-embedding mode.
- `$rerank` is inserted between `$vectorSearch` and the post-filter/limit stages.
- `numDocsToRerank` equals `k` — the reranker sees the same candidate set that is returned.
- The rerank score is returned as the numeric score in the `[Document, number]` tuple and also copied to `document.metadata.relevanceScore`.

**Test infrastructure:**
- New `vectorstores_rerank.int.test.ts` with four manual-embedding rerank tests and one combined auto-embed + rerank test.
- Rerank tests are skipped when `isUsingLocalAtlas()` is true (`$rerank` requires a real Atlas cluster, not the local Docker image).
- The combined auto-embed + rerank test additionally requires `VOYAGE_API_KEY`.
- Removed the earlier rerank tests that were incorrectly placed in `vectorstores_auto_embed.int.test.ts`.

> **Note:** `$rerank` is a preview feature and requires a MongoDB Atlas cluster enrolled in the preview program.

---

## fix(mongodb): fix flaky `MongoDBAtlasSemanticCache` integration tests

`waitForIndexToBeQueryable` returns as soon as the search index status is `READY`, but newly inserted documents are not immediately searchable even on a ready index. Tests that inserted a document and then immediately called `cache.lookup()` would intermittently return `null`.

Replaced all post-insert `waitForIndexToBeQueryable` calls with a new `waitForCacheIndexed` helper that polls `cache.lookup()` directly until the inserted entry is returned (up to 30 s).

---

## test(mongodb): update auto-embedding tests to use `mongodb/mongodb-atlas-local:preview`

The `mongodb/mongodb-atlas-local:latest` image does not support the `autoEmbed` index type. Updated `setup.ts` to use `mongodb/mongodb-atlas-local:preview`, pass through `VOYAGE_API_KEY` and `EMBEDDING_PROVIDER_ENDPOINT` environment variables, set `MONGODB_ATLAS_LOCAL_PREVIEW=true`, and increase the container startup timeout from 30 s to 120 s to allow the `mongot` process time to initialise.