### PR TITLE
fix(core): enforce prompt template recursion depth limits

### DIFF
--- a/.changeset/hunter-prompt-template-depth-guard.md
+++ b/.changeset/hunter-prompt-template-depth-guard.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": patch
+---
+
+fix(prompts): enforce maximum prompt template nesting depth
+
+Add recursion depth guards for mustache template parsing and dict prompt template traversal to prevent stack-exhaustion DoS from deeply nested attacker-controlled templates.

--- a/libs/langchain-core/src/prompts/dict.ts
+++ b/libs/langchain-core/src/prompts/dict.ts
@@ -2,6 +2,10 @@ import { Runnable } from "../runnables/base.js";
 import type { InputValues } from "../utils/types/index.js";
 import { TypedPromptInputValues } from "./base.js";
 import { parseTemplate, renderTemplate, TemplateFormat } from "./template.js";
+import {
+  MAX_PROMPT_TEMPLATE_DEPTH,
+  createPromptTemplateDepthError,
+} from "./utils.js";
 
 export class DictPromptTemplate<
   RunInput extends InputValues = InputValues,
@@ -55,8 +59,13 @@ export class DictPromptTemplate<
 
 function _getInputVariables(
   template: Record<string, unknown>,
-  templateFormat: TemplateFormat
+  templateFormat: TemplateFormat,
+  depth = 0
 ): Array<Extract<keyof InputValues, string>> {
+  if (depth >= MAX_PROMPT_TEMPLATE_DEPTH) {
+    throw createPromptTemplateDepthError();
+  }
+
   const inputVariables: Array<Extract<keyof InputValues, string>> = [];
   for (const v of Object.values(template)) {
     if (typeof v === "string") {
@@ -74,12 +83,18 @@ function _getInputVariables(
             }
           });
         } else if (typeof x === "object") {
-          inputVariables.push(..._getInputVariables(x, templateFormat));
+          inputVariables.push(
+            ..._getInputVariables(x, templateFormat, depth + 1)
+          );
         }
       }
     } else if (typeof v === "object" && v !== null) {
       inputVariables.push(
-        ..._getInputVariables(v as Record<string, unknown>, templateFormat)
+        ..._getInputVariables(
+          v as Record<string, unknown>,
+          templateFormat,
+          depth + 1
+        )
       );
     }
   }
@@ -89,8 +104,13 @@ function _getInputVariables(
 function _insertInputVariables(
   template: Record<string, unknown>,
   inputs: TypedPromptInputValues<InputValues>,
-  templateFormat: TemplateFormat
+  templateFormat: TemplateFormat,
+  depth = 0
 ): Record<string, unknown> {
+  if (depth >= MAX_PROMPT_TEMPLATE_DEPTH) {
+    throw createPromptTemplateDepthError();
+  }
+
   const formatted: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(template)) {
     if (typeof v === "string") {
@@ -101,7 +121,9 @@ function _insertInputVariables(
         if (typeof x === "string") {
           formattedV.push(renderTemplate(x, templateFormat, inputs));
         } else if (typeof x === "object") {
-          formattedV.push(_insertInputVariables(x, inputs, templateFormat));
+          formattedV.push(
+            _insertInputVariables(x, inputs, templateFormat, depth + 1)
+          );
         }
       }
       formatted[k] = formattedV;
@@ -109,7 +131,8 @@ function _insertInputVariables(
       formatted[k] = _insertInputVariables(
         v as Record<string, unknown>,
         inputs,
-        templateFormat
+        templateFormat,
+        depth + 1
       );
     } else {
       formatted[k] = v;

--- a/libs/langchain-core/src/prompts/template.ts
+++ b/libs/langchain-core/src/prompts/template.ts
@@ -1,7 +1,10 @@
 import mustache from "mustache";
 import { MessageContent } from "../messages/index.js";
 import type { InputValues } from "../utils/types/index.js";
-import { addLangChainErrorFields } from "../errors/index.js";
+import {
+  MAX_PROMPT_TEMPLATE_DEPTH,
+  createPromptTemplateDepthError,
+} from "./utils.js";
 
 function configureMustache() {
   // Use unescaped HTML
@@ -88,8 +91,13 @@ export const parseFString = (template: string): ParsedTemplateNode[] => {
  */
 const mustacheTemplateToNodes = (
   template: mustache.TemplateSpans,
-  context: string[] = []
+  context: string[] = [],
+  depth = 0
 ): ParsedTemplateNode[] => {
+  if (depth >= MAX_PROMPT_TEMPLATE_DEPTH) {
+    throw createPromptTemplateDepthError();
+  }
+
   const nodes: ParsedTemplateNode[] = [];
 
   for (const temp of template) {
@@ -104,7 +112,11 @@ const mustacheTemplateToNodes = (
       // If this is a section with nested content, recursively process it
       if (temp[0] === "#" && temp.length > 4 && Array.isArray(temp[4])) {
         const newContext = [...context, temp[1]];
-        const nestedNodes = mustacheTemplateToNodes(temp[4], newContext);
+        const nestedNodes = mustacheTemplateToNodes(
+          temp[4],
+          newContext,
+          depth + 1
+        );
         nodes.push(...nestedNodes);
       }
     } else {

--- a/libs/langchain-core/src/prompts/tests/dict.test.ts
+++ b/libs/langchain-core/src/prompts/tests/dict.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { DictPromptTemplate } from "../dict.js";
 import { load } from "../../load/index.js";
+import { MAX_PROMPT_TEMPLATE_DEPTH } from "../utils.js";
+
+function createNestedTemplate(depth: number): Record<string, unknown> {
+  let template: Record<string, unknown> = { text: "{text}" };
+  for (let i = 0; i < depth; i += 1) {
+    template = { nested: template };
+  }
+  return template;
+}
 
 describe("DictPromptTemplate", () => {
   it("should format dicts with f-string template values", async () => {
@@ -123,5 +132,47 @@ describe("DictPromptTemplate", () => {
         mimeType: "text/plain",
       })
     );
+  });
+
+  it("should reject deeply nested dict templates in constructor", () => {
+    const template = createNestedTemplate(MAX_PROMPT_TEMPLATE_DEPTH + 1);
+
+    try {
+      new DictPromptTemplate({
+        template,
+        templateFormat: "f-string",
+      });
+      throw new Error("Expected constructor to fail for deep nesting.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as { lc_error_code?: string }).lc_error_code).toBe(
+        "INVALID_PROMPT_INPUT"
+      );
+      expect((error as Error).message).toContain(
+        "Prompt template nesting exceeds maximum depth"
+      );
+    }
+  });
+
+  it("should reject deeply nested dict templates in format", async () => {
+    const prompt = new DictPromptTemplate({
+      template: { text: "{text}" },
+      templateFormat: "f-string",
+    });
+
+    prompt.template = createNestedTemplate(MAX_PROMPT_TEMPLATE_DEPTH + 1);
+
+    try {
+      await prompt.format({ text: "important message" });
+      throw new Error("Expected formatting to fail for deep nesting.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as { lc_error_code?: string }).lc_error_code).toBe(
+        "INVALID_PROMPT_INPUT"
+      );
+      expect((error as Error).message).toContain(
+        "Prompt template nesting exceeds maximum depth"
+      );
+    }
   });
 });

--- a/libs/langchain-core/src/prompts/tests/prompt.mustache.test.ts
+++ b/libs/langchain-core/src/prompts/tests/prompt.mustache.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "vitest";
 import { PromptTemplate } from "../prompt.js";
 import { parseTemplate } from "../template.js";
+import { MAX_PROMPT_TEMPLATE_DEPTH } from "../utils.js";
 
 test("Single input variable.", async () => {
   const template = "This is a {{foo}} test.";
@@ -112,4 +113,24 @@ test("Escaped variables", async () => {
     text: `hello i have a "quote`,
   });
   expect(result.value).toBe(`test: hello i have a "quote`);
+});
+
+test("Rejects deeply nested mustache sections", () => {
+  const depth = MAX_PROMPT_TEMPLATE_DEPTH + 1;
+  const template = "{{#dos}}".repeat(depth) + "x" + "{{/dos}}".repeat(depth);
+
+  try {
+    PromptTemplate.fromTemplate(template, {
+      templateFormat: "mustache",
+    });
+    throw new Error("Expected template parsing to fail for deep nesting.");
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { lc_error_code?: string }).lc_error_code).toBe(
+      "INVALID_PROMPT_INPUT"
+    );
+    expect((error as Error).message).toContain(
+      "Prompt template nesting exceeds maximum depth"
+    );
+  }
 });

--- a/libs/langchain-core/src/prompts/utils.ts
+++ b/libs/langchain-core/src/prompts/utils.ts
@@ -1,0 +1,12 @@
+import { addLangChainErrorFields } from "../errors/index.js";
+
+export const MAX_PROMPT_TEMPLATE_DEPTH = 256;
+
+export function createPromptTemplateDepthError() {
+  return addLangChainErrorFields(
+    new Error(
+      `Prompt template nesting exceeds maximum depth (${MAX_PROMPT_TEMPLATE_DEPTH}).`
+    ),
+    "INVALID_PROMPT_INPUT"
+  );
+}


### PR DESCRIPTION
## Summary

This patch fixes uncontrolled recursion in prompt template resolution paths that could lead to stack exhaustion with deeply nested attacker-controlled inputs.

It introduces a shared maximum nesting depth guard for prompt traversal and returns a controlled `INVALID_PROMPT_INPUT` error instead of surfacing runtime `RangeError` failures.

## Changes

### `@langchain/core` (`prompts`)

- Added a shared prompts utility module with:
  - `MAX_PROMPT_TEMPLATE_DEPTH` (`256`)
  - `createPromptTemplateDepthError()`
- Added depth-carried recursion guards to:
  - Mustache template node expansion in `prompts/template.ts`
  - Dict template variable extraction and insertion in `prompts/dict.ts`
- Reused the shared utility across prompt modules to avoid duplicated constants/error builders.
- Added regression tests to verify over-depth inputs fail deterministically with `INVALID_PROMPT_INPUT` for:
  - Deeply nested Mustache sections
  - Deeply nested dict templates during constructor variable discovery
  - Deeply nested dict templates during formatting

### Release metadata

- Added a patch changeset for `@langchain/core` documenting the recursion-depth hardening fix.
