### PR TITLE
docs(mcp-adapters): add x402 paid-server example (AgentScrape)

### DIFF
--- a/libs/langchain-mcp-adapters/examples/agentscrape_x402_example.ts
+++ b/libs/langchain-mcp-adapters/examples/agentscrape_x402_example.ts
@@ -1,0 +1,92 @@
+/**
+ * AgentScrape x402 MCP Example
+ *
+ * Connect LangChain to AgentScrape, a pay-per-call web-scraping MCP server that
+ * uses the x402 payment protocol on Base USDC. Agents pay autonomously per call,
+ * no signup or API keys required.
+ *
+ * AgentScrape exposes six tools as a remote MCP server via Streamable HTTP:
+ *   - scrape_webpage          ($0.003) — markdown/html/text/json scrape
+ *   - extract_structured_data ($0.005) — AI extraction via Groq + Llama 4 Scout
+ *   - screenshot_webpage      ($0.003) — PNG screenshot with viewport control
+ *   - extract_metadata        ($0.002) — title, OG, Twitter, JSON-LD
+ *   - create_browser_session  ($0.001) — stateful browser session
+ *   - run_workflow            ($0.008) — multi-step atomic workflow up to 20 steps
+ *
+ * Free tier: 10 calls per wallet in the first 30 days. Beyond that, payment in
+ * USDC on Base mainnet (eip155:8453). The first 402 Payment Required response
+ * carries the canonical x402 payment requirements header; this example shows the
+ * unpaid (free-tier) usage. For paid usage, integrate with Coinbase AgentKit's
+ * `x402ActionProvider` and supply the payment header on retry.
+ *
+ * Service URLs:
+ *   - Worker:    https://agent-scrape.healingsunhaven.workers.dev
+ *   - MCP:       https://agent-scrape.healingsunhaven.workers.dev/mcp
+ *   - x402:      https://agent-scrape.healingsunhaven.workers.dev/.well-known/x402.json
+ *   - A2A card:  https://agent-scrape.healingsunhaven.workers.dev/.well-known/agent.json
+ *   - GitHub:    https://github.com/hshintelligence/agent-scrape
+ *
+ * Run:
+ *   tsx examples/agentscrape_x402_example.ts
+ */
+
+import { createAgent } from "langchain";
+import { ChatOpenAI } from "@langchain/openai";
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+async function main(): Promise<void> {
+  // Connect to AgentScrape's remote MCP endpoint over Streamable HTTP.
+  // AgentScrape gracefully falls back to SSE for legacy clients via the
+  // standard MCP transport-negotiation handshake.
+  const client = new MultiServerMCPClient({
+    throwOnLoadError: true,
+    prefixToolNameWithServerName: true,
+    useStandardContentBlocks: true,
+
+    mcpServers: {
+      agentscrape: {
+        url: "https://agent-scrape.healingsunhaven.workers.dev/mcp",
+        // Default transport: streamable_http (auto-detected). Add headers
+        // here if you wire up x402 payment proofs for paid calls.
+        // headers: {
+        //   "X-PAYMENT-RESPONSE": "<base64-encoded x402 payment receipt>",
+        // },
+      },
+    },
+  });
+
+  // Pull all of AgentScrape's tools as LangChain tools.
+  const tools = await client.getTools();
+
+  console.log(
+    `Loaded ${tools.length} tools from AgentScrape:`,
+    tools.map((t) => t.name)
+  );
+
+  // Build a LangGraph agent that uses these tools.
+  const model = new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 });
+  const agent = createAgent({ llm: model, tools });
+
+  // Ask the agent to scrape a page.
+  const result = await agent.invoke({
+    messages: [
+      {
+        role: "user",
+        content:
+          "Scrape https://www.x402.org and tell me the headline plus a 2-sentence summary.",
+      },
+    ],
+  });
+
+  console.log(
+    "\nAgent response:\n",
+    result.messages[result.messages.length - 1].content
+  );
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error("AgentScrape example failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What this PR adds

Adds `libs/langchain-mcp-adapters/examples/agentscrape_x402_example.ts` — a working example showing how to connect `MultiServerMCPClient` to [AgentScrape](https://agent-scrape.healingsunhaven.workers.dev), a live x402-protocol pay-per-call web-scraping MCP server.

## Why

The existing examples cover free MCP servers (math, filesystem, calculator, firecrawl-with-key). There's no example showing how to integrate with **x402-native MCP servers** — the emerging standard for agent-native payment introduced by Coinbase. This example fills that gap.

## What AgentScrape is

- Live remote MCP server: `https://agent-scrape.healingsunhaven.workers.dev/mcp` (Streamable HTTP)
- Six tools: scrape, extract (Groq+Llama 4), screenshot, metadata, session, workflow
- Open source MIT: https://github.com/hshintelligence/agent-scrape
- Free tier: 10 calls per wallet in first 30 days (so this example works zero-config)
- Paid mode: USDC on Base mainnet via x402 v2

## Why this is safe

- Adds one new file under `examples/` — no behavior changes to the adapter
- Uses only public APIs already exported by `@langchain/mcp-adapters`
- Example works zero-config out of the box (free tier)
- AgentScrape is vetted on [punkpeye/awesome-mcp-servers (#6837 merged)](https://github.com/punkpeye/awesome-mcp-servers/pull/6837), Glama (License A / Quality A), Smithery (82/100), mcp.so

Happy to address feedback — happy to scope this back to a smaller diff, rename, or move under a subdirectory if preferred.