### PR TITLE
fix(anthropic): send task budget beta header for all supported models

### DIFF
--- a/.changeset/anthropic-task-budget-betas.md
+++ b/.changeset/anthropic-task-budget-betas.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): add task budget beta header for all models that support task budgets
+
+`getTaskBudgetBetas` only attached the `task-budgets-2026-03-13` beta header for `claude-opus-4-7`, so setting `outputConfig.task_budget` on `claude-opus-4-8`, `claude-fable-5`, or `claude-mythos-5` sent the beta-gated field without the required header. Task budgets are in beta on all of these models, so the header is now attached for the full adaptive-only model set.

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -2101,13 +2101,47 @@ describe("Opus 4.7", () => {
       });
     }
   );
+});
 
-  test("auto-adds task budget beta when outputConfig.task_budget is provided", () => {
+describe("Task budget beta auto-append", () => {
+  const taskBudgetModels = [
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+  ] as const;
+
+  test.each(taskBudgetModels)(
+    "auto-adds task budget beta for %s when outputConfig.task_budget is provided",
+    (modelName) => {
+      const model = new ChatAnthropic({
+        model: modelName,
+        apiKey: "testing",
+        outputConfig: {
+          effort: "high",
+          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+          task_budget: { type: "tokens", total: 128000 } as any,
+        },
+      });
+
+      const params = model.invocationParams({});
+
+      expect(params.betas).toContain("task-budgets-2026-03-13");
+      expect(params.output_config).toEqual({
+        effort: "high",
+        task_budget: {
+          type: "tokens",
+          total: 128000,
+        },
+      });
+    }
+  );
+
+  test("does not add task budget beta for unsupported models", () => {
     const model = new ChatAnthropic({
-      model: "claude-opus-4-7",
+      model: "claude-sonnet-4-6",
       apiKey: "testing",
       outputConfig: {
-        effort: "high",
         // oxlint-disable-next-line @typescript-eslint/no-explicit-any
         task_budget: { type: "tokens", total: 128000 } as any,
       },
@@ -2115,14 +2149,19 @@ describe("Opus 4.7", () => {
 
     const params = model.invocationParams({});
 
-    expect(params.betas).toContain("task-budgets-2026-03-13");
-    expect(params.output_config).toEqual({
-      effort: "high",
-      task_budget: {
-        type: "tokens",
-        total: 128000,
-      },
+    expect(params.betas ?? []).not.toContain("task-budgets-2026-03-13");
+  });
+
+  test("does not add task budget beta when task_budget is not set", () => {
+    const model = new ChatAnthropic({
+      model: "claude-fable-5",
+      apiKey: "testing",
+      outputConfig: { effort: "high" },
     });
+
+    const params = model.invocationParams({});
+
+    expect(params.betas ?? []).not.toContain("task-budgets-2026-03-13");
   });
 });
 

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -33,10 +33,6 @@ function isThinkingEnabled(thinking: AnthropicThinkingConfigParam): boolean {
   return thinking.type === "enabled" || thinking.type === "adaptive";
 }
 
-export function isOpus47Model(model?: string): boolean {
-  return modelStartsWithAnyPrefix(model, ["claude-opus-4-7"]);
-}
-
 export function isAdaptiveOnlyModel(model?: string): boolean {
   return modelStartsWithAnyPrefix(model, ADAPTIVE_ONLY_MODEL_PREFIXES);
 }
@@ -51,7 +47,9 @@ export function getTaskBudgetBetas(
     "task_budget" in outputConfig &&
     outputConfig.task_budget != null;
 
-  return isOpus47Model(model) && hasTaskBudget
+  // Task budgets are in beta on the same models that are adaptive-only
+  // (Opus 4.7/4.8, Fable 5, Mythos 5).
+  return isAdaptiveOnlyModel(model) && hasTaskBudget
     ? (["task-budgets-2026-03-13"] as AnthropicBeta[])
     : [];
 }


### PR DESCRIPTION
## Summary

`getTaskBudgetBetas` only attached the `task-budgets-2026-03-13` beta header for `claude-opus-4-7`, so setting `outputConfig.task_budget` on `claude-opus-4-8`, `claude-fable-5`, or `claude-mythos-5` sent the beta gated field without the required header. The API rejects those requests.

Per the [task budgets docs](https://platform.claude.com/docs/en/build-with-claude/task-budgets), the feature is in beta on Opus 4.7, Opus 4.8, Fable 5, and Mythos 5. #11040 added Fable 5 and Mythos 5 support and introduced `isAdaptiveOnlyModel`, which covers all four models, then migrated the sampling, thinking, and validation gates to it. `getTaskBudgetBetas` was left on the narrower `isOpus47Model` check.

## Changes

* Gate `getTaskBudgetBetas` on `isAdaptiveOnlyModel` instead of `isOpus47Model`, so the header is attached for every model that supports task budgets.
* Remove the now unused `isOpus47Model` helper. It was not exported from the package entry point and had no other callers.
* Expand the task budget unit test to cover all four supported models, plus negative cases for an unsupported model and for when `task_budget` is unset.

## Testing

`pnpm test` in `libs/providers/langchain-anthropic` passes all 200 unit tests. Lint and format are clean.