### PR TITLE
fix(@langchain/aws): drop empty AIMessages to avoid Converse API ValidationException

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Integrations are a core component of LangChain. LangChain provides standard inte
 - **Interoperability**: LangChain components expose a standard interface, allowing developers to easily swap them for each other. If you implement a LangChain integration, any developer using a different component will easily be able to swap yours in.
 - **Best Practices**: Through their standard interface, LangChain components encourage and facilitate best practices (streaming, async, etc.) that improve developer experience and application performance.
 
-See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/langchain/how_to) in our docs.
+See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/learn) in our docs.
 
 #### Integration Packages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Integrations are a core component of LangChain. LangChain provides standard inte
 - **Interoperability**: LangChain components expose a standard interface, allowing developers to easily swap them for each other. If you implement a LangChain integration, any developer using a different component will easily be able to swap yours in.
 - **Best Practices**: Through their standard interface, LangChain components encourage and facilitate best practices (streaming, async, etc.) that improve developer experience and application performance.
 
-See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/langchain/how_to/#custom) in our docs.
+See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/langchain/how_to) in our docs.
 
 #### Integration Packages
 
@@ -146,8 +146,8 @@ Dev releases are useful for:
 This project uses the following tools, which are worth getting familiar with if you plan to contribute:
 
 - **[pnpm](https://pnpm.io/) (v10.14.0)** - dependency management
-- **[oxlint](https://oxc.rs/docs/guide/usage/linter/)** - enforcing standard lint rules
-- **[oxfmt](https://oxc.rs/docs/guide/usage/formatter/)** - enforcing standard code formatting
+- **[oxlint](https://oxc.rs/docs/guide/usage/linter)** - enforcing standard lint rules
+- **[oxfmt](https://oxc.rs/docs/guide/usage/formatter)** - enforcing standard code formatting
 - **[vitest](https://vitest.dev/)** - testing code
 
 ## 🚀 Quick Start
@@ -195,7 +195,7 @@ pnpm --filter @langchain/core build
 
 ### Linting
 
-We use [oxlint](https://oxc.rs/docs/guide/usage/linter/) to enforce standard lint rules. To run the linter:
+We use [oxlint](https://oxc.rs/docs/guide/usage/linter) to enforce standard lint rules. To run the linter:
 
 ```bash
 pnpm --filter langchain lint
@@ -203,7 +203,7 @@ pnpm --filter langchain lint
 
 ### Formatting
 
-We use [oxfmt](https://oxc.rs/docs/guide/usage/formatter/) to enforce code formatting style. To run the formatter:
+We use [oxfmt](https://oxc.rs/docs/guide/usage/formatter) to enforce code formatting style. To run the formatter:
 
 ```bash
 pnpm format

--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -56,7 +56,7 @@ LangChain.js is written in TypeScript and can be used in:
 ## 📖 Additional Resources
 
 - [Getting started](https://docs.langchain.com/oss/javascript/langchain/overview): Installation, setting up the environment, simple examples
-- [Learn](https://docs.langchain.com/oss/javascript/langchain/learn): Learn about the core concepts of LangChain.
+- [Learn](https://docs.langchain.com/oss/javascript/learn): Learn about the core concepts of LangChain.
 - [LangChain Forum](https://forum.langchain.com): Connect with the community and share all of your technical questions, ideas, and feedback.
 - [Chat LangChain](https://chat.langchain.com): Ask questions & chat with our documentation.
 

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1962,3 +1962,82 @@ describe("document content block conversion", () => {
     expect(name1).not.toBe(name2);
   });
 });
+
+describe("convertToConverseMessages - empty AIMessage filtering", () => {
+  // Bedrock Converse API rejects messages with empty content arrays
+  // (ValidationException: "content: must be a non-empty array"). When an
+  // AIMessage has neither text content nor tool_calls, it must be dropped
+  // before being sent. See #11055.
+  test("drops AIMessage with empty string content and no tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Hi"),
+      new AIMessage({ content: "" }),
+      new HumanMessage("How are you?"),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+    expect(result.converseMessages[0].role).toBe("user");
+    expect(result.converseMessages[1].role).toBe("user");
+  });
+
+  test("drops AIMessage with empty content array and no tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Hi"),
+      new AIMessage({ content: [] }),
+      new HumanMessage("How are you?"),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+  });
+
+  test("keeps AIMessage with empty string content but with tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Get weather"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "getWeather",
+            args: { city: "Berkeley" },
+            id: "call_1",
+          },
+        ],
+      }),
+      new ToolMessage({ tool_call_id: "call_1", content: "70F" }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(3);
+    const assistantMsg = result.converseMessages[1];
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content).toHaveLength(1);
+    expect(assistantMsg.content![0]).toHaveProperty("toolUse");
+  });
+
+  test("keeps AIMessage with empty content array but with tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Get weather"),
+      new AIMessage({
+        content: [],
+        tool_calls: [
+          {
+            name: "getWeather",
+            args: { city: "Berkeley" },
+            id: "call_1",
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+    expect(result.converseMessages[1].content![0]).toHaveProperty("toolUse");
+  });
+
+  test("keeps AIMessage with normal text content", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({ content: "Hello back" }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(1);
+    expect(result.converseMessages[0].content![0]).toEqual({ text: "Hello back" });
+  });
+});

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -574,7 +574,7 @@ function convertSystemMessageToConverseMessage(
   );
 }
 
-function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
+function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message | null {
   if (msg.response_metadata?.output_version === "v1") {
     return {
       role: "assistant",
@@ -648,6 +648,19 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         },
       })),
     ];
+  }
+
+  // Bedrock Converse API rejects messages with empty content arrays
+  // (ValidationException: "content: must be a non-empty array"). This can
+  // happen when an AIMessage has neither text content nor tool_calls — e.g.
+  // an intermediate assistant message that was synthesised by a middleware
+  // hook without text. Drop the message entirely so the rest of the
+  // conversation can still go through.
+  if (
+    (!assistantMsg.content || assistantMsg.content.length === 0) &&
+    (!msg.tool_calls || msg.tool_calls.length === 0)
+  ) {
+    return null;
   }
 
   return assistantMsg;
@@ -767,7 +780,8 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
       } else {
         throw new Error(`Unsupported message type: ${msg.type}`);
       }
-    });
+    })
+    .filter((msg): msg is Bedrock.Message => msg !== null);
 
   // Combine consecutive user tool result messages into a single message
   const combinedConverseMessages = converseMessages.reduce<Bedrock.Message[]>(


### PR DESCRIPTION
Bedrock Converse API rejects messages with empty content arrays ("ValidationException: content: must be a non-empty array"). When an AIMessage has neither text content nor tool_calls — common with intermediate assistant turns synthesised by middleware hooks — convertAIMessageToConverseMessage produced a Bedrock.Message with content: [] that the SDK sent verbatim.

Return null from convertAIMessageToConverseMessage for empty AIMessages and filter nulls in convertToConverseMessages. AIMessages that have tool_calls but empty content are still preserved (tool_use blocks alone satisfy Bedrock's content requirement).

5 new tests cover the four empty-AIMessage shapes (empty string content, empty content array, each with and without tool_calls) plus a sanity check that normal text content still passes through. All 62 tests in chat_models.test.ts pass.

Fixes #11055.