### PR TITLE
fix(agents): prevent unhandled rejection on HITL interrupts in createToolCallTransformer

### DIFF
--- a/.changeset/fix-hitl-unhandled-rejection.md
+++ b/.changeset/fix-hitl-unhandled-rejection.md
@@ -1,0 +1,7 @@
+---
+"langchain": patch
+---
+
+fix(agents): prevent unhandled promise rejection on HITL interrupts in `createToolCallTransformer`
+
+When a Human-In-The-Loop interrupt arrives via a `tool-error` event, the `output` promise for the affected tool call was rejected before any consumer could attach a `.catch()` handler, causing a fatal `unhandledRejection` crash. The fix adds detection for HITL interrupt payloads (those whose serialised value contains an `actionRequests` array) and skips the rejection, keeping the tool call pending — consistent with the existing handling for headless tool interrupts.

--- a/libs/langchain/src/agents/stream.ts
+++ b/libs/langchain/src/agents/stream.ts
@@ -167,6 +167,27 @@ function isHeadlessToolInterruptError(
 }
 
 /**
+ * Returns true when `message` is a serialised LangGraph interrupt array
+ * containing at least one HITL interrupt (i.e. an entry whose `value` has
+ * an `actionRequests` array).  These interrupts must NOT be surfaced as
+ * rejected output promises — the tool call is merely paused, not errored.
+ */
+function isHITLInterruptError(message: string): boolean {
+  try {
+    const parsed = JSON.parse(message) as unknown;
+    if (!Array.isArray(parsed)) return false;
+    return parsed.some((entry) => {
+      if (entry == null || typeof entry !== "object") return false;
+      const value = (entry as { value?: unknown }).value;
+      if (value == null || typeof value !== "object") return false;
+      return Array.isArray((value as { actionRequests?: unknown }).actionRequests);
+    });
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Detects serialized LangChain `ToolMessage` values that can appear on
  * `tool-finished.output` after crossing a protocol or serialization boundary.
  *
@@ -322,6 +343,9 @@ export function createToolCallTransformer(
                 ((data as Record<string, unknown>).message as string) ??
                 "unknown error";
               if (isHeadlessToolInterruptError(message, toolCallId)) {
+                return true;
+              }
+              if (isHITLInterruptError(message)) {
                 return true;
               }
               pending.rejectOutput(new Error(message));

--- a/libs/langchain/src/agents/tests/stream.test.ts
+++ b/libs/langchain/src/agents/tests/stream.test.ts
@@ -510,6 +510,88 @@ describe("streamEvents", () => {
     expect(await iterator.next()).toEqual({ done: true, value: undefined });
   });
 
+  it("keeps tool call output pending (not rejected) on a HITL interrupt tool-error (issue #10933)", async () => {
+    // Regression test for: unhandled promise rejection when a HITL interrupt
+    // arrives via tool-error before any consumer attaches a .catch() handler.
+    //
+    // The output promise must remain pending after the interrupt event so that
+    // finalize() (or a subsequent tool-finished event) can resolve it cleanly.
+    const transformer = createToolCallTransformer([])();
+    const projection = transformer.init();
+    const toolEvent = (data: Record<string, unknown>): ProtocolEvent =>
+      ({
+        method: "tools",
+        params: {
+          namespace: ["tools:abc"],
+          data,
+        },
+      }) as ProtocolEvent;
+
+    transformer.process(
+      toolEvent({
+        event: "tool-started",
+        tool_call_id: "call_w1",
+        tool_name: "write_file",
+        input: '{"filename":"test.txt","content":"hello"}',
+      })
+    );
+
+    const iterator = projection.toolCalls[Symbol.asyncIterator]();
+    const pendingCall = await iterator.next();
+
+    // Simulate the HITL tool-error event that arrives before any consumer
+    // can attach a .catch() handler — this is the race that caused the
+    // unhandled rejection in issue #10933.
+    transformer.process(
+      toolEvent({
+        event: "tool-error",
+        tool_call_id: "call_w1",
+        message: JSON.stringify([
+          {
+            id: "interrupt_hitl_1",
+            value: {
+              actionRequests: [
+                {
+                  name: "write_file",
+                  args: { filename: "test.txt", content: "hello" },
+                  description:
+                    "Tool execution requires approval\n\nTool: write_file",
+                },
+              ],
+              reviewConfigs: [
+                {
+                  actionName: "write_file",
+                  allowedDecisions: ["approve"],
+                },
+              ],
+            },
+          },
+        ]),
+      })
+    );
+
+    // The tool call must still be present and pending — a HITL interrupt
+    // pauses execution rather than erroring it.
+    expect(pendingCall.done).toBe(false);
+    expect(pendingCall.value.callId).toBe("call_w1");
+
+    // Verify the output promise is still pending (not rejected) by racing it
+    // against an immediately-resolved sentinel.  Without the fix, the output
+    // promise would have been rejected synchronously, so `await Promise.race`
+    // would throw.  With the fix it remains pending and the sentinel wins.
+    const sentinel = Symbol("pending");
+    const result = await Promise.race([
+      pendingCall.value.output,
+      Promise.resolve(sentinel),
+    ]);
+    expect(result).toBe(sentinel);
+
+    // Finalize resolves all pending promises — output should now settle.
+    transformer.finalize?.();
+    await expect(pendingCall.value.output).resolves.toBeUndefined();
+    expect(await pendingCall.value.status).toBe("finished");
+  });
+
   it("unwraps ToolMessage outputs in tool call streams", async () => {
     const transformer = createToolCallTransformer([])();
     const projection = transformer.init();


### PR DESCRIPTION
Closes #10933

## Root cause

In `createToolCallTransformer` (`langchain/src/agents/stream.ts`), each tool call entry creates an `output` promise and stores its `rejectOutput` resolver. When a `tool-error` event arrives, the transformer has a fast-path for **headless** tool interrupts via `isHeadlessToolInterruptError` — those return early without rejecting the promise. However, **HITL** interrupts from `humanInTheLoopMiddleware` carry a structurally different payload:

```json
[{ "id": "…", "value": { "actionRequests": […], "reviewConfigs": […] } }]
```

`isHeadlessToolInterruptError` only matches the headless shape (`value.type === "tool"`), so HITL interrupts fell through to `pending.rejectOutput(new Error(message))`. Because the langgraph `pump` fires `tool-started` and `tool-error` synchronously in the same tick, the rejection happened before any user-space consumer could attach a `.catch()` handler, producing a fatal `unhandledRejection` crash.

## Fix

Add `isHITLInterruptError` that detects interrupt arrays whose serialised `value` contains an `actionRequests` array. When matched, return `true` early (keeping the tool call promise pending), exactly as headless interrupts are handled.

## Test

Added a unit test in `libs/langchain/src/agents/tests/stream.test.ts` that:
1. Fires a `tool-started` event for a HITL-gated tool.
2. Immediately fires the `tool-error` event with a HITL interrupt payload (before any consumer attaches a handler — the exact race from the bug).
3. Asserts the `output` promise is still **pending** (not rejected) using `Promise.race` with an immediately-resolved sentinel.
4. Asserts that `finalize()` then cleanly resolves the promise.

The test fails on the unpatched code (the `Promise.race` would throw because the `output` promise is already rejected) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)