### PR TITLE
docs(ibm): fix "Recieved" typo in tool_choice error message

### DIFF
--- a/libs/providers/langchain-ibm/src/chat_models/ibm.ts
+++ b/libs/providers/langchain-ibm/src/chat_models/ibm.ts
@@ -425,7 +425,7 @@ function _convertToolChoiceToWatsonxToolChoice(
   } else if ("type" in toolChoice) return { toolChoice };
   else
     throw new Error(
-      `Unrecognized tool_choice type. Expected string or TextChatParameterTools. Recieved ${toolChoice}`
+      `Unrecognized tool_choice type. Expected string or TextChatParameterTools. Received ${toolChoice}`
     );
 }
 


### PR DESCRIPTION
## Summary
- Fix a small typo (`Recieved` → `Received`) in the user-facing error message thrown from `_convertToolChoiceToWatsonxToolChoice` in `@langchain/ibm`.
- The error message is what `ChatWatsonx` consumers see when they pass an invalid `tool_choice`, so the typo is visible in the wild.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm format:check` → all matched files use the correct format
- `pnpm lint` → no issues
- `pnpm --filter @langchain/ibm build` → build successful (incl. `attw` and `publint`)
- `pnpm --filter @langchain/ibm test` → 7 test files / 118 tests passed, no type errors

No behavioral change — single-line spelling fix in an error message.

Made with [Cursor](https://cursor.com)