### PR TITLE
fix(google-genai): merge custom tools with native Gemini tools

### DIFF
--- a/.changeset/google-genai-hybrid-tools.md
+++ b/.changeset/google-genai-hybrid-tools.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): merge custom tool declarations into native Gemini tools

--- a/libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts
@@ -1,9 +1,11 @@
 import { test, expect, describe } from "vitest";
+import type { CodeExecutionTool } from "@google/generative-ai";
 import { AIMessage } from "@langchain/core/messages";
 import { convertBaseMessagesToContent } from "../utils/common.js";
 import { z } from "zod";
 import { tool } from "@langchain/core/tools";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { convertToolsToGenAI } from "../utils/tools.js";
 
 test("converts standard tool_call content blocks to Google functionCall format", () => {
   // Create AIMessage with standard tool_call content block
@@ -42,6 +44,50 @@ test("converts standard tool_call content blocks to Google functionCall format",
     number1: 2,
     number2: 3,
   });
+});
+
+test("merges LangChain tool declarations into native Gemini tools", () => {
+  const codeExecutionTool: CodeExecutionTool = {
+    codeExecution: {},
+  };
+  const lookupTool = tool(async () => "ok", {
+    name: "lookup_record",
+    description: "Looks up a record by ID.",
+    schema: z.object({
+      id: z.string().describe("Record ID"),
+    }),
+  });
+
+  const result = convertToolsToGenAI([codeExecutionTool, lookupTool]);
+
+  expect(result.tools).toHaveLength(1);
+  expect(result.tools[0]).toMatchObject({
+    codeExecution: {},
+  });
+  expect("functionDeclarations" in result.tools[0]).toBe(true);
+  if (!("functionDeclarations" in result.tools[0])) return;
+  expect(result.tools[0].functionDeclarations).toHaveLength(1);
+  expect(result.tools[0].functionDeclarations?.[0].name).toBe("lookup_record");
+});
+
+test("preserves empty and declaration-only Gemini tool lists", () => {
+  expect(convertToolsToGenAI([]).tools).toEqual([]);
+
+  const lookupTool = tool(async () => "ok", {
+    name: "lookup_record",
+    description: "Looks up a record by ID.",
+    schema: z.object({
+      id: z.string().describe("Record ID"),
+    }),
+  });
+
+  const result = convertToolsToGenAI([lookupTool]);
+
+  expect(result.tools).toHaveLength(1);
+  expect("functionDeclarations" in result.tools[0]).toBe(true);
+  if (!("functionDeclarations" in result.tools[0])) return;
+  expect(result.tools[0].functionDeclarations).toHaveLength(1);
+  expect(result.tools[0].functionDeclarations?.[0].name).toBe("lookup_record");
 });
 
 describe("Gemini Tool Schema Validation - Empty String in Enum", () => {

--- a/libs/providers/langchain-google-genai/src/utils/tools.ts
+++ b/libs/providers/langchain-google-genai/src/utils/tools.ts
@@ -37,7 +37,7 @@ export function convertToolsToGenAI(
 }
 
 function processTools(tools: GoogleGenerativeAIToolType[]): GenerativeAITool[] {
-  let functionDeclarationTools: FunctionDeclaration[] = [];
+  const functionDeclarationTools: FunctionDeclaration[] = [];
   const genAITools: GenerativeAITool[] = [];
 
   tools.forEach((tool) => {
@@ -62,39 +62,45 @@ function processTools(tools: GoogleGenerativeAIToolType[]): GenerativeAITool[] {
     }
   });
 
-  const genAIFunctionDeclaration = genAITools.find(
-    (t) => "functionDeclarations" in t
-  );
-  if (genAIFunctionDeclaration) {
+  if (functionDeclarationTools.length > 0) {
+    const genAIFunctionDeclaration = genAITools.find(
+      (t) => "functionDeclarations" in t
+    );
+    if (genAITools.length === 0) {
+      return [
+        {
+          functionDeclarations: functionDeclarationTools,
+        },
+      ];
+    }
+
+    if (!genAIFunctionDeclaration && genAITools.length > 0) {
+      return genAITools.map((tool, index) => {
+        if (index === 0) {
+          return {
+            ...tool,
+            functionDeclarations: functionDeclarationTools,
+          };
+        }
+        return tool;
+      });
+    }
+
     return genAITools.map((tool) => {
-      if (
-        functionDeclarationTools?.length > 0 &&
-        "functionDeclarations" in tool
-      ) {
-        const newTool = {
+      if ("functionDeclarations" in tool) {
+        return {
+          ...tool,
           functionDeclarations: [
             ...(tool.functionDeclarations || []),
             ...functionDeclarationTools,
           ],
         };
-        // Clear the functionDeclarationTools array so it is not passed again
-        functionDeclarationTools = [];
-        return newTool;
       }
       return tool;
     });
   }
 
-  return [
-    ...genAITools,
-    ...(functionDeclarationTools.length > 0
-      ? [
-          {
-            functionDeclarations: functionDeclarationTools,
-          },
-        ]
-      : []),
-  ];
+  return genAITools;
 }
 
 function convertOpenAIToolToGenAI(


### PR DESCRIPTION
## Summary
- merge LangChain/OpenAI tool declarations into an existing native Gemini tool object when both are supplied to `@langchain/google-genai`
- preserve empty tool lists and declaration-only tool conversion behavior
- add regression coverage for native Gemini + custom LangChain tools

Fixes #10819.

## Testing
- `pnpm exec oxfmt --check libs/providers/langchain-google-genai/src/utils/tools.ts libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts .changeset/google-genai-hybrid-tools.md`
- `pnpm exec oxlint libs/providers/langchain-google-genai/src/utils/tools.ts libs/providers/langchain-google-genai/src/tests/tool_call_conversion.test.ts`
- `pnpm --filter @langchain/google-genai test:single src/tests/tool_call_conversion.test.ts`
- `pnpm --filter @langchain/google-genai build`