### PR TITLE
fix(google-genai): strip/remap exclusiveMinimum/exclusiveMaximum in responseSchema

### DIFF
--- a/.changeset/fix-gemini-exclusive-min-max.md
+++ b/.changeset/fix-gemini-exclusive-min-max.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): strip/remap `exclusiveMinimum`/`exclusiveMaximum` in `responseSchema` (Gemini does not support them)

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -178,6 +178,56 @@ test("removeAdditionalProperties can remove all instances of additionalPropertie
   ).toBeUndefined();
 });
 
+test("removeAdditionalProperties remaps exclusiveMinimum/exclusiveMaximum for integer schemas and strips them otherwise", () => {
+  const integerSchema = removeAdditionalProperties({
+    type: "integer",
+    exclusiveMinimum: 0,
+    exclusiveMaximum: 10,
+  });
+  expect(integerSchema).not.toHaveProperty("exclusiveMinimum");
+  expect(integerSchema).not.toHaveProperty("exclusiveMaximum");
+  expect(integerSchema.minimum).toBe(1);
+  expect(integerSchema.maximum).toBe(9);
+
+  const numberSchema = removeAdditionalProperties({
+    type: "number",
+    exclusiveMinimum: 0,
+    exclusiveMaximum: 1,
+  });
+  expect(numberSchema).not.toHaveProperty("exclusiveMinimum");
+  expect(numberSchema).not.toHaveProperty("exclusiveMaximum");
+  expect(numberSchema).not.toHaveProperty("minimum");
+  expect(numberSchema).not.toHaveProperty("maximum");
+
+  const tighterMin = removeAdditionalProperties({
+    type: "integer",
+    minimum: 5,
+    exclusiveMinimum: 2,
+  });
+  expect(tighterMin.minimum).toBe(5);
+
+  const looserMin = removeAdditionalProperties({
+    type: "integer",
+    minimum: 0,
+    exclusiveMinimum: 5,
+  });
+  expect(looserMin.minimum).toBe(6);
+
+  const nestedSchema = removeAdditionalProperties({
+    type: "object",
+    properties: {
+      duration_minutes: {
+        type: "integer",
+        exclusiveMinimum: 0,
+      },
+    },
+  });
+  expect(nestedSchema.properties?.duration_minutes).not.toHaveProperty(
+    "exclusiveMinimum"
+  );
+  expect(nestedSchema.properties?.duration_minutes.minimum).toBe(1);
+});
+
 test("convertMessageContentToParts correctly handles message types", () => {
   const messages = [
     new SystemMessage("You are a helpful assistant"),

--- a/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
+++ b/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
@@ -42,6 +42,31 @@ export function removeAdditionalProperties(
       delete newObj.strict;
     }
 
+    // Gemini's responseSchema does not support exclusiveMinimum /
+    // exclusiveMaximum. For integer schemas we can losslessly remap to
+    // minimum / maximum; for other types we drop the keyword so the
+    // request is not rejected with a 400.
+    if ("exclusiveMinimum" in newObj) {
+      const exclusiveMin = newObj.exclusiveMinimum;
+      if (newObj.type === "integer" && typeof exclusiveMin === "number") {
+        const remapped = exclusiveMin + 1;
+        if (typeof newObj.minimum !== "number" || newObj.minimum < remapped) {
+          newObj.minimum = remapped;
+        }
+      }
+      delete newObj.exclusiveMinimum;
+    }
+    if ("exclusiveMaximum" in newObj) {
+      const exclusiveMax = newObj.exclusiveMaximum;
+      if (newObj.type === "integer" && typeof exclusiveMax === "number") {
+        const remapped = exclusiveMax - 1;
+        if (typeof newObj.maximum !== "number" || newObj.maximum > remapped) {
+          newObj.maximum = remapped;
+        }
+      }
+      delete newObj.exclusiveMaximum;
+    }
+
     for (const key in newObj) {
       if (key in newObj) {
         if (Array.isArray(newObj[key])) {


### PR DESCRIPTION
Fixes #10956

## Problem

`ChatGoogleGenerativeAI.withStructuredOutput(zodSchema)` (and `bindTools` / direct `generationConfig.responseSchema`) returns 400 Bad Request from Gemini when the JSON Schema contains `exclusiveMinimum` / `exclusiveMaximum`. Gemini's `responseSchema` only accepts `minimum` / `maximum`. Zod schemas like `z.number().int().positive()` emit `exclusiveMinimum: 0` under Draft 7 and trigger the failure.

## Fix

Extended `removeAdditionalProperties` in `libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts` (the shared sanitizer used by all three Gemini schema paths) to:

- **Integer schemas**: losslessly remap
  - `exclusiveMinimum: N` → `minimum: N + 1`
  - `exclusiveMaximum: N` → `maximum: N - 1`

  Only tightens an existing bound; never loosens.

- **Non-integer schemas**: drop the keyword (cannot be expressed in Gemini's grammar).

## Tests

Added vitest cases in `libs/providers/langchain-google-genai/src/tests/chat_models.test.ts`:

- Integer remap (`exclusiveMinimum` / `exclusiveMaximum` converted)
- Non-integer schema (keywords stripped, no remap)
- Pre-existing tighter `minimum` / `maximum` preserved (no loosening)
- Nested object properties recursed into

## Changeset

`.changeset/fix-gemini-exclusive-min-max.md` — `@langchain/google-genai` patch.