### PR TITLE
fix(core): handle empty chat generations

### DIFF
--- a/.changeset/clean-chat-generations.md
+++ b/.changeset/clean-chat-generations.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Throw a diagnostic error when chat model invoke returns an empty generation.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -290,7 +290,12 @@ export abstract class BaseChatModel<
       options,
       options?.callbacks
     );
-    const chatGeneration = result.generations[0][0] as ChatGeneration;
+    const chatGeneration = result.generations?.[0]?.[0] as
+      | ChatGeneration
+      | undefined;
+    if (chatGeneration?.message === undefined) {
+      throw new Error("Received empty response from chat model call.");
+    }
     // TODO: Remove cast after figuring out inheritance
     return chatGeneration.message as OutputMessageType;
   }

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -126,6 +126,18 @@ test("Test ChatModel uses callbacks with a cache", async () => {
   expect(response2.content).toEqual(acc);
 });
 
+test("Test ChatModel invoke throws a diagnostic error for empty generations", async () => {
+  const model = new FakeChatModel({});
+  vi.spyOn(model, "generatePrompt").mockResolvedValue({
+    generations: [[]],
+    llmOutput: {},
+  });
+
+  await expect(model.invoke("Hello there!")).rejects.toThrow(
+    "Received empty response from chat model call."
+  );
+});
+
 test("Test ChatModel legacy params withStructuredOutput", async () => {
   const model = new FakeListChatModel({
     responses: [`{ "test": true, "nested": { "somethingelse": "somevalue" } }`],


### PR DESCRIPTION
Fixes #9545.

## Summary
- guard `BaseChatModel.invoke()` against empty chat generation results before reading `.message`
- reuse the existing empty-response diagnostic error instead of leaking a native TypeError
- add a regression test for empty generation arrays
- add a patch changeset for `@langchain/core`

## Validation
- `pnpm --filter @langchain/core exec vitest run src/language_models/tests/chat_models.test.ts`
- `pnpm exec oxfmt --check libs/langchain-core/src/language_models/chat_models.ts libs/langchain-core/src/language_models/tests/chat_models.test.ts`
- `pnpm exec oxlint libs/langchain-core/src/language_models/chat_models.ts libs/langchain-core/src/language_models/tests/chat_models.test.ts`
- `pnpm --filter @langchain/core test`
- `pnpm --filter @langchain/core build`

## Commit Verification
- Commit `3e3e5c883f4f822cb380a7efa74d6e19e99b8f03` is SSH signed and GitHub reports `verified: true`.