### PR TITLE
fix(openai): wrap responses stream errors

### DIFF
--- a/.changeset/responses-stream-errors.md
+++ b/.changeset/responses-stream-errors.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Wrap Responses API stream iteration errors with existing OpenAI client error handling.

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -248,24 +248,29 @@ export class ChatOpenAIResponses<
       options
     );
 
-    for await (const data of streamIterable) {
-      if (options.signal?.aborted) {
-        return;
+    try {
+      for await (const data of streamIterable) {
+        if (options.signal?.aborted) {
+          return;
+        }
+        const chunk = convertResponsesDeltaToChatGenerationChunk(data);
+        if (chunk == null) continue;
+        yield chunk;
+        await runManager?.handleLLMNewToken(
+          chunk.text || "",
+          {
+            prompt: options.promptIndex ?? 0,
+            completion: 0,
+          },
+          undefined,
+          undefined,
+          undefined,
+          { chunk }
+        );
       }
-      const chunk = convertResponsesDeltaToChatGenerationChunk(data);
-      if (chunk == null) continue;
-      yield chunk;
-      await runManager?.handleLLMNewToken(
-        chunk.text || "",
-        {
-          prompt: options.promptIndex ?? 0,
-          completion: 0,
-        },
-        undefined,
-        undefined,
-        undefined,
-        { chunk }
-      );
+    } catch (e) {
+      const error = wrapOpenAIClientError(e);
+      throw error;
     }
   }
 

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -87,7 +87,7 @@ describe("streaming errors", () => {
     };
 
     async function* streamWithError() {
-      throw originalError;
+      yield await Promise.reject(originalError);
     }
 
     model.completionWithRetry = vi

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { ContextOverflowError } from "@langchain/core/errors";
+import { HumanMessage } from "@langchain/core/messages";
+import { describe, it, expect, vi } from "vitest";
 import { ChatOpenAIResponses } from "../responses.js";
 
 describe("constructor shorthand", () => {
@@ -69,6 +71,43 @@ describe("service_tier configuration", () => {
 
     const params = model.invocationParams({});
     expect(params.service_tier).toBe("auto");
+  });
+});
+
+describe("streaming errors", () => {
+  it("wraps errors thrown while iterating the response stream", async () => {
+    const model = new ChatOpenAIResponses({ model: "gpt-4o" });
+    const originalError = {
+      code: "context_length_exceeded",
+      message: "The request exceeds the context window.",
+      constructor: { name: "APIError" },
+      toString() {
+        return `APIError: ${this.message} (code: ${this.code})`;
+      },
+    };
+
+    async function* streamWithError() {
+      throw originalError;
+    }
+
+    model.completionWithRetry = vi
+      .fn()
+      .mockResolvedValue(streamWithError()) as typeof model.completionWithRetry;
+
+    let caughtError: unknown;
+    try {
+      for await (const _ of model._streamResponseChunks(
+        [new HumanMessage("hello")],
+        {}
+      )) {
+        // The mocked stream throws before yielding chunks.
+      }
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBeInstanceOf(ContextOverflowError);
+    expect((caughtError as ContextOverflowError).cause).toBe(originalError);
   });
 });
 


### PR DESCRIPTION
Fixes #10979

Wraps errors thrown while iterating Responses API streams with the existing OpenAI client error wrapper, so mid-stream errors are converted consistently.

Tests:
- `corepack.cmd pnpm --dir libs\providers\langchain-openai exec vitest run src/chat_models/tests/responses.test.ts`
- `corepack.cmd pnpm --dir libs\providers\langchain-openai exec oxfmt --check src/chat_models/responses.ts src/chat_models/tests/responses.test.ts`