### PR TITLE
feat(langchain): add `when` predicate to human-in-the-loop middleware

### DIFF
--- a/.changeset/feat-hitl-when-predicate.md
+++ b/.changeset/feat-hitl-when-predicate.md
@@ -1,0 +1,10 @@
+---
+"langchain": patch
+---
+
+feat(langchain): add `when` predicate to human-in-the-loop middleware
+
+Add an optional `when` callback on `InterruptOnConfig` so callers can
+dynamically skip interrupts for specific tool calls. The predicate receives
+a `ToolCallRequest` (batch `afterModel` context) and returns whether to
+interrupt or auto-approve, matching Python `HumanInTheLoopMiddleware`.

--- a/libs/langchain/src/agents/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middleware/hitl.ts
@@ -10,6 +10,37 @@ import { interrupt } from "@langchain/langgraph";
 import { createMiddleware } from "../middleware.js";
 import type { AgentBuiltInState, Runtime } from "../runtime.js";
 import type { JumpToTarget } from "../constants.js";
+import type { ToolCallRequest } from "./types.js";
+
+const WhenFunctionSchema = z
+  .function()
+  .args(z.custom<ToolCallRequest<AgentBuiltInState>>()) // request
+  .returns(z.union([z.boolean(), z.promise(z.boolean())]));
+
+/**
+ * Predicate controlling whether a given tool call triggers an interrupt.
+ *
+ * Receives a {@link ToolCallRequest} and returns `true` to interrupt or `false`
+ * to auto-approve the tool call.
+ *
+ * The request is constructed with `tool` set to `undefined` and `runtime` set to
+ * the node-level {@link Runtime}, so it reflects the batch (`afterModel`) context
+ * rather than a per-call tool execution.
+ *
+ * @param request - The tool call request being evaluated
+ * @returns `true` to interrupt for the tool call, `false` to auto-approve it.
+ * May also return a promise resolving to a boolean.
+ *
+ * @example
+ * ```typescript
+ * import { type WhenPredicate } from "langchain";
+ *
+ * // Only interrupt delete_file calls targeting /etc
+ * const when: WhenPredicate = (request) =>
+ *   String(request.toolCall.args.path ?? "").startsWith("/etc");
+ * ```
+ */
+export type WhenPredicate = z.infer<typeof WhenFunctionSchema>;
 
 const DescriptionFunctionSchema = z
   .function()
@@ -99,6 +130,28 @@ const InterruptOnConfigSchema = z.object({
    * JSON schema for the arguments associated with the action, if edits are allowed.
    */
   argsSchema: z.record(z.any()).optional(),
+  /**
+   * Optional predicate controlling whether to interrupt for a given tool call.
+   *
+   * Receives a {@link ToolCallRequest} and returns `true` to interrupt or
+   * `false` to auto-approve the tool call.
+   *
+   * The request is constructed with `tool` set to `undefined` and `runtime` set
+   * to the node-level {@link Runtime}, so `request.tool` is not available.
+   *
+   * @example
+   * ```typescript
+   * import type { InterruptOnConfig } from "langchain";
+   *
+   * // Only interrupt delete_file calls targeting /etc
+   * const config: InterruptOnConfig = {
+   *   allowedDecisions: ["approve", "reject"],
+   *   when: (request) =>
+   *     String(request.toolCall.args.path ?? "").startsWith("/etc"),
+   * };
+   * ```
+   */
+  when: WhenFunctionSchema.optional(),
 });
 export type InterruptOnConfig = z.input<typeof InterruptOnConfigSchema>;
 
@@ -313,6 +366,7 @@ export type HumanInTheLoopMiddlewareConfig = InferInteropZodInput<
  * @param options.interruptOn[toolName].allowedDecisions - Array of decision types allowed for this tool (e.g., ["approve", "edit", "reject"])
  * @param options.interruptOn[toolName].description - Custom approval message for the tool. Can be either a static string or a callable that dynamically generates the description based on agent state, runtime, and tool call information
  * @param options.interruptOn[toolName].argsSchema - JSON schema for the arguments associated with the action, if edits are allowed
+ * @param options.interruptOn[toolName].when - Optional predicate that dynamically controls whether a tool call triggers an interrupt. Returns `true` to interrupt or `false` to auto-approve the tool call.
  * @param options.descriptionPrefix - Default prefix for approval messages (default: "Tool execution requires approval"). Only used for tools that do not define a custom `description` in their InterruptOnConfig.
  *
  * @returns A middleware instance that can be passed to `createAgent`
@@ -515,6 +569,30 @@ export function humanInTheLoopMiddleware(
     return { actionRequest, reviewConfig };
   };
 
+  /**
+   * Return `false` if the `when` predicate rejects this tool call, `true` otherwise.
+   *
+   * When no `when` predicate is configured the tool call always interrupts.
+   */
+  const shouldInterrupt = async (
+    toolCall: ToolCall,
+    config: InterruptOnConfig,
+    state: AgentBuiltInState,
+    runtime: Runtime<unknown>
+  ): Promise<boolean> => {
+    const { when } = config;
+    if (when == null) {
+      return true;
+    }
+    const request: ToolCallRequest<AgentBuiltInState> = {
+      toolCall,
+      tool: undefined,
+      state,
+      runtime,
+    };
+    return when(request);
+  };
+
   const processDecision = (
     decision: Decision,
     toolCall: ToolCall,
@@ -651,7 +729,16 @@ export function humanInTheLoopMiddleware(
         const autoApprovedToolCalls: ToolCall[] = [];
 
         for (const toolCall of lastMessage.tool_calls) {
-          if (toolCall.name in resolvedConfigs) {
+          const interruptConfig = resolvedConfigs[toolCall.name];
+          /**
+           * A tool call is interrupted only when it has a resolved config and its
+           * optional `when` predicate doesn't opt it out. Otherwise it is
+           * auto-approved.
+           */
+          if (
+            interruptConfig &&
+            (await shouldInterrupt(toolCall, interruptConfig, state, runtime))
+          ) {
             interruptToolCalls.push(toolCall);
           } else {
             autoApprovedToolCalls.push(toolCall);

--- a/libs/langchain/src/agents/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/hitl.test.ts
@@ -2012,9 +2012,7 @@ describe("humanInTheLoopMiddleware", () => {
           write_file: {
             allowedDecisions: ["approve"],
             when: (request) =>
-              String(request.toolCall.args.filename ?? "").startsWith(
-                "danger"
-              ),
+              String(request.toolCall.args.filename ?? "").startsWith("danger"),
           },
         },
       });
@@ -2068,9 +2066,7 @@ describe("humanInTheLoopMiddleware", () => {
           write_file: {
             allowedDecisions: ["approve"],
             when: (request) =>
-              String(request.toolCall.args.filename ?? "").startsWith(
-                "danger"
-              ),
+              String(request.toolCall.args.filename ?? "").startsWith("danger"),
           },
         },
       });

--- a/libs/langchain/src/agents/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/hitl.test.ts
@@ -24,6 +24,7 @@ import {
   _AnyIdAIMessage,
 } from "../../tests/utils.js";
 import type { Interrupt } from "../../types.js";
+import type { ToolCallRequest } from "../types.js";
 
 const writeFileFn = vi.fn(
   async ({ filename, content }: { filename: string; content: string }) => {
@@ -2001,6 +2002,196 @@ describe("humanInTheLoopMiddleware", () => {
         filename: "original2.txt",
         content: "Original 2",
       });
+    });
+  });
+
+  describe("when predicate", () => {
+    it("auto-approves the tool call when `when` returns false", async () => {
+      const hitlMiddleware = humanInTheLoopMiddleware({
+        interruptOn: {
+          write_file: {
+            allowedDecisions: ["approve"],
+            when: (request) =>
+              String(request.toolCall.args.filename ?? "").startsWith(
+                "danger"
+              ),
+          },
+        },
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          [
+            {
+              id: "call_1",
+              name: "write_file",
+              args: { filename: "safe.txt", content: "Safe content" },
+            },
+          ],
+          [],
+        ],
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createAgent({
+        model,
+        checkpointer,
+        tools: [writeFileTool],
+        middleware: [hitlMiddleware],
+      });
+
+      const config = {
+        configurable: { thread_id: "test-when-false" },
+      };
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Write to safe.txt")] },
+        config
+      );
+
+      // The agent should run to completion without interrupting.
+      const state = await agent.graph.getState(config);
+      expect(state.next.length).toBe(0);
+      expect(state.tasks?.[0]?.interrupts ?? []).toHaveLength(0);
+
+      // The tool executed because the `when` predicate auto-approved it.
+      expect(writeFileFn).toHaveBeenCalledTimes(1);
+      expect(writeFileFn).toHaveBeenCalledWith(
+        { filename: "safe.txt", content: "Safe content" },
+        expect.anything()
+      );
+    });
+
+    it("interrupts for the tool call when `when` returns true", async () => {
+      const hitlMiddleware = humanInTheLoopMiddleware({
+        interruptOn: {
+          write_file: {
+            allowedDecisions: ["approve"],
+            when: (request) =>
+              String(request.toolCall.args.filename ?? "").startsWith(
+                "danger"
+              ),
+          },
+        },
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          [
+            {
+              id: "call_1",
+              name: "write_file",
+              args: { filename: "danger.txt", content: "Dangerous content" },
+            },
+          ],
+        ],
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createAgent({
+        model,
+        checkpointer,
+        tools: [writeFileTool],
+        middleware: [hitlMiddleware],
+      });
+
+      const config = {
+        configurable: { thread_id: "test-when-true" },
+      };
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Write to danger.txt")] },
+        config
+      );
+
+      // The tool must not run until the human approves.
+      expect(writeFileFn).not.toHaveBeenCalled();
+
+      const state = await agent.graph.getState(config);
+      expect(state.next.length).toBe(1);
+
+      const task = state.tasks?.[0];
+      expect(task?.interrupts).toHaveLength(1);
+      const hitlRequest = task!.interrupts[0].value as HITLRequest;
+      expect(hitlRequest.actionRequests).toHaveLength(1);
+      expect(hitlRequest.actionRequests[0]?.name).toBe("write_file");
+    });
+
+    it("passes a ToolCallRequest with the correct values to `when`", async () => {
+      const captured: ToolCallRequest[] = [];
+
+      const hitlMiddleware = humanInTheLoopMiddleware({
+        interruptOn: {
+          write_file: {
+            allowedDecisions: ["approve"],
+            when: (request) => {
+              captured.push(request);
+              return true;
+            },
+          },
+        },
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          [
+            {
+              id: "tc-1",
+              name: "write_file",
+              args: { filename: "report.txt", content: "data" },
+            },
+          ],
+        ],
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createAgent({
+        model,
+        checkpointer,
+        tools: [writeFileTool],
+        middleware: [hitlMiddleware],
+      });
+
+      const config = {
+        configurable: { thread_id: "test-when-args" },
+      };
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Write report")] },
+        config
+      );
+
+      expect(captured).toHaveLength(1);
+      const request = captured[0]!;
+
+      // The captured tool call matches the one emitted by the model.
+      expect(request.toolCall).toEqual({
+        id: "tc-1",
+        name: "write_file",
+        args: { filename: "report.txt", content: "data" },
+        type: "tool_call",
+      });
+
+      // In batch mode the request is constructed without a concrete tool.
+      expect(request.tool).toBeUndefined();
+
+      // The request carries the live agent state: the human prompt followed by
+      // the AI message whose tool call is being evaluated.
+      expect(request.state.messages).toEqual([
+        new _AnyIdHumanMessage("Write report"),
+        expect.objectContaining({
+          tool_calls: [
+            expect.objectContaining({ id: "tc-1", name: "write_file" }),
+          ],
+        }),
+      ]);
+      const lastMessage =
+        request.state.messages[request.state.messages.length - 1];
+      expect(AIMessage.isInstance(lastMessage)).toBe(true);
+
+      // The request exposes the node-level runtime.
+      expect(request.runtime).toBeDefined();
+      expect(request.runtime.configurable?.thread_id).toBe("test-when-args");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add optional `when` predicate on `InterruptOnConfig` for `humanInTheLoopMiddleware`, aligned with langchain-ai/langchain#37579.
- Introduce exported `WhenPredicate` type; predicate receives a batch-mode `ToolCallRequest` (`tool` undefined, node-level `runtime`) and returns whether to interrupt or auto-approve.
- Add unit tests for skip interrupt, fire interrupt, and captured request shape (tool call, state messages, runtime thread id).
