### PR TITLE
fix(core): preserve AIMessage content blocks

### DIFF
--- a/.changeset/preserve-ai-message-content-blocks.md
+++ b/.changeset/preserve-ai-message-content-blocks.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve AIMessage content blocks
+
+Keep existing v1 contentBlocks when constructing AIMessage instances so serialized messages do not lose block content during deserialization.

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -102,7 +102,8 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
       if (
         initParams.response_metadata !== undefined &&
         "output_version" in initParams.response_metadata &&
-        initParams.response_metadata.output_version === "v1"
+        initParams.response_metadata.output_version === "v1" &&
+        initParams.content !== undefined
       ) {
         initParams.contentBlocks =
           initParams.content as Array<ContentBlock.Standard>;

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -66,6 +66,20 @@ describe("AIMessage", () => {
     ]);
   });
 
+  it("should preserve contentBlocks when output version is v1", () => {
+    const message = new AIMessage({
+      contentBlocks: [{ type: "text", text: "Hi there!" }],
+      response_metadata: {
+        output_version: "v1",
+      },
+    });
+
+    expect(message.content).toEqual([{ type: "text", text: "Hi there!" }]);
+    expect(message.contentBlocks).toEqual([
+      { type: "text", text: "Hi there!" },
+    ]);
+  });
+
   describe(".contentBlocks", () => {
     it("should have tool call content blocks from .tool_calls", () => {
       const message = new AIMessage({


### PR DESCRIPTION
## Summary
- Preserve existing v1 contentBlocks when constructing AIMessage instances.
- Add a focused regression for AIMessage constructor behavior with output_version v1.

fixes https://github.com/langchain-ai/langgraphjs/issues/1949
