### PR TITLE
docs: fix Google provider comment wording

### DIFF
--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -298,7 +298,7 @@ export interface GoogleAIModelParams extends GoogleModelParams {
   /**
    * Presence penalty applied to the next token's logprobs
    * if the token has already been seen in the response.
-   * This penalty is binary on/off and not dependant on the
+   * This penalty is binary on/off and not dependent on the
    * number of times the token is used (after the first).
    * Use frequencyPenalty for a penalty that increases with each use.
    * A positive penalty will discourage the use of tokens that have

--- a/libs/providers/langchain-google/src/chat_models/api-types.ts
+++ b/libs/providers/langchain-google/src/chat_models/api-types.ts
@@ -386,7 +386,7 @@ export namespace Gemini {
      * Optional. Presence penalty applied to the next token's logprobs if the token has
      * already been seen in the response.
      * 
-     * This penalty is binary on/off and not dependant on the number of times the
+     * This penalty is binary on/off and not dependent on the number of times the
      * token is used (after the first). Use
      * frequency_penalty
      * for a penalty that increases with each use.


### PR DESCRIPTION
Fixes a small wording typo in Google provider presence-penalty comments by changing "dependant" to "dependent". No runtime behavior changes.