### PR TITLE
fix(google): handle EU location for Vertex AI endpoint routing

### DIFF
--- a/.changeset/eu-vertex-endpoint-fix.md
+++ b/.changeset/eu-vertex-endpoint-fix.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): handle EU location for Vertex AI endpoint routing

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -243,6 +243,21 @@ export abstract class BaseChatGoogle<
     return this._location || "global";
   }
 
+  /**
+   * Returns the effective location for use in API paths.
+   * Maps special location values like "eu" to valid region identifiers.
+   */
+  protected get apiLocation(): string {
+    const loc = this._location || "global";
+    // Map "eu" to a valid EU region for API calls
+    // When users specify "eu", they want EU data residency,
+    // which requires using a valid EU region in the API path
+    if (loc === "eu") {
+      return "europe-west1";
+    }
+    return loc;
+  }
+
   protected get endpoint(): string {
     if (typeof this._endpoint !== "undefined") {
       return this._endpoint;
@@ -253,6 +268,9 @@ export abstract class BaseChatGoogle<
     } else if (this.location === "global") {
       // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#use_the_global_endpoint
       return "aiplatform.googleapis.com";
+    } else if (this._location === "eu") {
+      // Special case for EU data residency - use the EU representative endpoint
+      return "aiplatform.eu.rep.googleapis.com";
     } else {
       return `${this.location}-aiplatform.googleapis.com`;
     }
@@ -299,7 +317,7 @@ export abstract class BaseChatGoogle<
     const projectId = await this.apiClient.getProjectId();
     return `https://${this.endpoint}/${
       this.apiVersion
-    }/projects/${projectId}/locations/${this.location}/publishers/${
+    }/projects/${projectId}/locations/${this.apiLocation}/publishers/${
       this.publisher
     }/models/${this.model}:${urlMethod ?? this.urlMethod}`;
   }

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -1326,6 +1326,21 @@ describe("Google Mock", () => {
     const textCall = newTokenCalls.find((c) => c.text.includes("plot"));
     expect(textCall).toBeDefined();
   });
+
+  test("EU location generates correct endpoint and API location", async () => {
+    const llm = newChatGoogle({
+      model: "gemini-3.1-flash-lite",
+      responseFile: "gemini-chat-001.json",
+      location: "eu",
+    });
+
+    await llm.invoke("Hello");
+
+    // Verify the URL uses the EU representative endpoint
+    expect(recorder?.request?.url).toContain("aiplatform.eu.rep.googleapis.com");
+    // Verify the location in the path is a valid EU region
+    expect(recorder?.request?.url).toContain("/locations/europe-west1/");
+  });
 });
 
 function makeSerializableSchema() {


### PR DESCRIPTION
This PR fixes ChatGoogle's handling of the EU location for Vertex AI endpoint routing. When users set `location: "eu"` to ensure EU data residency, the code was incorrectly constructing the endpoint URL as `eu-aiplatform.googleapis.com`, which resulted in 404 errors because "eu" is not a valid Google Cloud region identifier.

The fix introduces two changes in `BaseChatGoogle`:

1. When `location` is set to "eu", the endpoint URL now correctly uses Google's EU representative endpoint `aiplatform.eu.rep.googleapis.com` instead of constructing an invalid region-prefixed URL.

2. A new `apiLocation` getter maps "eu" to the valid EU region "europe-west1" for use in API request paths, ensuring that the location parameter in the URL path is a valid region identifier while preserving the EU representative endpoint.

These changes allow users to simply set `location: "eu"` without needing to manually override the endpoint parameter, and ensure that API requests are properly routed through Google's EU data residency infrastructure.

Fixes #11019
