### PR TITLE
fix(core): only treat arrays of content blocks as ToolMessage content

### DIFF
--- a/.changeset/open-months-grin.md
+++ b/.changeset/open-months-grin.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): only treat arrays of content blocks as ToolMessage content
+
+Fix tool outputs that are arrays of plain objects being forwarded as malformed message content. An array is now only treated as message content blocks when every element is an object with a `type`; otherwise it is JSON-stringified.

--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -1024,6 +1024,10 @@ export function tool<
   >;
 }
 
+function _isMessageContentBlockShaped(item: unknown) {
+  return typeof item === "object" && item !== null && "type" in item;
+}
+
 function _formatToolOutput<TOutput extends ToolOutputType>(params: {
   content: TOutput;
   name: string;
@@ -1036,7 +1040,7 @@ function _formatToolOutput<TOutput extends ToolOutputType>(params: {
     if (
       typeof content === "string" ||
       (Array.isArray(content) &&
-        content.every((item) => typeof item === "object"))
+        content.every(_isMessageContentBlockShaped))
     ) {
       return new ToolMessage({
         status: "success",

--- a/libs/langchain-core/src/tools/index.ts
+++ b/libs/langchain-core/src/tools/index.ts
@@ -1039,8 +1039,7 @@ function _formatToolOutput<TOutput extends ToolOutputType>(params: {
   if (toolCallId && !isDirectToolOutput(content)) {
     if (
       typeof content === "string" ||
-      (Array.isArray(content) &&
-        content.every(_isMessageContentBlockShaped))
+      (Array.isArray(content) && content.every(_isMessageContentBlockShaped))
     ) {
       return new ToolMessage({
         status: "success",

--- a/libs/langchain-core/src/tools/tests/tools.test.ts
+++ b/libs/langchain-core/src/tools/tests/tools.test.ts
@@ -87,6 +87,54 @@ test("ToolMessage content coerces to empty string when tool returns undefined", 
   expect(toolResult).toHaveProperty("content", "");
 });
 
+test("ToolMessage content is JSON-stringified when a tool returns an array of plain objects", async () => {
+  const toolCall = {
+    id: "testid",
+    args: { location: "San Francisco" },
+    name: "weather",
+    type: "tool_call",
+  } as const;
+
+  const forecast = [
+    { day: "Mon", highF: 64, condition: "Foggy" },
+    { day: "Tue", highF: 67, condition: "Sunny" },
+  ];
+
+  const weatherTool = tool(() => forecast, {
+    name: "weather",
+    schema: z.object({ location: z.string() }),
+  });
+
+  const toolResult = await weatherTool.invoke(toolCall);
+
+  expect(toolResult).toBeInstanceOf(ToolMessage);
+  expect(toolResult.content).toBe(JSON.stringify(forecast));
+});
+
+test("ToolMessage content passes an array of content blocks through unchanged", async () => {
+  const toolCall = {
+    id: "testid",
+    args: { location: "San Francisco" },
+    name: "weather",
+    type: "tool_call",
+  } as const;
+
+  const blocks = [
+    { type: "text", text: "Sunny" },
+    { type: "image_url", image_url: { url: "https://example.com/sf.png" } },
+  ];
+
+  const weatherTool = tool(() => blocks, {
+    name: "weather",
+    schema: z.object({ location: z.string() }),
+  });
+
+  const toolResult = await weatherTool.invoke(toolCall);
+
+  expect(toolResult).toBeInstanceOf(ToolMessage);
+  expect(toolResult.content).toEqual(blocks);
+});
+
 test("Does not return tool message if responseFormat is content_and_artifact and returns a tuple and a tool call with no id is passed in", async () => {
   const weatherSchema = z.object({
     location: z.string(),


### PR DESCRIPTION
## Summary
A tool that returns an array of plain objects — e.g. a lookup that returns `[{ id, name }, …]` produces an invalid provider request. The objects have no type field, so the request is malformed. The failure mode differs by provider:

- OpenAI: `400 Missing required parameter: 'messages[N].content[0].type'`
- Anthropic: The converter drops blocks it doesn't recognize, so the `tool_result` is empty. This results in a silent failure

The docs don't specify what behavior to expect when submitting an array of non-message-content-block data, but we shouldn't be allowing things to fail. Python handles this by serializing, so I (mostly) matched the JS impl to python's

**Repro**: https://github.com/aolsenjazz/tool-call-array

## Callouts
see https://github.com/langchain-ai/langchainjs/pull/11092#discussion_r3446785622

- Scoped narrowly as we're touching a core system. The Python impl goes a bit further in inspecting the shape of the tool result by comparing the `type` attribute to an allow list. I opted against that
- Only affects arrays of objects without a type: it now stringifies instead of producing a broken request
- This bug is impacting our deepagents evals. 7 tests in the `tool-usage-relational` suite are failing loudly (openai) or silently (anthropic)

## Tests
- Add two tests to `tools.test.ts`
  - Ensure that an array of plain objects is stringified
  - Ensure that an array of content blocks (with `type` attr) is unchanged
- Manually verified end-to-end against live OpenAI (gpt-4.1-mini) and Anthropic (claude-haiku-4-5): a tool returning an array of objects now produces a grounded answer on both — no 400, no silent drop.
