### PR TITLE
fix(core): preserve functionCall.id on Gemini tool_call content blocks

### DIFF
--- a/.changeset/fix-google-genai-functioncall-id.md
+++ b/.changeset/fix-google-genai-functioncall-id.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve functionCall.id on Gemini tool_call translation

--- a/libs/langchain-core/src/messages/block_translators/google_genai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_genai.ts
@@ -45,9 +45,18 @@ function convertToV1FromChatGoogleMessage(
         _isString(block.functionCall.name) &&
         _isObject(block.functionCall.args)
       ) {
+        // Gemini's native functionCall blocks carry their own id field.
+        // Prefer it over the AIMessage-level id so `contentBlocks[i].id`
+        // matches the same id reported by `tool_calls[i].id` and by the
+        // agent loop when matching responses. Falls back to message.id
+        // for backwards compatibility with blocks that don't include id.
+        const functionCallId =
+          typeof block.functionCall.id === "string"
+            ? block.functionCall.id
+            : message.id;
         yield {
           type: "tool_call",
-          id: message.id,
+          id: functionCallId,
           name: block.functionCall.name,
           args: block.functionCall.args,
         };

--- a/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
@@ -150,4 +150,60 @@ describe("ChatGoogleGenAITranslator", () => {
       },
     ]);
   });
+
+  // Regression test for https://github.com/langchain-ai/langchainjs/issues/11110 —
+  // Gemini's native functionCall blocks carry an id field, but
+  // ChatGoogleGenAITranslator was using `message.id` (the AIMessage's
+  // top-level id) instead. The result: `contentBlocks[i].id` was
+  // undefined for every tool_call while `tool_calls[i].id` had the
+  // Gemini id. Agents matching tool calls by contentBlock.id failed.
+  it("should preserve functionCall.id on the tool_call content block", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google-genai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
+  it("should fall back to message.id when functionCall.id is missing", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      id: "msg_42",
+      response_metadata: { model_provider: "google-genai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "msg_42",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Gemini's native functionCall blocks carry their own id field, but ChatGoogleGenAITranslator.translateContent used `message.id` (the AIMessage-level id) as the tool_call id. The result: `contentBlocks[i].id` was undefined for every tool_call while `tool_calls[i].id` had the Gemini id. Agent loops that match tool responses by contentBlock.id silently dropped them.

Prefer `functionCall.id` when present, fall back to `message.id` when not.

2 new tests cover the functionCall.id path and the message.id fallback.

Fixes #11110.