### PR TITLE
feat(weaviate): add X-Weaviate-Client-Integration telemetry header

### DIFF
--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -54,6 +54,56 @@ function makeSearchMockClient() {
   };
 }
 
+/** Let the fire-and-forget header registration settle before asserting. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+test("registers the X-Weaviate-Client-Integration header via getConnectionDetails", async () => {
+  const headers: Record<string, string> = {};
+  const client = {
+    collections: {},
+    getConnectionDetails: vi
+      .fn()
+      .mockResolvedValue({ host: "localhost", headers }),
+  } as unknown as WeaviateClient;
+
+  const store = new WeaviateStore(new FakeEmbeddings(), { client });
+  await flushMicrotasks();
+
+  expect(store).toBeInstanceOf(WeaviateStore);
+  // Mutates the live headers object by reference, so subsequent client requests
+  // carry the telemetry header on both transports.
+  expect(headers["X-Weaviate-Client-Integration"]).toBe(
+    `langchain/${__PKG_VERSION__}`
+  );
+});
+
+test("integration header registration never throws when unsupported", async () => {
+  const client = { collections: {} } as unknown as WeaviateClient;
+
+  const store = new WeaviateStore(new FakeEmbeddings(), { client });
+  await flushMicrotasks();
+
+  expect(store).toBeInstanceOf(WeaviateStore);
+});
+
+test("integration header registration leaves array-form headers untouched", async () => {
+  const headers: [string, string][] = [["X-Existing", "1"]];
+  const client = {
+    collections: {},
+    getConnectionDetails: vi.fn().mockResolvedValue({ headers }),
+  } as unknown as WeaviateClient;
+
+  const store = new WeaviateStore(new FakeEmbeddings(), { client });
+  await flushMicrotasks();
+
+  expect(store).toBeInstanceOf(WeaviateStore);
+  expect(headers).toEqual([["X-Existing", "1"]]);
+});
+
 test("initialize with jsonSchema calls createFromJson", async () => {
   const { client, spies } = makeMockClient();
   const jsonSchema = { class: "MyCollection", properties: [] };

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -87,6 +87,48 @@ export interface WeaviateLibArgs {
   jsonSchema?: WeaviateClass;
 }
 
+/**
+ * Integration identifier reported to Weaviate telemetry. Matches the Python
+ * `langchain-weaviate` integration: the value is intentionally just `langchain`
+ * (not language-specific) since language disambiguation is already carried by
+ * the client's own `X-Weaviate-Client` header.
+ */
+const INTEGRATION_NAME = "langchain";
+
+/**
+ * Telemetry header that tags the connection so Weaviate can track langchain
+ * usage across both the HTTP and gRPC transports.
+ */
+const INTEGRATION_HEADER = "X-Weaviate-Client-Integration";
+
+/**
+ * Best-effort registration of the {@link INTEGRATION_HEADER} on a Weaviate
+ * client. Never throws.
+ *
+ * Unlike the Python `weaviate-client`, the JS client exposes no public
+ * `integrations.configure(...)` API. However, `getConnectionDetails()` returns
+ * the client's live `headers` object by reference, and the client spreads that
+ * same object into every HTTP and gRPC request. Mutating it therefore tags all
+ * subsequent requests with `X-Weaviate-Client-Integration: langchain/<version>`
+ * without depending on any private internals. The whole thing is wrapped so a
+ * future change to the client's shape silently skips registration instead of
+ * breaking store construction.
+ */
+async function registerIntegrationHeader(
+  client: WeaviateClient
+): Promise<void> {
+  try {
+    const { headers } = await client.getConnectionDetails();
+    // The client only spreads object-form headers into requests, so only the
+    // `Record<string, string>` form can be augmented in place.
+    if (headers && !Array.isArray(headers)) {
+      headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${__PKG_VERSION__}`;
+    }
+  } catch {
+    // Best-effort telemetry: never let header registration break the store.
+  }
+}
+
 export class WeaviateDocument extends Document {
   generated?: string;
 
@@ -128,6 +170,10 @@ export class WeaviateStore extends VectorStore {
     super(embeddings, args);
 
     this.client = args.client;
+    // Tag the connection for Weaviate telemetry. Fire-and-forget and best-effort
+    // (the helper never throws) so it mirrors Python's registration in `__init__`
+    // without blocking synchronous construction.
+    registerIntegrationHeader(this.client);
     // `class` is Weaviate's legacy field name for the collection identifier in the
     // raw REST/JSON schema — it is not the standard JSON Schema `class` keyword.
     // See WeaviateClass in weaviate-client/openapi/types.

--- a/libs/providers/langchain-weaviate/tsdown.config.ts
+++ b/libs/providers/langchain-weaviate/tsdown.config.ts
@@ -1,7 +1,9 @@
 import { getBuildConfig, cjsCompatPlugin } from "@langchain/build";
+import pkg from "./package.json" with { type: "json" };
 
 export default getBuildConfig({
   entry: ["./src/index.ts"],
+  define: { __PKG_VERSION__: JSON.stringify(pkg.version) },
   plugins: [
     cjsCompatPlugin({
       files: ["dist/", "CHANGELOG.md", "README.md", "LICENSE"],

--- a/libs/providers/langchain-weaviate/vitest.config.ts
+++ b/libs/providers/langchain-weaviate/vitest.config.ts
@@ -3,6 +3,9 @@ import {
   defineConfig,
   type UserConfigExport,
 } from "vitest/config";
+import pkg from "./package.json" with { type: "json" };
+
+const define = { __PKG_VERSION__: JSON.stringify(pkg.version) };
 
 export default defineConfig((env) => {
   const common: UserConfigExport = {
@@ -18,6 +21,7 @@ export default defineConfig((env) => {
 
   if (env.mode === "standard-unit") {
     return {
+      define,
       test: {
         ...common.test,
         testTimeout: 100_000,
@@ -31,6 +35,7 @@ export default defineConfig((env) => {
 
   if (env.mode === "standard-int") {
     return {
+      define,
       test: {
         ...common.test,
         testTimeout: 100_000,
@@ -44,6 +49,7 @@ export default defineConfig((env) => {
 
   if (env.mode === "int") {
     return {
+      define,
       test: {
         ...common.test,
         globals: false,
@@ -57,6 +63,7 @@ export default defineConfig((env) => {
   }
 
   return {
+    define,
     test: {
       ...common.test,
       environment: "node",


### PR DESCRIPTION
## Summary

Tags Weaviate connections opened by `WeaviateStore` with an
`X-Weaviate-Client-Integration: langchain/<version>` header so Weaviate can
track LangChain.js usage in its telemetry. This mirrors the Python
`langchain-weaviate` integration, which registers the same identifier.

## Motivation

The Python `weaviate-client` exposes a public `integrations.configure(...)` API
that LangChain's Python integration calls to identify itself. The JS client has
no equivalent public API, so until now JS LangChain traffic was indistinguishable
from raw client traffic in Weaviate telemetry. This change closes that gap on the
JS side.

## Design decisions

- **Header registration without private internals.** `getConnectionDetails()`
  returns the client's live `headers` object *by reference*, and the client
  spreads that same object into every HTTP and gRPC request. Mutating it in place
  tags all subsequent requests on both transports without reaching into any
  private client internals.
- **Best-effort and non-blocking.** Registration is fire-and-forget from the
  constructor and the helper never throws — if a future client version changes
  shape (e.g. `getConnectionDetails` missing, or array-form headers), it silently
  skips registration rather than breaking store construction. This matches the
  spirit of Python's registration in `__init__`.
- **Integration name is just `langchain`** (not language-specific), consistent
  with the Python integration; language is already disambiguated by the client's
  own `X-Weaviate-Client` header.
- **Version injection.** `__PKG_VERSION__` is defined at build time via `tsdown`
  and mirrored in `vitest.config.ts` so tests can assert the exact header value.

## Tests

Added unit tests covering the three paths:
- header is registered via `getConnectionDetails` (asserts `langchain/<version>`)
- registration never throws when the client doesn't support it
- array-form headers are left untouched

## Risk

Low. The feature is purely additive telemetry, runs best-effort, and cannot
affect store construction or query behavior even if header registration fails.
