### PR TITLE
fix(core): restore contentBlocks content on stored-message deserialization

### DIFF
--- a/.changeset/content-blocks-stored-roundtrip.md
+++ b/.changeset/content-blocks-stored-roundtrip.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): restore contentBlocks content on stored-message deserialization
+
+A message built with the `contentBlocks` input field serialized its content under the snake-cased `content_blocks` key, which `mapStoredMessageToChatMessage` did not map back to `contentBlocks`, so the message round-tripped to empty content. Remap it before construction, mirroring the `load()` reviver.

--- a/libs/langchain-core/src/messages/tests/message_utils.test.ts
+++ b/libs/langchain-core/src/messages/tests/message_utils.test.ts
@@ -6,6 +6,7 @@ import { ChatMessage } from "../chat.js";
 import { HumanMessage } from "../human.js";
 import { SystemMessage } from "../system.js";
 import { ToolMessage } from "../tool.js";
+import { load } from "../../load/index.js";
 import {
   filterMessages,
   mergeMessageRuns,
@@ -782,5 +783,32 @@ describe("chat message conversions", () => {
       mapStoredMessagesToChatMessages(storedMessages);
 
     expect(convertedBackMessages).toEqual(originalMessages);
+  });
+
+  it("preserves contentBlocks content through a stored-message round-trip", () => {
+    // A message built via the `contentBlocks` input field serializes its
+    // content under the snake-cased `content_blocks` key, which the
+    // stored-message deserializer must map back to `contentBlocks`. Otherwise
+    // the message round-trips to empty content.
+    const message = new AIMessage({
+      contentBlocks: [{ type: "text", text: "hello" }],
+    });
+
+    const stored = mapChatMessagesToStoredMessages([message]);
+    const [back] = mapStoredMessagesToChatMessages(stored);
+
+    expect(back.text).toBe("hello");
+    expect(back.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("preserves contentBlocks content through a load() round-trip", async () => {
+    const message = new AIMessage({
+      contentBlocks: [{ type: "text", text: "hello" }],
+    });
+
+    const revived = await load<AIMessage>(JSON.stringify(message.toJSON()));
+
+    expect(revived.text).toBe("hello");
+    expect(revived.content).toEqual([{ type: "text", text: "hello" }]);
   });
 });

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -447,30 +447,57 @@ function mapV1MessageToStoredMessage(
   }
 }
 
+/**
+ * A message constructed via the `contentBlocks` input field persists its
+ * content under the snake-cased `content_blocks` key, because serialization is
+ * driven by the constructor's `lc_kwargs` (see `BaseMessage`). The full
+ * `load()` reviver remaps snake_case keys back to camelCase, but this lighter
+ * stored-message path passes the data straight to the constructor, which only
+ * recognizes `content` and `contentBlocks`. Without this remap, `content_blocks`
+ * is ignored and the message round-trips to empty content. Map it back to
+ * `contentBlocks` so the content survives.
+ */
+function restoreContentBlocksField(
+  data: StoredMessage["data"]
+): StoredMessage["data"] {
+  if (!("content_blocks" in data)) {
+    return data;
+  }
+  const { content_blocks, ...rest } = data as StoredMessage["data"] & {
+    content_blocks?: BaseMessageFields["contentBlocks"];
+  };
+  // Prefer an explicit `contentBlocks` if one is already present.
+  if ((rest as BaseMessageFields).contentBlocks !== undefined) {
+    return rest;
+  }
+  return { ...rest, contentBlocks: content_blocks } as StoredMessage["data"];
+}
+
 export function mapStoredMessageToChatMessage(message: StoredMessage) {
   const storedMessage = mapV1MessageToStoredMessage(message);
+  const data = restoreContentBlocksField(storedMessage.data);
   switch (storedMessage.type) {
     case "human":
-      return new HumanMessage(storedMessage.data);
+      return new HumanMessage(data);
     case "ai":
-      return new AIMessage(storedMessage.data);
+      return new AIMessage(data);
     case "system":
-      return new SystemMessage(storedMessage.data);
+      return new SystemMessage(data);
     case "function":
-      if (storedMessage.data.name === undefined) {
+      if (data.name === undefined) {
         throw new Error("Name must be defined for function messages");
       }
-      return new FunctionMessage(storedMessage.data as FunctionMessageFields);
+      return new FunctionMessage(data as FunctionMessageFields);
     case "tool":
-      if (storedMessage.data.tool_call_id === undefined) {
+      if (data.tool_call_id === undefined) {
         throw new Error("Tool call ID must be defined for tool messages");
       }
-      return new ToolMessage(storedMessage.data as ToolMessageFields);
+      return new ToolMessage(data as ToolMessageFields);
     case "generic": {
-      if (storedMessage.data.role === undefined) {
+      if (data.role === undefined) {
         throw new Error("Role must be defined for chat messages");
       }
-      return new ChatMessage(storedMessage.data as ChatMessageFields);
+      return new ChatMessage(data as ChatMessageFields);
     }
     default:
       throw new Error(`Got unexpected type: ${storedMessage.type}`);


### PR DESCRIPTION
Fixes #11096

## What

A message constructed with the `contentBlocks` input field round-trips to empty content through the stored-message helpers (`mapChatMessagesToStoredMessages` → `mapStoredMessagesToChatMessages`).

## Why

Serialization is driven by the constructor's `lc_kwargs`. Building a message with `{ contentBlocks: ... }` leaves the key as `contentBlocks`, which `keyToJson` snake-cases to `content_blocks` on the way out — and there's no `content` key. The full `load()` reviver already remaps snake_case keys back to camelCase via `keyFromJson`, so that path reconstructs correctly. But `mapStoredMessageToChatMessage` passes the stored `data` straight into the message constructor, which only recognizes `content` and `contentBlocks`. `content_blocks` is therefore ignored and the rebuilt message ends up with `content: []`.

```ts
const msg = new AIMessage({ contentBlocks: [{ type: "text", text: "hello" }] });
const back = mapStoredMessagesToChatMessages(mapChatMessagesToStoredMessages([msg]));
back[0].text; // "" — expected "hello"
```

## How

`mapStoredMessageToChatMessage` now remaps `content_blocks` → `contentBlocks` on the stored data before handing it to the constructor, mirroring what the `load()` reviver already does. This also recovers any messages that were already persisted with the `content_blocks` key. An existing `contentBlocks` value, if present, is preferred. No change to serialization output.

## Testing

Added two round-trip tests in `message_utils.test.ts` (stored-message helpers + `load()`) covering content built via `contentBlocks`. The first fails on `main` and passes with this change; the `load()` one guards the already-working path against regressions.

```
$ pnpm --filter @langchain/core test
 Test Files  97 passed (97)
      Tests  1447 passed | 1 skipped (1448)
Type Errors  no errors
```

`pnpm lint` and `pnpm format:check` are clean on the changed files.