### PR TITLE
perplexity: add X-Pplx-Integration attribution header

### DIFF
--- a/.changeset/perplexity-attribution-header.md
+++ b/.changeset/perplexity-attribution-header.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Add the Perplexity integration attribution header to Search retriever and tool requests.

--- a/libs/providers/langchain-perplexity/src/retrievers.ts
+++ b/libs/providers/langchain-perplexity/src/retrievers.ts
@@ -4,6 +4,7 @@ import {
 } from "@langchain/core/retrievers";
 import { Document } from "@langchain/core/documents";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { getPerplexityHeaders } from "./utils/headers.js";
 
 /**
  * Recency filters supported by the Perplexity Search API.
@@ -177,10 +178,7 @@ export class PerplexitySearchRetriever extends BaseRetriever {
 
     const response = await fetch(PERPLEXITY_SEARCH_URL, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers: getPerplexityHeaders(this.apiKey),
       body: JSON.stringify(body),
     });
 

--- a/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/retrievers.test.ts
@@ -22,6 +22,8 @@ const MOCK_RESPONSE = {
   ],
 };
 
+const EXPECTED_INTEGRATION_HEADER = `langchainjs/${__PKG_VERSION__}`;
+
 function mockFetchOnce(response: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn().mockResolvedValue({
     ok,
@@ -187,6 +189,7 @@ describe("PerplexitySearchRetriever", () => {
       expect(init.headers).toEqual({
         Authorization: "Bearer test-key",
         "Content-Type": "application/json",
+        "X-Pplx-Integration": EXPECTED_INTEGRATION_HEADER,
       });
       expect(JSON.parse(init.body)).toEqual({
         query: "test query",

--- a/libs/providers/langchain-perplexity/src/tests/tools.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/tools.test.ts
@@ -19,6 +19,8 @@ const MOCK_RESPONSE = {
   ],
 };
 
+const EXPECTED_INTEGRATION_HEADER = `langchainjs/${__PKG_VERSION__}`;
+
 function mockFetchOnce(response: unknown, ok = true, status = 200) {
   const fetchMock = vi.fn().mockResolvedValue({
     ok,
@@ -167,6 +169,7 @@ describe("PerplexitySearchResults", () => {
       expect(init.headers).toEqual({
         Authorization: "Bearer test-key",
         "Content-Type": "application/json",
+        "X-Pplx-Integration": EXPECTED_INTEGRATION_HEADER,
       });
       expect(JSON.parse(init.body)).toEqual({
         query: "test query",

--- a/libs/providers/langchain-perplexity/src/tools.ts
+++ b/libs/providers/langchain-perplexity/src/tools.ts
@@ -1,5 +1,6 @@
 import { Tool, type ToolParams } from "@langchain/core/tools";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { getPerplexityHeaders } from "./utils/headers.js";
 import type {
   PerplexitySearchRecencyFilter,
   PerplexitySearchRequestBody,
@@ -131,10 +132,7 @@ export class PerplexitySearchResults extends Tool {
 
       const response = await fetch(PERPLEXITY_SEARCH_URL, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: getPerplexityHeaders(this.apiKey),
         body: JSON.stringify(body),
       });
 

--- a/libs/providers/langchain-perplexity/src/utils/headers.ts
+++ b/libs/providers/langchain-perplexity/src/utils/headers.ts
@@ -1,0 +1,11 @@
+const PERPLEXITY_INTEGRATION_SLUG = "langchainjs";
+
+const PERPLEXITY_INTEGRATION_HEADER = `${PERPLEXITY_INTEGRATION_SLUG}/${__PKG_VERSION__}`;
+
+export function getPerplexityHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    "X-Pplx-Integration": PERPLEXITY_INTEGRATION_HEADER,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `X-Pplx-Integration: langchainjs/<package-version>` to Perplexity Search retriever and tool requests
- Centralize Search API request headers in the Perplexity package
- Extend the existing retriever and tool unit tests to assert the attribution header is sent

This follows up on #10781, which added `PerplexitySearchRetriever` and `PerplexitySearchResults`.

## Testing

- `pnpm --filter @langchain/core build`
- `pnpm --filter @langchain/perplexity test`
- `pnpm --filter @langchain/perplexity build`
- `pnpm exec oxlint libs/providers/langchain-perplexity`

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_