### PR TITLE
docs(examples): add Bilig WorkPaper tool example

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-sdk/dsql-signer": "^3.1022.0",
     "@azure/identity": "^4.13.1",
+    "@bilig/workpaper": "^0.67.10",
     "@browserbasehq/stagehand": "^3.2.0",
     "@clickhouse/client": "^1.18.2",
     "@cloudflare/workers-types": "^4.20260508.1",

--- a/examples/src/createAgent/biligWorkPaperTools.ts
+++ b/examples/src/createAgent/biligWorkPaperTools.ts
@@ -1,0 +1,162 @@
+import { createAgent, tool } from "langchain";
+import { z } from "zod";
+import {
+  WorkPaper,
+  createWorkPaperFromDocument,
+  exportWorkPaperDocument,
+  parseWorkPaperDocument,
+  serializeWorkPaperDocument,
+} from "@bilig/workpaper";
+
+type RawCellContent = string | number | boolean | null;
+
+type SummaryRow = {
+  metric: unknown;
+  value: unknown;
+  formula: unknown;
+};
+
+function buildQuoteWorkPaper() {
+  return WorkPaper.buildFromSheets({
+    Inputs: [
+      ["Metric", "Value"],
+      ["Qualified opportunities", 20],
+      ["Win rate", 0.25],
+      ["Average ARR", 12000],
+      ["Expansion multiplier", 1.1],
+    ],
+    Summary: [
+      ["Metric", "Value"],
+      ["Expected customers", "=Inputs!B2*Inputs!B3"],
+      ["Expected ARR", "=B2*Inputs!B4"],
+      ["Expansion ARR", "=B3*Inputs!B5"],
+      ["Target gap", "=B4-100000"],
+    ],
+  });
+}
+
+function readSummaryRows(workbook: WorkPaper): SummaryRow[] {
+  const range = workbook.simpleCellRangeFromString("Summary!A1:B5");
+  if (!range) {
+    throw new Error("Summary range is invalid.");
+  }
+
+  const values = workbook.getRangeValues(range).slice(1);
+  const formulas = workbook.getRangeSerialized(range).slice(1);
+
+  return values.map((row, index) => {
+    const [metric, value] = row;
+    const [, formula] = formulas[index] ?? [];
+
+    return {
+      metric: cellValue(metric),
+      value: cellValue(value),
+      formula,
+    };
+  });
+}
+
+function createWorkPaperTools(workbook: WorkPaper) {
+  const readSummary = tool(
+    async () => ({
+      range: "Summary!A1:B5",
+      rows: readSummaryRows(workbook),
+    }),
+    {
+      name: "read_workpaper_summary",
+      description:
+        "Read calculated quote summary values and formula contracts from the WorkPaper.",
+      schema: z.object({}),
+    }
+  );
+
+  const setInputCell = tool(
+    async ({ address, value }: { address: string; value: RawCellContent }) => {
+      const inputsSheet = workbook.getSheetId("Inputs");
+      if (inputsSheet === undefined) {
+        throw new Error("Inputs sheet is missing.");
+      }
+
+      const cell = workbook.simpleCellAddressFromString(address, inputsSheet);
+      if (!cell) {
+        throw new Error(`Invalid Inputs cell address: ${address}`);
+      }
+
+      const before = readSummaryRows(workbook);
+      const previousValue = workbook.getCellSerialized(cell);
+
+      workbook.setCellContents(cell, value);
+
+      const after = readSummaryRows(workbook);
+      const serialized = serializeWorkPaperDocument(
+        exportWorkPaperDocument(workbook, { includeConfig: true })
+      );
+      const restored = createWorkPaperFromDocument(
+        parseWorkPaperDocument(serialized)
+      );
+      const restoredAfter = readSummaryRows(restored);
+
+      return {
+        editedCell: `Inputs!${address}`,
+        previousValue,
+        newValue: workbook.getCellSerialized(cell),
+        before,
+        after,
+        afterRestore: restoredAfter,
+        persistedDocumentBytes: serialized.length,
+        restoredMatchesAfter:
+          JSON.stringify(restoredAfter) === JSON.stringify(after),
+      };
+    },
+    {
+      name: "set_workpaper_input_cell",
+      description:
+        "Set one WorkPaper input cell, recalculate dependent formulas, persist JSON, and verify restored formula readback.",
+      schema: z.object({
+        address: z
+          .string()
+          .describe("A single A1 address in the Inputs sheet, for example B3."),
+        value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+      }),
+    }
+  );
+
+  return {
+    readSummary,
+    setInputCell,
+  };
+}
+
+export async function run() {
+  const workbook = buildQuoteWorkPaper();
+  const { readSummary, setInputCell } = createWorkPaperTools(workbook);
+
+  createAgent({
+    model: "openai:gpt-4o-mini",
+    tools: [readSummary, setInputCell],
+    systemPrompt:
+      "You help users update formula-backed WorkPapers. Always read calculated outputs after editing inputs.",
+  });
+
+  console.log("Agent configured with WorkPaper tools:", [
+    "read_workpaper_summary",
+    "set_workpaper_input_cell",
+  ]);
+  console.log("Initial summary:", await readSummary.invoke({}));
+  console.log(
+    "Edit proof:",
+    await setInputCell.invoke({
+      address: "B3",
+      value: 0.4,
+    })
+  );
+  console.log("Updated summary:", await readSummary.invoke({}));
+}
+
+function cellValue(cell: unknown) {
+  if (typeof cell === "object" && cell !== null && "value" in cell) {
+    return (cell as { value: unknown }).value;
+  }
+
+  return cell;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@azure/identity':
         specifier: ^4.13.1
         version: 4.13.1
+      '@bilig/workpaper':
+        specifier: ^0.67.10
+        version: 0.67.10
       '@browserbasehq/stagehand':
         specifier: ^3.2.0
         version: 3.2.1(@cfworker/json-schema@4.1.1)(deepmerge@4.3.1)(encoding@0.1.13)(zod@4.3.6)
@@ -3099,6 +3102,36 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bilig/core@0.67.10':
+    resolution: {integrity: sha512-05oL0s3xTl6+4MsGiB5oSRPNhDu01toUF8TyT+Co3Wi4Ge5N4nFo1Go0d4ANyphdG0LAq55JIyfsNLbiDWpwQA==}
+    engines: {node: '>=22.0.0'}
+
+  '@bilig/formula@0.67.10':
+    resolution: {integrity: sha512-GMfMA88XyRE58G7I45EcwDPvcH4BRLWxqnKG5RpedpZN9ztt4sLOtGBZq4gLqaRB/rppjNVKIBCpUlkirsPoeg==}
+    engines: {node: '>=22.0.0'}
+
+  '@bilig/headless@0.67.10':
+    resolution: {integrity: sha512-MoELn4EKTvCZc2xDsQOJ/lGbbLEzdYWtabtH/aa04OX/k6H/icipIePHRk/PLiTptL6Os+gesHycpBZdfNiQdA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  '@bilig/protocol@0.67.10':
+    resolution: {integrity: sha512-Q3ds3YmD/L1vP+pvYvhX6U1/dDJn2mq/ApDz0Mdg7uA1lkd5lOakahg/WBDg3AJqmnaSoM3zxPCAvxTCRkekDA==}
+    engines: {node: '>=22.0.0'}
+
+  '@bilig/wasm-kernel@0.67.10':
+    resolution: {integrity: sha512-gQ+oiLnSy81fGUx3HWoPahDEcsLrii8ZNqezQuaSF7fowgMlPT6iBt/TEw4X1EP2mEg1Er0YqCeJEcaDQjJhRQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@bilig/workbook@0.67.10':
+    resolution: {integrity: sha512-rP7HgtCrtfP3HHAedR5jIgCJNUV5i8J6g1a9mTVYlcBeEelpyzYLGpziL4YpWAhHv8NeMYSXNH33IzB+yxYvOA==}
+    engines: {node: '>=22.0.0'}
+
+  '@bilig/workpaper@0.67.10':
+    resolution: {integrity: sha512-egpvCeOujqt3AoEXWKgtlwMB0Jj87Fd7VpyweiiksWFsjY731PIS4bRQ4eGILGsuH5jQF+0sQoJl/9Hon5euFQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -6240,6 +6273,15 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.2.0:
+    resolution: {integrity: sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   afinn-165-financialmarketnews@3.0.0:
     resolution: {integrity: sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==}
 
@@ -6558,6 +6600,11 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bilig-workpaper@0.67.10:
+    resolution: {integrity: sha512-flYERf64a+ue7MFxhIny5N1V3T0OgXqKpUKrf0JAQwSgaNAFdueCJ7u9c0VaKLLWAkHxvOn8xaNVwgno9z7+fg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -6734,6 +6781,10 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -6942,6 +6993,11 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  codepage@1.14.0:
+    resolution: {integrity: sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
   cohere-ai@7.21.0:
     resolution: {integrity: sha512-AouvBkDho9gnEAnk5oY99p/VHfjP6AkDhZLv/tyB2TIFm7IEd6QQl00jaqBtAbOZnMT297Scq3pkqOUCTr886A==}
     engines: {node: '>=18.0.0'}
@@ -7032,6 +7088,12 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@2.14.1:
+    resolution: {integrity: sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==}
+
+  commander@2.17.1:
+    resolution: {integrity: sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==}
 
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -7425,6 +7487,9 @@ packages:
   effect@3.20.0:
     resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
 
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
   efrt@2.7.0:
     resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
     engines: {node: '>=12.0.0'}
@@ -7663,6 +7728,10 @@ packages:
     resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
     engines: {node: '>=18'}
 
+  exit-on-epipe@1.0.1:
+    resolution: {integrity: sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==}
+    engines: {node: '>=0.8'}
+
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
@@ -7764,10 +7833,6 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.7.1:
-    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
-    hasBin: true
-
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
@@ -7804,8 +7869,14 @@ packages:
   fetch-ponyfill@7.1.0:
     resolution: {integrity: sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==}
 
+  fflate@0.3.11:
+    resolution: {integrity: sha512-Rr5QlUeGN1mbOHlaqcSYMKVpPbgLy0AWT/W0EHxA6NGI12yO1jpoui2zBBvU2G824ltM6Ut8BFgfHSBGfkmS0A==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -7911,6 +7982,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -10202,6 +10277,11 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  printj@1.1.2:
+    resolution: {integrity: sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
   prisma@4.16.2:
     resolution: {integrity: sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==}
     engines: {node: '>=14.17'}
@@ -10801,6 +10881,10 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
 
@@ -10930,9 +11014,6 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
-  strnum@2.2.3:
-    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
@@ -11798,9 +11879,17 @@ packages:
     resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wordnet-db@3.1.14:
     resolution: {integrity: sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==}
@@ -11874,6 +11963,17 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xlsx-js-style@1.2.0:
+    resolution: {integrity: sha512-DDT4FXFSWfT4DXMSok/m3TvmP1gvO3dn0Eu/c+eXHW5Kzmp7IczNkxg/iEPnImbG9X0Vb8QhROda5eatSR/97Q==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
@@ -13121,7 +13221,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
       '@smithy/types': 4.14.1
-      fast-xml-parser: 5.7.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.22':
@@ -13461,6 +13561,43 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bilig/core@0.67.10':
+    dependencies:
+      '@bilig/formula': 0.67.10
+      '@bilig/protocol': 0.67.10
+      '@bilig/wasm-kernel': 0.67.10
+      '@bilig/workbook': 0.67.10
+      effect: 3.21.0
+
+  '@bilig/formula@0.67.10':
+    dependencies:
+      '@bilig/protocol': 0.67.10
+
+  '@bilig/headless@0.67.10':
+    dependencies:
+      '@bilig/core': 0.67.10
+      '@bilig/formula': 0.67.10
+      '@bilig/protocol': 0.67.10
+      fast-xml-parser: 5.7.3
+      fflate: 0.3.11
+      fflate-stream: fflate@0.8.3
+      xlsx: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+      xlsx-js-style: 1.2.0
+
+  '@bilig/protocol@0.67.10': {}
+
+  '@bilig/wasm-kernel@0.67.10': {}
+
+  '@bilig/workbook@0.67.10':
+    dependencies:
+      '@bilig/formula': 0.67.10
+      '@bilig/protocol': 0.67.10
+
+  '@bilig/workpaper@0.67.10':
+    dependencies:
+      '@bilig/headless': 0.67.10
+      bilig-workpaper: 0.67.10
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -14115,7 +14252,7 @@ snapshots:
       abort-controller: 3.0.0
       async-retry: 1.3.3
       duplexify: 4.1.3
-      fast-xml-parser: 5.7.1
+      fast-xml-parser: 5.7.3
       gaxios: 6.7.1(encoding@0.1.13)
       google-auth-library: 9.15.1(encoding@0.1.13)
       html-entities: 2.6.0
@@ -17011,6 +17148,13 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.2.0:
+    dependencies:
+      exit-on-epipe: 1.0.1
+      printj: 1.1.2
+
+  adler-32@1.3.1: {}
+
   afinn-165-financialmarketnews@3.0.0: {}
 
   afinn-165@2.0.2: {}
@@ -17351,6 +17495,10 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bilig-workpaper@0.67.10:
+    dependencies:
+      '@bilig/headless': 0.67.10
+
   binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
@@ -17589,6 +17737,11 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -17822,6 +17975,11 @@ snapshots:
 
   co@4.6.0: {}
 
+  codepage@1.14.0:
+    dependencies:
+      commander: 2.14.1
+      exit-on-epipe: 1.0.1
+
   cohere-ai@7.21.0:
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -17905,6 +18063,10 @@ snapshots:
   commander@13.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@2.14.1: {}
+
+  commander@2.17.1: {}
 
   commander@9.5.0: {}
 
@@ -18274,6 +18436,11 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  effect@3.21.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   efrt@2.7.0: {}
 
   electron-to-chromium@1.5.343: {}
@@ -18564,6 +18731,8 @@ snapshots:
 
   exit-hook@4.0.0: {}
 
+  exit-on-epipe@1.0.1: {}
+
   exit-x@0.2.2: {}
 
   expand-template@2.0.3: {}
@@ -18696,13 +18865,6 @@ snapshots:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
 
-  fast-xml-parser@5.7.1:
-    dependencies:
-      '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.2.3
-
   fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
@@ -18744,7 +18906,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  fflate@0.3.11: {}
+
   fflate@0.8.2: {}
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -18861,6 +19027,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fraction.js@5.3.4: {}
 
@@ -21686,6 +21854,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  printj@1.1.2: {}
+
   prisma@4.16.2:
     dependencies:
       '@prisma/engines': 4.16.2
@@ -22457,6 +22627,10 @@ snapshots:
 
   sqlstring@2.3.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   ssh-remote-port-forward@1.0.4:
     dependencies:
       '@types/ssh2': 0.5.52
@@ -22586,8 +22760,6 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
-
-  strnum@2.2.3: {}
 
   strnum@2.3.0: {}
 
@@ -23733,7 +23905,11 @@ snapshots:
       triple-beam: 1.4.1
       winston-transport: 4.9.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wordnet-db@3.1.14: {}
 
@@ -23788,6 +23964,21 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xlsx-js-style@1.2.0:
+    dependencies:
+      adler-32: 1.2.0
+      cfb: 1.2.2
+      codepage: 1.14.0
+      commander: 2.17.1
+      crc-32: 1.2.2
+      exit-on-epipe: 1.0.1
+      fflate: 0.3.11
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-naming@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds a `createAgent` example that exposes a Bilig WorkPaper quote model as LangChain tools.
- The write tool edits an input cell, recalculates dependent formulas, serializes the WorkPaper JSON, restores it, and verifies readback.

## Validation

- `pnpm --dir examples exec tsx -e "import('./src/createAgent/biligWorkPaperTools.ts').then(({ run }) => run())"`
  - initial Expected ARR: `60000`
  - after setting `Inputs!B3` to `0.4`, Expected ARR: `96000`
  - `restoredMatchesAfter: true`
- `pnpm --dir examples exec tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck src/createAgent/biligWorkPaperTools.ts`
- `git diff --check`

`pnpm --filter examples build` currently fails on existing `src/createAgent/middleware/*` and `src/createAgent/supervisor.ts` `Command` type errors outside this example.
