### PR TITLE
fix(anthropic): omit default disabled thinking from requests

### DIFF
--- a/.changeset/anthropic-omit-default-disabled-thinking.md
+++ b/.changeset/anthropic-omit-default-disabled-thinking.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Stop sending `thinking: { type: "disabled" }` on `ChatAnthropic` requests when the user never configured thinking. The disabled value is now only emitted when it is explicitly set, so adaptive-only models (e.g. `claude-fable-5`) that reject an explicit `thinking.type: "disabled"` no longer fail with a 400 on a default `ChatAnthropic` instance.

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1014,6 +1014,14 @@ export class ChatAnthropicMessages<
 
   thinking: AnthropicThinkingConfigParam = { type: "disabled" };
 
+  /**
+   * Whether `thinking` was explicitly configured by the user. When it was not,
+   * the default `{ type: "disabled" }` is kept off the request so that models
+   * which reject an explicit disabled value (e.g. adaptive-only models) are not
+   * sent an unsupported parameter.
+   */
+  protected thinkingExplicitlySet = false;
+
   contextManagement?: AnthropicContextManagementConfigParam;
 
   outputConfig?: AnthropicOutputConfig;
@@ -1085,7 +1093,10 @@ export class ChatAnthropicMessages<
     this.streaming = fields?.streaming ?? false;
     this.streamUsage = fields?.streamUsage ?? this.streamUsage;
 
-    this.thinking = fields?.thinking ?? this.thinking;
+    if (fields?.thinking !== undefined) {
+      this.thinking = fields.thinking;
+      this.thinkingExplicitlySet = true;
+    }
     this.contextManagement =
       fields?.contextManagement ?? this.contextManagement;
     this.outputConfig = fields?.outputConfig ?? this.outputConfig;
@@ -1250,7 +1261,7 @@ export class ChatAnthropicMessages<
         strict: options?.strict,
       }),
       tool_choice,
-      thinking: this.thinking,
+      thinking: this.thinkingExplicitlySet ? this.thinking : undefined,
       context_management: this.contextManagement,
       ...this.invocationKwargs,
       container: options?.container,

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -299,6 +299,42 @@ test("invocationParams includes container with thinking enabled", () => {
   expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 1000 });
 });
 
+test("invocationParams omits thinking when not explicitly configured", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    anthropicApiKey: "testing",
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.thinking).toBeUndefined();
+});
+
+test("invocationParams includes thinking when explicitly disabled", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    anthropicApiKey: "testing",
+    thinking: { type: "disabled" },
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.thinking).toEqual({ type: "disabled" });
+});
+
+test("invocationParams includes thinking when explicitly enabled", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    temperature: 1,
+    anthropicApiKey: "testing",
+    thinking: { type: "enabled", budget_tokens: 1000 },
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.thinking).toEqual({ type: "enabled", budget_tokens: 1000 });
+});
+
 test("invocationParams returns undefined tools when tools is undefined", () => {
   const model = new ChatAnthropic({
     modelName: "claude-haiku-4-5",


### PR DESCRIPTION
Fixes #11052

## Problem

`ChatAnthropic` always sent `thinking: { type: "disabled" }` on every request, because the `thinking` field defaults to `{ type: "disabled" }` and `invocationParams()` passed it through unconditionally.

Adaptive-only models such as `claude-fable-5` reject an explicit `thinking.type: "disabled"` with an HTTP 400 (`"thinking.type.disabled" is not supported for this model`). As a result, a default `ChatAnthropic` instance could not call those models at all:

```ts
import { ChatAnthropic } from "@langchain/anthropic";
const model = new ChatAnthropic({ model: "claude-fable-5" });
await model.invoke("hi"); // 400 BadRequestError
```

## Fix

Only emit the `thinking` parameter when the user explicitly configured it. The class still defaults `this.thinking` to `{ type: "disabled" }` (so existing reads of `this.thinking?.type` are unaffected), but a new `thinkingExplicitlySet` flag tracks whether the user passed `thinking` to the constructor. When they did not, `thinking` is omitted from the request entirely, restoring the pre-disabled-default behaviour.

Explicit configuration is preserved unchanged: passing `thinking: { type: "disabled" }`, `{ type: "enabled", ... }`, or `{ type: "adaptive" }` is still sent through as before.

## Verification

All commands run from `libs/providers/langchain-anthropic` (after building `@langchain/core`):

- `pnpm test` — 198 passed (16 files), no type errors
- `pnpm build` — typecheck/compile clean (`attw`/`publint` clean)
- `npx oxlint` + `npx oxfmt --check` on the changed files — clean

Added three regression tests in `src/tests/chat_models.test.ts`:
- `invocationParams omits thinking when not explicitly configured` (the regression)
- `invocationParams includes thinking when explicitly disabled`
- `invocationParams includes thinking when explicitly enabled`

The first test was proven to fail on revert: temporarily restoring `thinking: this.thinking` makes it fail with `expected { type: 'disabled' } to be undefined`, while the other 108 tests in the file still pass. Restoring the fix returns all to green.

A changeset is included (`@langchain/anthropic`: patch).
