### PR TITLE
fix(openai): keep scalar response_metadata last-wins across finish_reason chunks

### DIFF
--- a/.changeset/grumpy-bottles-jump.md
+++ b/.changeset/grumpy-bottles-jump.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): keep scalar `response_metadata` fields last-wins when a provider emits multiple `finish_reason` chunks
+
+`ChatOpenAI` completions streaming attaches `finish_reason`, `model_name`, `system_fingerprint`, and `service_tier` to every finish-reason chunk. `AIMessageChunk.concat` string-concatenates these scalar fields, so OpenAI-compatible providers that emit more than one finish-reason chunk (e.g. OpenRouter) produced corrupted metadata such as `finish_reason: "stopstop"` and a doubled `model_name`. These fields are now treated as last-wins on merge. Numeric `usage_metadata` summing is unchanged.

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -44,6 +44,37 @@ type ChatCompletionsInvocationParams = Omit<
 >;
 
 /**
+ * Scalar `response_metadata` fields that identify the response rather than
+ * accumulate across chunks. They are last-wins on merge: `AIMessageChunk.concat`
+ * string-concatenates string fields, so these must be restored when a provider
+ * emits more than one finish_reason chunk to avoid corruption (e.g. "stopstop").
+ */
+const SCALAR_RESPONSE_METADATA_KEYS = [
+  "finish_reason",
+  "model_name",
+  "system_fingerprint",
+  "service_tier",
+] as const;
+
+/**
+ * Overwrite the scalar `response_metadata` fields on `target` with the
+ * (defined) values from `incoming`, in place. Used after `concat` to undo the
+ * string-concatenation it applies to these last-wins identity/finish fields.
+ */
+function mergeScalarResponseMetadata(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  target: Record<string, any>,
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  incoming: Record<string, any>
+): void {
+  for (const key of SCALAR_RESPONSE_METADATA_KEYS) {
+    if (incoming[key] != null) {
+      target[key] = incoming[key];
+    }
+  }
+}
+
+/**
  * OpenAI Completions API implementation.
  * @internal
  */
@@ -170,6 +201,14 @@ export class ChatOpenAICompletions<
           finalChunks[index] = chunk;
         } else {
           finalChunks[index] = finalChunks[index].concat(chunk);
+          // `concat` string-concatenates response_metadata fields. These
+          // scalar identity/finish fields are last-wins, not accumulated, so
+          // restore them when a provider emits more than one finish_reason
+          // chunk (e.g. OpenRouter) to avoid e.g. "stopstop" / doubled names.
+          mergeScalarResponseMetadata(
+            finalChunks[index].message.response_metadata,
+            chunk.message.response_metadata
+          );
         }
       }
       const generations = Object.entries(finalChunks)

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -115,6 +115,78 @@ describe("ChatOpenAICompletions streaming usage_metadata callback", () => {
   });
 });
 
+describe("ChatOpenAICompletions streaming scalar response_metadata", () => {
+  it("keeps scalar metadata last-wins when a provider emits multiple finish_reason chunks", async () => {
+    const model = new ChatOpenAICompletions({
+      model: "anthropic/claude-haiku-4.5",
+      apiKey: "test-key",
+      streaming: true,
+    });
+
+    // Some OpenAI-compatible providers (e.g. OpenRouter) emit more than one
+    // chunk carrying a non-null finish_reason. Each one re-attaches the scalar
+    // identity fields, which must not be string-concatenated when chunks merge.
+    const fakeStream = (async function* () {
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" as const, content: "Hello" },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: null,
+        model: "anthropic/claude-haiku-4.5",
+        service_tier: null,
+      };
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { content: "" },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: "fp_abc123",
+        model: "anthropic/claude-haiku-4.5",
+        service_tier: "default",
+      };
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { content: "" },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: "fp_abc123",
+        model: "anthropic/claude-haiku-4.5",
+        service_tier: "default",
+      };
+    })();
+
+    model.completionWithRetry = vi
+      .fn()
+      .mockResolvedValue(fakeStream) as typeof model.completionWithRetry;
+
+    const result = await model._generate([new HumanMessage("test")], {});
+    const message = result.generations[0].message as AIMessageChunk;
+
+    expect(message.response_metadata.finish_reason).toBe("stop");
+    expect(message.response_metadata.model_name).toBe(
+      "anthropic/claude-haiku-4.5"
+    );
+    expect(message.response_metadata.system_fingerprint).toBe("fp_abc123");
+    expect(message.response_metadata.service_tier).toBe("default");
+  });
+});
+
 describe("ChatOpenAICompletions reasoning_content compatibility", () => {
   it("should preserve reasoning_content on streamed assistant chunks", async () => {
     const model = new ChatOpenAICompletions({


### PR DESCRIPTION
`ChatOpenAI` streaming string-concatenates scalar `response_metadata` fields (`finish_reason`, `model_name`, ...) when a provider emits multiple finish_reason chunks (e.g. OpenRouter → "stopstop"). Makes them last-wins while preserving numeric `usage_metadata` summing. Mirrors #10159.

Fixes #11054