### PR TITLE
ci(infra): pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,20 +31,20 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{matrix.language}}"
           output: results-${{matrix.language}}
 
       - name: Store sarif file as artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-results-${{matrix.language}}
           path: results-${{matrix.language}}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: 💬 Comment on PR
         if: steps.version.outputs.success == '1' && steps.published.outputs.count != '0' && github.ref != 'refs/heads/main'
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Get the current branch name

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-cjs/
 lib/
 .yarn
 .turbo
+.eslintcache
 .env
 .env.local
 npm-debug.log*


### PR DESCRIPTION
Four GitHub Actions references were still on floating tags, which would fail under GitHub's "require actions to be pinned to a full-length commit SHA" policy. Pinning them lets that org/branch setting be enabled without breaking CI, and aligns the last stragglers with the SHA-pinning convention already used across the rest of the repo.