### PR TITLE
fix(groq): tighten @langchain/core peer dependency to ^1.1.30

### DIFF
--- a/.changeset/groq-core-peer-range.md
+++ b/.changeset/groq-core-peer-range.md
@@ -1,0 +1,5 @@
+---
+"@langchain/groq": patch
+---
+
+Tighten the `@langchain/core` peer dependency to `^1.1.30`, the version that introduced the `utils/standard_schema` and `language_models/structured_output` export subpaths imported by `ChatGroq`. The previous `^1.0.0` range allowed core versions below 1.1.30 that lack these exports, causing module-not-found build failures.

--- a/libs/providers/langchain-groq/package.json
+++ b/libs/providers/langchain-groq/package.json
@@ -30,7 +30,7 @@
     "groq-sdk": "^1.2.1"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0"
+    "@langchain/core": "^1.1.30"
   },
   "devDependencies": {
     "@langchain/core": "workspace:^",


### PR DESCRIPTION
Fixes #11068

Tightens the `@langchain/core` peer dependency of `@langchain/groq` from `^1.0.0` to `^1.1.30`.

`ChatGroq` imports `@langchain/core/utils/standard_schema` and
`@langchain/core/language_models/structured_output`, both added to core's
`exports` map in 1.1.30. The previous `^1.0.0` range let package managers
resolve core to 1.0.0–1.1.29 which satisfies the peer but lacks those
subpaths producing module-not-found failures at build/runtime. The new
range reflects the actual minimum.

No tests were added but a changeset file has been added. 