### PR TITLE
fix(langchain): drop tool messages not immediately after their tool call

### DIFF
--- a/.changeset/fix-context-editing-tool-adjacency.md
+++ b/.changeset/fix-context-editing-tool-adjacency.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): remove tool messages that are not immediately after their tool call in context editing

--- a/libs/langchain/src/agents/middleware/contextEditing.ts
+++ b/libs/langchain/src/agents/middleware/contextEditing.ts
@@ -289,48 +289,26 @@ export class ClearToolUsesEdit implements ContextEdit {
     const { messages, model, countTokens } = params;
     const tokens = await countTokens(messages);
 
-    /**
-     * Always remove orphaned tool messages (those without corresponding AI messages)
-     * regardless of whether editing is triggered
-     */
-    const orphanedIndices: number[] = [];
+    /** Drop tool messages that do not immediately follow their matching AI tool call. */
+    const invalidToolIndices: number[] = [];
     for (let i = 0; i < messages.length; i++) {
-      const msg = messages[i];
-      if (ToolMessage.isInstance(msg)) {
-        // Check if this tool message has a corresponding AI message
-        const aiMessage = this.#findAIMessageForToolCall(
-          messages.slice(0, i),
-          msg.tool_call_id
-        );
-
-        if (!aiMessage) {
-          // Orphaned tool message - mark for removal
-          orphanedIndices.push(i);
-        } else {
-          // Check if the AI message actually has this tool call
-          const toolCall = aiMessage.tool_calls?.find(
-            (call) => call.id === msg.tool_call_id
-          );
-          if (!toolCall) {
-            // Orphaned tool message - mark for removal
-            orphanedIndices.push(i);
-          }
-        }
+      if (this.#isInvalidToolMessagePlacement(messages, i)) {
+        invalidToolIndices.push(i);
       }
     }
 
     /**
-     * Remove orphaned tool messages in reverse order to maintain indices
+     * Remove invalid tool messages in reverse order to maintain indices
      */
-    for (let i = orphanedIndices.length - 1; i >= 0; i--) {
-      messages.splice(orphanedIndices[i]!, 1);
+    for (let i = invalidToolIndices.length - 1; i >= 0; i--) {
+      messages.splice(invalidToolIndices[i]!, 1);
     }
 
     /**
-     * Recalculate tokens after removing orphaned messages
+     * Recalculate tokens after removing invalid tool messages
      */
     let currentTokens = tokens;
-    if (orphanedIndices.length > 0) {
+    if (invalidToolIndices.length > 0) {
       currentTokens = await countTokens(messages);
     }
 
@@ -701,6 +679,31 @@ export class ClearToolUsesEdit implements ContextEdit {
     }
 
     return DEFAULT_KEEP;
+  }
+
+  /** True when the tool message is missing id or not right after its AI tool call. */
+  #isInvalidToolMessagePlacement(
+    messages: BaseMessage[],
+    index: number
+  ): boolean {
+    const msg = messages[index];
+    if (!ToolMessage.isInstance(msg)) {
+      return false;
+    }
+
+    const toolCallId = msg.tool_call_id;
+    if (!toolCallId) {
+      return true;
+    }
+
+    const previousMessage = messages[index - 1];
+    if (!previousMessage || !AIMessage.isInstance(previousMessage)) {
+      return true;
+    }
+
+    return !previousMessage.tool_calls?.some((call) => {
+      return call.id === toolCallId;
+    });
   }
 
   #findAIMessageForToolCall(

--- a/libs/langchain/src/agents/middleware/tests/contextEditing.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/contextEditing.test.ts
@@ -770,5 +770,77 @@ describe("contextEditingMiddleware", () => {
       const clearedMessages = filterClearedMessages(result.messages);
       expect(clearedMessages.length).toBe(0);
     });
+
+    it("should remove tool messages not immediately after their tool call", async () => {
+      const edit = new ClearToolUsesEdit({
+        trigger: { tokens: 1_000_000 },
+        keep: { messages: 3 },
+      });
+
+      const messages: BaseMessage[] = [
+        new HumanMessage("First question"),
+        new AIMessage({
+          content: "Searching",
+          tool_calls: [
+            { id: "toolu_old", name: "search", args: { query: "a" } },
+          ],
+        }),
+        new ToolMessage({
+          content: "[cleared]",
+          tool_call_id: "toolu_old",
+          response_metadata: {
+            context_editing: { cleared: true, strategy: "clear_tool_uses" },
+          },
+        }),
+        new AIMessage("First answer"),
+        new HumanMessage("Follow-up"),
+        // Misplaced duplicate: valid id exists earlier, but previous message is human
+        new ToolMessage({
+          content: "[cleared]",
+          tool_call_id: "toolu_old",
+          response_metadata: {
+            context_editing: { cleared: true, strategy: "clear_tool_uses" },
+          },
+        }),
+        new AIMessage({
+          content: "Searching again",
+          tool_calls: [
+            { id: "toolu_new", name: "search", args: { query: "b" } },
+          ],
+        }),
+        new ToolMessage({
+          content: "fresh results",
+          tool_call_id: "toolu_new",
+        }),
+        new AIMessage("Second answer"),
+      ];
+
+      const countTokens: TokenCounter = async () => 0;
+      await edit.apply({
+        messages,
+        model: new FakeToolCallingChatModel({
+          responses: [new AIMessage("ok")],
+        }),
+        countTokens,
+      });
+
+      expect(
+        messages.some(
+          (msg) =>
+            ToolMessage.isInstance(msg) &&
+            msg.tool_call_id === "toolu_old" &&
+            messages[messages.indexOf(msg) - 1] &&
+            HumanMessage.isInstance(messages[messages.indexOf(msg) - 1])
+        )
+      ).toBe(false);
+
+      const toolMessages = messages.filter(ToolMessage.isInstance);
+      expect(toolMessages).toHaveLength(2);
+      expect(toolMessages[0]?.tool_call_id).toBe("toolu_old");
+      expect(toolMessages[1]?.tool_call_id).toBe("toolu_new");
+      expect(
+        AIMessage.isInstance(messages[messages.indexOf(toolMessages[1]!) - 1])
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`ClearToolUsesEdit` treated a `ToolMessage` as valid if **any** earlier `AIMessage` had the same `tool_call_id`. Provider APIs (Anthropic, etc.) require the tool result to follow **immediately** after the assistant message that issued that `tool_use`.

Misplaced or duplicate cleared tool rows (e.g. after a new `HumanMessage`) were kept and caused `400` errors such as:

> `unexpected tool_use_id found in tool_result blocks … Each tool_result block must have a corresponding tool_use block in the previous message.`

This PR removes `ToolMessage`s that lack a `tool_call_id` or whose previous message is not the matching `AIMessage`.

## Changes

- Add `#isInvalidToolMessagePlacement()` with adjacency checks
- Run removal before context clearing (same hook as the previous orphan pass)
- Add regression test for `Human` → misplaced `Tool` → `AI` tool call
- Changeset: `langchain` patch

## Test plan

- [x] `pnpm test src/agents/middleware/tests/contextEditing.test.ts` in `libs/langchain`
- [x] `pnpm lint` and `pnpm format:check` at repo root

## Repro (before)

```text
Human
AI (tool_calls: toolu_old)
Tool (toolu_old, cleared)
AI (answer)
Human
Tool (toolu_old, cleared)   ← kept incorrectly; previous msg is Human
AI (tool_calls: toolu_new)
Tool (toolu_new)
```

After: the misplaced `Tool` row is dropped; the in-place pair after the first AI remains.
