### PR TITLE
fix(deepseek): disable structured output for v4-pro and v4-flash models

### DIFF
--- a/.changeset/fix-deepseek-structured-output.md
+++ b/.changeset/fix-deepseek-structured-output.md
@@ -1,0 +1,5 @@
+---
+"@langchain/deepseek": patch
+---
+
+fix(deepseek): disable structured output for v4-pro and v4-flash models

--- a/libs/providers/langchain-deepseek/src/profiles.ts
+++ b/libs/providers/langchain-deepseek/src/profiles.ts
@@ -29,7 +29,7 @@ const PROFILES: Record<string, ModelProfile> = {
     audioOutputs: false,
     videoOutputs: false,
     toolCalling: true,
-    structuredOutput: true,
+    structuredOutput: false,
   },
   "deepseek-reasoner": {
     maxInputTokens: 1000000,
@@ -57,7 +57,7 @@ const PROFILES: Record<string, ModelProfile> = {
     audioOutputs: false,
     videoOutputs: false,
     toolCalling: true,
-    structuredOutput: true,
+    structuredOutput: false,
   },
 };
 export default PROFILES;


### PR DESCRIPTION
The model profiles for deepseek-v4-pro and deepseek-v4-flash incorrectly declared `structuredOutput: true`, causing `withStructuredOutput()` to attempt function calling with `tool_choice`. These models route to DeepSeek's reasoning mode, which rejects the `tool_choice` parameter with the error "Thinking mode does not support this tool_choice".

This fix updates `libs/providers/langchain-deepseek/src/profiles.ts` to set `structuredOutput: false` for both models, preventing `withStructuredOutput()` from being used with these reasoning models until an alternative implementation (such as JSON mode) is available.

Fixes #10954
