### PR TITLE
fix(openai): drop reasoning content blocks on the legacy Completions path

### DIFF
--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -818,6 +818,21 @@ export const convertMessagesToCompletionsMessageParams: Converter<
             ) {
               return [];
             }
+            // Drop reasoning blocks — the Chat Completions input schema
+            // does not accept `reasoning` as a content-part type, even on
+            // reasoning-capable models. The v1 path
+            // (convertStandardContentMessageToCompletionsMessage above)
+            // already filters to text; mirror that here so replayed history
+            // carrying a reasoning block doesn't 400 on the legacy path.
+            // See langchain-ai/langchainjs#11049.
+            if (
+              typeof m === "object" &&
+              m !== null &&
+              "type" in m &&
+              m.type === "reasoning"
+            ) {
+              return [];
+            }
             return m;
           });
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -524,6 +524,33 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
+    it("should drop reasoning blocks from content (legacy path)", () => {
+      // Regression for langchain-ai/langchainjs#11049. A message replayed
+      // from history (e.g. a LangGraph checkpoint, or a turn produced when
+      // reasoning was enabled and then disabled for this follow-up) can
+      // carry a `reasoning` content block without
+      // `response_metadata.output_version === "v1"`, which routes through
+      // the legacy path. The Chat Completions API rejects `reasoning` as
+      // an input content-part type, so the block must be dropped here the
+      // same way the v1 path filters to text.
+      const message = new AIMessage({
+        content: [
+          { type: "reasoning", reasoning: "The user wants a simple sum." },
+          { type: "text", text: "4" },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        role: "assistant",
+        content: [{ type: "text", text: "4" }],
+      });
+    });
+
     it("should drop tool_use blocks alongside thinking blocks", () => {
       const message = new AIMessage({
         content: [


### PR DESCRIPTION
Closes #11049.

## Summary

`convertMessagesToCompletionsMessageParams` has two branches that should agree on the same input but don't:

- **v1 path** (`convertStandardContentMessageToCompletionsMessage`) — filters `message.contentBlocks` to `text`, so `reasoning` blocks are already dropped.
- **Legacy path** (`message.content.flatMap(...)`) — only special-cased `tool_use`. Any other unrecognised block falls through `return m;` and is forwarded verbatim, so a `{ type: "reasoning" }` block sent on this path produces:

```
400 Invalid value: 'reasoning'. Supported values are: 'text', 'image_url',
'input_audio', 'refusal', 'audio', and 'file'.
```

This is reachable in normal usage: assistant messages persisted by a LangGraph checkpoint (or replayed when a reasoning model is swapped out for a cheaper non-reasoning model — e.g. `gpt-4o-mini` for a title / summary call) carry the block forward, and without `response_metadata.output_version === "v1"` they route through the legacy path.

## Fix

Mirror the v1 path's filter: drop reasoning blocks on the legacy branch the same way `tool_use` is already dropped, so both paths agree on the same input.

```ts
if (typeof m === "object" && m !== null && "type" in m && m.type === "reasoning") {
  return [];
}
```

## Tests

`should drop reasoning blocks from content (legacy path)` in `src/converters/tests/completions.test.ts` builds an `AIMessage` carrying a `{ type: "reasoning" }` block alongside a `{ type: "text", text: "4" }` block (with no `output_version` metadata, so the legacy path runs) and asserts the serialized request only contains the text block. All 20 tests in `completions.test.ts` pass.