### PR TITLE
fix(pinecone): return early from addVectors when vectors array is empty

### DIFF
--- a/.changeset/fix-pinecone-empty-upsert.md
+++ b/.changeset/fix-pinecone-empty-upsert.md
@@ -1,0 +1,12 @@
+---
+"@langchain/pinecone": patch
+---
+
+fix(pinecone): return early from `addVectors` when given an empty array
+
+Guard `addVectors` with an early `return []` when `vectors.length === 0` to
+prevent a "Must pass in at least 1 record to upsert." error that the
+`@pinecone-database/pinecone` SDK throws when `upsert` is called with no
+records. This makes `addDocuments([])` and `addVectors([], [])` safe no-ops
+instead of throwing, which can happen when a document splitter produces zero
+chunks or when all documents are filtered out before embedding.

--- a/libs/providers/langchain-pinecone/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-pinecone/src/tests/vectorstores.test.ts
@@ -155,6 +155,56 @@ test("PineconeStore throws when no config or index is passed", async () => {
   expect(() => new PineconeStore(embeddings, {})).toThrow();
 });
 
+test("PineconeStore addDocuments with empty input does not throw and does not call upsert", async () => {
+  // Simulate the Pinecone SDK error that would be thrown when upsert receives an empty array,
+  // matching the behaviour of @pinecone-database/pinecone@>=5 which validates records.length > 0
+  const upsert = vi.fn().mockImplementation((records: unknown[]) => {
+    if (!records || records.length === 0) {
+      throw new Error("Must pass in at least 1 record to upsert.");
+    }
+    return Promise.resolve();
+  });
+  const client = {
+    namespace: vi.fn().mockReturnValue({
+      upsert,
+      query: vi.fn().mockResolvedValue({
+        matches: [],
+      }),
+    }),
+  };
+  const embeddings = new FakeEmbeddings();
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  const ids = await store.addDocuments([]);
+  expect(ids).toEqual([]);
+  expect(upsert).not.toHaveBeenCalled();
+});
+
+test("PineconeStore addVectors with empty input does not throw and does not call upsert", async () => {
+  // Simulate the Pinecone SDK error that would be thrown when upsert receives an empty array,
+  // matching the behaviour of @pinecone-database/pinecone@>=5 which validates records.length > 0
+  const upsert = vi.fn().mockImplementation((records: unknown[]) => {
+    if (!records || records.length === 0) {
+      throw new Error("Must pass in at least 1 record to upsert.");
+    }
+    return Promise.resolve();
+  });
+  const client = {
+    namespace: vi.fn().mockReturnValue({
+      upsert,
+      query: vi.fn().mockResolvedValue({
+        matches: [],
+      }),
+    }),
+  };
+  const embeddings = new FakeEmbeddings();
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  const ids = await store.addVectors([], []);
+  expect(ids).toEqual([]);
+  expect(upsert).not.toHaveBeenCalled();
+});
+
 test("PineconeStore throws when config and index is passed", async () => {
   const upsert = vi.fn();
   const client = {

--- a/libs/providers/langchain-pinecone/src/vectorstores.ts
+++ b/libs/providers/langchain-pinecone/src/vectorstores.ts
@@ -288,6 +288,9 @@ export class PineconeStore extends VectorStore {
     documents: Document[],
     options?: { ids?: string[]; namespace?: string } | string[]
   ) {
+    if (vectors.length === 0) {
+      return [];
+    }
     const ids = Array.isArray(options) ? options : options?.ids;
     const documentIds = ids == null ? documents.map(() => uuid()) : ids;
     const pineconeVectors = vectors.map((values, idx) => {


### PR DESCRIPTION
Closes #10890

## Root cause

`PineconeStore.addVectors` passes every batch of vectors to `namespace.upsert(chunk)` via a loop over the result of `chunkArray(vectors, 100)`. When `vectors` is non-empty that loop is correct, but the function has no guard against being called with an empty array at the top level.

The `@pinecone-database/pinecone` SDK (v5+) validates that at least one record is provided and throws:

```
PineconeArgumentError: Must pass in at least 1 record to upsert.
```

This bubbles up to user code whenever:
- A document splitter produces zero chunks from the input PDF/text.
- All documents are filtered out before embedding.
- `addDocuments([])` / `addVectors([], [])` is called explicitly.

## Fix

Add an early-return guard at the top of `addVectors`:

```ts
if (vectors.length === 0) {
  return [];
}
```

This makes empty input a silent no-op, matching the expected behaviour of an "add nothing" operation.

## Tests

Two new unit tests in `vectorstores.test.ts`:

- `addDocuments([])` — does not throw, returns `[]`, never calls `upsert`.
- `addVectors([], [])` — does not throw, returns `[]`, never calls `upsert`.

The mock `upsert` is configured to throw the SDK error if called with an empty array, so the tests would fail without the guard.

```
Tests  14 passed (14)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)