### PR TITLE
fix(core): keep streamed text and tool calls in separate content blocks

### DIFF
--- a/.changeset/streaming-text-toolcall-index-collision.md
+++ b/.changeset/streaming-text-toolcall-index-collision.md
@@ -1,0 +1,15 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): keep streamed text and tool calls in separate content blocks
+
+When a legacy stream chunk carried both string `content` and a tool call,
+`convertChunksToEvents` placed the text at content block index `0` and used
+the provider's `tool_call_chunk.index` (also `0`) directly as the content
+block index. The two collided: the tool call fields were merged onto the
+existing text block, which stayed `type: "text"`, so the finalized
+`AIMessage` had `tool_calls: []` and agents would stop instead of running
+the tool. Provider tool-call indexes are scoped to the tool-call list, not
+to the global content-block list, so each distinct tool call is now mapped
+onto its own freshly allocated content block index.

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -154,6 +154,11 @@ export async function* convertChunksToEvents(
     | undefined;
   let audioStream: AudioStreamState | undefined;
   const emittedImageKeys = new Set<string>();
+  // Provider tool-call indexes are scoped to the tool-call list, not to the
+  // global content-block list, so they cannot be used as block indexes
+  // directly (e.g. text occupies block 0 and a tool call with index 0 would
+  // collide with it). Map each distinct tool call onto its own block index.
+  const toolCallBlockIndexes = new Map<string, number>();
 
   for await (const chunk of chunks) {
     options?.signal?.throwIfAborted();
@@ -239,10 +244,18 @@ export async function* convertChunksToEvents(
       msg.tool_call_chunks.length > 0
     ) {
       for (const toolChunk of msg.tool_call_chunks) {
-        const blockIndex =
+        const toolCallKey =
           typeof toolChunk.index === "number"
-            ? toolChunk.index
-            : activeBlocks.size;
+            ? `index:${toolChunk.index}`
+            : typeof toolChunk.id === "string"
+              ? `id:${toolChunk.id}`
+              : `position:${toolCallBlockIndexes.size}`;
+
+        let blockIndex = toolCallBlockIndexes.get(toolCallKey);
+        if (blockIndex === undefined) {
+          blockIndex = nextBlockIndex(activeBlocks);
+          toolCallBlockIndexes.set(toolCallKey, blockIndex);
+        }
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {

--- a/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
@@ -170,6 +170,48 @@ class FakeToolCallStreamModel extends BaseChatModel {
 }
 
 /**
+ * A model that yields string text content and a tool call in the same chunk,
+ * where the provider tool-call index (0) collides with the text block index.
+ */
+class FakeTextAndToolCallStreamModel extends BaseChatModel {
+  _llmType() {
+    return "fake-text-and-tool-stream";
+  }
+
+  async _generate(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return { generations: [] };
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: "I will call a tool",
+        id: "msg_text_tool",
+        tool_call_chunks: [
+          { id: "call_1", name: "eval", args: '{"code"', index: 0 },
+        ],
+      }),
+      text: "I will call a tool",
+    });
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: "",
+        tool_call_chunks: [{ args: ':"new Date()"}', index: 0 }],
+      }),
+      text: "",
+    });
+  }
+}
+
+/**
  * A model that yields chunks with usage_metadata.
  */
 class FakeUsageStreamModel extends BaseChatModel {
@@ -488,6 +530,44 @@ describe("_streamChatModelEvents bridge", () => {
       expect(toolFinish).toBeDefined();
       expect(toolFinish!.content.name).toBe("search");
       expect(toolFinish!.content.args).toEqual({ q: "hello" });
+    });
+
+    test("keeps text and a same-index tool call as separate blocks", async () => {
+      const model = new FakeTextAndToolCallStreamModel({});
+      const events: ChatModelStreamEvent[] = [];
+      for await (const event of model._streamChatModelEvents(
+        [],
+        {} as BaseChatModelCallOptions
+      )) {
+        events.push(event);
+      }
+
+      // The text block and the tool call must not share a content block index.
+      const starts = events.filter(
+        (e) => e.event === "content-block-start"
+      ) as Array<{ index: number; content: ContentBlock }>;
+      const textStart = starts.find((e) => e.content.type === "text");
+      const toolStart = starts.find(
+        (e) => e.content.type === "tool_call_chunk"
+      );
+      expect(textStart).toBeDefined();
+      expect(toolStart).toBeDefined();
+      expect(textStart!.index).not.toBe(toolStart!.index);
+
+      // The finalized message must surface the tool call so agents run it.
+      const message = await model.streamV2("hi").output;
+      expect(message.tool_calls).toEqual([
+        {
+          name: "eval",
+          args: { code: "new Date()" },
+          id: "call_1",
+          type: "tool_call",
+        },
+      ]);
+      const textBlock = (
+        message.content as Array<{ type: string; text?: string }>
+      ).find((b) => b.type === "text");
+      expect(textBlock?.text).toBe("I will call a tool");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #11074.

When a legacy stream chunk carries both string `content` and a tool call (common for OpenAI-compatible models that emit a brief text preamble before a tool call), `convertChunksToEvents` could drop the tool call entirely — the final `AIMessage` ended up with `tool_calls: []` and a `ReactAgent` would stop instead of executing the tool.

### Root cause

Streamed string text is assigned content block index `0`:

```ts
const blockIndex = 0; // text path
```

Tool call chunks then used the provider's `tool_call_chunk.index` directly as the content block index:

```ts
const blockIndex =
  typeof toolChunk.index === "number" ? toolChunk.index : activeBlocks.size;
```

A provider's first tool call commonly has `index === 0`, so it collided with the already-active text block. Because block `0` already existed as `type: "text"`, the tool-call branch skipped creating a new `tool_call_chunk` block and merged the tool fields onto the text block — which stayed `type: "text"`. `finalizeContentBlock` therefore never produced a `tool_call`, so `AIMessage.tool_calls` was empty.

Provider tool-call indexes are scoped to the tool-call list, not to the global content-block list. The fix maps each distinct tool call onto its own freshly allocated content block index (via the existing `nextBlockIndex` helper), keeping streamed text at block `0` and the first tool call at block `1`. Continuation chunks for the same tool call (same provider index / id) still resolve to the same block.

### Behavior unchanged for non-colliding streams

When there is no text block, `nextBlockIndex` allocates `0` for the first tool call and `1` for the second, exactly matching the previous indexes — so existing tool-call streaming is unaffected (verified by the existing `FakeToolCallStreamModel` test).

## Testing

Added a regression test (`FakeTextAndToolCallStreamModel`) mirroring the issue repro: a chunk with both text and a `tool_call_chunk` at `index: 0`, followed by an args continuation chunk. It asserts the text and tool call land on different content block indexes and that the finalized message surfaces the tool call. Reverse-verified: the test fails without the fix.

## AI Disclosure

This fix was prepared with AI assistance (issue analysis, implementation, and tests).