### PR TITLE
docs(google-cloud-sql-pg): add deprecation warning and changeset

### DIFF
--- a/.changeset/deprecate-google-cloud-sql-pg.md
+++ b/.changeset/deprecate-google-cloud-sql-pg.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-cloud-sql-pg": patch
+---
+
+chore(google-cloud-sql-pg): deprecate package

--- a/libs/providers/langchain-google-cloud-sql-pg/README.md
+++ b/libs/providers/langchain-google-cloud-sql-pg/README.md
@@ -1,5 +1,8 @@
 # @langchain/google-cloud-sql-pg
 
+> [!WARNING]
+> `@langchain/google-cloud-sql-pg` is deprecated and will no longer receive updates.
+
 The LangChain package for CloudSQL for Postgres provides a way to connect to Cloud SQL instances from the LangChain ecosystem.
 
 Main features:


### PR DESCRIPTION
## Summary

Adds a deprecation notice for `@langchain/google-cloud-sql-pg` and documents the change with a changeset so it is reflected in release notes.

## Changes

- `libs/providers/langchain-google-cloud-sql-pg`
- Added a warning admonition to the README indicating the package is deprecated, no longer receiving updates, and will be removed in a future release.
