### PR TITLE
fix(anthropic): handle web_fetch_tool_result content blocks in streaming and message serialization

### DIFF
--- a/.changeset/anthropic-web-fetch-tool-result.md
+++ b/.changeset/anthropic-web-fetch-tool-result.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Handle `web_fetch_tool_result` server-tool result blocks in streaming and message serialization. The block was previously dropped while streaming and stripped on input, causing Anthropic to return HTTP 400 ("web_fetch tool use ... without a corresponding web_fetch_tool_result block") on the following turn.

--- a/libs/providers/langchain-anthropic/src/tests/chat_models-web_fetch.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models-web_fetch.test.ts
@@ -1,0 +1,96 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { test, expect } from "vitest";
+import {
+  AIMessage,
+  ContentBlock,
+  HumanMessage,
+} from "@langchain/core/messages";
+import { _makeMessageChunkFromAnthropicEvent } from "../utils/message_outputs.js";
+import { _convertMessagesToAnthropicPayload } from "../utils/message_inputs.js";
+
+test("Web Fetch Tool - streaming content_block_start is preserved on the chunk", () => {
+  // What Anthropic streams once the server-side fetch resolves.
+  const event = {
+    type: "content_block_start",
+    index: 1,
+    content_block: {
+      type: "web_fetch_tool_result",
+      tool_use_id: "srvtoolu_01ABC123",
+      content: {
+        type: "web_fetch_result",
+        url: "https://example.com",
+        retrieved_at: "2025-01-01T00:00:00Z",
+        content: {
+          type: "document",
+          title: "Example Domain",
+          source: {
+            type: "text",
+            media_type: "text/plain",
+            data: "This domain is for use in documentation examples.",
+          },
+        },
+      },
+    },
+  };
+
+  const result = _makeMessageChunkFromAnthropicEvent(
+    event as unknown as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
+    {
+      streamUsage: true,
+      coerceContentToString: false,
+    }
+  );
+
+  expect(result).not.toBeNull();
+  const content = result?.chunk.content as ContentBlock[];
+  expect(content.some((block) => block.type === "web_fetch_tool_result")).toBe(
+    true
+  );
+  // No tool call chunks are emitted for a result block.
+  expect(result?.chunk.tool_call_chunks ?? []).toEqual([]);
+});
+
+test("Web Fetch Tool - LangChain message round-trips to Anthropic format", () => {
+  // What LangChain holds after a web fetch response.
+  const langChainMessage = new AIMessage({
+    content: [
+      {
+        type: "server_tool_use",
+        id: "srvtoolu_01DEF456",
+        name: "web_fetch",
+        input: { url: "https://example.com" },
+      },
+      {
+        type: "web_fetch_tool_result",
+        tool_use_id: "srvtoolu_01DEF456",
+        content: {
+          type: "web_fetch_result",
+          url: "https://example.com",
+          retrieved_at: "2025-01-01T00:00:00Z",
+          content: {
+            type: "document",
+            title: "Example Domain",
+            source: {
+              type: "text",
+              media_type: "text/plain",
+              data: "This domain is for use in documentation examples.",
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  const result = _convertMessagesToAnthropicPayload([
+    new HumanMessage("Follow up question about the fetched page"),
+    langChainMessage,
+  ]);
+
+  // The web_fetch_tool_result block must survive serialization so Anthropic
+  // can match it to the preceding web_fetch tool use on the next turn.
+  const assistantContent = result.messages[1]
+    .content as Anthropic.Beta.BetaContentBlockParam[];
+  expect(
+    assistantContent.some((block) => block.type === "web_fetch_tool_result")
+  ).toBe(true);
+});

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -166,6 +166,7 @@ function* _formatContentBlocks(
     "tool_use",
     "web_search_result",
     "web_search_tool_result",
+    "web_fetch_tool_result",
   ];
   const textTypes = ["text", "text_delta"];
   for (const contentPart of content) {

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -75,6 +75,7 @@ export function _makeMessageChunkFromAnthropicEvent(
       "document",
       "server_tool_use",
       "web_search_tool_result",
+      "web_fetch_tool_result",
     ].includes(data.content_block.type)
   ) {
     const contentBlock = data.content_block;


### PR DESCRIPTION
## Description

The Anthropic provider drops `web_fetch_tool_result` server-tool result blocks. Two hardcoded allowlists include `web_search_tool_result` but omit its sibling `web_fetch_tool_result`:

- `libs/providers/langchain-anthropic/src/utils/message_outputs.ts` — the `content_block_start` allowlist in `_makeMessageChunkFromAnthropicEvent` did not include `web_fetch_tool_result`, so the block was dropped from the streamed `AIMessageChunk`.
- `libs/providers/langchain-anthropic/src/utils/message_inputs.ts` — the `toolTypes` array in `_formatContentBlocks` did not include `web_fetch_tool_result`, so the block was stripped on input serialization.

As a consequence, on the turn after a `web_fetch` call the request was sent with a `web_fetch` server tool use but no matching result block, and Anthropic responded with HTTP 400: `web_fetch tool use ... without a corresponding web_fetch_tool_result block`.

## Fix

Add `"web_fetch_tool_result"` alongside `"web_search_tool_result"` in both allowlists. This is a narrow, behavior-neutral parity change — `web_fetch_tool_result` is now handled exactly the same way `web_search_tool_result` already is.

## Tests

Added `libs/providers/langchain-anthropic/src/tests/chat_models-web_fetch.test.ts`, mirroring the existing `chat_models-web_search.test.ts`:

1. A synthetic `content_block_start` event whose `content_block.type === "web_fetch_tool_result"` is fed through `_makeMessageChunkFromAnthropicEvent`, asserting the block survives into the `AIMessageChunk`.
2. A round-trip of an `AIMessage` containing a `web_fetch_tool_result` block through `_convertMessagesToAnthropicPayload` (which exercises `_formatContentBlocks`), asserting the block is retained, not stripped.

Both tests fail on the unpatched code and pass with the fix. Full `@langchain/anthropic` unit suite: 197 tests passing, build and lint clean.

Fixes #9911
