### PR TITLE
fix(core): preserve assistant text when reasoning models reuse protocol index

### DIFF
--- a/.changeset/fix-chatmodelstream-reasoning-text-assembly.md
+++ b/.changeset/fix-chatmodelstream-reasoning-text-assembly.md
@@ -1,0 +1,10 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve assistant text when reasoning models reuse protocol index
+
+Reasoning models can emit `text-delta` events at the same content-block index as
+a `reasoning` block. `ChatModelStream._assembleMessage` now routes incompatible
+deltas to a separate slot instead of silently dropping them, so assembled
+`AIMessage`s (and graph checkpoints that persist them) retain assistant text.

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: 💬 Comment on PR
         if: steps.version.outputs.success == '1' && steps.published.outputs.count != '0' && github.ref != 'refs/heads/main'
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Get the current branch name

--- a/libs/langchain-core/src/language_models/stream.ts
+++ b/libs/langchain-core/src/language_models/stream.ts
@@ -128,6 +128,111 @@ function applyDelta(
 }
 
 /**
+ * Map a content-block delta to the block `type` it targets — but only for the
+ * delta kinds that {@link applyDelta} silently drops when applied to a block of
+ * a different type (`text-delta` → `text`, `reasoning-delta` → `reasoning`).
+ *
+ * `data-delta` and `block-delta` are merged into whatever block currently
+ * occupies the slot, so they never need rerouting and return `undefined`.
+ *
+ * @internal
+ */
+function droppableDeltaType(
+  delta: ContentBlockDelta
+): "text" | "reasoning" | undefined {
+  if (delta.type === "text-delta") return "text";
+  if (delta.type === "reasoning-delta") return "reasoning";
+  return undefined;
+}
+
+/**
+ * Whether a delta of `deltaType` can be folded into a block of `blockType`
+ * without losing data. Mirrors the accepted combinations in {@link applyDelta}:
+ * reasoning deltas accumulate into both `reasoning` and `thinking` blocks.
+ *
+ * @internal
+ */
+function blockAcceptsDelta(
+  blockType: string,
+  deltaType: "text" | "reasoning"
+): boolean {
+  if (deltaType === "text") return blockType === "text";
+  return blockType === "reasoning" || blockType === "thinking";
+}
+
+/**
+ * Build a fresh content block from a droppable delta, used when a rerouted
+ * delta lands on a previously-unused slot.
+ *
+ * @internal
+ */
+function blockFromDroppableDelta(
+  delta: ContentBlockDelta
+): ContentBlock | undefined {
+  if (delta.type === "text-delta") {
+    return { type: "text", text: delta.text } as ContentBlock;
+  }
+  if (delta.type === "reasoning-delta") {
+    return { type: "reasoning", reasoning: delta.reasoning } as ContentBlock;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the assembly slot for a streamed `content-block-delta`, accounting
+ * for providers (notably OpenAI's Responses API) that reuse a single protocol
+ * `index` across blocks of different types — most commonly emitting assistant
+ * `text` deltas at the same `index` as a preceding `reasoning` block.
+ *
+ * When the delta is incompatible with the block already at `protocolIndex`, it
+ * is routed to a distinct slot (tracked in `aliases`) instead of being dropped.
+ *
+ * @internal
+ */
+function resolveDeltaBlockIndex(
+  contentBlocks: Array<ContentBlock | undefined>,
+  aliases: Map<string, number>,
+  protocolIndex: number,
+  deltaType: "text" | "reasoning"
+): number {
+  const current = contentBlocks[protocolIndex];
+  if (current == null || blockAcceptsDelta(current.type, deltaType)) {
+    return protocolIndex;
+  }
+  const key = `${protocolIndex}::${deltaType}`;
+  const existing = aliases.get(key);
+  if (existing != null) return existing;
+  const nextIndex = contentBlocks.length;
+  aliases.set(key, nextIndex);
+  return nextIndex;
+}
+
+/**
+ * Resolve the slot a `content-block-finish` should write to, honoring any slot
+ * a colliding delta was previously rerouted to so a finish does not clobber an
+ * unrelated block sharing its protocol `index`.
+ *
+ * @internal
+ */
+function resolveFinishBlockIndex(
+  aliases: Map<string, number>,
+  protocolIndex: number,
+  blockType: string
+): number {
+  const deltaType =
+    blockType === "text"
+      ? "text"
+      : blockType === "reasoning" || blockType === "thinking"
+        ? "reasoning"
+        : undefined;
+  if (deltaType != null) {
+    const existing = aliases.get(`${protocolIndex}::${deltaType}`);
+    if (existing != null) return existing;
+  }
+  return protocolIndex;
+}
+
+/**
  * Returns the typed delta carried by a content-block delta event.
  *
  * Stream protocol compliant language models store incremental updates in
@@ -618,6 +723,9 @@ export class ChatModelStream
   /** @internal */
   private async _assembleMessage(): Promise<AIMessage> {
     const contentBlocks: Array<ContentBlock | undefined> = [];
+    // Tracks slots that colliding (otherwise-dropped) deltas were rerouted to,
+    // keyed by `${protocolIndex}::${deltaType}`.
+    const blockIndexAliases = new Map<string, number>();
     let id: string | undefined;
     let usage: UsageMetadata | undefined;
     let metadata: Record<string, unknown> = {};
@@ -635,17 +743,40 @@ export class ChatModelStream
           break;
 
         case "content-block-delta": {
-          const current = contentBlocks[event.index];
           const delta = getEventDelta(event);
+          if (!delta) break;
+          const deltaType = droppableDeltaType(delta);
+          const index =
+            deltaType == null
+              ? event.index
+              : resolveDeltaBlockIndex(
+                  contentBlocks,
+                  blockIndexAliases,
+                  event.index,
+                  deltaType
+                );
+          const current = contentBlocks[index];
           if (current) {
-            if (delta) contentBlocks[event.index] = applyDelta(current, delta);
+            contentBlocks[index] = applyDelta(current, delta);
+          } else if (deltaType != null) {
+            // A reasoning/text delta arrived for a slot with no started block
+            // (e.g. a text delta colliding with a reasoning block's index).
+            // Materialize the block instead of dropping the content.
+            const created = blockFromDroppableDelta(delta);
+            if (created) contentBlocks[index] = created;
           }
           break;
         }
 
-        case "content-block-finish":
-          contentBlocks[event.index] = event.content;
+        case "content-block-finish": {
+          const index = resolveFinishBlockIndex(
+            blockIndexAliases,
+            event.index,
+            event.content.type
+          );
+          contentBlocks[index] = event.content;
           break;
+        }
 
         case "usage":
           usage = normalizeUsage(event.usage);

--- a/libs/langchain-core/src/language_models/stream.ts
+++ b/libs/langchain-core/src/language_models/stream.ts
@@ -179,57 +179,18 @@ function blockFromDroppableDelta(
 }
 
 /**
- * Resolve the assembly slot for a streamed `content-block-delta`, accounting
- * for providers (notably OpenAI's Responses API) that reuse a single protocol
- * `index` across blocks of different types — most commonly emitting assistant
- * `text` deltas at the same `index` as a preceding `reasoning` block.
- *
- * When the delta is incompatible with the block already at `protocolIndex`, it
- * is routed to a distinct slot (tracked in `aliases`) instead of being dropped.
+ * Map a finalized block `type` back to the droppable delta type that would
+ * accumulate into it, so a `content-block-finish` can be matched to a block
+ * that an earlier colliding delta was rerouted to.
  *
  * @internal
  */
-function resolveDeltaBlockIndex(
-  contentBlocks: Array<ContentBlock | undefined>,
-  aliases: Map<string, number>,
-  protocolIndex: number,
-  deltaType: "text" | "reasoning"
-): number {
-  const current = contentBlocks[protocolIndex];
-  if (current == null || blockAcceptsDelta(current.type, deltaType)) {
-    return protocolIndex;
-  }
-  const key = `${protocolIndex}::${deltaType}`;
-  const existing = aliases.get(key);
-  if (existing != null) return existing;
-  const nextIndex = contentBlocks.length;
-  aliases.set(key, nextIndex);
-  return nextIndex;
-}
-
-/**
- * Resolve the slot a `content-block-finish` should write to, honoring any slot
- * a colliding delta was previously rerouted to so a finish does not clobber an
- * unrelated block sharing its protocol `index`.
- *
- * @internal
- */
-function resolveFinishBlockIndex(
-  aliases: Map<string, number>,
-  protocolIndex: number,
+function blockTypeToDeltaType(
   blockType: string
-): number {
-  const deltaType =
-    blockType === "text"
-      ? "text"
-      : blockType === "reasoning" || blockType === "thinking"
-        ? "reasoning"
-        : undefined;
-  if (deltaType != null) {
-    const existing = aliases.get(`${protocolIndex}::${deltaType}`);
-    if (existing != null) return existing;
-  }
-  return protocolIndex;
+): "text" | "reasoning" | undefined {
+  if (blockType === "text") return "text";
+  if (blockType === "reasoning" || blockType === "thinking") return "reasoning";
+  return undefined;
 }
 
 /**
@@ -722,14 +683,25 @@ export class ChatModelStream
 
   /** @internal */
   private async _assembleMessage(): Promise<AIMessage> {
-    const contentBlocks: Array<ContentBlock | undefined> = [];
-    // Tracks slots that colliding (otherwise-dropped) deltas were rerouted to,
-    // keyed by `${protocolIndex}::${deltaType}`.
-    const blockIndexAliases = new Map<string, number>();
+    // Blocks are keyed by stable identity (not array position) and tracked in
+    // insertion order. Real protocol blocks use `index:<i>`; deltas that reuse
+    // an `index` for an incompatible type (e.g. a reasoning model emitting
+    // assistant `text` at a `reasoning` block's index) get an `alias:` key so a
+    // later `content-block-start` at that numeric index cannot clobber them.
+    const blocks = new Map<string, ContentBlock>();
+    const order: string[] = [];
     let id: string | undefined;
     let usage: UsageMetadata | undefined;
     let metadata: Record<string, unknown> = {};
     let finishReason: string | undefined;
+
+    const indexKey = (index: number) => `index:${index}`;
+    const aliasKey = (index: number, deltaType: "text" | "reasoning") =>
+      `alias:${index}:${deltaType}`;
+    const setBlock = (key: string, block: ContentBlock) => {
+      if (!blocks.has(key)) order.push(key);
+      blocks.set(key, block);
+    };
 
     for await (const event of this._buffer.iterate()) {
       switch (event.event) {
@@ -739,42 +711,48 @@ export class ChatModelStream
           break;
 
         case "content-block-start":
-          contentBlocks[event.index] = event.content;
+          setBlock(indexKey(event.index), event.content);
           break;
 
         case "content-block-delta": {
           const delta = getEventDelta(event);
           if (!delta) break;
           const deltaType = droppableDeltaType(delta);
-          const index =
-            deltaType == null
-              ? event.index
-              : resolveDeltaBlockIndex(
-                  contentBlocks,
-                  blockIndexAliases,
-                  event.index,
-                  deltaType
-                );
-          const current = contentBlocks[index];
+          // `data-delta` / `block-delta` always merge into the block at this
+          // protocol index. Droppable deltas (`text`/`reasoning`) reroute to an
+          // alias slot when the indexed block is an incompatible type.
+          let key = indexKey(event.index);
+          if (deltaType != null) {
+            const base = blocks.get(key);
+            if (base != null && !blockAcceptsDelta(base.type, deltaType)) {
+              key = aliasKey(event.index, deltaType);
+            }
+          }
+          const current = blocks.get(key);
           if (current) {
-            contentBlocks[index] = applyDelta(current, delta);
+            setBlock(key, applyDelta(current, delta));
           } else if (deltaType != null) {
-            // A reasoning/text delta arrived for a slot with no started block
-            // (e.g. a text delta colliding with a reasoning block's index).
-            // Materialize the block instead of dropping the content.
+            // The target slot has no started block (e.g. a text delta colliding
+            // with a reasoning block's index). Materialize the block instead of
+            // dropping the content.
             const created = blockFromDroppableDelta(delta);
-            if (created) contentBlocks[index] = created;
+            if (created) setBlock(key, created);
           }
           break;
         }
 
         case "content-block-finish": {
-          const index = resolveFinishBlockIndex(
-            blockIndexAliases,
-            event.index,
-            event.content.type
-          );
-          contentBlocks[index] = event.content;
+          // A finish references the same numeric index as its block's start; if
+          // that index was rerouted for this block type, honor the alias so the
+          // finish does not overwrite an unrelated block sharing the index.
+          const deltaType = blockTypeToDeltaType(event.content.type);
+          const aliased =
+            deltaType != null ? aliasKey(event.index, deltaType) : undefined;
+          const key =
+            aliased != null && blocks.has(aliased)
+              ? aliased
+              : indexKey(event.index);
+          setBlock(key, event.content);
           break;
         }
 
@@ -798,7 +776,8 @@ export class ChatModelStream
       }
     }
 
-    const filteredBlocks = contentBlocks
+    const filteredBlocks = order
+      .map((key) => blocks.get(key))
       .filter((b): b is ContentBlock => b != null)
       .map(standardizeToolBlock);
 

--- a/libs/langchain-core/src/language_models/stream.ts
+++ b/libs/langchain-core/src/language_models/stream.ts
@@ -683,24 +683,27 @@ export class ChatModelStream
 
   /** @internal */
   private async _assembleMessage(): Promise<AIMessage> {
-    // Blocks are keyed by stable identity (not array position) and tracked in
-    // insertion order. Real protocol blocks use `index:<i>`; deltas that reuse
-    // an `index` for an incompatible type (e.g. a reasoning model emitting
-    // assistant `text` at a `reasoning` block's index) get an `alias:` key so a
-    // later `content-block-start` at that numeric index cannot clobber them.
-    const blocks = new Map<string, ContentBlock>();
-    const order: string[] = [];
+    // Real protocol blocks are keyed by their numeric `index` so final ordering
+    // follows the protocol's positional semantics even when block starts are
+    // interleaved (e.g. `index: 1` before `index: 0`).
+    const indexBlocks = new Map<number, ContentBlock>();
+    // Deltas that reuse an `index` for an incompatible type (e.g. a reasoning
+    // model emitting assistant `text` at a `reasoning` block's index) are kept
+    // in a separate keyspace (`${index}:${deltaType}`) so a later
+    // `content-block-start` at that numeric index cannot clobber them. Aliases
+    // are appended after all real blocks, in first-seen order.
+    const aliasBlocks = new Map<string, ContentBlock>();
+    const aliasOrder: string[] = [];
     let id: string | undefined;
     let usage: UsageMetadata | undefined;
     let metadata: Record<string, unknown> = {};
     let finishReason: string | undefined;
 
-    const indexKey = (index: number) => `index:${index}`;
     const aliasKey = (index: number, deltaType: "text" | "reasoning") =>
-      `alias:${index}:${deltaType}`;
-    const setBlock = (key: string, block: ContentBlock) => {
-      if (!blocks.has(key)) order.push(key);
-      blocks.set(key, block);
+      `${index}:${deltaType}`;
+    const setAlias = (key: string, block: ContentBlock) => {
+      if (!aliasBlocks.has(key)) aliasOrder.push(key);
+      aliasBlocks.set(key, block);
     };
 
     for await (const event of this._buffer.iterate()) {
@@ -711,48 +714,57 @@ export class ChatModelStream
           break;
 
         case "content-block-start":
-          setBlock(indexKey(event.index), event.content);
+          indexBlocks.set(event.index, event.content);
           break;
 
         case "content-block-delta": {
           const delta = getEventDelta(event);
           if (!delta) break;
           const deltaType = droppableDeltaType(delta);
-          // `data-delta` / `block-delta` always merge into the block at this
-          // protocol index. Droppable deltas (`text`/`reasoning`) reroute to an
-          // alias slot when the indexed block is an incompatible type.
-          let key = indexKey(event.index);
-          if (deltaType != null) {
-            const base = blocks.get(key);
-            if (base != null && !blockAcceptsDelta(base.type, deltaType)) {
-              key = aliasKey(event.index, deltaType);
+          const base = indexBlocks.get(event.index);
+
+          // Droppable deltas (`text`/`reasoning`) reroute to an alias when the
+          // block at their index is an incompatible type, so the content is not
+          // silently dropped by `applyDelta`.
+          if (
+            deltaType != null &&
+            base != null &&
+            !blockAcceptsDelta(base.type, deltaType)
+          ) {
+            const key = aliasKey(event.index, deltaType);
+            const current = aliasBlocks.get(key);
+            if (current) {
+              setAlias(key, applyDelta(current, delta));
+            } else {
+              const created = blockFromDroppableDelta(delta);
+              if (created) setAlias(key, created);
             }
-          }
-          const current = blocks.get(key);
-          if (current) {
-            setBlock(key, applyDelta(current, delta));
+          } else if (base != null) {
+            // `data-delta` / `block-delta`, or a compatible droppable delta,
+            // merges into the block at this protocol index.
+            indexBlocks.set(event.index, applyDelta(base, delta));
           } else if (deltaType != null) {
-            // The target slot has no started block (e.g. a text delta colliding
-            // with a reasoning block's index). Materialize the block instead of
-            // dropping the content.
+            // A reasoning/text delta arrived before any `content-block-start`
+            // for this index. Materialize the block at its protocol index
+            // instead of dropping the content.
             const created = blockFromDroppableDelta(delta);
-            if (created) setBlock(key, created);
+            if (created) indexBlocks.set(event.index, created);
           }
           break;
         }
 
         case "content-block-finish": {
           // A finish references the same numeric index as its block's start; if
-          // that index was rerouted for this block type, honor the alias so the
+          // that index was rerouted for this block type, update the alias so the
           // finish does not overwrite an unrelated block sharing the index.
           const deltaType = blockTypeToDeltaType(event.content.type);
-          const aliased =
+          const alias =
             deltaType != null ? aliasKey(event.index, deltaType) : undefined;
-          const key =
-            aliased != null && blocks.has(aliased)
-              ? aliased
-              : indexKey(event.index);
-          setBlock(key, event.content);
+          if (alias != null && aliasBlocks.has(alias)) {
+            setAlias(alias, event.content);
+          } else {
+            indexBlocks.set(event.index, event.content);
+          }
           break;
         }
 
@@ -776,8 +788,14 @@ export class ChatModelStream
       }
     }
 
-    const filteredBlocks = order
-      .map((key) => blocks.get(key))
+    const orderedBlocks: ContentBlock[] = [
+      ...[...indexBlocks.keys()]
+        .sort((a, b) => a - b)
+        .map((index) => indexBlocks.get(index)!),
+      ...aliasOrder.map((key) => aliasBlocks.get(key)!),
+    ];
+
+    const filteredBlocks = orderedBlocks
       .filter((b): b is ContentBlock => b != null)
       .map(standardizeToolBlock);
 

--- a/libs/langchain-core/src/language_models/tests/stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream.test.ts
@@ -540,6 +540,54 @@ describe("ChatModelStream", () => {
       expect(message.text).toBe("Two quick approaches:");
     });
 
+    test("orders blocks by numeric index when starts arrive interleaved", async () => {
+      // The protocol's `index` is positional: a stream that starts index 1
+      // before index 0 must still assemble as [0, 1], not first-seen order.
+      const stream = new ChatModelStream(
+        iterEvents([
+          { event: "message-start", id: "msg_interleaved" },
+          {
+            event: "content-block-start",
+            index: 1,
+            content: { type: "text", text: "" },
+          },
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "text", text: "" },
+          },
+          {
+            event: "content-block-delta",
+            index: 1,
+            delta: { type: "text-delta", text: "second" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: { type: "text-delta", text: "first" },
+          },
+          {
+            event: "content-block-finish",
+            index: 0,
+            content: { type: "text", text: "first" },
+          },
+          {
+            event: "content-block-finish",
+            index: 1,
+            content: { type: "text", text: "second" },
+          },
+          { event: "message-finish", reason: "stop" },
+        ])
+      );
+
+      const message = await stream.output;
+
+      expect(message.contentBlocks).toEqual([
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+      ]);
+    });
+
     test("does not let a later content-block-start clobber rerouted text", async () => {
       // Regression: a colliding text delta at index 0 must not be assigned a
       // numeric slot that a subsequent real `content-block-start` (here index 1)
@@ -601,13 +649,13 @@ describe("ChatModelStream", () => {
 
       const message = await stream.output;
 
-      // Insertion order: reasoning (index 0), then the rerouted text (created
-      // when its colliding delta arrived, before the index 1 start), then the
-      // tool call (index 1). The text survives the index 1 start.
+      // Real blocks keep numeric index order (reasoning @0, tool_call @1); the
+      // rerouted text is appended after them in its own keyspace, so the index 1
+      // start cannot overwrite it.
       expect(message.contentBlocks).toEqual([
         { type: "reasoning", reasoning: "Reasoning" },
-        { type: "text", text: "Answer" },
         { type: "tool_call", id: "call_1", name: "calc", args: { x: 1 } },
+        { type: "text", text: "Answer" },
       ]);
       expect(message.text).toBe("Answer");
       expect(message.tool_calls).toEqual([

--- a/libs/langchain-core/src/language_models/tests/stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream.test.ts
@@ -483,6 +483,63 @@ describe("ChatModelStream", () => {
       expect(message.response_metadata?.finish_reason).toBe("tool_use");
     });
 
+    test("keeps assistant text emitted at a reasoning block's protocol index", async () => {
+      // Reproduces OpenAI Responses streaming for reasoning models: text deltas
+      // are emitted at `index: 0`, which is already occupied by a reasoning
+      // block. Without type-aware routing the text is silently dropped from the
+      // assembled message (and therefore from anything that persists it).
+      const stream = new ChatModelStream(
+        iterEvents([
+          { event: "message-start", id: "msg_reasoning_text" },
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "reasoning", reasoning: "Think A" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: { type: "reasoning-delta", reasoning: " more" },
+          },
+          {
+            event: "content-block-start",
+            index: 1,
+            content: { type: "reasoning", reasoning: "Think B" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: { type: "text-delta", text: "Two quick" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: { type: "text-delta", text: " approaches:" },
+          },
+          {
+            event: "content-block-finish",
+            index: 0,
+            content: { type: "reasoning", reasoning: "Think A more" },
+          },
+          {
+            event: "content-block-finish",
+            index: 1,
+            content: { type: "reasoning", reasoning: "Think B" },
+          },
+          { event: "message-finish", reason: "stop" },
+        ])
+      );
+
+      const message = await stream.output;
+
+      expect(message.contentBlocks).toEqual([
+        { type: "reasoning", reasoning: "Think A more" },
+        { type: "reasoning", reasoning: "Think B" },
+        { type: "text", text: "Two quick approaches:" },
+      ]);
+      expect(message.text).toBe("Two quick approaches:");
+    });
+
     test("normalizes provider tool-use blocks into tool calls", async () => {
       const stream = new ChatModelStream(
         iterEvents([

--- a/libs/langchain-core/src/language_models/tests/stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream.test.ts
@@ -540,6 +540,81 @@ describe("ChatModelStream", () => {
       expect(message.text).toBe("Two quick approaches:");
     });
 
+    test("does not let a later content-block-start clobber rerouted text", async () => {
+      // Regression: a colliding text delta at index 0 must not be assigned a
+      // numeric slot that a subsequent real `content-block-start` (here index 1)
+      // can overwrite. The rerouted text lives in its own keyspace.
+      const stream = new ChatModelStream(
+        iterEvents([
+          { event: "message-start", id: "msg_reroute_clobber" },
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "reasoning", reasoning: "Reasoning" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: { type: "text-delta", text: "Answer" },
+          },
+          {
+            event: "content-block-start",
+            index: 1,
+            content: {
+              type: "tool_call_chunk",
+              id: "call_1",
+              name: "calc",
+              args: "",
+            } as unknown as ContentBlock,
+          },
+          {
+            event: "content-block-delta",
+            index: 1,
+            delta: {
+              type: "block-delta",
+              fields: {
+                type: "tool_call_chunk",
+                id: "call_1",
+                name: "calc",
+                args: '{"x":1}',
+              },
+            },
+          },
+          {
+            event: "content-block-finish",
+            index: 0,
+            content: { type: "reasoning", reasoning: "Reasoning" },
+          },
+          {
+            event: "content-block-finish",
+            index: 1,
+            content: {
+              type: "tool_call",
+              id: "call_1",
+              name: "calc",
+              args: { x: 1 },
+            } as unknown as ContentBlock,
+          },
+          { event: "message-finish", reason: "tool_use" },
+        ])
+      );
+
+      const message = await stream.output;
+
+      // Insertion order: reasoning (index 0), then the rerouted text (created
+      // when its colliding delta arrived, before the index 1 start), then the
+      // tool call (index 1). The text survives the index 1 start.
+      expect(message.contentBlocks).toEqual([
+        { type: "reasoning", reasoning: "Reasoning" },
+        { type: "text", text: "Answer" },
+        { type: "tool_call", id: "call_1", name: "calc", args: { x: 1 } },
+      ]);
+      expect(message.text).toBe("Answer");
+      expect(message.tool_calls).toEqual([
+        { type: "tool_call", id: "call_1", name: "calc", args: { x: 1 } },
+      ]);
+    });
+
     test("normalizes provider tool-use blocks into tool calls", async () => {
       const stream = new ChatModelStream(
         iterEvents([


### PR DESCRIPTION
## Summary
- Fix `ChatModelStream._assembleMessage` dropping assistant text when reasoning models emit `text-delta` events at the same protocol index as a `reasoning` block (OpenAI Responses API behavior).
- Route incompatible deltas to a separate content slot and honor the same aliases on `content-block-finish`, matching the SDK's type-aware index resolution.
- Add a regression test reproducing the colliding-index event sequence from the langgraph reasoning-token fixture.
