### PR TITLE
fix(langchain): propagate ReactAgent withConfig defaults to inner graph

### DIFF
--- a/.changeset/propagate-reactagent-graph-default-config.md
+++ b/.changeset/propagate-reactagent-graph-default-config.md
@@ -1,0 +1,9 @@
+---
+"langchain": patch
+---
+
+fix(langchain): propagate ReactAgent withConfig defaults to inner graph
+
+Apply static defaults from `#defaultConfig` onto the compiled pregel so
+`recursionLimit`, metadata, and other LangGraph config survives LangGraph API
+loading, which unwraps ReactAgent to `.graph` before execution.

--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -79,6 +79,7 @@ import type {
 } from "./middleware/types.js";
 import { type ResponseFormatUndefined } from "./responses.js";
 import { getHookConstraint } from "./middleware/utils.js";
+import { toGraphDefaultConfig } from "./utils.js";
 
 /**
  * In the ReAct pattern we have three main nodes:
@@ -684,6 +685,18 @@ export class ReactAgent<
       description: this.options.description,
       transformers: compileTransformers,
     }) as unknown as AgentGraph<Types>;
+
+    /**
+     * LangGraph API resolves exported agents by unwrapping ReactAgent to the
+     * inner compiled graph (see langgraph-api load.utils `afterResolve`) and
+     * calls streamEvents on that pregel directly. That path only sees config
+     * baked into the graph via `.withConfig()`, not ReactAgent's #defaultConfig
+     * merged at invoke/stream time — so propagate static defaults here.
+     */
+    const graphDefaultConfig = toGraphDefaultConfig(this.#defaultConfig);
+    if (Object.keys(graphDefaultConfig).length > 0) {
+      this.#graph = this.#graph.withConfig(graphDefaultConfig);
+    }
   }
 
   /**

--- a/libs/langchain/src/agents/tests/reactAgent.test.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.test.ts
@@ -1155,6 +1155,32 @@ describe("createAgent", () => {
       expect(configuredAgent.options.systemPrompt).toBe(systemPrompt);
     });
 
+    it("should propagate withConfig defaults to the compiled graph", () => {
+      const model = new FakeToolCallingModel();
+      const agent = createAgent({
+        model,
+        tools: [],
+      }).withConfig({ recursionLimit: 1000, tags: ["test"] });
+
+      expect(agent.graph.config?.recursionLimit).toBe(1000);
+      expect(agent.graph.config?.tags).toContain("test");
+    });
+
+    it("should apply built-in default metadata to the compiled graph", () => {
+      const model = new FakeToolCallingModel();
+      const agent = createAgent({
+        model,
+        tools: [],
+        name: "weather-agent",
+      });
+
+      expect(agent.graph.config?.metadata?.ls_integration).toBe(
+        "langchain_create_agent"
+      );
+      expect(agent.graph.config?.metadata?.lc_agent_name).toBe("weather-agent");
+      expect(agent.graph.config?.configurable?.ls_agent_type).toBe("root");
+    });
+
     it("should propagate configurable values to tools", async () => {
       // This test verifies that config values set via withConfig()
       // are actually propagated to the graph and accessible in tools

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -627,3 +627,31 @@ export function wrapToolCall(
     })
   );
 }
+
+
+/**
+ * Static LangGraph config keys propagated from ReactAgent defaults onto the
+ * compiled inner graph. This ensures values set via `withConfig()` survive
+ * LangGraph API loading, which unwraps ReactAgent to `.graph` before execution.
+ */
+const GRAPH_DEFAULT_CONFIG_KEYS = [
+  "tags",
+  "metadata",
+  "runName",
+  "maxConcurrency",
+  "recursionLimit",
+  "configurable",
+] as const satisfies readonly (keyof RunnableConfig)[];
+
+export function toGraphDefaultConfig(
+  config: RunnableConfig
+): Omit<RunnableConfig, "store" | "writer" | "interrupt"> {
+  const result: Record<string, unknown> = {};
+  for (const key of GRAPH_DEFAULT_CONFIG_KEYS) {
+    const value = config[key];
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result as Omit<RunnableConfig, "store" | "writer" | "interrupt">;
+}

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -628,7 +628,6 @@ export function wrapToolCall(
   );
 }
 
-
 /**
  * Static LangGraph config keys propagated from ReactAgent defaults onto the
  * compiled inner graph. This ensures values set via `withConfig()` survive


### PR DESCRIPTION
## Summary
- Propagate ReactAgent `#defaultConfig` onto the compiled inner graph at construction time via `toGraphDefaultConfig()` and `.withConfig()`.
- Fixes `recursionLimit`, metadata, and other static LangGraph config being dropped when LangGraph API resolves exported agents through the inner `.graph` (see langgraph-api `load.utils` `afterResolve`).
- Adds unit tests asserting `withConfig()` defaults and built-in metadata appear on `agent.graph.config`.
