### PR TITLE
fix(google-genai): sanitize exclusive response schema bounds

### DIFF
--- a/.changeset/google-genai-exclusive-bounds.md
+++ b/.changeset/google-genai-exclusive-bounds.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): remove unsupported exclusive numeric bounds from Gemini response schemas

--- a/libs/providers/langchain-google-genai/src/tests/zod_to_genai_parameters.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/zod_to_genai_parameters.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod/v3";
+import {
+  jsonSchemaToGeminiParameters,
+  schemaToGenerativeAIParameters,
+} from "../utils/zod_to_genai_parameters.js";
+
+describe("schemaToGenerativeAIParameters", () => {
+  test("removes exclusive numeric bounds from Zod response schemas", () => {
+    const schema = z.object({
+      durationMinutes: z.number().int().positive(),
+      confidence: z.number().positive(),
+      rating: z.number().int().lt(5),
+    });
+
+    const result = schemaToGenerativeAIParameters(schema);
+    const properties = result.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(JSON.stringify(result)).not.toContain("exclusiveMinimum");
+    expect(JSON.stringify(result)).not.toContain("exclusiveMaximum");
+    expect(properties.durationMinutes).toMatchObject({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(properties.confidence).toMatchObject({
+      type: "number",
+      minimum: 0,
+    });
+    expect(properties.rating).toMatchObject({
+      type: "integer",
+      maximum: 4,
+    });
+  });
+
+  test("removes nested exclusive bounds from plain JSON schemas", () => {
+    const result = jsonSchemaToGeminiParameters({
+      type: "object",
+      properties: {
+        activity: {
+          type: "object",
+          properties: {
+            durationMinutes: {
+              type: "integer",
+              exclusiveMinimum: 0,
+            },
+          },
+        },
+      },
+    });
+
+    const activity = (
+      result.properties as Record<string, Record<string, unknown>>
+    ).activity;
+    const durationMinutes = (
+      activity.properties as Record<string, Record<string, unknown>>
+    ).durationMinutes;
+
+    expect(JSON.stringify(result)).not.toContain("exclusiveMinimum");
+    expect(durationMinutes).toMatchObject({
+      type: "integer",
+      minimum: 1,
+    });
+  });
+});

--- a/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
+++ b/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
@@ -25,6 +25,35 @@ export interface GenerativeAIJsonSchemaDirty extends GenerativeAIJsonSchema {
   additionalProperties?: boolean;
 }
 
+function removeExclusiveBounds(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  obj: Record<string, any>
+) {
+  const isInteger = obj.type === "integer";
+
+  if ("exclusiveMinimum" in obj) {
+    const { exclusiveMinimum } = obj;
+    delete obj.exclusiveMinimum;
+
+    if (typeof exclusiveMinimum === "number" && !("minimum" in obj)) {
+      obj.minimum = isInteger
+        ? Math.floor(exclusiveMinimum) + 1
+        : exclusiveMinimum;
+    }
+  }
+
+  if ("exclusiveMaximum" in obj) {
+    const { exclusiveMaximum } = obj;
+    delete obj.exclusiveMaximum;
+
+    if (typeof exclusiveMaximum === "number" && !("maximum" in obj)) {
+      obj.maximum = isInteger
+        ? Math.ceil(exclusiveMaximum) - 1
+        : exclusiveMaximum;
+    }
+  }
+}
+
 export function removeAdditionalProperties(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   obj: Record<string, any>
@@ -41,6 +70,8 @@ export function removeAdditionalProperties(
     if ("strict" in newObj) {
       delete newObj.strict;
     }
+
+    removeExclusiveBounds(newObj);
 
     for (const key in newObj) {
       if (key in newObj) {


### PR DESCRIPTION
## Summary

- sanitize `exclusiveMinimum` / `exclusiveMaximum` before sending Google GenAI response schemas to Gemini
- preserve tighter integer semantics by converting exclusive integer bounds to inclusive `minimum` / `maximum`
- add unit coverage for Zod and plain JSON schemas

Fixes #10956

## Tests

- `pnpm --filter @langchain/core build`
- `pnpm --filter @langchain/google-genai test:single src/tests/zod_to_genai_parameters.test.ts`
- `pnpm --filter @langchain/google-genai build`
- `pnpm --filter @langchain/google-genai test`
- `pnpm exec oxfmt --check libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts libs/providers/langchain-google-genai/src/tests/zod_to_genai_parameters.test.ts .changeset/google-genai-exclusive-bounds.md`
- `pnpm exec oxlint libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts libs/providers/langchain-google-genai/src/tests/zod_to_genai_parameters.test.ts`
