### PR TITLE
fix(langchain): answer every tool call when the model returns multiple structured outputs

### DIFF
--- a/.changeset/answer-all-structured-output-tool-calls.md
+++ b/.changeset/answer-all-structured-output-tool-calls.md
@@ -1,0 +1,7 @@
+---
+"langchain": patch
+---
+
+fix(langchain): answer every tool call when the model returns multiple structured outputs
+
+When a `ToolStrategy` response format is used and the model emits more than one structured-output tool call in a single turn, `AgentNode` answered only the first call and left the rest unanswered. The retry request was therefore missing tool results for those calls, which providers reject (e.g. OpenAI `400 INVALID_TOOL_RESULTS`), after which the agent could loop until the recursion limit. The retry now emits a `ToolMessage` for every tool call in the response, so the message sequence is valid and the agent retries as intended.

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -803,6 +803,47 @@ export class AgentNode<
     }
   }
 
+  /**
+   * Answer every tool call in `response` with a `ToolMessage` before retrying.
+   * Providers reject the next request (e.g. OpenAI `400 INVALID_TOOL_RESULTS`)
+   * if a tool call from the assistant message is left unanswered, which is what
+   * happened when the model emitted multiple structured-output calls and only
+   * the first was answered. The triggering call keeps the meaningful `content`;
+   * a duplicate structured-output call and a co-emitted real tool call each get
+   * a short, accurate placeholder.
+   */
+  #buildToolStrategyRetryMessages(
+    response: AIMessage,
+    primaryToolCallId: string,
+    content: string,
+    responseFormat: ToolResponseFormat
+  ): BaseMessage[] {
+    const toolCalls = response.tool_calls ?? [];
+    const toolMessages = toolCalls.map((call) => {
+      if (call.id === primaryToolCallId) {
+        return new ToolMessage({ tool_call_id: call.id ?? "", content });
+      }
+      // `responseFormat.tools` holds the structured-output (extract) tools: a
+      // leftover one is a rejected duplicate, anything else is a real tool not run here.
+      const isStructuredOutputCall = call.name in responseFormat.tools;
+      return new ToolMessage({
+        tool_call_id: call.id ?? "",
+        content: isStructuredOutputCall
+          ? "Ignored: respond with exactly one structured output."
+          : "Not run: retrying to resolve the structured output.",
+      });
+    });
+
+    // Never emit an empty retry update if the response has no tool calls.
+    if (toolMessages.length === 0) {
+      toolMessages.push(
+        new ToolMessage({ tool_call_id: primaryToolCallId, content })
+      );
+    }
+
+    return [response, ...toolMessages];
+  }
+
   async #handleToolStrategyError(
     error: ToolStrategyError,
     response: AIMessage,
@@ -852,13 +893,12 @@ export class AgentNode<
     ) {
       return new Command({
         update: {
-          messages: [
+          messages: this.#buildToolStrategyRetryMessages(
             response,
-            new ToolMessage({
-              content: error.message,
-              tool_call_id: toolCallId,
-            }),
-          ],
+            toolCallId,
+            error.message,
+            responseFormat
+          ),
         },
         goto: AGENT_NODE_NAME,
       });
@@ -870,13 +910,12 @@ export class AgentNode<
     if (typeof errorHandler === "string") {
       return new Command({
         update: {
-          messages: [
+          messages: this.#buildToolStrategyRetryMessages(
             response,
-            new ToolMessage({
-              content: errorHandler,
-              tool_call_id: toolCallId,
-            }),
-          ],
+            toolCallId,
+            errorHandler,
+            responseFormat
+          ),
         },
         goto: AGENT_NODE_NAME,
       });
@@ -893,13 +932,12 @@ export class AgentNode<
 
       return new Command({
         update: {
-          messages: [
+          messages: this.#buildToolStrategyRetryMessages(
             response,
-            new ToolMessage({
-              content,
-              tool_call_id: toolCallId,
-            }),
-          ],
+            toolCallId,
+            content,
+            responseFormat
+          ),
         },
         goto: AGENT_NODE_NAME,
       });
@@ -910,13 +948,12 @@ export class AgentNode<
      */
     return new Command({
       update: {
-        messages: [
+        messages: this.#buildToolStrategyRetryMessages(
           response,
-          new ToolMessage({
-            content: error.message,
-            tool_call_id: toolCallId,
-          }),
-        ],
+          toolCallId,
+          error.message,
+          responseFormat
+        ),
       },
       goto: AGENT_NODE_NAME,
     });

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -4,7 +4,7 @@ import { z as z4 } from "zod/v4";
 
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { AIMessage } from "@langchain/core/messages";
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
 import type { SerializableSchema } from "@langchain/core/utils/standard_schema";
 
 import { fakeModel } from "@langchain/core/testing";
@@ -92,6 +92,23 @@ describe("structured output handling", () => {
         expect(res.structuredResponse).toEqual({
           foo: "valid structured value",
         });
+
+        // No tool call may be left unanswered, or the retry 400s on a real provider.
+        const answeredToolCallIds = new Set(
+          res.messages
+            .filter(ToolMessage.isInstance)
+            .map((msg) => msg.tool_call_id)
+        );
+        const requestedToolCallIds = res.messages
+          .filter(AIMessage.isInstance)
+          .flatMap((msg) => msg.tool_calls ?? [])
+          .map((call) => call.id)
+          .filter((id): id is string => id != null);
+
+        expect(requestedToolCallIds.length).toBeGreaterThan(0);
+        for (const id of requestedToolCallIds) {
+          expect(answeredToolCallIds.has(id)).toBe(true);
+        }
       });
 
       it("should throw if error handler is set to false", async () => {
@@ -177,19 +194,22 @@ describe("structured output handling", () => {
           messages: [{ role: "user", content: "hi!" }],
         });
 
-        expect(res.messages).toHaveLength(6);
+        expect(res.messages).toHaveLength(7);
         expect(res.messages[0].content).toContain("hi!");
         expect((res.messages[1] as AIMessage).tool_calls).toEqual(toolCalls);
         expect(res.messages[2].content).toContain(
           "The model has called multiple tools"
         );
-        expect((res.messages[3] as AIMessage).tool_calls).toEqual(toolCall2);
-        expect(res.messages[4].content).toContain(
+        // call_1 carries the error message; the orphaned call_2 is also answered.
+        expect((res.messages[2] as ToolMessage).tool_call_id).toBe("call_1");
+        expect((res.messages[3] as ToolMessage).tool_call_id).toBe("call_2");
+        expect((res.messages[4] as AIMessage).tool_calls).toEqual(toolCall2);
+        expect(res.messages[5].content).toContain(
           JSON.stringify({
             foo: "valid structured value",
           })
         );
-        expect(res.messages[5].content).toContain(
+        expect(res.messages[6].content).toContain(
           "Returning structured response"
         );
         expect(res.structuredResponse).toEqual({
@@ -252,17 +272,20 @@ describe("structured output handling", () => {
           messages: [{ role: "user", content: "hi!" }],
         });
 
-        expect(res.messages).toHaveLength(6);
+        expect(res.messages).toHaveLength(7);
         expect(res.messages[0].content).toContain("hi!");
         expect((res.messages[1] as AIMessage).tool_calls).toEqual(toolCalls);
         expect(res.messages[2].content).toContain("foobar");
-        expect((res.messages[3] as AIMessage).tool_calls).toEqual(toolCall2);
-        expect(res.messages[4].content).toContain(
+        // call_1 carries the handler's message; the orphaned call_2 is also answered.
+        expect((res.messages[2] as ToolMessage).tool_call_id).toBe("call_1");
+        expect((res.messages[3] as ToolMessage).tool_call_id).toBe("call_2");
+        expect((res.messages[4] as AIMessage).tool_calls).toEqual(toolCall2);
+        expect(res.messages[5].content).toContain(
           JSON.stringify({
             foo: "fixed structured value",
           })
         );
-        expect(res.messages[5].content).toContain(
+        expect(res.messages[6].content).toContain(
           "Returning structured response"
         );
         expect(res.structuredResponse).toEqual({

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -4,7 +4,7 @@ import { z as z4 } from "zod/v4";
 
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import type { SerializableSchema } from "@langchain/core/utils/standard_schema";
 
@@ -98,6 +98,23 @@ describe("structured output handling", () => {
         expect(res.structuredResponse).toEqual({
           foo: "valid structured value",
         });
+
+        // No tool call may be left unanswered, or the retry 400s on a real provider.
+        const answeredToolCallIds = new Set(
+          res.messages
+            .filter(ToolMessage.isInstance)
+            .map((msg) => msg.tool_call_id)
+        );
+        const requestedToolCallIds = res.messages
+          .filter(AIMessage.isInstance)
+          .flatMap((msg) => msg.tool_calls ?? [])
+          .map((call) => call.id)
+          .filter((id): id is string => id != null);
+
+        expect(requestedToolCallIds.length).toBeGreaterThan(0);
+        for (const id of requestedToolCallIds) {
+          expect(answeredToolCallIds.has(id)).toBe(true);
+        }
       });
 
       it("should throw if error handler is set to false", async () => {
@@ -183,19 +200,22 @@ describe("structured output handling", () => {
           messages: [{ role: "user", content: "hi!" }],
         });
 
-        expect(res.messages).toHaveLength(6);
+        expect(res.messages).toHaveLength(7);
         expect(res.messages[0].content).toContain("hi!");
         expect((res.messages[1] as AIMessage).tool_calls).toEqual(toolCalls);
         expect(res.messages[2].content).toContain(
           "The model has called multiple tools"
         );
-        expect((res.messages[3] as AIMessage).tool_calls).toEqual(toolCall2);
-        expect(res.messages[4].content).toContain(
+        // call_1 carries the error message; the orphaned call_2 is also answered.
+        expect((res.messages[2] as ToolMessage).tool_call_id).toBe("call_1");
+        expect((res.messages[3] as ToolMessage).tool_call_id).toBe("call_2");
+        expect((res.messages[4] as AIMessage).tool_calls).toEqual(toolCall2);
+        expect(res.messages[5].content).toContain(
           JSON.stringify({
             foo: "valid structured value",
           })
         );
-        expect(res.messages[5].content).toContain(
+        expect(res.messages[6].content).toContain(
           "Returning structured response"
         );
         expect(res.structuredResponse).toEqual({
@@ -258,17 +278,20 @@ describe("structured output handling", () => {
           messages: [{ role: "user", content: "hi!" }],
         });
 
-        expect(res.messages).toHaveLength(6);
+        expect(res.messages).toHaveLength(7);
         expect(res.messages[0].content).toContain("hi!");
         expect((res.messages[1] as AIMessage).tool_calls).toEqual(toolCalls);
         expect(res.messages[2].content).toContain("foobar");
-        expect((res.messages[3] as AIMessage).tool_calls).toEqual(toolCall2);
-        expect(res.messages[4].content).toContain(
+        // call_1 carries the handler's message; the orphaned call_2 is also answered.
+        expect((res.messages[2] as ToolMessage).tool_call_id).toBe("call_1");
+        expect((res.messages[3] as ToolMessage).tool_call_id).toBe("call_2");
+        expect((res.messages[4] as AIMessage).tool_calls).toEqual(toolCall2);
+        expect(res.messages[5].content).toContain(
           JSON.stringify({
             foo: "fixed structured value",
           })
         );
-        expect(res.messages[5].content).toContain(
+        expect(res.messages[6].content).toContain(
           "Returning structured response"
         );
         expect(res.structuredResponse).toEqual({


### PR DESCRIPTION
Fixes #11020

## What

On the `ToolStrategy` structured-output path, when the model emits more than one structured-output tool call in a single turn, `AgentNode` answered only the first call and left the rest unanswered. The retry request is then malformed (every tool call in the assistant message needs a matching `ToolMessage`), so the provider rejects it (OpenAI `400 INVALID_TOOL_RESULTS`) and the agent can loop to the recursion limit.

This affects any model on the ToolStrategy path (`profile.structuredOutput !== true`, e.g. Azure OpenAI and Anthropic) or any caller that explicitly uses `toolStrategy(...)`. Models on `ProviderStrategy` (native `json_schema`) are unaffected, since there is no `extract` tool.

## Fix

The retry now emits a `ToolMessage` for every tool call in the response (`#buildToolStrategyRetryMessages`). The call that triggered the error keeps the meaningful content; the rest are closed with a short placeholder. The single-call path is unchanged (one call, one `ToolMessage`).

## Mixed-turn note

If a real tool call is co-emitted alongside the duplicate structured-output calls (e.g. `[extract, extract, web_search]`), it is also answered, with a "not run, retrying" placeholder, because the retry routes back to the model rather than the tool node. The model can re-issue it on the retry. Happy to switch this to stripping the extra calls if you prefer a different shape.

## Tests / checks

- Augmented the existing multiple-structured-output test to assert no tool call is left orphaned, and updated two tests that encoded the old single-`ToolMessage` sequence.
- `pnpm lint`, `pnpm format:check`, `pnpm --filter langchain test` (801 unit tests) and `pnpm --filter langchain build` all pass.
- Changeset included (`langchain: patch`).
