### PR TITLE
fix: Streaming text + tool call can collide content block indexes, causing `AIMessage.tool_calls` to be empty

### DIFF
--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -154,6 +154,7 @@ export async function* convertChunksToEvents(
     | undefined;
   let audioStream: AudioStreamState | undefined;
   const emittedImageKeys = new Set<string>();
+  const toolCallBlockIndexes = new Map<string, number>();
 
   for await (const chunk of chunks) {
     options?.signal?.throwIfAborted();
@@ -239,10 +240,20 @@ export async function* convertChunksToEvents(
       msg.tool_call_chunks.length > 0
     ) {
       for (const toolChunk of msg.tool_call_chunks) {
-        const blockIndex =
-          typeof toolChunk.index === "number"
-            ? toolChunk.index
-            : activeBlocks.size;
+        let toolCallKey: string;
+        if (typeof toolChunk.index === "number") {
+          toolCallKey = `index:${toolChunk.index}`;
+        } else if (typeof toolChunk.id === "string") {
+          toolCallKey = `id:${toolChunk.id}`;
+        } else {
+          toolCallKey = `next:${toolCallBlockIndexes.size}`;
+        }
+
+        let blockIndex = toolCallBlockIndexes.get(toolCallKey);
+        if (blockIndex === undefined) {
+          blockIndex = nextBlockIndex(activeBlocks);
+          toolCallBlockIndexes.set(toolCallKey, blockIndex);
+        }
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {

--- a/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
@@ -5,6 +5,8 @@ import {
   BaseChatModel,
   type BaseChatModelCallOptions,
 } from "../chat_models.js";
+import { convertChunksToEvents } from "../compat.js";
+import { ChatModelStream } from "../stream.js";
 import type { ChatModelStreamEvent } from "../event.js";
 import type { BaseMessage } from "../../messages/base.js";
 import type { CallbackManagerForLLMRun } from "../../callbacks/manager.js";
@@ -488,6 +490,62 @@ describe("_streamChatModelEvents bridge", () => {
       expect(toolFinish).toBeDefined();
       expect(toolFinish!.content.name).toBe("search");
       expect(toolFinish!.content.args).toEqual({ q: "hello" });
+    });
+
+    test("keeps text and tool call chunks in separate content blocks", async () => {
+      async function* chunks() {
+        yield new ChatGenerationChunk({
+          message: new AIMessageChunk({
+            content: "I will call a tool",
+            tool_call_chunks: [
+              {
+                index: 0,
+                id: "call_1",
+                name: "eval",
+                args: '{"code"',
+              },
+            ],
+          }),
+          text: "I will call a tool",
+        });
+
+        yield new ChatGenerationChunk({
+          message: new AIMessageChunk({
+            content: "",
+            tool_call_chunks: [
+              {
+                index: 0,
+                args: ':"new Date()"}',
+              },
+            ],
+          }),
+          text: "",
+        });
+      }
+
+      const stream = new ChatModelStream(convertChunksToEvents(chunks()));
+      const message = await stream.output;
+
+      expect(message.content).toEqual([
+        {
+          type: "text",
+          text: "I will call a tool",
+        },
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "eval",
+          args: { code: "new Date()" },
+        },
+      ]);
+      expect(message.tool_calls).toEqual([
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "eval",
+          args: { code: "new Date()" },
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

Implemented and committed the fix.

Summary:
- Updated `convertChunksToEvents` in `@langchain/core` so legacy streamed `tool_call_chunks` are mapped to their own content block indexes instead of directly reusing provider tool call indexes.
- This prevents streamed text block index `0` from colliding with provider tool call index `0`.
- Added a regression test covering streamed text plus tool call chunks sharing provider index `0`, verifying:
  - final content contains separate `text` and `tool_call` blocks
  - `AIMessage.tool_calls` is populated correctly

Verification:
- Passed targeted test:
  - `cd libs/langchain-core && pnpm exec vitest run src/language_models/tests/stream_bridge.test.ts`
  - Result: 13 tests passed
- Also specifically ran the new regression test successfully.
- Attempted build:
  - `pnpm --filter @langchain/core build`
  - Build did not complete due to an existing tooling/config issue importing `/workspace/internal/build/src/index.ts` via `tsdown`/`unrun` (`Unknown file extension ".ts"`), unrelated to the code change.

Commit:
- `2fe42e624 fix(core): avoid stream tool call block collisions`

Closes #11074
