### PR TITLE
fix(langchain): prevent null jumpTo writes in middleware

### DIFF
--- a/.changeset/mean-radios-hope.md
+++ b/.changeset/mean-radios-hope.md
@@ -1,0 +1,7 @@
+---
+"langchain": patch
+---
+
+fix(agents): avoid nullish jumpTo updates from middleware no-op returns
+
+Middleware hook outputs are now treated as sparse updates so no-op hooks do not emit `jumpTo` writes. This prevents concurrent graph update errors in structured output retry flows with multiple `afterModel` middleware hooks while preserving explicit jump routing behavior.

--- a/libs/langchain/src/agents/ReactAgent.ts
+++ b/libs/langchain/src/agents/ReactAgent.ts
@@ -895,12 +895,18 @@ export class ReactAgent<
       if (allowJump && builtInState.jumpTo) {
         const destination = parseJumpToTarget(builtInState.jumpTo);
         if (destination === END) {
-          return exitNode;
+          if (exitNode === END) {
+            return END;
+          }
+          return new Send(exitNode, { ...state, jumpTo: undefined });
         }
         if (destination === TOOLS_NODE_NAME) {
           // If trying to jump to tools but no tools are available, go to exitNode
           if (!hasToolsAvailable) {
-            return exitNode;
+            if (exitNode === END) {
+              return END;
+            }
+            return new Send(exitNode, { ...state, jumpTo: undefined });
           }
           return new Send(TOOLS_NODE_NAME, { ...state, jumpTo: undefined });
         }
@@ -1052,11 +1058,17 @@ export class ReactAgent<
         /**
          * When beforeAgent jumps to END, route to exitNode (first afterAgent node)
          */
-        return exitNode;
+        if (exitNode === END) {
+          return END;
+        }
+        return new Send(exitNode, { ...state, jumpTo: undefined });
       }
       if (destination === TOOLS_NODE_NAME) {
         if (!hasToolsAvailable) {
-          return exitNode;
+          if (exitNode === END) {
+            return END;
+          }
+          return new Send(exitNode, { ...state, jumpTo: undefined });
         }
         return new Send(TOOLS_NODE_NAME, { ...state, jumpTo: undefined });
       }

--- a/libs/langchain/src/agents/nodes/AfterAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterAgentNode.ts
@@ -13,6 +13,7 @@ export class AfterAgentNode<
   TContextSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "afterAgentNodes"];
+  protected hookPhase = "afterAgent" as const;
 
   constructor(
     public middleware: AgentMiddleware<

--- a/libs/langchain/src/agents/nodes/AfterModelNode.ts
+++ b/libs/langchain/src/agents/nodes/AfterModelNode.ts
@@ -13,6 +13,7 @@ export class AfterModelNode<
   TContextSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "afterModelNodes"];
+  protected hookPhase = "afterModel" as const;
 
   constructor(
     public middleware: AgentMiddleware<

--- a/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeAgentNode.ts
@@ -13,6 +13,7 @@ export class BeforeAgentNode<
   TContextSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "beforeAgentNodes"];
+  protected hookPhase = "beforeAgent" as const;
 
   constructor(
     public middleware: AgentMiddleware<

--- a/libs/langchain/src/agents/nodes/BeforeModelNode.ts
+++ b/libs/langchain/src/agents/nodes/BeforeModelNode.ts
@@ -13,6 +13,7 @@ export class BeforeModelNode<
   TContextSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends MiddlewareNode<TStateSchema, TContextSchema> {
   lc_namespace = ["langchain", "agents", "beforeModelNodes"];
+  protected hookPhase = "beforeModel" as const;
 
   constructor(
     public middleware: AgentMiddleware<

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -110,12 +110,10 @@ export abstract class MiddlewareNode<
     );
 
     /**
-     * If result is undefined, the hook made no state changes — return
-     * only the jumpTo sentinel so we don't re-emit every input key as
-     * a state update.
+     * If result is undefined, the hook made no state changes.
      */
     if (!result) {
-      return { jumpTo: undefined };
+      return {};
     }
 
     /**
@@ -138,10 +136,7 @@ export abstract class MiddlewareNode<
       constraint = "afterModel.canJumpTo";
     }
 
-    if (
-      typeof result.jumpTo === "string" &&
-      !jumpToConstraint?.includes(result.jumpTo as JumpToTarget)
-    ) {
+    if (result.jumpTo && !jumpToConstraint?.includes(result.jumpTo)) {
       const suggestion =
         jumpToConstraint && jumpToConstraint.length > 0
           ? `must be one of: ${jumpToConstraint?.join(", ")}.`
@@ -154,26 +149,27 @@ export abstract class MiddlewareNode<
     /**
      * If result is a control action, handle it
      */
-    if (typeof result === "object" && "type" in result) {
+    if (typeof result === "object" && result !== null && "type" in result) {
       // Handle control actions
       if (result.type === "terminate") {
         if (result.error) {
           throw result.error;
         }
-        return {
-          ...state,
-          ...(result.result || {}),
-          jumpTo: result.jumpTo,
-        };
+        const { jumpTo: _ignored, ...update } = (result.result ?? {}) as Record<
+          string,
+          unknown
+        >;
+        return result.jumpTo ? { ...update, jumpTo: result.jumpTo } : update;
       }
 
       throw new Error(`Invalid control action: ${JSON.stringify(result)}`);
     }
 
     /**
-     * If result is a state update, merge it with current state
+     * If result is a state update, return sparse updates only.
      */
-    return { ...state, ...result, jumpTo: result.jumpTo };
+    const { jumpTo: _ignored, ...update } = result as Record<string, unknown>;
+    return result.jumpTo ? { ...update, jumpTo: result.jumpTo } : update;
   }
 
   get nodeOptions() {

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -45,6 +45,8 @@ export abstract class MiddlewareNode<
     invokeState: TStateSchema,
     config?: LangGraphRunnableConfig
   ): Promise<NodeOutput<TStateSchema>> {
+    const clearJumpToByDefault = this.name?.startsWith("AfterAgentNode_");
+
     /**
      * Filter context based on middleware's contextSchema
      */
@@ -113,8 +115,13 @@ export abstract class MiddlewareNode<
      * If result is undefined, the hook made no state changes.
      */
     if (!result) {
-      return {};
+      return clearJumpToByDefault ? { jumpTo: undefined } : {};
     }
+
+    const jumpTarget =
+      typeof result.jumpTo === "string"
+        ? (result.jumpTo as JumpToTarget)
+        : undefined;
 
     /**
      * Verify that the jump target is allowed for the middleware
@@ -136,14 +143,14 @@ export abstract class MiddlewareNode<
       constraint = "afterModel.canJumpTo";
     }
 
-    if (result.jumpTo && !jumpToConstraint?.includes(result.jumpTo)) {
+    if (jumpTarget && !jumpToConstraint?.includes(jumpTarget)) {
       const suggestion =
         jumpToConstraint && jumpToConstraint.length > 0
           ? `must be one of: ${jumpToConstraint?.join(", ")}.`
           : constraint
             ? `no ${constraint} defined in middleware ${this.middleware.name}`
             : "";
-      throw new Error(`Invalid jump target: ${result.jumpTo}, ${suggestion}.`);
+      throw new Error(`Invalid jump target: ${jumpTarget}, ${suggestion}.`);
     }
 
     /**
@@ -159,7 +166,10 @@ export abstract class MiddlewareNode<
           string,
           unknown
         >;
-        return result.jumpTo ? { ...update, jumpTo: result.jumpTo } : update;
+        if (jumpTarget) {
+          return { ...update, jumpTo: jumpTarget };
+        }
+        return clearJumpToByDefault ? { ...update, jumpTo: undefined } : update;
       }
 
       throw new Error(`Invalid control action: ${JSON.stringify(result)}`);
@@ -169,7 +179,10 @@ export abstract class MiddlewareNode<
      * If result is a state update, return sparse updates only.
      */
     const { jumpTo: _ignored, ...update } = result as Record<string, unknown>;
-    return result.jumpTo ? { ...update, jumpTo: result.jumpTo } : update;
+    if (jumpTarget) {
+      return { ...update, jumpTo: jumpTarget };
+    }
+    return clearJumpToByDefault ? { ...update, jumpTo: undefined } : update;
   }
 
   get nodeOptions() {

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -21,10 +21,18 @@ type NodeOutput<TStateSchema extends Record<string, any>> =
   | Command<any, TStateSchema, string>
   | { jumpTo?: JumpToTarget };
 
+type MiddlewareHookPhase =
+  | "beforeAgent"
+  | "beforeModel"
+  | "afterModel"
+  | "afterAgent";
+
 export abstract class MiddlewareNode<
   TStateSchema extends Record<string, any>,
   TContextSchema extends Record<string, any>,
 > extends RunnableCallable<TStateSchema, NodeOutput<TStateSchema>> {
+  protected abstract hookPhase: MiddlewareHookPhase;
+
   abstract middleware: AgentMiddleware<
     z.ZodObject<z.ZodRawShape>,
     z.ZodObject<z.ZodRawShape>
@@ -45,7 +53,7 @@ export abstract class MiddlewareNode<
     invokeState: TStateSchema,
     config?: LangGraphRunnableConfig
   ): Promise<NodeOutput<TStateSchema>> {
-    const clearJumpToByDefault = this.name?.startsWith("AfterAgentNode_");
+    const clearJumpToByDefault = this.hookPhase === "afterAgent";
 
     /**
      * Filter context based on middleware's contextSchema
@@ -126,21 +134,26 @@ export abstract class MiddlewareNode<
     /**
      * Verify that the jump target is allowed for the middleware
      */
-    let jumpToConstraint: JumpToTarget[] | undefined;
-    let constraint: string | undefined;
+    let jumpToConstraint: JumpToTarget[] | undefined = undefined;
+    let constraint: string;
 
-    if (this.name?.startsWith("BeforeAgentNode_")) {
-      jumpToConstraint = getHookConstraint(this.middleware.beforeAgent);
-      constraint = "beforeAgent.canJumpTo";
-    } else if (this.name?.startsWith("BeforeModelNode_")) {
-      jumpToConstraint = getHookConstraint(this.middleware.beforeModel);
-      constraint = "beforeModel.canJumpTo";
-    } else if (this.name?.startsWith("AfterAgentNode_")) {
-      jumpToConstraint = getHookConstraint(this.middleware.afterAgent);
-      constraint = "afterAgent.canJumpTo";
-    } else if (this.name?.startsWith("AfterModelNode_")) {
-      jumpToConstraint = getHookConstraint(this.middleware.afterModel);
-      constraint = "afterModel.canJumpTo";
+    switch (this.hookPhase) {
+      case "beforeAgent":
+        jumpToConstraint = getHookConstraint(this.middleware.beforeAgent);
+        constraint = "beforeAgent.canJumpTo";
+        break;
+      case "beforeModel":
+        jumpToConstraint = getHookConstraint(this.middleware.beforeModel);
+        constraint = "beforeModel.canJumpTo";
+        break;
+      case "afterAgent":
+        jumpToConstraint = getHookConstraint(this.middleware.afterAgent);
+        constraint = "afterAgent.canJumpTo";
+        break;
+      case "afterModel":
+        jumpToConstraint = getHookConstraint(this.middleware.afterModel);
+        constraint = "afterModel.canJumpTo";
+        break;
     }
 
     if (jumpTarget && !jumpToConstraint?.includes(jumpTarget)) {

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -10,6 +10,7 @@ import {
   ToolCall,
 } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
+import { FakeListChatModel } from "@langchain/core/utils/testing";
 import { z as z4 } from "zod";
 import {
   Command,
@@ -25,9 +26,55 @@ import {
   providerStrategy,
   toolStrategy,
 } from "../index.js";
+import { AfterModelNode } from "../nodes/AfterModelNode.js";
 import { FakeToolCallingChatModel, FakeToolCallingModel } from "./utils.js";
 import { MiddlewareError } from "../errors.js";
 import type { JsonSchemaFormat } from "../responses.js";
+
+class FakeListToolCallingChatModel extends FakeListChatModel {
+  get profile() {
+    return {
+      toolCalling: true,
+      structuredOutput: true,
+    };
+  }
+
+  bindTools(_tools: unknown[]) {
+    // This model returns pre-seeded tool calls from queued responses.
+    return this;
+  }
+
+  _formatGeneration(response: string) {
+    try {
+      const payload = JSON.parse(response) as {
+        content?: string;
+        tool_calls?: Array<{
+          name: string;
+          args: Record<string, unknown>;
+          id?: string;
+        }>;
+      };
+
+      if (Array.isArray(payload.tool_calls)) {
+        return {
+          message: new AIMessage({
+            content: payload.content ?? "",
+            tool_calls: payload.tool_calls.map((toolCall, index) => ({
+              ...toolCall,
+              id: toolCall.id ?? `call_${index + 1}`,
+              type: "tool_call",
+            })),
+          }),
+          text: payload.content ?? "",
+        };
+      }
+    } catch {
+      // Fall back to plain text responses.
+    }
+
+    return super._formatGeneration(response);
+  }
+}
 
 describe("middleware", () => {
   it("should propagate state schema to middleware hooks and result", async () => {
@@ -3152,6 +3199,112 @@ describe("middleware", () => {
             msg.content.includes("Failed to parse structured output")
         )
       ).toBe(true);
+    });
+
+    it("should not throw concurrent jumpTo updates when structured output retries with two no-op afterModel hooks", async () => {
+      const responseFormat = toolStrategy(z.object({ answer: z.string() }));
+      const toolName = responseFormat[0].name;
+      const model = new FakeListToolCallingChatModel({
+        responses: [
+          JSON.stringify({
+            content: "",
+            tool_calls: [
+              { name: toolName, args: { wrong: 123 }, id: "call_1" },
+            ],
+          }),
+          JSON.stringify({
+            content: "",
+            tool_calls: [
+              { name: toolName, args: { answer: "correct" }, id: "call_2" },
+            ],
+          }),
+        ],
+      });
+
+      const noopAfterModelA = createMiddleware({
+        name: "NoopAfterModelA",
+        afterModel: async () => undefined,
+      });
+      const noopAfterModelB = createMiddleware({
+        name: "NoopAfterModelB",
+        afterModel: async () => undefined,
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        responseFormat,
+        middleware: [noopAfterModelA, noopAfterModelB],
+      });
+
+      const result = await agent.invoke({
+        messages: [{ role: "user", content: "test" }],
+      });
+
+      expect(result.structuredResponse).toEqual({ answer: "correct" });
+      expect(
+        result.messages.some(
+          (msg: BaseMessage) =>
+            ToolMessage.isInstance(msg) &&
+            typeof msg.content === "string" &&
+            msg.content.includes("Failed to parse structured output")
+        )
+      ).toBe(true);
+    });
+
+    it("should keep explicit afterModel jumpTo routing with other no-op afterModel middleware", async () => {
+      const toolFn = vi.fn(async () => "tool result");
+      const testTool = tool(toolFn, {
+        name: "test_tool",
+        description: "test tool",
+        schema: z.object({}),
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [[{ name: "test_tool", args: {}, id: "call_1" }]],
+      });
+
+      const noopAfterModel = createMiddleware({
+        name: "NoopAfterModel",
+        afterModel: async () => undefined,
+      });
+      const jumpAfterModel = createMiddleware({
+        name: "JumpAfterModel",
+        afterModel: {
+          canJumpTo: ["end"],
+          hook: async () => ({ jumpTo: "end" }),
+        },
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [testTool],
+        middleware: [noopAfterModel, jumpAfterModel],
+      });
+
+      const result = await agent.invoke({
+        messages: [new HumanMessage("run tool")],
+      });
+
+      expect(toolFn).not.toHaveBeenCalled();
+      expect(result.messages.some((m) => ToolMessage.isInstance(m))).toBe(
+        false
+      );
+    });
+
+    it("should return an empty update when afterModel hook returns undefined", async () => {
+      const middleware = createMiddleware({
+        name: "UndefinedAfterModel",
+        afterModel: async () => undefined,
+      });
+      const node = new AfterModelNode(middleware);
+
+      const update = await node.invokeMiddleware({
+        messages: [new HumanMessage("hello")],
+      });
+
+      expect(update).toEqual({});
+      expect(update).not.toHaveProperty("jumpTo");
     });
   });
 

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -2698,6 +2698,59 @@ describe("middleware", () => {
       expect(result.messages[0].content).toBe("Test");
     });
 
+    it("should clear jumpTo before entering afterAgent chain from beforeAgent", async () => {
+      const executionLog: string[] = [];
+
+      const middleware1 = createMiddleware({
+        name: "Middleware1",
+        beforeAgent: {
+          hook: async () => {
+            executionLog.push("before_agent_1");
+            return {
+              jumpTo: "end",
+            };
+          },
+          canJumpTo: ["end"],
+        },
+        afterAgent: async () => {
+          executionLog.push("after_agent_1");
+        },
+      });
+
+      const middleware2 = createMiddleware({
+        name: "Middleware2",
+        afterAgent: {
+          canJumpTo: ["end"],
+          hook: async () => {
+            executionLog.push("after_agent_2");
+            return undefined;
+          },
+        },
+      });
+
+      const model = new FakeToolCallingChatModel({
+        responses: [new AIMessage("Response")],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [middleware1, middleware2],
+      });
+
+      await agent.invoke({
+        messages: [new HumanMessage("Test")],
+      });
+
+      // jumpTo should be consumed before entering afterAgent chain;
+      // otherwise middleware2's router would immediately route to END.
+      expect(executionLog).toEqual([
+        "before_agent_1",
+        "after_agent_2",
+        "after_agent_1",
+      ]);
+    });
+
     it("should terminate when afterModel jumps to end (skips tools)", async () => {
       const executionLog: string[] = [];
 
@@ -2749,6 +2802,76 @@ describe("middleware", () => {
       expect(result.messages[0].content).toBe("Test");
       expect(AIMessage.isInstance(result.messages[1])).toBe(true);
       expect((result.messages[1] as AIMessage).tool_calls?.length).toBe(1);
+      expect(result.messages.some((m) => ToolMessage.isInstance(m))).toBe(
+        false
+      );
+    });
+
+    it("should clear jumpTo before entering afterAgent chain from afterModel", async () => {
+      const executionLog: string[] = [];
+
+      const toolFn = vi.fn(async ({ query }: { query: string }) => {
+        executionLog.push("tool_execution");
+        return `${query}`;
+      });
+
+      const sampleTool = tool(toolFn, {
+        name: "sample_tool",
+        description: "Sample tool",
+        schema: z.object({
+          query: z.string(),
+        }),
+      });
+
+      const middleware1 = createMiddleware({
+        name: "Middleware1",
+        afterModel: {
+          hook: async () => {
+            executionLog.push("after_model_1");
+            return {
+              jumpTo: "end",
+            };
+          },
+          canJumpTo: ["end"],
+        },
+        afterAgent: async () => {
+          executionLog.push("after_agent_1");
+        },
+      });
+
+      const middleware2 = createMiddleware({
+        name: "Middleware2",
+        afterAgent: {
+          canJumpTo: ["end"],
+          hook: async () => {
+            executionLog.push("after_agent_2");
+            return undefined;
+          },
+        },
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          [{ name: "sample_tool", args: { query: "Test" }, id: "test_id" }],
+        ],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [sampleTool],
+        middleware: [middleware1, middleware2],
+      });
+
+      const result = await agent.invoke({
+        messages: [new HumanMessage("Test")],
+      });
+
+      expect(executionLog).toEqual([
+        "after_model_1",
+        "after_agent_2",
+        "after_agent_1",
+      ]);
+      expect(toolFn).not.toHaveBeenCalled();
       expect(result.messages.some((m) => ToolMessage.isInstance(m))).toBe(
         false
       );


### PR DESCRIPTION
## Summary

Addresses the upstream agent middleware bug reported in `langchain-ai/deepagentsjs#480` where concurrent writes to the `jumpTo` channel could trigger:

`InvalidUpdateError: Invalid update for channel "jumpTo" with values [null,null]`

This change makes middleware node outputs sparse and only emits `jumpTo` when it is explicitly set to a valid string target, preventing nullish `jumpTo` writes during structured-output retry flows with multiple `afterModel` middleware hooks.

## Changes

### `langchain` / agents middleware node

- Updated `MiddlewareNode.invokeMiddleware` to avoid emitting `jumpTo` for no-op middleware results.
- Changed control-action and normal middleware update paths to strip `jumpTo` from intermediate updates and only include it when present as a valid string target.
- Kept existing jump target validation behavior (`canJumpTo`) for explicit jump targets.
- Preserved terminate control-action behavior while ensuring sparse state updates.

### `langchain` / agent middleware tests

- Added regression coverage for structured-output retry with two no-op `afterModel` middlewares to ensure no concurrent `jumpTo` update error.
- Added a routing regression ensuring explicit `afterModel` `jumpTo` still works with another no-op `afterModel` middleware.
- Added a direct middleware node test confirming `undefined` `afterModel` results produce an empty update with no `jumpTo` key.
