### PR TITLE
docs(libs/langchain): fix dead Learn link in README

### DIFF
--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -56,7 +56,7 @@ LangChain.js is written in TypeScript and can be used in:
 ## 📖 Additional Resources
 
 - [Getting started](https://docs.langchain.com/oss/javascript/langchain/overview): Installation, setting up the environment, simple examples
-- [Learn](https://docs.langchain.com/oss/javascript/langchain/learn): Learn about the core concepts of LangChain.
+- [Learn](https://docs.langchain.com/oss/javascript/learn): Learn about the core concepts of LangChain.
 - [LangChain Forum](https://forum.langchain.com): Connect with the community and share all of your technical questions, ideas, and feedback.
 - [Chat LangChain](https://chat.langchain.com): Ask questions & chat with our documentation.
 


### PR DESCRIPTION
Replaces `docs.langchain.com/oss/javascript/langchain/learn` (404) with `docs.langchain.com/oss/javascript/learn` (200) in `libs/langchain/README.md`. The Learn page moved up to the docs root. Follow-up to #11089 which missed this specific URL.