### PR TITLE
fix(google-genai): remap exclusiveMinimum/exclusiveMaximum for Gemini schemas

### DIFF
--- a/.changeset/fix-genai-exclusive-bounds.md
+++ b/.changeset/fix-genai-exclusive-bounds.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+Fix `@langchain/google-genai` structured output / tool schemas failing with a Gemini 400 (`Unknown name "exclusiveMinimum"`) when a Zod schema uses `.positive()`, `.negative()`, `.gt()`, or `.lt()`. These emit `exclusiveMinimum`/`exclusiveMaximum`, which Gemini's schema does not support; they are now remapped to the supported `minimum`/`maximum` keywords (mirroring `@langchain/google-common`).

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -178,6 +178,30 @@ test("removeAdditionalProperties can remove all instances of additionalPropertie
   ).toBeUndefined();
 });
 
+test("removeAdditionalProperties remaps exclusiveMinimum/exclusiveMaximum to minimum/maximum", () => {
+  // Zod's .positive()/.negative()/.gt()/.lt() emit exclusiveMinimum/exclusiveMaximum,
+  // which Gemini's responseSchema rejects with a 400. They must be remapped.
+  const schema = z.object({
+    pos: z.number().positive(), // exclusiveMinimum: 0
+    neg: z.number().negative(), // exclusiveMaximum: 0
+    gt: z.number().gt(5), // exclusiveMinimum: 5
+    lt: z.number().lt(10), // exclusiveMaximum: 10
+  });
+
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  const props = (removeAdditionalProperties(toJsonSchema(schema)) as any)
+    .properties;
+
+  expect(props.pos).not.toHaveProperty("exclusiveMinimum");
+  expect(props.pos.minimum).toBe(0.01);
+  expect(props.neg).not.toHaveProperty("exclusiveMaximum");
+  expect(props.neg.maximum).toBe(-0.01);
+  expect(props.gt).not.toHaveProperty("exclusiveMinimum");
+  expect(props.gt.minimum).toBeCloseTo(5.00001);
+  expect(props.lt).not.toHaveProperty("exclusiveMaximum");
+  expect(props.lt.maximum).toBeCloseTo(9.99999);
+});
+
 test("convertMessageContentToParts correctly handles message types", () => {
   const messages = [
     new SystemMessage("You are a helpful assistant"),

--- a/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
+++ b/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
@@ -42,6 +42,26 @@ export function removeAdditionalProperties(
       delete newObj.strict;
     }
 
+    // Gemini's schema only supports `minimum`/`maximum`, not their exclusive
+    // variants. Zod's .positive()/.negative()/.gt()/.lt() emit
+    // exclusiveMinimum/exclusiveMaximum, and forwarding those yields a 400
+    // ("Unknown name exclusiveMinimum"). Remap to the inclusive keywords,
+    // mirroring @langchain/google-common's handling.
+    if ("exclusiveMinimum" in newObj && newObj.exclusiveMinimum === 0) {
+      newObj.minimum = 0.01;
+      delete newObj.exclusiveMinimum;
+    } else if ("exclusiveMinimum" in newObj) {
+      newObj.minimum = newObj.exclusiveMinimum + 0.00001;
+      delete newObj.exclusiveMinimum;
+    }
+    if ("exclusiveMaximum" in newObj && newObj.exclusiveMaximum === 0) {
+      newObj.maximum = -0.01;
+      delete newObj.exclusiveMaximum;
+    } else if ("exclusiveMaximum" in newObj) {
+      newObj.maximum = newObj.exclusiveMaximum - 0.00001;
+      delete newObj.exclusiveMaximum;
+    }
+
     for (const key in newObj) {
       if (key in newObj) {
         if (Array.isArray(newObj[key])) {


### PR DESCRIPTION
Closes #10956.

`@langchain/google-genai`'s `withStructuredOutput(zodSchema)` (and tool schemas) fail with a Gemini **400** when the Zod schema uses `.positive()`, `.negative()`, `.gt()`, or `.lt()`:

> Invalid JSON payload received. Unknown name "exclusiveMinimum" at 'generation_config.response_schema...'

`z.number().positive()` compiles to `{ exclusiveMinimum: 0 }` (JSON Schema Draft 7), and the package's `removeAdditionalProperties` only stripped `additionalProperties`/`$schema`/`strict` — it forwarded `exclusiveMinimum`/`exclusiveMaximum` verbatim, which Gemini's schema doesn't support.

**Fix:** `removeAdditionalProperties` now remaps `exclusiveMinimum` → `minimum` and `exclusiveMaximum` → `maximum` (mirroring `@langchain/google-common`'s existing handling). It's centralized there, so it covers both tool parameters and the responseSchema path. Added a unit test covering `.positive()`/`.negative()`/`.gt()`/`.lt()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
