### PR TITLE
fix(core): remap provider tool_call indices so they don't collide with text

### DIFF
--- a/.changeset/fix-compat-tool-call-index-collision.md
+++ b/.changeset/fix-compat-tool-call-index-collision.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): remap provider tool_call indices so they do not collide with parallel blocks

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -148,6 +148,11 @@ export async function* convertChunksToEvents(
     number,
     { type: string; accumulated: ContentBlock }
   >();
+  // Map from a tool_call chunk's provider index/id to its remapped content
+  // block index. Provider tool_call indices are scoped to the tool_call list,
+  // so we can't reuse them as the content-block index (would collide with
+  // text at the same indices). See #11074.
+  const toolCallBlockIndexes = new Map<string, number>();
   let messageStarted = false;
   let lastUsage:
     | { input_tokens: number; output_tokens: number; total_tokens: number }
@@ -238,11 +243,26 @@ export async function* convertChunksToEvents(
       msg.tool_call_chunks &&
       msg.tool_call_chunks.length > 0
     ) {
+      // Provider tool-call indexes are scoped to the tool-call list, not to
+      // all content blocks. Without remapping, a streamed tool_call with
+      // index 0 collides with the text block (also index 0) and the second
+      // tool_call's index 1 collides with whatever happens to be at index 1.
+      // Remap tool_call chunks to fresh block indices so text and tool_calls
+      // share no block index. #11074
       for (const toolChunk of msg.tool_call_chunks) {
-        const blockIndex =
+        const toolCallKey =
           typeof toolChunk.index === "number"
-            ? toolChunk.index
-            : activeBlocks.size;
+            ? `index:${toolChunk.index}`
+            : typeof toolChunk.id === "string"
+              ? `id:${toolChunk.id}`
+              : `next:${toolCallBlockIndexes.size}`;
+
+        let blockIndex = toolCallBlockIndexes.get(toolCallKey);
+
+        if (blockIndex === undefined) {
+          blockIndex = nextBlockIndex(activeBlocks);
+          toolCallBlockIndexes.set(toolCallKey, blockIndex);
+        }
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {

--- a/libs/langchain-core/src/language_models/tests/compat.test.ts
+++ b/libs/langchain-core/src/language_models/tests/compat.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "vitest";
+import { AIMessageChunk } from "../../messages/ai.js";
+import { ChatGenerationChunk } from "../../outputs.js";
+import { convertChunksToEvents } from "../compat.js";
+import type { ContentBlock } from "../../messages/content/index.js";
+
+function chunkWith(
+  content: string | Array<Record<string, unknown>>,
+  toolCallChunks: AIMessageChunk["tool_call_chunks"] = []
+): ChatGenerationChunk {
+  const message = new AIMessageChunk({
+    content: content as never,
+    tool_call_chunks: toolCallChunks,
+  });
+  return new ChatGenerationChunk({ message, text: "" });
+}
+
+async function collectEvents(
+  gen: AsyncGenerator<unknown>
+): Promise<Array<Record<string, unknown>>> {
+  const out: Array<Record<string, unknown>> = [];
+  for await (const ev of gen) out.push(ev as Record<string, unknown>);
+  return out;
+}
+
+describe("convertChunksToEvents - tool_call index collision (issue #11074)", () => {
+  test("text + tool_call do not share block index 0", async () => {
+    // Provider tool-call index is scoped to the tool-call list, so a
+    // tool_call with `index: 0` must not collide with the text block
+    // (which also implicitly sits at index 0).
+    const chunks = [
+      chunkWith("I will call a tool", [
+        { index: 0, id: "call_1", name: "eval", args: '{"code"' },
+      ]),
+      chunkWith("", [
+        { index: 0, args: ':"new Date()"}' },
+      ]),
+    ];
+
+    const events = await collectEvents(
+      convertChunksToEvents((async function* () {
+        for (const c of chunks) yield c;
+      })())
+    );
+
+    const blockStarts = events
+      .filter((e) => e.event === "content-block-start")
+      .map((e) => ({ index: e.index, type: (e.content as ContentBlock).type }));
+
+    // Two distinct blocks: text (no provider index) and tool_call
+    // (provider index 0). They must not share an event index.
+    expect(blockStarts).toHaveLength(2);
+    expect(new Set(blockStarts.map((b) => b.index)).size).toBe(2);
+    expect(blockStarts.find((b) => b.type === "text")).toBeDefined();
+    expect(
+      blockStarts.find((b) => b.type === "tool_call_chunk")
+    ).toBeDefined();
+
+    // The accumulated tool_call args should still parse to the full JSON.
+    const toolFinish = events.find(
+      (e) =>
+        e.event === "content-block-finish" &&
+        ((e.content as ContentBlock).type === "tool_call" ||
+          (e.content as ContentBlock).type === "invalid_tool_call")
+    );
+    expect(toolFinish).toBeDefined();
+    expect((toolFinish!.content as ContentBlock.Tools.ToolCall).args).toEqual({
+      code: "new Date()",
+    });
+  });
+
+  test("two parallel tool_calls get distinct block indices", async () => {
+    // A second tool_call (provider index 1) must get its own block —
+    // no collision with the first tool_call (provider index 0).
+    const chunks = [
+      chunkWith("", [{ index: 0, id: "call_a", name: "fn_a", args: "{}" }]),
+      chunkWith("", [{ index: 1, id: "call_b", name: "fn_b", args: "{}" }]),
+    ];
+
+    const events = await collectEvents(
+      convertChunksToEvents((async function* () {
+        for (const c of chunks) yield c;
+      })())
+    );
+
+    const toolStarts = events
+      .filter(
+        (e) =>
+          e.event === "content-block-start" &&
+          (e.content as ContentBlock).type === "tool_call_chunk"
+      )
+      .map((e) => e.index);
+
+    expect(toolStarts).toHaveLength(2);
+    expect(new Set(toolStarts).size).toBe(2);
+  });
+
+  test("single tool_call with index 0 still works", async () => {
+    // Regression guard: the original happy path (only one tool_call)
+    // continues to produce a single tool_call block.
+    const chunks = [
+      chunkWith("", [{ index: 0, id: "call_x", name: "fn_x", args: '{"a":1}' }]),
+    ];
+
+    const events = await collectEvents(
+      convertChunksToEvents((async function* () {
+        for (const c of chunks) yield c;
+      })())
+    );
+
+    const toolStarts = events.filter(
+      (e) =>
+        e.event === "content-block-start" &&
+        (e.content as ContentBlock).type === "tool_call_chunk"
+    );
+    expect(toolStarts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Provider tool_call indices are scoped to the tool_call list, not the content block list. convertChunksToEvents was using them directly as content-block indices, so a streamed tool_call with index 0 collided with the text block (also at index 0). The second chunk's tool_call_args replaced the text, AIMessage.tool_calls was empty, and the agent never invoked the tool.

Map each tool_call chunk to a fresh block index via nextBlockIndex(), cached by provider index (falling back to id, then sequence). Text and tool_calls now share no block index.

3 new tests: text+tool_call collision, two parallel tool_calls, single-tool_call happy path.

Fixes #11074.