### PR TITLE
fix(aws): handle citation deltas in stream

### DIFF
--- a/libs/langchain-aws/src/common.ts
+++ b/libs/langchain-aws/src/common.ts
@@ -789,6 +789,23 @@ export function handleConverseStreamContentBlockDelta(
         ],
       }),
     });
+  } else if (
+    "citation" in contentBlockDelta.delta &&
+    contentBlockDelta.delta.citation
+  ) {
+    return new ChatGenerationChunk({
+      text: "",
+      message: new AIMessageChunk({
+        content: [
+          {
+            type: "citations_content",
+            citationsContent: {
+              citations: [contentBlockDelta.delta.citation],
+            },
+          },
+        ],
+      }),
+    });
   } else {
     throw new Error(
       `Unsupported content block type(s): ${JSON.stringify(

--- a/libs/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/langchain-aws/src/tests/chat_models.test.ts
@@ -11,6 +11,7 @@ import {
   ConversationRole as BedrockConversationRole,
   type Message as BedrockMessage,
   type SystemContentBlock as BedrockSystemContentBlock,
+  type ContentBlockDeltaEvent,
 } from "@aws-sdk/client-bedrock-runtime";
 import { z } from "zod";
 import { describe, expect, test } from "@jest/globals";
@@ -442,6 +443,31 @@ test("Streaming supports empty string chunks", async () => {
   expect(finalChunk).toBeDefined();
   if (!finalChunk) return;
   expect(finalChunk.content).toBe("Hello world!");
+});
+
+test("Streaming supports citation deltas", async () => {
+  const contentBlock = {
+    contentBlockIndex: 0,
+    delta: {
+      citation: {
+        id: "citation-1",
+      },
+    },
+  } as unknown as ContentBlockDeltaEvent;
+
+  const chunk = handleConverseStreamContentBlockDelta(contentBlock).message;
+  expect(chunk.content).toEqual([
+    {
+      type: "citations_content",
+      citationsContent: {
+        citations: [
+          {
+            id: "citation-1",
+          },
+        ],
+      },
+    },
+  ]);
 });
 
 describe("tool_choice works for supported models", () => {


### PR DESCRIPTION
Fix streaming citation deltas for ChatBedrockConverse by adding citation handling in the stream delta converter. This mirrors the non‑streaming citations_content shape and prevents Unsupported content block type errors when PDFs with citations are streamed. Added a unit test for citation deltas.

Fixes #10942