### PR TITLE
fix(groq): require @langchain/core >= 1.1.30 in peer dependency

### DIFF
--- a/.changeset/groq-core-peer-dependency.md
+++ b/.changeset/groq-core-peer-dependency.md
@@ -1,0 +1,11 @@
+---
+"@langchain/groq": patch
+---
+
+fix(groq): require `@langchain/core` >= 1.1.30 in peer dependency
+
+The package imports `@langchain/core/utils/standard_schema` and
+`@langchain/core/language_models/structured_output`, both of which were
+introduced in `@langchain/core@1.1.30`. The previous `^1.0.0` peer
+dependency range allowed installing incompatible older versions and
+caused module-resolution failures at build/runtime.

--- a/libs/providers/langchain-groq/package.json
+++ b/libs/providers/langchain-groq/package.json
@@ -30,7 +30,7 @@
     "groq-sdk": "^1.2.1"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0"
+    "@langchain/core": "^1.1.30"
   },
   "devDependencies": {
     "@langchain/core": "workspace:^",


### PR DESCRIPTION
## Summary
- Bump `@langchain/groq` `peerDependencies."@langchain/core"` from `^1.0.0` to `^1.1.30`.
- The package imports `@langchain/core/utils/standard_schema` and `@langchain/core/language_models/structured_output`, both added in `@langchain/core@1.1.30`. The previous range allowed older 1.x core to be installed, producing module-resolution errors at build/runtime.

## Validation
- `pnpm install` — workspace resolves cleanly
- `pnpm --filter @langchain/core build` — passes
- `pnpm --filter @langchain/groq build` — passes (attw + publint clean)
- `pnpm --filter @langchain/groq test` — 40/40 pass
- `pnpm format:check` — passes
- `pnpm lint` — passes

Fixes #11068

Made with [Cursor](https://cursor.com)