### PR TITLE
fix(anthropic): drop default disabled thinking for adaptive-only models

### DIFF
--- a/.changeset/anthropic-adaptive-only-disabled-thinking.md
+++ b/.changeset/anthropic-adaptive-only-disabled-thinking.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): drop default disabled thinking for adaptive-only models
+
+`ChatAnthropic` defaults `thinking` to `{ type: "disabled" }`, but adaptive-only models (`claude-fable-5`, `claude-mythos-5`, and the other 5-series / opus-4.7+ models) reject `thinking.type: "disabled"` with `400 invalid_request_error` — they default to adaptive mode when thinking is omitted. As a result `new ChatAnthropic({ model: "claude-fable-5" }).invoke(...)` failed on every default-configured request. The disabled thinking param is now dropped for these models so the API applies its adaptive default.

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -37,6 +37,7 @@ import { _convertMessagesToAnthropicPayload } from "./utils/message_inputs.js";
 import {
   getSamplingParams,
   getTaskBudgetBetas,
+  resolveThinkingParam,
   validateInvocationParamCompatibility,
 } from "./utils/params.js";
 import {
@@ -1250,7 +1251,7 @@ export class ChatAnthropicMessages<
         strict: options?.strict,
       }),
       tool_choice,
-      thinking: this.thinking,
+      thinking: resolveThinkingParam(this.model, this.thinking),
       context_management: this.contextManagement,
       ...this.invocationKwargs,
       container: options?.container,

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -404,6 +404,32 @@ test("adaptive thinking throws on topP", () => {
   );
 });
 
+test("invocationParams drops default disabled thinking for adaptive-only models (claude-fable-5)", () => {
+  // claude-fable-5 / claude-mythos-5 reject `thinking.type: "disabled"` and
+  // default to adaptive mode when thinking is omitted. ChatAnthropic defaults
+  // `thinking` to `{ type: "disabled" }`, so without dropping it every
+  // default-configured request to these models 400s.
+  const model = new ChatAnthropic({
+    model: "claude-fable-5",
+    apiKey: "testing",
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.thinking).toBeUndefined();
+});
+
+test("invocationParams keeps disabled thinking for non-adaptive-only models", () => {
+  const model = new ChatAnthropic({
+    model: "claude-haiku-4-5-20251001",
+    apiKey: "testing",
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.thinking).toEqual({ type: "disabled" });
+});
+
 test("Can properly format messages with container_upload blocks", async () => {
   const messageHistory = [
     new HumanMessage({

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -109,6 +109,21 @@ export function validateInvocationParamCompatibility(
   }
 }
 
+export function resolveThinkingParam(
+  model: string | undefined,
+  thinking: AnthropicThinkingConfigParam
+): AnthropicThinkingConfigParam | undefined {
+  // Adaptive-only models (e.g. claude-fable-5, claude-mythos-5) reject
+  // `thinking.type: "disabled"` — they default to adaptive mode when thinking
+  // is omitted. ChatAnthropic defaults `thinking` to `{ type: "disabled" }`, so
+  // without this these models 400 on every default-configured request. Drop the
+  // disabled thinking param for them and let the API apply its adaptive default.
+  if (isAdaptiveOnlyModel(model) && thinking.type === "disabled") {
+    return undefined;
+  }
+  return thinking;
+}
+
 export function getSamplingParams(
   fields: InvocationCompatibilityFields
 ): Pick<AnthropicInvocationParams, "temperature" | "top_k" | "top_p"> {


### PR DESCRIPTION
## Summary

Fixes #11052.

`new ChatAnthropic({ model: "claude-fable-5" }).invoke("hi")` fails with:

```
400 invalid_request_error: "thinking.type.disabled" is not supported for this model.
Thinking defaults to adaptive mode when not specified; use "thinking.type.enabled"
with "budget_tokens" for extended thinking.
```

`ChatAnthropic` defaults `thinking` to `{ type: "disabled" }` (chat_models.ts), and `invocationParams` always forwarded it. Adaptive-only models — `claude-fable-5`, `claude-mythos-5`, `claude-mythos-preview`, `claude-opus-4-7`, `claude-opus-4-8` (the existing `ADAPTIVE_ONLY_MODEL_PREFIXES`) — reject `thinking.type: "disabled"` and instead default to adaptive when thinking is omitted. So every default-configured request to these models 400s.

## Fix

Added `resolveThinkingParam(model, thinking)` in `utils/params.ts` (alongside the existing `validateInvocationParamCompatibility` / `getSamplingParams` adaptive-only helpers). It returns `undefined` — dropping the param — when the model is adaptive-only and `thinking.type === "disabled"`, letting the API apply its adaptive default. All other models keep their thinking value unchanged.

This complements the existing 5-series handling, which already covered `enabled` / `budget_tokens` / sampling params but not the default `disabled` case.

## Tests

- `claude-fable-5` with default thinking → `params.thinking` is omitted.
- Control: a non-adaptive-only model (`claude-haiku-4-5`) still sends `{ type: "disabled" }` (no regression).
- Reverse-verified: reverting the fix makes the fable-5 test fail.
- Full `chat_models.test.ts` passes (108 tests); `oxfmt --check`, `oxlint`, and the package build are green.

## AI Disclosure

This bug was investigated and the fix authored with AI assistance (Claude).