### PR TITLE
fix(langchain): align HITL default reject message with Python middleware

### DIFF
--- a/libs/langchain/src/agents/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middleware/hitl.ts
@@ -649,7 +649,9 @@ export function humanInTheLoopMiddleware(
       // Create a tool message with the human's text response
       const content =
         decision.message ??
-        `User rejected the tool call for \`${toolCall.name}\` with id ${toolCall.id}`;
+        `User rejected the tool call for \`${toolCall.name}\` with id ${toolCall.id}. ` +
+        `The tool was not executed. Do not retry this tool call unless the user ` +
+        `explicitly requests it.`;
 
       const toolMessage = new ToolMessage({
         content,


### PR DESCRIPTION
## Summary

The `humanInTheLoopMiddleware` default reject message in JS is shorter than the equivalent default in the Python `langchain` v1 middleware. This PR ports the Python text so both libraries emit the same default when a human rejects a tool call without supplying an explicit `decision.message`.

As a measured side-effect, this substantially reduces a retry-loop failure mode on OpenAI's small production models in agent loops.

## Change

One line in `libs/langchain/src/agents/middleware/hitl.ts` (`processDecision`, reject branch):

**Before**
```ts
const content =
  decision.message ??
  `User rejected the tool call for \`${toolCall.name}\` with id ${toolCall.id}`;
```

**After**
```ts
const content =
  decision.message ??
  `User rejected the tool call for \`${toolCall.name}\` with id ${toolCall.id}. ` +
  `The tool was not executed. Do not retry this tool call unless the user ` +
  `explicitly requests it.`;
```

The new text matches the Python middleware verbatim: [`libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py`](https://github.com/langchain-ai/langchain/blob/master/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py).

## Why

### Cross-language parity

Two language SDKs of the same library should emit the same default for the same semantic operation. Python's `RejectDecision` branch already uses the longer text; JS does not.

### Measured behavior improvement on small OpenAI models

In an agentic-loop scenario (system prompt encouraging the model to persist toward the user's goal, a single benign tool call rejected by the human), the current default causes small OpenAI models to immediately retry the rejected tool call. The proposed default cuts that substantially. All measurements at **N=30 per cell**, end-to-end through the **identical graph setup** in both languages (real `createAgent` + `humanInTheLoopMiddleware` + `MemorySaver`), sending `{ type: "reject" }` so the middleware uses its own default. **Only the language and middleware patch state differ between columns.**

| Model | JS — current default | JS — this PR | Python middleware (reference) |
|---|---|---|---|
| `gpt-4o-mini` | 30/30 (100%) | 9/30 (30%) | 3/30 (10%) |
| `gpt-3.5-turbo` | 30/30 (100%) | 13/30 (43%) | 3/30 (10%) |

### Bias-mitigation controls (N=30 each, `gpt-4o-mini`, isolated API)

- **Same-length filler message without the "do not retry" directive** still produces 100% retry → the directive content does the work, not the message length.
- **Without the agentic system prompt:** 57% retry on the current default, 0% on this PR's default → the effect persists outside agentic framing.
- **Different tool (`send_email`):** 100% → 3% → effect generalizes beyond `get_weather`.
- **Larger models (`gpt-4o`, `claude-sonnet-4-6`) and `claude-haiku-4-5`:** unaffected by either message.

### Honest residual gap

The Python middleware achieves 10% retry on both models with byte-identical message text; this PR brings JS to 30–43%. The gap is not in the message string — it likely comes from other JS-only code-path behaviors (`jumpTo: "model"` on reject, tool_calls reordering when a rejection is present in a batch) that the Python middleware does not do. Those are out of scope for this PR and worth a follow-up issue.

## Test plan

- [ ] CI passes
- [ ] Existing HITL tests pass (this PR only changes the default content string; tests that supply an explicit `decision.message` are unaffected)
- [ ] Manual repro: agent on `gpt-4o-mini` with HITL middleware → reject a tool call → next AI turn should rarely re-emit the same tool call (vs. ~always with the current default)

## Reproducer

Standalone scripts (Node + Python) demonstrating before/after on the real middleware and against the Python reference are available on request as a gist.
