### PR TITLE
Preserve streamed chunk metadata for google-genai callbacks

### DIFF
--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -1045,7 +1045,14 @@ export class ChatGoogleGenerativeAI
       }
 
       yield chunk;
-      await runManager?.handleLLMNewToken(chunk.text ?? "");
+      await runManager?.handleLLMNewToken(
+        chunk.text ?? "",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { chunk }
+      );
     }
   }
 

--- a/libs/providers/langchain-google-genai/src/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models_stream_events.test.ts
@@ -189,4 +189,51 @@ describe("ChatGoogleGenerativeAI.streamEvents", () => {
     ]);
     expect(getTestClient(model).systemInstruction).toBeUndefined();
   });
+
+  test("passes streamed chunk metadata to handleLLMNewToken callbacks", async () => {
+    const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
+
+    try {
+      const model = new ChatGoogleGenerativeAI({
+        apiKey: "fake-key",
+        model: "gemini-2.0-flash",
+        streaming: true,
+      });
+      vi.spyOn(getTestClient(model), "generateContentStream").mockResolvedValue({
+        stream: geminiReasoningStream(),
+      });
+
+      const callbackCalls: { token: string; chunk: unknown }[] = [];
+
+      await model.invoke([new HumanMessage("Hello")], {
+        callbacks: [
+          {
+            handleLLMNewToken(
+              token: string,
+              _idx,
+              _runId,
+              _parentRunId,
+              _tags,
+              fields
+            ) {
+              callbackCalls.push({ token, chunk: fields?.chunk });
+            },
+          },
+        ],
+      });
+
+      expect(callbackCalls).toHaveLength(1);
+      expect(callbackCalls[0]?.token).toBe("");
+      expect(callbackCalls[0]?.chunk).toBeDefined();
+      expect(callbackCalls[0]?.chunk).toMatchObject({
+        text: "",
+        message: {
+          content: [{ type: "thinking", thinking: "Let me reason..." }],
+        },
+      });
+    } finally {
+      process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+    }
+  });
 });


### PR DESCRIPTION
Callback-based consumers rely on handleLLMNewToken fields.chunk to observe non-text stream payloads like reasoning-only chunks. google-genai yielded the chunk but only forwarded text, which dropped that metadata for callback and tracer consumers.

The change passes the yielded chunk through handleLLMNewToken and adds a regression test covering a thinking-only streamed chunk.

Constraint: Callback consumers can receive thinking-only chunks with empty token text
Rejected: Rely on streamEvents assertions only | callback and tracer consumers would still lose chunk metadata
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep provider streaming callbacks aligned with the yielded ChatGenerationChunk payloads
Tested: pnpm --filter @langchain/core build
Tested: pnpm --filter @langchain/google-genai build
Tested: pnpm --filter @langchain/google-genai test:single src/tests/chat_models_stream_events.test.ts
Tested: pnpm --filter @langchain/google-genai test
Not-tested: Integration tests against live Gemini API

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
