### PR TITLE
fix(openai): omit empty reasoning item id in Responses API input

### DIFF
--- a/.changeset/openai-reasoning-stream-id.md
+++ b/.changeset/openai-reasoning-stream-id.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): omit empty reasoning item id in Responses API input
+
+Reasoning blocks reassembled from streaming chunks (e.g. via `streamEvents`) never carry an id, since OpenAI's streaming protocol only includes it in non-streaming responses. When such a message was replayed as Responses API input on the next turn, the reasoning item was emitted with `id: ""`, which OpenAI rejects with `400 Invalid 'input[n].id': ''`. The `id` field is now omitted when absent, matching how the legacy reconstruction path already handles a missing id.

--- a/.changeset/openai-reasoning-stream-id.md
+++ b/.changeset/openai-reasoning-stream-id.md
@@ -2,6 +2,8 @@
 "@langchain/openai": patch
 ---
 
-fix(openai): omit empty reasoning item id in Responses API input
+fix(openai): omit empty id and content on reasoning items in Responses API input
 
-Reasoning blocks reassembled from streaming chunks (e.g. via `streamEvents`) never carry an id, since OpenAI's streaming protocol only includes it in non-streaming responses. When such a message was replayed as Responses API input on the next turn, the reasoning item was emitted with `id: ""`, which OpenAI rejects with `400 Invalid 'input[n].id': ''`. The `id` field is now omitted when absent, matching how the legacy reconstruction path already handles a missing id.
+Reasoning blocks reassembled from streaming chunks (e.g. via `streamEvents`) never carry an id, since OpenAI's streaming protocol only includes it in non-streaming responses. When such a message was replayed as Responses API input on the next turn, the reasoning item was emitted with `id: ""`, which OpenAI rejects with `400 Invalid 'input[n].id': ''`. The `id` field is now omitted when absent.
+
+A second error surfaced immediately after that fix: the same converter set a populated `content` array on the reasoning input item, which the Responses API also rejects (`400 Invalid 'input[n].content': array too long. Expected an array with maximum length 0`). Reasoning input items only carry `summary`, so `content` is no longer forwarded. Thanks to @csrujanreddy for catching the second issue and verifying both fixes against the live API.

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1155,21 +1155,15 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       // `id: ""` makes the Responses API reject the turn with
       // `400 Invalid 'input[n].id': ''`, so we omit the field instead — the
       // same way the legacy reconstruction path leaves a missing id off.
-      const reasoningItem: OpenAIClient.Responses.ResponseReasoningItem = {
+      // Reasoning input items only carry `summary` — the Responses API rejects
+      // a populated `content` array on input (`400 Invalid 'input[n].content':
+      // array too long. Expected an array with maximum length 0`). The reasoning
+      // text is already represented in `summary`, so we do not forward `content`.
+      return {
         type: "reasoning",
         ...(block.id ? { id: block.id } : {}),
         summary,
       } as OpenAIClient.Responses.ResponseReasoningItem;
-
-      if (block.reasoning) {
-        reasoningItem.content = [
-          {
-            type: "reasoning_text" as const,
-            text: block.reasoning,
-          },
-        ];
-      }
-      return reasoningItem;
     };
 
     const convertFunctionCall = (

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1149,11 +1149,17 @@ export const convertStandardContentMessageToResponsesInput: Converter<
             }))
           : [{ type: "summary_text" as const, text: "" }];
 
+      // Only include `id` when we actually have one. Reasoning blocks
+      // reassembled from streaming chunks (e.g. via `streamEvents`) never
+      // carry an id, since OpenAI's streaming protocol omits it. Emitting
+      // `id: ""` makes the Responses API reject the turn with
+      // `400 Invalid 'input[n].id': ''`, so we omit the field instead — the
+      // same way the legacy reconstruction path leaves a missing id off.
       const reasoningItem: OpenAIClient.Responses.ResponseReasoningItem = {
         type: "reasoning",
-        id: block.id ?? "",
+        ...(block.id ? { id: block.id } : {}),
         summary,
-      };
+      } as OpenAIClient.Responses.ResponseReasoningItem;
 
       if (block.reasoning) {
         reasoningItem.content = [

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -748,6 +748,33 @@ describe("convertStandardContentMessageToResponsesInput", () => {
     ]);
   });
 
+  it("omits id on reasoning blocks reassembled from streaming (no id)", () => {
+    // Reasoning blocks rebuilt from streaming chunks (e.g. via streamEvents)
+    // never carry an id. Emitting `id: ""` makes the Responses API reject the
+    // follow-up turn with `400 Invalid 'input[n].id': ''`, so the id field
+    // must be omitted entirely rather than defaulted to an empty string.
+    const message = new AIMessage({
+      contentBlocks: [
+        {
+          type: "reasoning",
+          reasoning: "Thoughts...",
+        },
+      ],
+      response_metadata: { model_provider: "openai" },
+    });
+
+    const result = convertStandardContentMessageToResponsesInput(message);
+
+    expect(result).toEqual([
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "Thoughts..." }],
+        content: [{ type: "reasoning_text", text: "Thoughts..." }],
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty("id");
+  });
+
   it("converts tool call blocks and aggregates chunk fallbacks", () => {
     const message = new AIMessage({
       contentBlocks: [

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -743,9 +743,10 @@ describe("convertStandardContentMessageToResponsesInput", () => {
         type: "reasoning",
         id: "reason-1",
         summary: [{ type: "summary_text", text: "Thoughts..." }],
-        content: [{ type: "reasoning_text", text: "Thoughts..." }],
       },
     ]);
+    // The Responses API rejects a populated `content` on reasoning input items.
+    expect(result[0]).not.toHaveProperty("content");
   });
 
   it("omits id on reasoning blocks reassembled from streaming (no id)", () => {
@@ -769,10 +770,10 @@ describe("convertStandardContentMessageToResponsesInput", () => {
       {
         type: "reasoning",
         summary: [{ type: "summary_text", text: "Thoughts..." }],
-        content: [{ type: "reasoning_text", text: "Thoughts..." }],
       },
     ]);
     expect(result[0]).not.toHaveProperty("id");
+    expect(result[0]).not.toHaveProperty("content");
   });
 
   it("converts tool call blocks and aggregates chunk fallbacks", () => {


### PR DESCRIPTION
## Summary

Fixes #11044.

Reasoning blocks reassembled from streaming chunks (e.g. via `agent.streamEvents()`) never carry an `id` — OpenAI's streaming protocol only includes the reasoning item `id` in non-streaming responses. When such a message is replayed as Responses API **input** on the next turn (after a tool result), `convertReasoningBlock` emitted the item with `id: block.id ?? ""`, i.e. `id: ""`. OpenAI rejects that with:

```
400 Invalid 'input[n].id': ''. Expected an ID that begins with 'rs'.
```

This only happens on the `streamEvents` path when the model produces a reasoning summary **and** a tool call in the same turn; `agent.stream()` is unaffected because it reuses the original response output items (which keep their ids).

## Fix

Omit the `id` field entirely when it is absent, instead of defaulting to an empty string. An empty `id` is the only malformed value OpenAI rejects here; a missing `id` is accepted (and is already how the legacy reconstruction path, `convertReasoningSummaryToResponsesReasoningItem`, behaves when a reasoning item has no id). This keeps the two converter paths consistent.

## Tests

- Added a unit test in `convertStandardContentMessageToResponsesInput` covering a reasoning block with no id, asserting the emitted item omits `id` rather than setting `id: ""`.
- Reverse-verified: with the previous `?? ""` behavior the new test fails (output contains `id: ""`).
- Full `converters/tests/responses.test.ts` suite passes (84 tests); `oxfmt --check`, `oxlint`, and the package build are green.

## Areas for careful review

Whether reasoning items should be *dropped* entirely when they have no id (cannot be referenced by OpenAI) vs. sent without an id (current approach). I kept them, matching the existing `convertReasoningSummaryToResponsesReasoningItem` behavior, to preserve the reasoning summary as context.

## AI Disclosure

This bug was investigated and the fix authored with AI assistance (Claude).