### PR TITLE
fix(anthropic): preserve user cache_control

### DIFF
--- a/.changeset/tame-claudes-cache.md
+++ b/.changeset/tame-claudes-cache.md
@@ -1,0 +1,6 @@
+---
+"@langchain/anthropic": patch
+"langchain": patch
+---
+
+Preserve user-provided Anthropic `cache_control` settings when prompt caching middleware is enabled.

--- a/libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts
+++ b/libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts
@@ -237,11 +237,19 @@ export function anthropicPromptCachingMiddleware(
        *
        * @see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
        */
+      const existingCacheControl =
+        request.modelSettings?.cache_control ??
+        (
+          request.model as {
+            invocationKwargs?: { cache_control?: unknown };
+          }
+        ).invocationKwargs?.cache_control;
+
       return handler({
         ...request,
         modelSettings: {
           ...request.modelSettings,
-          cache_control: {
+          cache_control: existingCacheControl ?? {
             type: "ephemeral" as const,
             ttl,
           },

--- a/libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts
+++ b/libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts
@@ -16,6 +16,7 @@ import { ChatOpenAI } from "@langchain/openai";
 
 import { anthropicPromptCachingMiddleware } from "../promptCaching.js";
 import { createAgent } from "../../../../index.js";
+import { createMiddleware } from "../../../../middleware.js";
 
 function createMockModel(name = "ChatAnthropic", modelType = "anthropic") {
   // Mock Anthropic model
@@ -89,6 +90,92 @@ describe("anthropicPromptCachingMiddleware", () => {
     expect(bindToolsOptions?.cache_control).toEqual({
       type: "ephemeral",
       ttl: "5m",
+    });
+  });
+
+  it("should preserve cache_control already supplied by earlier model settings", async () => {
+    const model = createMockModel();
+
+    const existingCacheControlMiddleware = createMiddleware({
+      name: "ExistingCacheControlMiddleware",
+      wrapModelCall: (request, handler) =>
+        handler({
+          ...request,
+          modelSettings: {
+            ...request.modelSettings,
+            cache_control: {
+              type: "ephemeral" as const,
+              ttl: "1h",
+            },
+          },
+        }),
+    });
+
+    const middleware = anthropicPromptCachingMiddleware({
+      ttl: "5m",
+      minMessagesToCache: 3,
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [existingCacheControlMiddleware, middleware],
+    });
+
+    const messages = [
+      new SystemMessage("You are a helpful assistant"),
+      new HumanMessage("Hello"),
+      new AIMessage("Hi there!"),
+      new HumanMessage("How are you?"),
+      new AIMessage("I'm doing well, thanks!"),
+      new HumanMessage("What's the weather like?"),
+    ];
+
+    await agent.invoke({ messages });
+
+    const bindToolsOptions = (model as ReturnType<typeof createMockModel>)
+      ._lastBindToolsOptions;
+    expect(bindToolsOptions?.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  it("should preserve constructor-level cache_control from the model", async () => {
+    const model = Object.assign(createMockModel(), {
+      invocationKwargs: {
+        cache_control: {
+          type: "ephemeral" as const,
+          ttl: "1h",
+        },
+      },
+    });
+
+    const middleware = anthropicPromptCachingMiddleware({
+      ttl: "5m",
+      minMessagesToCache: 3,
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    const messages = [
+      new SystemMessage("You are a helpful assistant"),
+      new HumanMessage("Hello"),
+      new AIMessage("Hi there!"),
+      new HumanMessage("How are you?"),
+      new AIMessage("I'm doing well, thanks!"),
+      new HumanMessage("What's the weather like?"),
+    ];
+
+    await agent.invoke({ messages });
+
+    const bindToolsOptions = (model as ReturnType<typeof createMockModel>)
+      ._lastBindToolsOptions;
+    expect(bindToolsOptions?.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
     });
   });
 

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1275,7 +1275,8 @@ export class ChatAnthropicMessages<
       output_config: mergedOutputConfig,
       inference_geo: options?.inferenceGeo ?? this.inferenceGeo,
       mcp_servers: options?.mcp_servers,
-      cache_control: options?.cache_control,
+      cache_control:
+        options?.cache_control ?? this.invocationKwargs?.cache_control,
     };
 
     validateInvocationParamCompatibility({

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -1553,6 +1553,38 @@ test("invocationParams includes cache_control with 1h ttl", () => {
   expect(params.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 });
 
+test("invocationParams preserves constructor cache_control when no call option is provided", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    temperature: 0,
+    anthropicApiKey: "testing",
+    invocationKwargs: {
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    },
+  });
+
+  const params = model.invocationParams({});
+
+  expect(params.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+});
+
+test("invocationParams prefers call option cache_control over constructor cache_control", () => {
+  const model = new ChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    temperature: 0,
+    anthropicApiKey: "testing",
+    invocationKwargs: {
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    },
+  });
+
+  const params = model.invocationParams({
+    cache_control: { type: "ephemeral", ttl: "5m" },
+  });
+
+  expect(params.cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
+});
+
 test("invocationParams does not include cache_control when not provided", () => {
   const model = new ChatAnthropic({
     modelName: "claude-haiku-4-5-20251001",


### PR DESCRIPTION
Fixes #11099

## Summary

- preserve constructor-level Anthropic `invocationKwargs.cache_control` in `ChatAnthropic` invocation params when no per-call `cache_control` is supplied
- avoid overwriting an existing Anthropic `cache_control` value in `anthropicPromptCachingMiddleware`
- add regression coverage for constructor-provided cache control and middleware/modelSettings-preserved cache control
- add a patch changeset for `@langchain/anthropic` and `langchain`

## Why

When DeepAgents/Anthropic prompt caching is enabled, a user can configure a model-level cache control value such as:

```ts
new ChatAnthropic({
  model: "claude-haiku-4-5",
  invocationKwargs: {
    cache_control: { type: "ephemeral", ttl: "1h" },
  },
});
```

Before this change, `invocationParams()` only surfaced per-call `cache_control`, and the Anthropic prompt caching middleware always wrote its own default cache control into `modelSettings`. That could replace the user-provided 1h TTL with the middleware default 5m TTL and lead Anthropic to reject the request because cache-control blocks with differing TTLs were submitted.

## Testing

- `pnpm changeset status --since origin/main`
- `pnpm format:check -- .changeset/tame-claudes-cache.md libs/providers/langchain-anthropic/src/chat_models.ts libs/providers/langchain-anthropic/src/tests/chat_models.test.ts libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts`
- `pnpm exec lint-staged`
- `pnpm lint`
- `pnpm exec oxlint libs/providers/langchain-anthropic/src/chat_models.ts libs/providers/langchain-anthropic/src/tests/chat_models.test.ts libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts`
- `pnpm --filter @langchain/anthropic test src/tests/chat_models.test.ts`
- `pnpm --filter langchain test src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts`
- `pnpm --filter @langchain/anthropic build`
- `pnpm --filter langchain build`
- `git diff --check`
