### PR TITLE
feat(anthropic): add mythos 5 and fable 5 support

### DIFF
--- a/.changeset/hunter-mythos-fable-5.md
+++ b/.changeset/hunter-mythos-fable-5.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/anthropic": minor
+"@langchain/anthropic": patch
 ---
 
 feat(anthropic): add support for claude-fable-5 and claude-mythos-5 models

--- a/.changeset/hunter-mythos-fable-5.md
+++ b/.changeset/hunter-mythos-fable-5.md
@@ -1,0 +1,9 @@
+---
+"@langchain/anthropic": minor
+---
+
+feat(anthropic): add support for claude-fable-5 and claude-mythos-5 models
+
+- upgrade `@anthropic-ai/sdk` to `^0.103.0`
+- add default token handling and adaptive-thinking parameter compatibility for Anthropic 5-series models
+- add unit and integration coverage for default-parameter behavior on new model IDs

--- a/libs/providers/langchain-anthropic/package.json
+++ b/libs/providers/langchain-anthropic/package.json
@@ -27,7 +27,7 @@
     "typegen:profiles": "pnpm --filter @langchain/model-profiles make --config profiles.toml"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@anthropic-ai/sdk": "^0.103.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -83,6 +83,10 @@ import {
 const MODEL_DEFAULT_MAX_OUTPUT_TOKENS: Partial<
   Record<Anthropic.Model, number>
 > = {
+  // Claude 5 — 128K max output
+  "claude-fable-5": 16384,
+  "claude-mythos-5": 16384,
+  "claude-mythos-preview": 16384,
   // Claude 4.7 — 128K max output
   "claude-opus-4-7": 16384,
   // Claude 4.6 — 128K max output

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
@@ -67,6 +67,33 @@ const pdfModelName = "claude-haiku-4-5-20251001";
 // Use this model for all other tests
 const modelName = "claude-haiku-4-5-20251001";
 
+function isModelAccessRestrictedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  if (status === 403 || status === 404) {
+    return true;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message !== "string") {
+    return false;
+  }
+
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("model_not_available") ||
+    normalized.includes("data retention enabled") ||
+    normalized.includes("model_not_found") ||
+    normalized.includes("model not found") ||
+    normalized.includes("forbidden") ||
+    normalized.includes("not authorized") ||
+    normalized.includes("project glasswing")
+  );
+}
+
 test("Test ChatAnthropic", async () => {
   const chat = new ChatAnthropic({
     modelName,
@@ -1580,6 +1607,50 @@ describe("Opus 4.5", () => {
       "Please respond to this message simply with: Hello"
     );
     expect(response.content.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Fable 5", () => {
+  it("works with default parameters", async ({ skip }) => {
+    const model = new ChatAnthropic({
+      model: "claude-fable-5",
+    });
+
+    try {
+      const response = await model.invoke(
+        "Please respond to this message simply with: Hello"
+      );
+      expect(response.content.length).toBeGreaterThan(0);
+    } catch (error) {
+      if (isModelAccessRestrictedError(error)) {
+        skip();
+        return;
+      }
+      throw error;
+    }
+  });
+});
+
+describe("Mythos 5", () => {
+  it("works with default parameters when account access is enabled", async ({
+    skip,
+  }) => {
+    const model = new ChatAnthropic({
+      model: "claude-mythos-5",
+    });
+
+    try {
+      const response = await model.invoke(
+        "Please respond to this message simply with: Hello"
+      );
+      expect(response.content.length).toBeGreaterThan(0);
+    } catch (error) {
+      if (isModelAccessRestrictedError(error)) {
+        skip();
+        return;
+      }
+      throw error;
+    }
   });
 });
 

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -2002,6 +2002,11 @@ describe("Opus 4.6", () => {
 });
 
 describe("Opus 4.7", () => {
+  const adaptiveOnlyOpusModels = [
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+  ] as const;
+
   test("default max_tokens for claude-opus-4-7 is 16384", () => {
     const model = new ChatAnthropic({
       model: "claude-opus-4-7",
@@ -2013,74 +2018,89 @@ describe("Opus 4.7", () => {
     expect(params.max_tokens).toBe(16384);
   });
 
-  test("rejects thinking.type=enabled for claude-opus-4-7", () => {
-    const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
-      apiKey: "testing",
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      thinking: { type: "enabled", budget_tokens: 2048 } as any,
-    });
+  test.each(adaptiveOnlyOpusModels)(
+    "rejects thinking.type=enabled for %s",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        thinking: { type: "enabled", budget_tokens: 2048 } as any,
+      });
 
-    expect(() => model.invocationParams({})).toThrow(
-      'thinking.type="enabled" is not supported for claude-opus-4-7; use thinking.type="adaptive" instead'
-    );
-  });
+      expect(() => model.invocationParams({})).toThrow(
+        `thinking.type="enabled" is not supported for ${modelName}; use thinking.type="adaptive" instead`
+      );
+    }
+  );
 
-  test("rejects thinking.budget_tokens for claude-opus-4-7", () => {
-    const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
-      apiKey: "testing",
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      thinking: { type: "adaptive", budget_tokens: 2048 } as any,
-    });
+  test.each(adaptiveOnlyOpusModels)(
+    "rejects thinking.budget_tokens for %s",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        thinking: { type: "adaptive", budget_tokens: 2048 } as any,
+      });
 
-    expect(() => model.invocationParams({})).toThrow(
-      "thinking.budget_tokens is not supported for claude-opus-4-7; use outputConfig.effort instead"
-    );
-  });
+      expect(() => model.invocationParams({})).toThrow(
+        `thinking.budget_tokens is not supported for ${modelName}; use outputConfig.effort instead`
+      );
+    }
+  );
 
-  test("rejects non-default sampling params for claude-opus-4-7", () => {
-    const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
-      apiKey: "testing",
-      temperature: 0.1,
-    });
+  test.each(adaptiveOnlyOpusModels)(
+    "rejects non-default sampling params for %s",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        temperature: 0.1,
+      });
 
-    expect(() => model.invocationParams({})).toThrow(
-      "temperature is not supported for claude-opus-4-7 when set to non-default values"
-    );
-  });
+      expect(() => model.invocationParams({})).toThrow(
+        `temperature is not supported for ${modelName} when set to non-default values`
+      );
+    }
+  );
 
-  test("does not include sampling params for claude-opus-4-7 even if set to defaults", () => {
-    const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
-      apiKey: "testing",
-      temperature: 1,
-      topP: 1,
-    });
+  test.each(adaptiveOnlyOpusModels)(
+    "does not include sampling params for %s even if set to defaults",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        temperature: 1,
+        topP: 1,
+      });
 
-    const params = model.invocationParams({});
+      const params = model.invocationParams({});
 
-    expect(params.temperature).toBeUndefined();
-    expect(params.top_p).toBeUndefined();
-    expect(params.top_k).toBeUndefined();
-  });
+      expect(params.temperature).toBeUndefined();
+      expect(params.top_p).toBeUndefined();
+      expect(params.top_k).toBeUndefined();
+    }
+  );
 
-  test("passes thinking.display through for claude-opus-4-7", () => {
-    const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
-      apiKey: "testing",
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      thinking: { type: "adaptive", display: "summarized" } as any,
-    });
+  test.each(adaptiveOnlyOpusModels)(
+    "passes thinking.display through for %s",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        thinking: { type: "adaptive", display: "summarized" } as any,
+      });
 
-    const params = model.invocationParams({});
+      const params = model.invocationParams({});
 
-    expect(params.thinking).toEqual({
-      type: "adaptive",
-      display: "summarized",
-    });
-  });
+      expect(params.thinking).toEqual({
+        type: "adaptive",
+        display: "summarized",
+      });
+    }
+  );
 
   test("auto-adds task budget beta when outputConfig.task_budget is provided", () => {
     const model = new ChatAnthropic({

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -2106,6 +2106,51 @@ describe("Opus 4.7", () => {
   });
 });
 
+describe("Fable 5 and Mythos 5", () => {
+  const modelNames = ["claude-fable-5", "claude-mythos-5"] as const;
+
+  test.each(modelNames)("default max_tokens for %s is 16384", (modelName) => {
+    const model = new ChatAnthropic({
+      model: modelName,
+      apiKey: "testing",
+    });
+
+    const params = model.invocationParams({});
+    expect(params.max_tokens).toBe(16384);
+  });
+
+  test.each(modelNames)("rejects thinking.type=enabled for %s", (modelName) => {
+    const model = new ChatAnthropic({
+      model: modelName,
+      apiKey: "testing",
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      thinking: { type: "enabled", budget_tokens: 2048 } as any,
+    });
+
+    expect(() => model.invocationParams({})).toThrow(
+      `thinking.type="enabled" is not supported for ${modelName}; use thinking.type="adaptive" instead`
+    );
+  });
+
+  test.each(modelNames)(
+    "does not include sampling params for %s even if set to defaults",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        temperature: 1,
+        topP: 1,
+      });
+
+      const params = model.invocationParams({});
+
+      expect(params.temperature).toBeUndefined();
+      expect(params.top_p).toBeUndefined();
+      expect(params.top_k).toBeUndefined();
+    }
+  );
+});
+
 describe("withStructuredOutput - StandardSchema", () => {
   function makeSerializableSchema() {
     return {

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -16,6 +16,7 @@ type InvocationCompatibilityFields = {
 
 const ADAPTIVE_ONLY_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-opus-4-8",
   "claude-fable-5",
   "claude-mythos-5",
   "claude-mythos-preview",

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -14,12 +14,30 @@ type InvocationCompatibilityFields = {
   temperature?: number;
 };
 
+const ADAPTIVE_ONLY_MODEL_PREFIXES = [
+  "claude-opus-4-7",
+  "claude-fable-5",
+  "claude-mythos-5",
+  "claude-mythos-preview",
+] as const;
+
+function modelStartsWithAnyPrefix(
+  model: string | undefined,
+  prefixes: readonly string[]
+): boolean {
+  return model ? prefixes.some((prefix) => model.startsWith(prefix)) : false;
+}
+
 function isThinkingEnabled(thinking: AnthropicThinkingConfigParam): boolean {
   return thinking.type === "enabled" || thinking.type === "adaptive";
 }
 
 export function isOpus47Model(model?: string): boolean {
-  return model?.startsWith("claude-opus-4-7") ?? false;
+  return modelStartsWithAnyPrefix(model, ["claude-opus-4-7"]);
+}
+
+export function isAdaptiveOnlyModel(model?: string): boolean {
+  return modelStartsWithAnyPrefix(model, ADAPTIVE_ONLY_MODEL_PREFIXES);
 }
 
 export function getTaskBudgetBetas(
@@ -41,37 +59,38 @@ export function validateInvocationParamCompatibility(
   fields: InvocationCompatibilityFields
 ): void {
   const { model, thinking, topK, topP, temperature } = fields;
-  const opus47 = isOpus47Model(model);
+  const adaptiveOnlyModel = isAdaptiveOnlyModel(model);
+  const modelName = model ?? "this model";
 
-  if (opus47 && thinking.type === "enabled") {
+  if (adaptiveOnlyModel && thinking.type === "enabled") {
     throw new Error(
-      'thinking.type="enabled" is not supported for claude-opus-4-7; use thinking.type="adaptive" instead'
+      `thinking.type="enabled" is not supported for ${modelName}; use thinking.type="adaptive" instead`
     );
   }
   if (
-    opus47 &&
+    adaptiveOnlyModel &&
     typeof thinking === "object" &&
     thinking != null &&
     "budget_tokens" in thinking
   ) {
     throw new Error(
-      "thinking.budget_tokens is not supported for claude-opus-4-7; use outputConfig.effort instead"
+      `thinking.budget_tokens is not supported for ${modelName}; use outputConfig.effort instead`
     );
   }
-  if (opus47) {
+  if (adaptiveOnlyModel) {
     if (topK !== undefined) {
       throw new Error(
-        "topK is not supported for claude-opus-4-7; omit topK/topP/temperature or use model prompting instead"
+        `topK is not supported for ${modelName}; omit topK/topP/temperature or use model prompting instead`
       );
     }
     if (topP !== undefined && topP !== 1) {
       throw new Error(
-        "topP is not supported for claude-opus-4-7 when set to non-default values"
+        `topP is not supported for ${modelName} when set to non-default values`
       );
     }
     if (temperature !== undefined && temperature !== 1) {
       throw new Error(
-        "temperature is not supported for claude-opus-4-7 when set to non-default values"
+        `temperature is not supported for ${modelName} when set to non-default values`
       );
     }
   }
@@ -98,7 +117,7 @@ export function getSamplingParams(
     "temperature" | "top_k" | "top_p"
   > = {};
 
-  if (isThinkingEnabled(thinking) || isOpus47Model(model)) {
+  if (isThinkingEnabled(thinking) || isAdaptiveOnlyModel(model)) {
     return output;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
         version: link:../libs/providers/langchain-xai
       '@layerup/layerup-security':
         specifier: ^1.6.0
-        version: 1.6.0(encoding@0.1.13)(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
+        version: 1.6.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
       '@opensearch-project/opensearch':
         specifier: ^3.5.1
         version: 3.5.1
@@ -302,7 +302,7 @@ importers:
         version: 2.2.7
       exa-js:
         specifier: ^1.10.3
-        version: 1.10.3(encoding@0.1.13)(ws@5.2.5(bufferutil@4.1.0))
+        version: 1.10.3(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))
       firebase-admin:
         specifier: ^13.10.0
         version: 13.10.0(encoding@0.1.13)
@@ -323,25 +323,25 @@ importers:
         version: link:../libs/langchain
       langsmith:
         specifier: ^0.7.3
-        version: 0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(ws@5.2.5(bufferutil@4.1.0))
+        version: 0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0))
       lorem-ipsum:
         specifier: ^3.0.0
         version: 3.0.0
       lunary:
         specifier: ^0.8.8
-        version: 0.8.8(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5)
+        version: 0.8.8(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5)
       mariadb:
         specifier: ^3.5.2
         version: 3.5.2
       mem0ai:
         specifier: ^3.0.6
-        version: 3.0.6(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@5.2.5(bufferutil@4.1.0))
+        version: 3.0.6(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@8.21.0(bufferutil@4.1.0))
       mongodb:
         specifier: ^7.1.1
         version: 7.2.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9)
       openai:
         specifier: ^6.41.0
-        version: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
+        version: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
       peggy:
         specifier: ^5.1.0
         version: 5.1.0
@@ -717,7 +717,7 @@ importers:
         version: 4.13.1
       '@browserbasehq/stagehand':
         specifier: ^1.3.0
-        version: 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(zod@4.3.6)
+        version: 1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(zod@4.3.6)
       '@clickhouse/client':
         specifier: ^0.2.5
         version: 0.2.10
@@ -810,7 +810,7 @@ importers:
         version: link:../providers/langchain-xai
       '@layerup/layerup-security':
         specifier: ^1.5.12
-        version: 1.6.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
+        version: 1.6.0(encoding@0.1.13)(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
       '@opensearch-project/opensearch':
         specifier: ^2.2.0
         version: 2.13.0
@@ -876,7 +876,7 @@ importers:
         version: 1.2.0
       chromadb:
         specifier: ^1.5.3
-        version: 1.10.5(@google/generative-ai@0.24.1)(cohere-ai@7.21.0)(encoding@0.1.13)(ollama@0.6.3)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))
+        version: 1.10.5(@google/generative-ai@0.24.1)(cohere-ai@7.21.0)(encoding@0.1.13)(ollama@0.6.3)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))
       cohere-ai:
         specifier: ^7.14.0
         version: 7.21.0
@@ -897,7 +897,7 @@ importers:
         version: 2.2.7
       exa-js:
         specifier: ^1.10.3
-        version: 1.10.3(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))
+        version: 1.10.3(encoding@0.1.13)(ws@5.2.5(bufferutil@4.1.0))
       firebase-admin:
         specifier: ^13.10.0
         version: 13.10.0(encoding@0.1.13)
@@ -918,19 +918,19 @@ importers:
         version: 3.0.0
       lunary:
         specifier: ^0.8.8
-        version: 0.8.8(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5)
+        version: 0.8.8(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5)
       mariadb:
         specifier: ^3.5.1
         version: 3.5.2
       mem0ai:
         specifier: ^3.0.6
-        version: 3.0.6(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@4.7.1)(ws@8.21.0(bufferutil@4.1.0))
+        version: 3.0.6(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@4.7.1)(ws@5.2.5(bufferutil@4.1.0))
       mongodb:
         specifier: ^6.17.0
         version: 6.21.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9)
       openai:
         specifier: ^6.41.0
-        version: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
+        version: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
       peggy:
         specifier: ^5.1.0
         version: 5.1.0
@@ -982,7 +982,7 @@ importers:
     optionalDependencies:
       langsmith:
         specifier: '>=0.4.0 <1.0.0'
-        version: 0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0))
+        version: 0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(ws@5.2.5(bufferutil@4.1.0))
 
   libs/langchain-core:
     dependencies:
@@ -1144,8 +1144,8 @@ importers:
   libs/providers/langchain-anthropic:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.100.1
-        version: 0.100.1(zod@4.3.6)
+        specifier: ^0.103.0
+        version: 0.103.0(zod@4.3.6)
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
@@ -2543,8 +2543,8 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@anthropic-ai/sdk@0.100.1':
-    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
+  '@anthropic-ai/sdk@0.103.0':
+    resolution: {integrity: sha512-1uG7RNgoHTUxzOXqSCODKt0UTVlxWiHk/2Tt2/uQJiPW7XzBeKVuJyd3Aw6T3LPyvZV/jDTnPLX7SaM70WLLjA==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -12123,7 +12123,7 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@anthropic-ai/sdk@0.100.1(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.103.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -12156,7 +12156,7 @@ snapshots:
 
   '@anthropic-ai/vertex-sdk@0.16.1(encoding@0.1.13)(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.103.0(zod@4.3.6)
       google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -13284,14 +13284,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(zod@4.3.6)':
+  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(bufferutil@4.1.0)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
       '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
       '@playwright/test': 1.59.1
       deepmerge: 4.3.1
       dotenv: 17.4.2
-      openai: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
+      openai: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
       ws: 8.21.0(bufferutil@4.1.0)
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
@@ -17402,7 +17402,7 @@ snapshots:
   chromadb-js-bindings-win32-x64-msvc@1.3.3:
     optional: true
 
-  chromadb@1.10.5(@google/generative-ai@0.24.1)(cohere-ai@7.21.0)(encoding@0.1.13)(ollama@0.6.3)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)):
+  chromadb@1.10.5(@google/generative-ai@0.24.1)(cohere-ai@7.21.0)(encoding@0.1.13)(ollama@0.6.3)(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
@@ -17410,7 +17410,7 @@ snapshots:
       '@google/generative-ai': 0.24.1
       cohere-ai: 7.21.0
       ollama: 0.6.3
-      openai: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
+      openai: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
     transitivePeerDependencies:
       - encoding
 
@@ -19757,6 +19757,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       openai: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
       ws: 5.2.5(bufferutil@4.1.0)
+    optional: true
 
   langsmith@0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0)):
     dependencies:
@@ -19959,19 +19960,19 @@ snapshots:
 
   lru.min@1.1.4: {}
 
-  lunary@0.8.8(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5):
+  lunary@0.8.8(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(openai@6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5):
     dependencies:
       unctx: 2.5.0
     optionalDependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.103.0(zod@4.3.6)
       openai: 6.41.0(ws@5.2.5(bufferutil@4.1.0))(zod@4.3.6)
       react: 19.2.5
 
-  lunary@0.8.8(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5):
+  lunary@0.8.8(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(react@19.2.5):
     dependencies:
       unctx: 2.5.0
     optionalDependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.103.0(zod@4.3.6)
       openai: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
       react: 19.2.5
 
@@ -20045,40 +20046,9 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  mem0ai@3.0.6(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@4.7.1)(ws@8.21.0(bufferutil@4.1.0)):
+  mem0ai@3.0.6(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@4.7.1)(ws@5.2.5(bufferutil@4.1.0)):
     dependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
-      '@azure/identity': 4.13.1
-      '@azure/search-documents': 12.2.0
-      '@cloudflare/workers-types': 4.20260602.1
-      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
-      '@langchain/core': link:libs/langchain-core
-      '@mistralai/mistralai': 2.2.1(bufferutil@4.1.0)
-      '@qdrant/js-client-rest': 1.18.0(typescript@6.0.3)
-      '@supabase/supabase-js': 2.107.0
-      '@types/jest': 30.0.0
-      '@types/pg': 8.20.0
-      axios: 1.16.1(debug@4.3.4)
-      better-sqlite3: 12.9.0
-      cloudflare: 4.5.0(encoding@0.1.13)
-      compromise: 14.15.0
-      groq-sdk: 1.2.1
-      natural: 8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9)
-      ollama: 0.6.3
-      openai: 4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
-      pg: 8.21.0
-      redis: 4.7.1
-      uuid: 9.0.1
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
-      - ws
-
-  mem0ai@3.0.6(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@5.2.5(bufferutil@4.1.0)):
-    dependencies:
-      '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.103.0(zod@4.3.6)
       '@azure/identity': 4.13.1
       '@azure/search-documents': 12.2.0
       '@cloudflare/workers-types': 4.20260602.1
@@ -20097,6 +20067,37 @@ snapshots:
       natural: 8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9)
       ollama: 0.6.3
       openai: 4.104.0(encoding@0.1.13)(ws@5.2.5(bufferutil@4.1.0))(zod@3.25.76)
+      pg: 8.21.0
+      redis: 4.7.1
+      uuid: 9.0.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+      - ws
+
+  mem0ai@3.0.6(@anthropic-ai/sdk@0.103.0(zod@4.3.6))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260602.1)(@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0))(@langchain/core@libs+langchain-core)(@mistralai/mistralai@2.2.1(bufferutil@4.1.0))(@qdrant/js-client-rest@1.18.0(typescript@6.0.3))(@supabase/supabase-js@2.107.0)(@types/jest@30.0.0)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(cloudflare@4.5.0(encoding@0.1.13))(compromise@14.15.0)(encoding@0.1.13)(groq-sdk@1.2.1)(natural@8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9))(ollama@0.6.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ws@8.21.0(bufferutil@4.1.0)):
+    dependencies:
+      '@anthropic-ai/sdk': 0.103.0(zod@4.3.6)
+      '@azure/identity': 4.13.1
+      '@azure/search-documents': 12.2.0
+      '@cloudflare/workers-types': 4.20260602.1
+      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
+      '@langchain/core': link:libs/langchain-core
+      '@mistralai/mistralai': 2.2.1(bufferutil@4.1.0)
+      '@qdrant/js-client-rest': 1.18.0(typescript@6.0.3)
+      '@supabase/supabase-js': 2.107.0
+      '@types/jest': 30.0.0
+      '@types/pg': 8.20.0
+      axios: 1.16.1(debug@4.3.4)
+      better-sqlite3: 12.9.0
+      cloudflare: 4.5.0(encoding@0.1.13)
+      compromise: 14.15.0
+      groq-sdk: 1.2.1
+      natural: 8.1.1(@aws-sdk/credential-providers@3.1034.0)(@opentelemetry/api@1.9.1)(socks@2.8.9)
+      ollama: 0.6.3
+      openai: 4.104.0(encoding@0.1.13)(ws@8.21.0(bufferutil@4.1.0))(zod@3.25.76)
       pg: 8.21.0
       redis: 5.12.1(@opentelemetry/api@1.9.1)
       uuid: 9.0.1


### PR DESCRIPTION
## Summary

Adds Anthropic Claude 5-series model support to `@langchain/anthropic` by introducing `claude-fable-5` and `claude-mythos-5` handling and updating SDK compatibility.

This updates default invocation parameter behavior for the new model family, adds model-specific parameter validation coverage, and includes a changeset for release.

## Changes

### `@langchain/anthropic`

- Upgraded `@anthropic-ai/sdk` from `^0.100.1` to `^0.103.0`.
- Added default `max_tokens` family mapping entries for:
  - `claude-fable-5`
  - `claude-mythos-5`
  - `claude-mythos-preview`
- Extended adaptive-only invocation compatibility logic so Claude 5-series models follow the same sampling/thinking constraints as `claude-opus-4-7`.
- Added unit test coverage for Fable/Mythos default max token behavior and default sampling omission.
- Added integration tests for default-parameter invocations on Fable and Mythos, with access-gated skip behavior for environments lacking required Anthropic account entitlements.
