### PR TITLE
[codex] Fix AWS structured output Zod validation

### DIFF
--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -66,7 +66,10 @@ import {
   isSerializableSchema,
   SerializableSchema,
 } from "@langchain/core/utils/standard_schema";
-import { assembleStructuredOutputPipeline } from "@langchain/core/language_models/structured_output";
+import {
+  assembleStructuredOutputPipeline,
+  createFunctionCallingParser,
+} from "@langchain/core/language_models/structured_output";
 
 /**
  * Inputs for ChatBedrockConverse.
@@ -1247,18 +1250,19 @@ export class ChatBedrockConverse
     }
 
     const llm = this.bindTools(tools, toolChoiceObj);
+    const functionCallingParser = createFunctionCallingParser(
+      schema,
+      functionName
+    );
     const outputParser = RunnableLambda.from<AIMessageChunk, RunOutput>(
-      (input: AIMessageChunk): RunOutput => {
+      async (input, config) => {
         if (!input.tool_calls || input.tool_calls.length === 0) {
           throw new Error("No tool calls found in the response.");
         }
-        const toolCall = input.tool_calls.find(
-          (tc) => tc.name === functionName
-        );
-        if (!toolCall) {
+        if (!input.tool_calls.some((tc) => tc.name === functionName)) {
           throw new Error(`No tool call found with name ${functionName}.`);
         }
-        return toolCall.args as RunOutput;
+        return functionCallingParser.invoke(input, config);
       }
     );
 

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1777,6 +1777,79 @@ describe("withStructuredOutput - StandardSchema", () => {
   });
 });
 
+describe("withStructuredOutput - Zod validation", () => {
+  const baseConstructorArgs = {
+    region: "us-east-1",
+    credentials: {
+      secretAccessKey: "test-secret-key",
+      accessKeyId: "test-access-key",
+    },
+  };
+
+  const schema = z.object({
+    overview: z.string(),
+    keyFindings: z.array(z.object({ finding: z.string() })),
+  });
+
+  test("functionCalling rejects invalid Zod tool args", async () => {
+    const model = new ChatBedrockConverse({
+      ...baseConstructorArgs,
+      model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
+    vi
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn(model as any, "invoke")
+      .mockResolvedValue(
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              name: "extract",
+              args: { overview: "summary", keyFindings: "not an array" },
+              id: "1",
+              type: "tool_call",
+            },
+          ],
+        })
+      );
+
+    const structured = model.withStructuredOutput(schema);
+
+    await expect(async () => {
+      await structured.invoke("What?");
+    }).rejects.toThrow("Failed to parse");
+  });
+
+  test("functionCalling includeRaw returns null parsed value for invalid Zod tool args", async () => {
+    const mockResponse = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "extract",
+          args: { overview: "summary", keyFindings: "not an array" },
+          id: "1",
+          type: "tool_call",
+        },
+      ],
+    });
+    const model = new ChatBedrockConverse({
+      ...baseConstructorArgs,
+      model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
+    vi
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn(model as any, "invoke")
+      .mockResolvedValue(mockResponse);
+
+    const structured = model.withStructuredOutput(schema, {
+      includeRaw: true,
+    });
+
+    const result = await structured.invoke("What?");
+    expect(result).toEqual({ raw: mockResponse, parsed: null });
+  });
+});
+
 describe("bedrockApiKey / bedrockApiSecret credentials", () => {
   it("should accept bedrockApiKey and bedrockApiSecret in constructor", () => {
     const model = new ChatBedrockConverse({


### PR DESCRIPTION
Fixes #11024.

## What changed
- Route `ChatBedrockConverse.withStructuredOutput()` tool-call parsing through the shared `createFunctionCallingParser()` helper so Zod and Standard Schema outputs are validated instead of returning raw tool args.
- Preserve the existing AWS-specific errors for missing tool calls or missing named tool calls.
- Add regression coverage for invalid Zod tool args, including `includeRaw: true` returning `parsed: null` after parser failure.

## Validation
- `corepack pnpm --filter @langchain/aws test src/tests/chat_models.test.ts`
- `cd libs/providers/langchain-aws && corepack pnpm build:compile`