### PR TITLE
fix(core): finalize streamed Anthropic server tool args

### DIFF
--- a/.changeset/fuzzy-tools-stream.md
+++ b/.changeset/fuzzy-tools-stream.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): finalize streamed Anthropic server tool args
+
+Keep Anthropic `web_search` server-tool arguments as the raw streamed JSON string until the stream has produced valid JSON, then expose the parsed JSON object in the standard `server_tool_call` content block.

--- a/libs/langchain-core/src/messages/block_translators/anthropic.ts
+++ b/libs/langchain-core/src/messages/block_translators/anthropic.ts
@@ -293,6 +293,25 @@ export function convertToV1FromAnthropicMessage(
       typeof message.content === "string"
         ? [{ type: "text", text: message.content }]
         : message.content;
+    const getStreamedInputJson = (index: unknown): string | undefined => {
+      const input = content
+        .filter(
+          (contentBlock) =>
+            "index" in contentBlock &&
+            contentBlock.index === index &&
+            _isContentBlock(contentBlock, "input_json_delta") &&
+            _isString(contentBlock.input)
+        )
+        .map((contentBlock) => contentBlock.input)
+        .join("");
+      return input.length ? input : undefined;
+    };
+    const parseJsonObjectOrRaw = (
+      input: string
+    ): Record<string, unknown> | string => {
+      const parsed = safeParseJson<Record<string, unknown>>(input);
+      return _isObject(parsed) && !_isArray(parsed) ? parsed : input;
+    };
     for (const block of content) {
       // TextBlock
       if (_isContentBlock(block, "text") && _isString(block.text)) {
@@ -379,26 +398,30 @@ export function convertToV1FromAnthropicMessage(
       ) {
         const { name, id } = block;
         if (name === "web_search") {
-          const query = iife(() => {
+          const args = iife(() => {
+            const streamedInput = getStreamedInputJson(block.index);
+            if (streamedInput !== undefined) {
+              return parseJsonObjectOrRaw(streamedInput);
+            }
             if (typeof block.input === "string") {
-              return block.input;
+              return parseJsonObjectOrRaw(block.input);
             } else if (_isObject(block.input) && _isString(block.input.query)) {
-              return block.input.query;
+              return { query: block.input.query };
             } else if (_isString(block.partial_json)) {
               const json = safeParseJson<{ query?: string }>(
                 block.partial_json
               );
               if (json?.query) {
-                return json.query;
+                return { query: json.query };
               }
             }
-            return "";
+            return { query: "" };
           });
           yield {
             id,
             type: "server_tool_call",
             name: "web_search",
-            args: { query },
+            args,
           };
           continue;
         } else if (block.name === "code_execution") {

--- a/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
@@ -4,6 +4,86 @@ import { _makeMessageChunkFromAnthropicEvent } from "../message_outputs.js";
 const fields = { streamUsage: true, coerceContentToString: false };
 
 describe("_makeMessageChunkFromAnthropicEvent", () => {
+  test("keeps streamed server tool args raw while JSON is incomplete", () => {
+    const startEvent = {
+      type: "content_block_start" as const,
+      index: 1,
+      content_block: {
+        type: "server_tool_use" as const,
+        id: "srvtoolu_01",
+        name: "web_search",
+        input: "",
+      },
+    };
+    const deltaEvent = {
+      type: "content_block_delta" as const,
+      index: 1,
+      delta: {
+        type: "input_json_delta" as const,
+        partial_json: '{"query": "Melbourne Austr',
+      },
+    };
+
+    const start = _makeMessageChunkFromAnthropicEvent(
+      startEvent as Parameters<typeof _makeMessageChunkFromAnthropicEvent>[0],
+      fields
+    )!.chunk;
+    const delta = _makeMessageChunkFromAnthropicEvent(
+      deltaEvent as Parameters<typeof _makeMessageChunkFromAnthropicEvent>[0],
+      fields
+    )!.chunk;
+
+    const serverToolCall = start
+      .concat(delta)
+      .contentBlocks.find((block) => block.type === "server_tool_call");
+
+    expect(serverToolCall).toMatchObject({
+      id: "srvtoolu_01",
+      name: "web_search",
+      args: '{"query": "Melbourne Austr',
+    });
+  });
+
+  test("parses streamed server tool args after JSON is complete", () => {
+    const startEvent = {
+      type: "content_block_start" as const,
+      index: 1,
+      content_block: {
+        type: "server_tool_use" as const,
+        id: "srvtoolu_01",
+        name: "web_search",
+        input: "",
+      },
+    };
+    const deltaEvent = {
+      type: "content_block_delta" as const,
+      index: 1,
+      delta: {
+        type: "input_json_delta" as const,
+        partial_json: '{"query": "Melbourne Australia news today"}',
+      },
+    };
+
+    const start = _makeMessageChunkFromAnthropicEvent(
+      startEvent as Parameters<typeof _makeMessageChunkFromAnthropicEvent>[0],
+      fields
+    )!.chunk;
+    const delta = _makeMessageChunkFromAnthropicEvent(
+      deltaEvent as Parameters<typeof _makeMessageChunkFromAnthropicEvent>[0],
+      fields
+    )!.chunk;
+
+    const serverToolCall = start
+      .concat(delta)
+      .contentBlocks.find((block) => block.type === "server_tool_call");
+
+    expect(serverToolCall).toMatchObject({
+      id: "srvtoolu_01",
+      name: "web_search",
+      args: { query: "Melbourne Australia news today" },
+    });
+  });
+
   test("message_start chunk contains correct cache token counts", () => {
     const event = {
       type: "message_start" as const,


### PR DESCRIPTION
## Summary
- Keep streamed Anthropic `web_search` server-tool args as the raw JSON string while `input_json_delta` is still incomplete.
- Expose the parsed JSON object in the standard `server_tool_call` content block once the streamed JSON is complete.
- Add regression tests for both incomplete and complete streamed server-tool args, plus a patch changeset for `@langchain/core`.

## Why
`ChatAnthropic` streaming currently normalizes partial `web_search` server-tool inputs into `{ query: <partial raw JSON> }`, which makes it hard for callers to know when the server-side tool call is final. This matches the behavior reported in #9980 and lets callers distinguish partial args from finalized args without waiting for the tool result.

Fixes #9980

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @langchain/core build`
- [x] `pnpm --filter @langchain/anthropic exec vitest run src/utils/tests/message_outputs.test.ts -t "keeps streamed server tool args raw while JSON is incomplete"` (failed before fix, passed after fix)
- [x] `pnpm --filter @langchain/anthropic exec vitest run src/utils/tests/message_outputs.test.ts -t "parses streamed server tool args after JSON is complete"` (failed before fix, passed after fix)
- [x] `pnpm --filter @langchain/anthropic exec vitest run src/utils/tests/message_outputs.test.ts`
- [x] `pnpm --filter @langchain/anthropic test`
- [x] `pnpm --filter @langchain/core test`
- [x] `pnpm --filter @langchain/anthropic build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
