### PR TITLE
chore(deps-dev): bump hono to 4.12.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "@grpc/grpc-js": ">=1.8.22",
       "flatted": ">=3.4.2",
       "simple-git": ">=3.32.3",
-      "hono": ">=4.12.23",
+      "hono": ">=4.12.27",
       "@hono/node-server": ">=2.0.4",
       "express-rate-limit": ">=8.2.2",
       "basic-ftp": ">=5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   '@grpc/grpc-js': '>=1.8.22'
   flatted: '>=3.4.2'
   simple-git: '>=3.32.3'
-  hono: '>=4.12.23'
+  hono: '>=4.12.27'
   '@hono/node-server': '>=2.0.4'
   express-rate-limit: '>=8.2.2'
   basic-ftp: '>=5.3.0'
@@ -602,7 +602,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: '>=2.0.4'
-        version: 2.0.4(hono@4.12.23)
+        version: 2.0.4(hono@4.12.27)
       '@langchain/anthropic':
         specifier: workspace:*
         version: link:../providers/langchain-anthropic
@@ -652,8 +652,8 @@ importers:
         specifier: ^3.14.0
         version: 3.15.1
       hono:
-        specifier: '>=4.12.23'
-        version: 4.12.23
+        specifier: '>=4.12.27'
+        version: 4.12.27
       openai:
         specifier: ^6.41.0
         version: 6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6)
@@ -3707,19 +3707,19 @@ packages:
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.23'
+      hono: '>=4.12.27'
 
   '@hono/node-ws@1.3.1':
     resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@hono/node-server': '>=2.0.4'
-      hono: '>=4.12.23'
+      hono: '>=4.12.27'
 
   '@hono/zod-validator@0.7.6':
     resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
-      hono: '>=4.12.23'
+      hono: '>=4.12.27'
       zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.2':
@@ -8365,8 +8365,8 @@ packages:
   hnswlib-node@3.0.0:
     resolution: {integrity: sha512-fypn21qvVORassppC8/qNfZ5KAOspZpm/IbUkAtlqvbtDNnF5VVk5RWF7O5V6qwr7z+T3s1ePej6wQt5wRQ4Cg==}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -14121,22 +14121,22 @@ snapshots:
       protobufjs: 7.6.2
       yargs: 17.7.2
 
-  '@hono/node-server@2.0.4(hono@4.12.23)':
+  '@hono/node-server@2.0.4(hono@4.12.27)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.27
 
-  '@hono/node-ws@1.3.1(@hono/node-server@2.0.4(hono@4.12.23))(bufferutil@4.1.0)(hono@4.12.23)':
+  '@hono/node-ws@1.3.1(@hono/node-server@2.0.4(hono@4.12.27))(bufferutil@4.1.0)(hono@4.12.27)':
     dependencies:
-      '@hono/node-server': 2.0.4(hono@4.12.23)
-      hono: 4.12.23
+      '@hono/node-server': 2.0.4(hono@4.12.27)
+      hono: 4.12.27
       ws: 8.21.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@hono/zod-validator@0.7.6(hono@4.12.23)(zod@4.3.6)':
+  '@hono/zod-validator@0.7.6(hono@4.12.27)(zod@4.3.6)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.27
       zod: 4.3.6
 
   '@humanfs/core@0.19.2':
@@ -14593,9 +14593,9 @@ snapshots:
   '@langchain/langgraph-api@1.3.1(@langchain/core@libs+langchain-core)(@langchain/langgraph-checkpoint@1.1.2(@langchain/core@libs+langchain-core))(@langchain/langgraph-sdk@1.9.23(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@langchain/langgraph@1.4.4(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0))':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@hono/node-server': 2.0.4(hono@4.12.23)
-      '@hono/node-ws': 1.3.1(@hono/node-server@2.0.4(hono@4.12.23))(bufferutil@4.1.0)(hono@4.12.23)
-      '@hono/zod-validator': 0.7.6(hono@4.12.23)(zod@4.3.6)
+      '@hono/node-server': 2.0.4(hono@4.12.27)
+      '@hono/node-ws': 1.3.1(@hono/node-server@2.0.4(hono@4.12.27))(bufferutil@4.1.0)(hono@4.12.27)
+      '@hono/zod-validator': 0.7.6(hono@4.12.27)(zod@4.3.6)
       '@langchain/core': link:libs/langchain-core
       '@langchain/langgraph': 1.4.4(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@libs+langchain-core)
@@ -14606,7 +14606,7 @@ snapshots:
       dedent: 1.7.2
       dotenv: 16.6.1
       exit-hook: 4.0.0
-      hono: 4.12.23
+      hono: 4.12.27
       langsmith: 0.7.3(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.0(bufferutil@4.1.0))
       open: 10.2.0
       semver: 7.8.1
@@ -14769,7 +14769,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.4(hono@4.12.23)
+      '@hono/node-server': 2.0.4(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -14779,7 +14779,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.27
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -15104,13 +15104,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 2.0.4(hono@4.12.23)
+      '@hono/node-server': 2.0.4(hono@4.12.27)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.23
+      hono: 4.12.27
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -19087,7 +19087,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 8.7.0
 
-  hono@4.12.23: {}
+  hono@4.12.27: {}
 
   hookable@6.1.1: {}
 


### PR DESCRIPTION
## 10-second summary

This PR bumps the repository-level `hono` override from `>=4.12.23` to `>=4.12.27`, removing `hono@4.12.23` from `pnpm-lock.yaml`.

`hono@4.12.23` is affected by several Hono advisories, including a high-severity CORS middleware issue where credentialed CORS can reflect arbitrary origins when `credentials: true` is used without a restricted `origin`. This PR uses the existing root override strategy and updates only `package.json` plus the generated lockfile.

Note: Dependabot already opened #11081 for `hono@4.12.25`, but that PR is currently conflicting and has a much larger lockfile diff. This PR is based on current `main` and targets the current clean `4.12.27` release.

## What Changed

- Updated the root `pnpm.overrides.hono` floor from `>=4.12.23` to `>=4.12.27`.
- Regenerated `pnpm-lock.yaml` with `pnpm install --lockfile-only --ignore-scripts`.

## What Users Will See

No direct user-facing behavior change is expected. This is a dependency security update for dev/test and embedded server-related dependency paths.

## Surface Area

- [x] Internal / non-user-facing
- [ ] UI
- [ ] API
- [ ] Default behavior
- [ ] Data/model/schema

Notes: `hono` appears in LangChainJS dev/test and `@langchain/langgraph-api`-related dependency paths. This PR does not change source behavior.

## Why This Change Is Needed

This PR addresses Hono advisories affecting `hono@4.12.23`.

Primary advisory: GHSA-88fw-hqm2-52qc  
Severity: High  
CVE: CVE-2026-54290  
Patched version: `4.12.25`  
Target used here: `4.12.27`

The high-severity advisory matters when an app uses Hono CORS middleware with `credentials: true` and no restricted `origin`; in affected versions, arbitrary origins can be reflected and credentialed cross-origin responses can become readable.

## Advisory References

- Hono CORS advisory: https://github.com/honojs/hono/security/advisories/GHSA-88fw-hqm2-52qc
- Hono AWS Lambda Set-Cookie advisory: https://github.com/honojs/hono/security/advisories/GHSA-j6c9-x7qj-28xf
- OSV entry: https://osv.dev/vulnerability/GHSA-88fw-hqm2-52qc

## Where It Appears

Dependency path:

```text
package.json pnpm.overrides
-> hono >=4.12.23
-> pnpm-lock.yaml resolves hono@4.12.23
-> @hono/node-server / @hono/node-ws / @hono/zod-validator / @langchain/langgraph-api paths
```

Evidence:

- [`package.json`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/package.json#L76): root override now requires `hono >=4.12.27`.
- [`pnpm-lock.yaml`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/pnpm-lock.yaml#L27): lockfile override now records `hono >=4.12.27`.
- [`pnpm-lock.yaml`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/pnpm-lock.yaml#L654): `libs/langchain` resolves `hono` to `4.12.27`.
- [`pnpm-lock.yaml`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/pnpm-lock.yaml#L8368): lockfile package entry is now `hono@4.12.27`.
- [`pnpm-lock.yaml`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/pnpm-lock.yaml#L14596): `@langchain/langgraph-api` dependency path now resolves Hono-related packages against `hono@4.12.27`.

Generated dependency sidecars:

- `pnpm-lock.yaml`: updated.

## Code Usage Review

Direct vulnerable package imports: found in integration/dev test code.

- [`libs/langchain/src/agents/tests/stream.int.test.ts`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/libs/langchain/src/agents/tests/stream.int.test.ts#L7): imports `Hono`.
- [`libs/langchain/src/agents/tests/stream.int.test.ts`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/libs/langchain/src/agents/tests/stream.int.test.ts#L8): imports `cors` from `hono/cors`.
- [`libs/langchain/src/agents/tests/stream.int.test.ts`](https://github.com/gateway/langchainjs/blob/guardian/hono-security/libs/langchain/src/agents/tests/stream.int.test.ts#L9): imports `serve` from `@hono/node-server`.

Observed exposure: dev/test and embedded server dependency paths. This PR does not claim a default production runtime exploit path in LangChainJS.

## Fix

This PR updates dependency resolution so Hono resolves to `4.12.27`, which is newer than the `4.12.25` patched floor listed in the advisories and was clean in a focused Guardian exact-version scan.

Affected: `hono@4.12.23`  
Patched: `>=4.12.25`  
Target used: `4.12.27`

## Alternatives Considered

- Leave Dependabot #11081 to handle this: noted, but that PR is currently conflicting and has a broader lockfile diff.
- Target exactly `4.12.25`: rejected because `4.12.27` is the current clean release and keeps the override as a minimum floor.
- Broader dependency updates: rejected to keep this PR small and reviewable.

## Risk Assessment

Upgrade risk: low.

Reasoning:

- This is a patch-level Hono update.
- The repo already has a root override for Hono; this only raises that existing floor.
- The diff is limited to two dependency files.
- Direct source usage found is test/integration server code, not public API implementation.

## Validation

Ran:

- `pnpm install --lockfile-only --ignore-scripts`: completed successfully and updated `pnpm-lock.yaml`.
- Guardian full scan after the change: `hono@4.12.23` no longer appears in the top findings.
- Guardian exact-version scan for `hono@4.12.27`: no advisories returned from OSV, GHSA, or GitLab advisory data.
- `rg` check for `hono@4.12.23` / `hono: 4.12.23`: no remaining matches in manifests or lockfile.
- `git diff --check`: passed.

Suggested maintainer validation:

- `pnpm test:unit`
- Relevant environment/export tests that cover `libs/langchain` and `@langchain/langgraph-api` paths.

## Notes

This PR is not claiming active exploitation in this repo. It removes a known vulnerable Hono version from the resolved dependency graph with a focused lockfile update.

Powered by Guardian: https://github.com/gateway/guardian
