### PR TITLE
fix(openai): drop reasoning content blocks in legacy Chat Completions serializer

### DIFF
--- a/.changeset/openai-completions-drop-reasoning.md
+++ b/.changeset/openai-completions-drop-reasoning.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): drop reasoning content blocks in legacy Chat Completions serializer
+
+When an assistant message carrying a `reasoning` content block (e.g. replayed from a LangGraph checkpoint, or produced when reasoning was enabled then disabled) is sent through the Chat Completions API without `response_metadata.output_version === "v1"`, the legacy content path forwarded the block verbatim. OpenAI rejects it with `400 Invalid value: 'reasoning'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', ...`. Reasoning blocks are now dropped on this path, matching how `tool_use` blocks are already handled and how the v1 content path already filters to text.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -818,6 +818,18 @@ export const convertMessagesToCompletionsMessageParams: Converter<
             ) {
               return [];
             }
+            // Drop reasoning blocks — the Chat Completions API has no input
+            // content part for reasoning (it only surfaces in the Responses
+            // API or via additional_kwargs.reasoning_content). Replaying one
+            // verbatim from history triggers `400 Invalid value: 'reasoning'`.
+            if (
+              typeof m === "object" &&
+              m !== null &&
+              "type" in m &&
+              m.type === "reasoning"
+            ) {
+              return [];
+            }
             return m;
           });
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -562,5 +562,29 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       // tool_calls should still be present
       expect((result[0] as any).tool_calls).toHaveLength(1);
     });
+
+    it("should drop reasoning blocks from legacy content (not a valid Completions input part)", () => {
+      // An assistant turn replayed from history that carries a `reasoning`
+      // content block (e.g. persisted by a checkpoint, or produced when
+      // reasoning was enabled and later disabled). With no `output_version: v1`
+      // it goes through the legacy content path. Forwarding `type: "reasoning"`
+      // verbatim triggers `400 Invalid value: 'reasoning'` from OpenAI.
+      const message = new AIMessage({
+        content: [
+          { type: "reasoning", reasoning: "The user wants a simple sum." },
+          { type: "text", text: "4" },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      const contentArr = result[0].content as any[];
+      // reasoning is dropped; text passes through
+      expect(contentArr.some((c: any) => c.type === "reasoning")).toBe(false);
+      expect(contentArr).toEqual([{ type: "text", text: "4" }]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #11049.

When an assistant message carrying a `reasoning` content block is sent through the **Chat Completions** API on the legacy content path (i.e. without `response_metadata.output_version === "v1"`), `convertMessagesToCompletionsMessageParams` forwarded the block verbatim. OpenAI rejects it:

```
400 Invalid value: 'reasoning'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', ...
```

This happens whenever such a message is replayed from history — e.g. persisted by a LangGraph checkpoint, or produced when reasoning was enabled and then disabled for a follow-up request.

## Fix

Drop `reasoning` blocks on the legacy content path, mirroring how `tool_use` blocks are already dropped a few lines above (they're represented elsewhere / would cause an API error). Reasoning is internal model output with no Chat Completions input content part — the v1 content path already filters to `text` only, so this just brings the legacy path in line.

## Tests

- Added a unit test in the "Anthropic cross-provider compatibility" describe block: an `AIMessage` with a `reasoning` + `text` content array (no `output_version`), asserting the reasoning block is dropped and text passes through.
- Reverse-verified: neutralizing the drop makes the new test fail (reasoning leaks through).
- Full `converters/tests/completions.test.ts` passes (20 tests); `oxfmt --check`, `oxlint`, and the package build are green.

## Note

This is a sibling of #11045 (same `reasoning`-block-as-replayed-input problem on the Responses API). The two are independent and touch different files.

## AI Disclosure

This bug was investigated and the fix authored with AI assistance (Claude).