### PR TITLE
feat(tools): add HackerNewsTopStoriesTool

### DIFF
--- a/.changeset/seven-bikes-sing.md
+++ b/.changeset/seven-bikes-sing.md
@@ -1,0 +1,5 @@
+---
+"@langchain/classic": minor
+---
+
+Add HackerNewsTopStoriesTool

--- a/libs/langchain-classic/src/tools/hacker_news.ts
+++ b/libs/langchain-classic/src/tools/hacker_news.ts
@@ -1,0 +1,83 @@
+import { z } from "zod/v3";
+import { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
+import { StructuredTool } from "@langchain/core/tools";
+import { InferInteropZodOutput } from "@langchain/core/utils/types";
+
+const hackerNewsTopStoriesSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .default(5)
+    .describe("The maximum number of top stories to return."),
+});
+
+type HackerNewsTopStoriesSchema = typeof hackerNewsTopStoriesSchema;
+
+type HackerNewsItem = {
+  id: number;
+  title?: string;
+  url?: string;
+};
+
+/**
+ * Tool for fetching current top stories from Hacker News.
+ */
+export class HackerNewsTopStoriesTool extends StructuredTool<
+  typeof hackerNewsTopStoriesSchema
+> {
+  static lc_name(): string {
+    return "HackerNewsTopStoriesTool";
+  }
+
+  name = "hacker_news_top_stories";
+
+  description =
+    "Fetches the top stories from Hacker News. Useful for getting current tech news.";
+
+  schema = hackerNewsTopStoriesSchema;
+
+  async _call(
+    { limit }: InferInteropZodOutput<HackerNewsTopStoriesSchema>,
+    _runManager?: CallbackManagerForToolRun
+  ): Promise<string> {
+    const topStoriesResponse = await fetch(
+      "https://hacker-news.firebaseio.com/v0/topstories.json"
+    );
+
+    if (!topStoriesResponse.ok) {
+      throw new Error(
+        `Failed to fetch Hacker News top stories: ${topStoriesResponse.status} ${topStoriesResponse.statusText}`
+      );
+    }
+
+    const storyIds = (await topStoriesResponse.json()) as number[];
+    const selectedStoryIds = storyIds.slice(0, limit);
+
+    const stories = await Promise.all(
+      selectedStoryIds.map(async (id) => {
+        const itemResponse = await fetch(
+          `https://hacker-news.firebaseio.com/v0/item/${id}.json`
+        );
+
+        if (!itemResponse.ok) {
+          throw new Error(
+            `Failed to fetch Hacker News item ${id}: ${itemResponse.status} ${itemResponse.statusText}`
+          );
+        }
+
+        return (await itemResponse.json()) as HackerNewsItem | null;
+      })
+    );
+
+    return stories
+      .filter((story): story is HackerNewsItem => story !== null)
+      .map((story, index) => {
+        const title = story.title ?? "Untitled";
+        const url =
+          story.url ?? `https://news.ycombinator.com/item?id=${story.id}`;
+        return `${index + 1}. ${title} - ${url}`;
+      })
+      .join("\n");
+  }
+}

--- a/libs/langchain-classic/src/tools/index.ts
+++ b/libs/langchain-classic/src/tools/index.ts
@@ -19,6 +19,7 @@ export {
 export { RequestsGetTool, RequestsPostTool } from "./requests.js";
 export { VectorStoreQATool } from "./vectorstore.js";
 export { ReadFileTool, WriteFileTool } from "./fs.js";
+export { HackerNewsTopStoriesTool } from "./hacker_news.js";
 export {
   convertToOpenAIFunction as formatToOpenAIFunction,
   convertToOpenAITool as formatToOpenAITool,

--- a/libs/langchain-classic/src/tools/tests/hacker_news.test.ts
+++ b/libs/langchain-classic/src/tools/tests/hacker_news.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi, afterEach } from "vitest";
+
+import { HackerNewsTopStoriesTool } from "../hacker_news.js";
+
+describe("HackerNewsTopStoriesTool", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("instantiates correctly", () => {
+    const tool = new HackerNewsTopStoriesTool();
+
+    expect(tool.name).toBe("hacker_news_top_stories");
+  });
+
+  test("_call returns formatted top stories", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [123],
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          title: "Mock Story",
+          url: "https://mock.com",
+        }),
+      } as Response);
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = new HackerNewsTopStoriesTool();
+    const result = await tool._call({ limit: 1 });
+
+    expect(result).toContain("Mock Story");
+    expect(result).toContain("https://mock.com");
+  });
+});


### PR DESCRIPTION
## Description

Adds `HackerNewsTopStoriesTool`, a new structured tool for fetching current top stories from Hacker News.

The tool lets LLM agents retrieve up-to-date technology news by calling the Hacker News Firebase API, limiting the number of returned stories via an optional `limit` parameter, and formatting each story with its title and URL. This is useful for agents that need lightweight access to current tech trends, startup news, developer discussions, and industry updates.

## Issue

This is a new community integration.

## Dependencies

No new external npm dependencies were added.

The implementation uses the native Node.js `fetch` API and the existing LangChain tool/Zod infrastructure already present in the repository.

## Testing

Unit tests were added using Vitest.

The tests verify that:

- `HackerNewsTopStoriesTool` instantiates with the expected tool name.
- The network layer is mocked via `global.fetch`, avoiding real Hacker News API requests.
- The tool returns formatted output containing the mocked story title and URL.

The tests pass locally with:

```bash
pnpm --filter @langchain/classic test -- hacker_news.test.ts
```