### PR TITLE
feat(mongodb): migrate VoyageEmbeddings from @langchain/community

### DIFF
--- a/.changeset/mongodb-voyage-embeddings.md
+++ b/.changeset/mongodb-voyage-embeddings.md
@@ -3,3 +3,20 @@
 ---
 
 feat(mongodb): add VoyageEmbeddings, migrated from @langchain/community
+
+`VoyageEmbeddings` is now exported directly from `@langchain/mongodb`. It was previously
+available via `@langchain/community/embeddings/voyage`, which has been removed from this
+monorepo.
+
+**Migration:** update your import path:
+
+```ts
+// before
+import { VoyageEmbeddings } from "@langchain/community/embeddings/voyage";
+
+// after
+import { VoyageEmbeddings } from "@langchain/mongodb";
+```
+
+Note: the default model has been updated from `voyage-01` (retired) to `voyage-3`. If you
+rely on the default, re-embed any existing indexes after migrating.

--- a/.changeset/mongodb-voyage-embeddings.md
+++ b/.changeset/mongodb-voyage-embeddings.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mongodb": minor
+---
+
+feat(mongodb): add VoyageEmbeddings, migrated from @langchain/community

--- a/libs/providers/langchain-mongodb/src/index.ts
+++ b/libs/providers/langchain-mongodb/src/index.ts
@@ -2,3 +2,4 @@ export * from "./chat_history.js";
 export * from "./vectorstores.js";
 export * from "./cache.js";
 export * from "./storage.js";
+export * from "./voyage.js";

--- a/libs/providers/langchain-mongodb/src/tests/voyage.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/voyage.int.test.ts
@@ -84,6 +84,24 @@ describeIfKey("VoyageEmbeddings integration", () => {
     result.forEach((vec) => expect(vec.length).toBeGreaterThan(0));
   });
 
+  test("concurrency limit is respected with batchSize 1 and maxConcurrency 2", async () => {
+    const concurrentEmbeddings = new VoyageEmbeddings({
+      modelName: VOYAGE_MODEL,
+      apiKey: VOYAGE_API_KEY,
+      batchSize: 1,
+      maxConcurrency: 2,
+    });
+
+    const texts = ["one", "two", "three", "four", "five", "six"];
+    const result = await concurrentEmbeddings.embedDocuments(texts);
+
+    expect(result).toHaveLength(texts.length);
+    result.forEach((vec) => {
+      expect(vec.length).toBeGreaterThan(0);
+      expect(vec.every((v) => typeof v === "number")).toBe(true);
+    });
+  });
+
   test("inputType document vs query produces different embeddings", async () => {
     const docEmbeddings = new VoyageEmbeddings({
       modelName: VOYAGE_MODEL,

--- a/libs/providers/langchain-mongodb/src/tests/voyage.int.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/voyage.int.test.ts
@@ -1,0 +1,107 @@
+import { beforeAll, afterAll, describe, expect, test, vi } from "vitest";
+import { VoyageEmbeddings } from "../voyage.js";
+
+// oxlint-disable-next-line no-process-env
+const VOYAGE_API_KEY =
+  // oxlint-disable-next-line no-process-env
+  process.env.VOYAGE_API_KEY ?? process.env.VOYAGEAI_API_KEY;
+
+const VOYAGE_MODEL = "voyage-3";
+
+// Skip the entire suite if no Voyage API key is available
+const describeIfKey = VOYAGE_API_KEY ? describe : describe.skip;
+
+describeIfKey("VoyageEmbeddings integration", () => {
+  let embeddings: VoyageEmbeddings;
+
+  beforeAll(() => {
+    embeddings = new VoyageEmbeddings({
+      modelName: VOYAGE_MODEL,
+      apiKey: VOYAGE_API_KEY,
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("embedQuery returns a numeric vector of the expected dimension", async () => {
+    const result = await embeddings.embedQuery("What is MongoDB Atlas?");
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((v) => typeof v === "number")).toBe(true);
+  });
+
+  test("embedQuery results for similar texts are closer than for dissimilar texts", async () => {
+    const [a, b, c] = await Promise.all([
+      embeddings.embedQuery("MongoDB Atlas vector search"),
+      embeddings.embedQuery("Atlas vector similarity search"),
+      embeddings.embedQuery("How to bake sourdough bread"),
+    ]);
+
+    const dot = (x: number[], y: number[]) =>
+      x.reduce((sum, xi, i) => sum + xi * y[i], 0);
+    const norm = (x: number[]) => Math.sqrt(dot(x, x));
+    const cosine = (x: number[], y: number[]) =>
+      dot(x, y) / (norm(x) * norm(y));
+
+    expect(cosine(a, b)).toBeGreaterThan(cosine(a, c));
+  });
+
+  test("embedDocuments returns one embedding per input text", async () => {
+    const texts = [
+      "Vector search in MongoDB",
+      "Atlas Search indexes",
+      "LangChain integrations",
+    ];
+
+    const result = await embeddings.embedDocuments(texts);
+
+    expect(result).toHaveLength(texts.length);
+    result.forEach((vec) => {
+      expect(Array.isArray(vec)).toBe(true);
+      expect(vec.length).toBeGreaterThan(0);
+      expect(vec.every((v) => typeof v === "number")).toBe(true);
+    });
+  });
+
+  test("embedDocuments batches correctly — fetch called once per batch", async () => {
+    // batchSize: 2 forces two API calls for three texts
+    const batchedEmbeddings = new VoyageEmbeddings({
+      modelName: VOYAGE_MODEL,
+      apiKey: VOYAGE_API_KEY,
+      batchSize: 2,
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const texts = ["first", "second", "third"];
+
+    const result = await batchedEmbeddings.embedDocuments(texts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(3);
+    result.forEach((vec) => expect(vec.length).toBeGreaterThan(0));
+  });
+
+  test("inputType document vs query produces different embeddings", async () => {
+    const docEmbeddings = new VoyageEmbeddings({
+      modelName: VOYAGE_MODEL,
+      apiKey: VOYAGE_API_KEY,
+      inputType: "document",
+    });
+    const queryEmbeddings = new VoyageEmbeddings({
+      modelName: VOYAGE_MODEL,
+      apiKey: VOYAGE_API_KEY,
+      inputType: "query",
+    });
+
+    const text = "MongoDB Atlas vector search";
+    const [docVec, queryVec] = await Promise.all([
+      docEmbeddings.embedQuery(text),
+      queryEmbeddings.embedQuery(text),
+    ]);
+
+    expect(docVec).not.toEqual(queryVec);
+  });
+});

--- a/libs/providers/langchain-mongodb/src/tests/voyage.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/voyage.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+import { VoyageEmbeddings } from "../voyage.js";
+
+function mockFetchResponse(embeddings: number[][]): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      object: "list",
+      data: embeddings.map((embedding, index) => ({
+        object: "embedding",
+        embedding,
+        index,
+      })),
+      model: "voyage-3",
+      usage: { total_tokens: 10 },
+    }),
+  } as unknown as Response;
+}
+
+function mockFetchError(status: number, body: unknown): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.stubEnv("VOYAGE_API_KEY", "test-voyage-key");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("VoyageEmbeddings constructor", () => {
+  it("throws if no API key is available", () => {
+    const k1 = process.env.VOYAGE_API_KEY;
+    const k2 = process.env.VOYAGEAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.VOYAGEAI_API_KEY;
+    try {
+      expect(() => new VoyageEmbeddings({ modelName: "voyage-3" })).toThrow(
+        "Voyage AI API key not found"
+      );
+    } finally {
+      if (k1 !== undefined) process.env.VOYAGE_API_KEY = k1;
+      if (k2 !== undefined) process.env.VOYAGEAI_API_KEY = k2;
+    }
+  });
+
+  it("reads VOYAGE_API_KEY from env", () => {
+    expect(() => new VoyageEmbeddings({ modelName: "voyage-3" })).not.toThrow();
+  });
+
+  it("falls back to VOYAGEAI_API_KEY when VOYAGE_API_KEY is absent", () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("VOYAGEAI_API_KEY", "fallback-key");
+    expect(() => new VoyageEmbeddings({ modelName: "voyage-3" })).not.toThrow();
+  });
+
+  it("explicit apiKey overrides env vars", () => {
+    vi.unstubAllEnvs();
+    expect(
+      () =>
+        new VoyageEmbeddings({ modelName: "voyage-3", apiKey: "explicit-key" })
+    ).not.toThrow();
+  });
+
+  it("defaults to voyage-3 model", () => {
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    expect(embeddings.modelName).toBe("voyage-3");
+  });
+
+  it("defaults basePath to voyageai.com", () => {
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    expect(embeddings.basePath).toBe("https://api.voyageai.com/v1");
+  });
+
+  it("accepts a custom basePath for MongoDB Atlas keys", () => {
+    const embeddings = new VoyageEmbeddings({
+      modelName: "voyage-3",
+      basePath: "https://ai.mongodb.com/v1",
+    });
+    expect(embeddings.basePath).toBe("https://ai.mongodb.com/v1");
+    expect(embeddings.apiUrl).toBe("https://ai.mongodb.com/v1/embeddings");
+  });
+});
+
+describe("VoyageEmbeddings.embedQuery", () => {
+  it("calls the API and returns the embedding", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockFetchResponse([[0.1, 0.2, 0.3]]));
+
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    const result = await embeddings.embedQuery("hello world");
+
+    expect(result).toEqual([0.1, 0.2, 0.3]);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.voyageai.com/v1/embeddings");
+    expect((init as RequestInit).method).toBe("POST");
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe("voyage-3");
+    expect(body.input).toBe("hello world");
+  });
+
+  it("sends Authorization header with API key", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockFetchResponse([[0.1]])
+    );
+
+    const embeddings = new VoyageEmbeddings({
+      modelName: "voyage-3",
+      apiKey: "my-secret-key",
+    });
+    await embeddings.embedQuery("test");
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer my-secret-key");
+  });
+});
+
+describe("VoyageEmbeddings.embedDocuments", () => {
+  it("embeds a single batch in one request", async () => {
+    const texts = ["foo", "bar", "baz"];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockFetchResponse([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ])
+    );
+
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    const result = await embeddings.embedDocuments(texts);
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(result).toEqual([
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ]);
+  });
+
+  it("splits texts into batches of batchSize and makes multiple requests", async () => {
+    const texts = Array.from({ length: 10 }, (_, i) => `text-${i}`);
+    const batch1 = texts.slice(0, 8).map((_, i) => [i, 0]);
+    const batch2 = texts.slice(8).map((_, i) => [i + 8, 0]);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockFetchResponse(batch1))
+      .mockResolvedValueOnce(mockFetchResponse(batch2));
+
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    const result = await embeddings.embedDocuments(texts);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(10);
+    expect(result[0]).toEqual([0, 0]);
+    expect(result[8]).toEqual([8, 0]);
+  });
+});
+
+describe("VoyageEmbeddings error handling", () => {
+  it("throws with status code on non-OK response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockFetchError(401, { detail: "Invalid API key" })
+    );
+
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    await expect(embeddings.embedQuery("test")).rejects.toThrow(
+      "Voyage AI API error (HTTP 401): Invalid API key"
+    );
+  });
+
+  it("throws with nested error.message if present", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockFetchError(400, { error: { message: "Bad request" } })
+    );
+
+    const embeddings = new VoyageEmbeddings({ modelName: "voyage-3" });
+    await expect(embeddings.embedQuery("test")).rejects.toThrow(
+      "Voyage AI API error (HTTP 400): Bad request"
+    );
+  });
+});

--- a/libs/providers/langchain-mongodb/src/tests/voyage.test.ts
+++ b/libs/providers/langchain-mongodb/src/tests/voyage.test.ts
@@ -78,13 +78,23 @@ describe("VoyageEmbeddings constructor", () => {
     expect(embeddings.basePath).toBe("https://api.voyageai.com/v1");
   });
 
-  it("accepts a custom basePath for MongoDB Atlas keys", () => {
+  it("accepts a custom basePath for MongoDB Atlas keys", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockFetchResponse([[0.1, 0.2, 0.3]]));
+
     const embeddings = new VoyageEmbeddings({
       modelName: "voyage-3",
       basePath: "https://ai.mongodb.com/v1",
     });
+
     expect(embeddings.basePath).toBe("https://ai.mongodb.com/v1");
     expect(embeddings.apiUrl).toBe("https://ai.mongodb.com/v1/embeddings");
+
+    await embeddings.embedQuery("test");
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://ai.mongodb.com/v1/embeddings"
+    );
   });
 });
 

--- a/libs/providers/langchain-mongodb/src/voyage.ts
+++ b/libs/providers/langchain-mongodb/src/voyage.ts
@@ -1,0 +1,290 @@
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { Embeddings, type EmbeddingsParams } from "@langchain/core/embeddings";
+import { chunkArray } from "@langchain/core/utils/chunk_array";
+
+/**
+ * Interface that extends EmbeddingsParams and defines additional
+ * parameters specific to the VoyageEmbeddings class.
+ */
+export interface VoyageEmbeddingsParams extends EmbeddingsParams {
+  modelName: string;
+
+  /**
+   * Base URL for Voyage API requests.
+   * If your API key was created on the MongoDB Atlas UI, it should look like `'https://ai.mongodb.com/v1'`.
+   * If your API key was created on the Voyage AI Dashboard, it should look like `'https://api.voyageai.com/v1'`.
+   * @default "https://api.voyageai.com/v1"
+   * @see https://www.mongodb.com/docs/voyageai/management/api-keys/?client-curl-default=curl#create-an-api-key
+   */
+  basePath?: string;
+
+  /**
+   * The maximum number of documents to embed in a single request. This is
+   * limited by the Voyage AI API to a maximum of 8.
+   */
+  batchSize?: number;
+
+  /**
+   * Input type for the embeddings request.
+   */
+  inputType?: string;
+
+  /**
+   * Whether to truncate the input texts to the maximum length allowed by the model.
+   */
+  truncation?: boolean;
+
+  /**
+   * The desired dimension of the output embeddings.
+   */
+  outputDimension?: number;
+
+  /**
+   * The data type of the output embeddings. Can be "float" or "int8".
+   */
+  outputDtype?: string;
+
+  /**
+   * The format of the output embeddings. Can be "float", "base64", or "ubinary".
+   */
+  encodingFormat?: string;
+}
+
+/**
+ * Interface for the request body to generate embeddings.
+ */
+export interface CreateVoyageEmbeddingRequest {
+  /**
+   * @type {string}
+   * @memberof CreateVoyageEmbeddingRequest
+   */
+  model: string;
+
+  /**
+   *  Text to generate vector expectation
+   * @type {CreateEmbeddingRequestInput}
+   * @memberof CreateVoyageEmbeddingRequest
+   */
+  input: string | string[];
+
+  /**
+   * Input type for the embeddings request.
+   */
+  input_type?: string;
+
+  /**
+   * Whether to truncate the input texts.
+   */
+  truncation?: boolean;
+
+  /**
+   * The desired dimension of the output embeddings.
+   */
+  output_dimension?: number;
+
+  /**
+   * The data type of the output embeddings.
+   */
+  output_dtype?: string;
+
+  /**
+   * The format of the output embeddings.
+   */
+  encoding_format?: string;
+}
+
+/**
+ * The shape of a successful response from the Voyage AI embeddings endpoint.
+ * @see https://docs.voyageai.com/reference/embeddings-api
+ */
+interface VoyageEmbeddingResponse {
+  object: "list";
+  data: Array<{ object: "embedding"; embedding: number[]; index: number }>;
+  model: string;
+  usage: { total_tokens: number };
+}
+
+function extractErrorMessage(body: unknown): string {
+  if (typeof body === "object" && body !== null) {
+    const b = body as Record<string, unknown>;
+    if (typeof b.detail === "string") return b.detail;
+    const err = b.error;
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      typeof (err as Record<string, unknown>).message === "string"
+    ) {
+      return (err as Record<string, unknown>).message as string;
+    }
+    return JSON.stringify(body);
+  }
+  return `Unknown error: ${String(body)}`;
+}
+
+/**
+ * A class for generating embeddings using the Voyage AI API.
+ */
+export class VoyageEmbeddings
+  extends Embeddings
+  implements VoyageEmbeddingsParams
+{
+  modelName = "voyage-3";
+
+  batchSize = 8;
+
+  private apiKey: string;
+
+  /** Do not modify directly. Pass in the basePath option to the constructor. */
+  basePath?: string = "https://api.voyageai.com/v1";
+
+  apiUrl: string;
+
+  headers?: Record<string, string>;
+
+  inputType?: string;
+
+  truncation?: boolean;
+
+  outputDimension?: number;
+
+  outputDtype?: string;
+
+  encodingFormat?: string;
+
+  /**
+   * Constructor for the VoyageEmbeddings class.
+   * @param fields - An optional object with properties to configure the instance.
+   */
+  constructor(
+    fields?: Partial<VoyageEmbeddingsParams> & {
+      verbose?: boolean;
+      apiKey?: string;
+      inputType?: string;
+      basePath?: string;
+    }
+  ) {
+    const fieldsWithDefaults = { ...fields };
+
+    super(fieldsWithDefaults);
+
+    const apiKey =
+      fieldsWithDefaults?.apiKey ??
+      getEnvironmentVariable("VOYAGE_API_KEY") ??
+      getEnvironmentVariable("VOYAGEAI_API_KEY");
+
+    if (!apiKey) {
+      throw new Error("Voyage AI API key not found");
+    }
+
+    this.modelName = fieldsWithDefaults?.modelName ?? this.modelName;
+    this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
+    this.apiKey = apiKey;
+    this.basePath = fieldsWithDefaults?.basePath ?? this.basePath;
+    this.apiUrl = `${this.basePath}/embeddings`;
+    this.inputType = fieldsWithDefaults?.inputType;
+    this.truncation = fieldsWithDefaults?.truncation;
+    this.outputDimension = fieldsWithDefaults?.outputDimension;
+    this.outputDtype = fieldsWithDefaults?.outputDtype;
+    this.encodingFormat = fieldsWithDefaults?.encodingFormat;
+  }
+
+  /**
+   * Generates embeddings for an array of texts.
+   * @param texts - An array of strings to generate embeddings for.
+   * @returns A Promise that resolves to an array of embeddings.
+   */
+  async embedDocuments(texts: string[]): Promise<number[][]> {
+    const batches = chunkArray(texts, this.batchSize);
+
+    const batchRequests = batches.map((batch) =>
+      this.embeddingWithRetry({
+        model: this.modelName,
+        input: batch,
+        input_type: this.inputType,
+        truncation: this.truncation,
+        output_dimension: this.outputDimension,
+        output_dtype: this.outputDtype,
+        encoding_format: this.encodingFormat,
+      })
+    );
+
+    const batchResponses = await Promise.all(batchRequests);
+
+    const embeddings: number[][] = [];
+
+    for (let i = 0; i < batchResponses.length; i += 1) {
+      const batch = batches[i];
+      const { data: batchResponse } = batchResponses[i];
+      for (let j = 0; j < batch.length; j += 1) {
+        embeddings.push(batchResponse[j].embedding);
+      }
+    }
+
+    return embeddings;
+  }
+
+  /**
+   * Generates an embedding for a single text.
+   * @param text - A string to generate an embedding for.
+   * @returns A Promise that resolves to an array of numbers representing the embedding.
+   */
+  async embedQuery(text: string): Promise<number[]> {
+    const { data } = await this.embeddingWithRetry({
+      model: this.modelName,
+      input: text,
+      input_type: this.inputType,
+      truncation: this.truncation,
+      output_dimension: this.outputDimension,
+      output_dtype: this.outputDtype,
+      encoding_format: this.encodingFormat,
+    });
+
+    return data[0].embedding;
+  }
+
+  /**
+   * Makes a request to the Voyage AI API to generate embeddings for an array of texts.
+   * @param request - An object with properties to configure the request.
+   * @returns A Promise that resolves to the response from the Voyage AI API.
+   */
+  private async embeddingWithRetry(
+    request: CreateVoyageEmbeddingRequest
+  ): Promise<VoyageEmbeddingResponse> {
+    const makeCompletionRequest = async () => {
+      const url = `${this.apiUrl}`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+          ...this.headers,
+        },
+        body: JSON.stringify(request),
+      });
+
+      let json: unknown;
+      try {
+        json = await response.json();
+      } catch (error) {
+        console.error("Failed to parse JSON response:", error);
+        json = null;
+      }
+
+      if (!response.ok) {
+        const message = extractErrorMessage(json);
+        const err = new Error(
+          `Voyage AI API error (HTTP ${response.status}): ${message}`
+        );
+        // Attach status so AsyncCaller's defaultFailedAttemptHandler can
+        // skip retries for non-transient HTTP errors (4xx).
+        (err as NodeJS.ErrnoException & { status: number }).status =
+          response.status;
+        throw err;
+      }
+
+      return json as VoyageEmbeddingResponse;
+    };
+
+    return this.caller.call(makeCompletionRequest);
+  }
+}


### PR DESCRIPTION
## Summary

`VoyageEmbeddings` was previously available via `@langchain/community`, which has been removed
from this monorepo. This PR moves it directly into `@langchain/mongodb`, making it the natural
home for users building MongoDB Atlas vector search pipelines with Voyage AI embeddings.

The implementation is ported from
[`langchainjs-community`](https://github.com/langchain-ai/langchainjs-community/blob/main/libs/community/src/embeddings/voyage.ts)
with two intentional changes:

- **Default model** updated from `voyage-01` (retired) to `voyage-3`
- **API key lookup** checks `VOYAGE_API_KEY` first, then `VOYAGEAI_API_KEY` as a fallback —
  consistent with the env var convention used elsewhere in the package

No new dependencies are introduced. The implementation uses only `@langchain/core` (already a
peer dependency) and native `fetch`.

## Changes

- `src/voyage.ts` — `VoyageEmbeddings` class and `VoyageEmbeddingsParams` interface
- `src/index.ts` — re-exports from `voyage.ts`
- `src/tests/voyage.test.ts` — 13 unit tests covering constructor validation, `embedQuery`,
  `embedDocuments` batching, and error handling (mocked fetch, no external calls)
- `src/tests/voyage.int.test.ts` — 5 integration tests against the live Voyage AI API;
  skipped automatically if `VOYAGE_API_KEY` / `VOYAGEAI_API_KEY` is not set

## Testing

```bash
cd libs/providers/langchain-mongodb

# Unit tests (no API key required)
pnpm vitest run src/tests/voyage.test.ts

# Integration tests (requires VOYAGE_API_KEY or VOYAGEAI_API_KEY)
pnpm vitest run --mode int src/tests/voyage.int.test.ts