### PR TITLE
docs(tavily): fix "refering" typo in tool description

### DIFF
--- a/libs/providers/langchain-tavily/src/tavily-crawl.ts
+++ b/libs/providers/langchain-tavily/src/tavily-crawl.ts
@@ -264,7 +264,7 @@ export class TavilyCrawl extends StructuredTool<typeof inputSchema> {
 
   override description: string =
     "A powerful web crawler that initiates a structured web crawl starting from a specified " +
-    "base URL. The crawler uses a BFS Depth: refering to the number of link hops from the root URL. " +
+    "base URL. The crawler uses a BFS Depth: referring to the number of link hops from the root URL. " +
     "A page directly linked from the root is at BFS depth 1, regardless of its URL structure. " +
     "You can control how deep and wide it goes, and guide it to focus on specific sections of the site.";
 


### PR DESCRIPTION
## Summary
- Fix "refering" → "referring" in `TavilyCrawl.description` (`libs/providers/langchain-tavily/src/tavily-crawl.ts`).
- This string is the tool description that LLMs see when deciding to invoke the tool, so a cleaner prompt is a small quality win.

## Validation
- `pnpm --filter @langchain/tavily build` → build completes, attw/publint clean
- `git diff` → 1 line changed in a single file

Pre-existing lint and prettier issues on this package were not introduced by this change (they reproduce on `main`).

No linked issue.

Made with [Cursor](https://cursor.com)