### PR TITLE
fix(core): use Gemini functionCall id for tool_call content blocks

### DIFF
--- a/.changeset/google-toolcall-id-from-functioncall.md
+++ b/.changeset/google-toolcall-id-from-functioncall.md
@@ -1,0 +1,14 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): use Gemini functionCall id for tool_call content blocks
+
+When normalizing a Google/Gemini `AIMessage` via `contentBlocks`, the
+`functionCall` → `tool_call` translation always took its `id` from
+`message.id`, dropping the per-call `functionCall.id` that newer Gemini
+responses provide. The resulting `tool_call` block had a missing or wrong
+`id` (`message.tool_calls[0].id` and `contentBlocks[0].id` disagreed),
+breaking downstream code that correlates tool calls by id. The translator
+now prefers `functionCall.id` and falls back to `message.id` only when the
+call has no id of its own.

--- a/libs/langchain-core/src/messages/block_translators/google.ts
+++ b/libs/langchain-core/src/messages/block_translators/google.ts
@@ -71,7 +71,12 @@ function convertToV1FromChatGoogleMessage(
         ) {
           return {
             type: "tool_call",
-            id: message.id,
+            // Prefer the function call's own id (provided by newer Gemini
+            // responses); fall back to the message id for older payloads that
+            // don't carry a per-call id.
+            id: _isString(block.functionCall.id)
+              ? block.functionCall.id
+              : message.id,
             name: block.functionCall.name,
             args: block.functionCall.args,
           };

--- a/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
@@ -147,4 +147,54 @@ describe("ChatGoogleTranslator", () => {
       },
     ]);
   });
+
+  it("should use the functionCall id for the tool_call id when present", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
+  it("should fall back to the message id when the functionCall has no id", () => {
+    const message = new AIMessage({
+      id: "msg-fallback",
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "msg-fallback",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #11110.

When `AIMessage.contentBlocks` normalizes a Google/Gemini message, the `functionCall` → `tool_call` translation in `block_translators/google.ts` always took its `id` from `message.id`, discarding the per-call `functionCall.id` that newer Gemini responses include. As a result the standardized `tool_call` block had a missing or mismatched `id` — `message.tool_calls[0].id` and `message.contentBlocks[0].id` could disagree — which breaks downstream code that correlates tool calls by id.

### Fix

Prefer `functionCall.id` when present, falling back to `message.id` only when the call carries no id of its own (preserving behavior for older Gemini payloads that don't provide one):

```ts
id: _isString(block.functionCall.id) ? block.functionCall.id : message.id,
```

### Testing

Added two unit tests to `block_translators/tests/google.test.ts`:
- a `functionCall` with an `id` → the `tool_call` block uses that id (the repro from the issue);
- a `functionCall` without an `id` → falls back to `message.id`.

Reverse-verified: the first test fails without the fix. Both pass with it (7/7 in the file), `oxfmt`/`oxlint` clean, no type errors. Pure unit test — no live Gemini API required.

## AI Disclosure

This fix was prepared with AI assistance (issue analysis, implementation, and tests).