### PR TITLE
fix(openai): route standard url file blocks to native input_file in Responses API

### DIFF
--- a/.changeset/smart-deer-sniff.md
+++ b/.changeset/smart-deer-sniff.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): route standard url file blocks to native input_file in Responses API

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1657,6 +1657,35 @@ export const convertMessagesToResponsesInput: Converter<
             });
           }
           if (isDataContentBlock(item)) {
+            // The Responses API supports file URLs natively, but the Chat
+            // Completions converter rejects URL file blocks. Convert standard
+            // file blocks to the native `input_file` shape instead of routing
+            // them through the completions converter.
+            if (item.type === "file") {
+              const filename = getFilenameFromMetadata(item);
+              if (item.source_type === "url") {
+                return {
+                  type: "input_file",
+                  file_url: item.url,
+                  ...(filename ? { filename } : {}),
+                };
+              }
+              if (item.source_type === "id") {
+                return {
+                  type: "input_file",
+                  file_id: item.id,
+                  ...(filename ? { filename } : {}),
+                };
+              }
+              if (item.source_type === "base64") {
+                const mimeType = item.mime_type ?? "";
+                return {
+                  type: "input_file",
+                  file_data: `data:${mimeType};base64,${item.data}`,
+                  filename: getRequiredFilenameFromMetadata(item),
+                };
+              }
+            }
             return convertToProviderContentBlock(
               item,
               completionsApiContentBlockConverter

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1128,6 +1128,44 @@ describe("convertMessagesToResponsesInput", () => {
       );
       expect(fileBlock.filename).toBeUndefined();
     });
+
+    it("routes standard url file blocks to native input_file instead of the completions converter", () => {
+      const messages = [
+        new HumanMessage({
+          content: [
+            { type: "text", text: "What is in this document?" },
+            {
+              type: "file",
+              source_type: "url",
+              url: "https://example.com/document.pdf",
+              mime_type: "application/pdf",
+              metadata: { filename: "document.pdf" },
+            },
+          ],
+        }),
+      ];
+
+      const result = convertMessagesToResponsesInput({
+        messages,
+        model: "gpt-4o",
+        zdrEnabled: false,
+      });
+
+      expect(result).toMatchObject([
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "What is in this document?" },
+            {
+              type: "input_file",
+              file_url: "https://example.com/document.pdf",
+              filename: "document.pdf",
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe("ToolMessage conversion", () => {


### PR DESCRIPTION
**Fixes #9895**

### Problem
With `ChatOpenAI({ useResponsesApi: true })`, a standard file content block using `source_type: "url"` throws:

```
Error: URL file blocks with source_type url must be formatted as a data URL for ChatOpenAI
```

even though the Responses API supports file URLs natively.

### Root cause
`convertMessagesToResponsesInput` (used by the Responses chat model) routes every `isDataContentBlock` item through `completionsApiContentBlockConverter`. Its `fromStandardFileBlock` only accepts base64 *data* URLs for `source_type: "url"` and throws on plain HTTP URLs — correct for Chat Completions (which has no file-URL support), but wrong for the Responses API, which accepts `input_file.file_url`.

The newer `convertStandardContentMessageToResponsesInput` path (v1 `contentBlocks`) already handles this correctly via `resolveFileItem`; only the legacy standard-content path was affected.

### Fix
In `convertMessagesToResponsesInput`, convert standard **file** blocks to the native Responses `input_file` shape before falling back to the completions converter:

- `source_type: "url"` → `{ type: "input_file", file_url }`
- `source_type: "id"` → `{ type: "input_file", file_id }`
- `source_type: "base64"` → `{ type: "input_file", file_data }`

Filename is preserved from metadata when present, matching the existing `resolveFileItem` behavior. Non-file data blocks (image/audio) keep their existing routing.

### Tests
Added a regression test in `responses.test.ts` asserting a `source_type: "url"` file block converts to `input_file` with `file_url` (and preserves `filename`). Verified failing before the fix (with the exact reported error) and passing after; full converter suite (103 tests) green with no type errors.
