### PR TITLE
docs: add Tuning Engines OpenAI-compatible endpoint example

### DIFF
--- a/libs/providers/langchain-openai/README.md
+++ b/libs/providers/langchain-openai/README.md
@@ -58,6 +58,28 @@ const model = new ChatOpenAI({
 const response = await model.invoke(new HumanMessage("Hello world!"));
 ```
 
+### OpenAI-compatible endpoints
+
+`ChatOpenAI` can also call OpenAI-compatible endpoints by setting a custom
+`baseURL` in the underlying OpenAI client configuration. For example, you can
+point LangChain or LangGraph applications at Tuning Engines while keeping
+LangChain in control of prompts, chains, agents, tools, and orchestration:
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+
+const model = new ChatOpenAI({
+  apiKey: process.env.TUNING_ENGINES_API_KEY,
+  model: "gpt-4o-mini",
+  configuration: {
+    baseURL: "https://api.tuningengines.com/v1",
+  },
+});
+```
+
+Tuning Engines handles centralized model access, routing, policy checks, audit
+logs, traces, approvals, and cost visibility behind the OpenAI-compatible API.
+
 ### Streaming
 
 ```typescript


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
