### PR TITLE
fix(aws): support Bedrock bearer token auth

### DIFF
--- a/.changeset/itchy-sheep-dig.md
+++ b/.changeset/itchy-sheep-dig.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix: support Bedrock bearer token auth

--- a/libs/providers/langchain-aws/README.md
+++ b/libs/providers/langchain-aws/README.md
@@ -48,7 +48,7 @@ export BEDROCK_AWS_SECRET_ACCESS_KEY=
 export BEDROCK_AWS_ACCESS_KEY_ID=
 ```
 
-Alternatively, set the `AWS_BEARER_TOKEN_BEDROCK` environment variable locally for API Key authentication. For additional API key details, refer to [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
+Alternatively, set the `AWS_BEARER_TOKEN_BEDROCK` environment variable locally for API Key authentication, or pass it as `bedrockBearerToken`. Bearer token authentication is used instead of standard AWS credentials when configured. For additional API key details, refer to [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html).
 
 ```bash
 export BEDROCK_AWS_REGION=

--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -65,6 +65,11 @@ import {
 } from "./utils/message_outputs.js";
 import { normalizeBedrockError } from "./utils/errors.js";
 import {
+  AWS_BEARER_TOKEN_BEDROCK,
+  createBedrockBearerTokenClientConfig,
+  resolveBedrockBearerToken,
+} from "./utils/bedrock_auth.js";
+import {
   isSerializableSchema,
   SerializableSchema,
 } from "@langchain/core/utils/standard_schema";
@@ -109,6 +114,12 @@ export interface ChatBedrockConverseInput
    * `BEDROCK_AWS_SESSION_TOKEN` environment variable.
    */
   bedrockApiSessionToken?: string;
+
+  /**
+   * Bedrock API key for bearer-token authentication. Falls back to the
+   * `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+   */
+  bedrockBearerToken?: string;
 
   /**
    * Whether or not to stream responses
@@ -730,6 +741,7 @@ export class ChatBedrockConverse
       bedrockApiKey: "BEDROCK_AWS_ACCESS_KEY_ID",
       bedrockApiSecret: "BEDROCK_AWS_SECRET_ACCESS_KEY",
       bedrockApiSessionToken: "BEDROCK_AWS_SESSION_TOKEN",
+      bedrockBearerToken: AWS_BEARER_TOKEN_BEDROCK,
     };
   }
 
@@ -772,6 +784,8 @@ export class ChatBedrockConverse
   bedrockApiSecret?: string;
 
   bedrockApiSessionToken?: string;
+
+  bedrockBearerToken?: string;
 
   client: BedrockRuntimeClient;
 
@@ -821,9 +835,14 @@ export class ChatBedrockConverse
     const bedrockApiSessionToken =
       rest?.bedrockApiSessionToken ??
       getEnvironmentVariable("BEDROCK_AWS_SESSION_TOKEN");
+    const bedrockBearerToken = resolveBedrockBearerToken(
+      rest?.bedrockBearerToken
+    );
 
-    let credentials: CredentialType;
-    if (rest?.credentials) {
+    let credentials: CredentialType | undefined;
+    if (bedrockBearerToken) {
+      credentials = undefined;
+    } else if (rest?.credentials) {
       credentials = rest.credentials;
     } else if (bedrockApiKey && bedrockApiSecret) {
       credentials = {
@@ -858,6 +877,7 @@ export class ChatBedrockConverse
       fields.client ??
       new BedrockRuntimeClient({
         ...fields.clientOptions,
+        ...createBedrockBearerTokenClientConfig(bedrockBearerToken),
         region,
         credentials,
         endpoint: rest.endpointHost
@@ -889,6 +909,7 @@ export class ChatBedrockConverse
     this.bedrockApiKey = bedrockApiKey;
     this.bedrockApiSecret = bedrockApiSecret;
     this.bedrockApiSessionToken = bedrockApiSessionToken;
+    this.bedrockBearerToken = bedrockBearerToken;
     this.topP = rest?.topP;
     this.additionalModelRequestFields = rest?.additionalModelRequestFields;
     this.streamUsage = rest?.streamUsage ?? this.streamUsage;

--- a/libs/providers/langchain-aws/src/embeddings.ts
+++ b/libs/providers/langchain-aws/src/embeddings.ts
@@ -5,6 +5,10 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
 import { CredentialType } from "./types.js";
+import {
+  createBedrockBearerTokenClientConfig,
+  resolveBedrockBearerToken,
+} from "./utils/bedrock_auth.js";
 
 /**
  * Checks if the given model is an Amazon Nova embedding model.
@@ -43,6 +47,12 @@ export interface BedrockEmbeddingsParams extends EmbeddingsParams {
   region?: string;
 
   credentials?: CredentialType;
+
+  /**
+   * Bedrock API key for bearer-token authentication. Falls back to the
+   * `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+   */
+  bedrockBearerToken?: string;
 
   /**
    * Additional parameters to pass to the model as part of the InvokeModel
@@ -109,6 +119,8 @@ export class BedrockEmbeddings
 
   dimensions?: number;
 
+  bedrockBearerToken?: string;
+
   constructor(fields?: BedrockEmbeddingsParams) {
     super(fields ?? {});
 
@@ -116,13 +128,17 @@ export class BedrockEmbeddings
     this.clientOptions = fields?.clientOptions;
     this.modelParameters = fields?.modelParameters;
     this.dimensions = fields?.dimensions;
+    this.bedrockBearerToken = resolveBedrockBearerToken(
+      fields?.bedrockBearerToken
+    );
 
     this.client =
       fields?.client ??
       new BedrockRuntimeClient({
         ...fields?.clientOptions,
+        ...createBedrockBearerTokenClientConfig(this.bedrockBearerToken),
         region: fields?.region,
-        credentials: fields?.credentials,
+        credentials: this.bedrockBearerToken ? undefined : fields?.credentials,
       });
   }
 

--- a/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
@@ -24,7 +24,11 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => {
     }
   }
   class BedrockRuntimeClient {
+    static lastConfig: unknown;
     middlewareStack = { add: vi.fn() };
+    constructor(config: unknown) {
+      BedrockRuntimeClient.lastConfig = config;
+    }
     async send(command: unknown) {
       // Non-stream path
       if (
@@ -80,6 +84,7 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => {
 });
 
 import {
+  BedrockRuntimeClient,
   ConverseCommand,
   ConverseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
@@ -93,6 +98,54 @@ describe("ChatBedrockConverse invocationParams", () => {
     },
     model: "anthropic.claude-3-sonnet-20240229-v1:0",
   };
+
+  test("configures bearer auth from constructor token", async () => {
+    const model = new ChatBedrockConverse({
+      ...baseConstructorArgs,
+      bedrockBearerToken: "test-bearer-token",
+    });
+    const clientClass = BedrockRuntimeClient as unknown as {
+      lastConfig?: {
+        authSchemePreference?: string[];
+        credentials?: unknown;
+        token?: () => Promise<{ token: string }>;
+      };
+    };
+
+    expect(model.bedrockBearerToken).toBe("test-bearer-token");
+    expect(clientClass.lastConfig?.authSchemePreference).toEqual([
+      "httpBearerAuth",
+    ]);
+    expect(clientClass.lastConfig?.credentials).toBeUndefined();
+    await expect(clientClass.lastConfig?.token?.()).resolves.toEqual({
+      token: "test-bearer-token",
+    });
+  });
+
+  test("configures bearer auth from AWS_BEARER_TOKEN_BEDROCK", async () => {
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "env-bearer-token";
+    try {
+      const model = new ChatBedrockConverse(baseConstructorArgs);
+      const clientClass = BedrockRuntimeClient as unknown as {
+        lastConfig?: {
+          authSchemePreference?: string[];
+          credentials?: unknown;
+          token?: () => Promise<{ token: string }>;
+        };
+      };
+
+      expect(model.bedrockBearerToken).toBe("env-bearer-token");
+      expect(clientClass.lastConfig?.authSchemePreference).toEqual([
+        "httpBearerAuth",
+      ]);
+      expect(clientClass.lastConfig?.credentials).toBeUndefined();
+      await expect(clientClass.lastConfig?.token?.()).resolves.toEqual({
+        token: "env-bearer-token",
+      });
+    } finally {
+      delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    }
+  });
 
   describe("inferenceConfig conditional logic", () => {
     test("covers all inferenceConfig scenarios compactly", () => {

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1880,6 +1880,10 @@ describe("bedrockApiKey / bedrockApiSecret credentials", () => {
       "bedrockApiSessionToken",
       "BEDROCK_AWS_SESSION_TOKEN"
     );
+    expect(model.lc_secrets).toHaveProperty(
+      "bedrockBearerToken",
+      "AWS_BEARER_TOKEN_BEDROCK"
+    );
   });
 });
 

--- a/libs/providers/langchain-aws/src/tests/embeddings.test.ts
+++ b/libs/providers/langchain-aws/src/tests/embeddings.test.ts
@@ -11,6 +11,25 @@ describe("BedrockEmbeddings", () => {
     },
   };
 
+  it("configures bearer auth from constructor token", async () => {
+    const embeddings = new BedrockEmbeddings({
+      ...baseConstructorArgs,
+      bedrockBearerToken: "test-bearer-token",
+    });
+    const clientConfig = embeddings.client.config as {
+      authSchemePreference?: () => Promise<string[]>;
+      token?: () => Promise<{ token: string }>;
+    };
+
+    expect(embeddings.bedrockBearerToken).toBe("test-bearer-token");
+    await expect(clientConfig.authSchemePreference?.()).resolves.toEqual([
+      "httpBearerAuth",
+    ]);
+    await expect(clientConfig.token?.()).resolves.toEqual({
+      token: "test-bearer-token",
+    });
+  });
+
   describe("Nova embedding model support", () => {
     it("should use messages format for Nova embedding models", async () => {
       const mockSend = vi.fn().mockResolvedValue({

--- a/libs/providers/langchain-aws/src/utils/bedrock_auth.ts
+++ b/libs/providers/langchain-aws/src/utils/bedrock_auth.ts
@@ -1,0 +1,21 @@
+import type { BedrockRuntimeClientConfig } from "@aws-sdk/client-bedrock-runtime";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+
+export const AWS_BEARER_TOKEN_BEDROCK = "AWS_BEARER_TOKEN_BEDROCK";
+
+export function resolveBedrockBearerToken(token?: string): string | undefined {
+  return token ?? getEnvironmentVariable(AWS_BEARER_TOKEN_BEDROCK);
+}
+
+export function createBedrockBearerTokenClientConfig(
+  token?: string
+): Pick<BedrockRuntimeClientConfig, "authSchemePreference" | "token"> {
+  if (!token) {
+    return {};
+  }
+
+  return {
+    authSchemePreference: ["httpBearerAuth"],
+    token: async () => ({ token }),
+  };
+}


### PR DESCRIPTION
## Description
Adds `AWS_BEARER_TOKEN_BEDROCK`/`bedrockBearerToken` handling for `@langchain/aws` Bedrock clients, mirroring Python's bearer-token preference by passing a token provider and `httpBearerAuth` preference instead of AWS credentials.

## Self-Hosted Release Note
`@langchain/aws` now supports Bedrock API key bearer auth via `AWS_BEARER_TOKEN_BEDROCK`.

## Test Plan
- [x] Added unit coverage for constructor and env-var bearer token client config.

Made by [Open SWE](https://openswe.vercel.app/agents/d049cf05-300a-00bd-d9eb-999e0e7863e4)