### PR TITLE
fix(@langchain/aws): drop empty AIMessages to avoid Converse API ValidationException

### DIFF
--- a/.changeset/fix-aws-empty-aimessages.md
+++ b/.changeset/fix-aws-empty-aimessages.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(@langchain/aws): drop empty AIMessages to avoid Converse API ValidationException

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1962,3 +1962,82 @@ describe("document content block conversion", () => {
     expect(name1).not.toBe(name2);
   });
 });
+
+describe("convertToConverseMessages - empty AIMessage filtering", () => {
+  // Bedrock Converse API rejects messages with empty content arrays
+  // (ValidationException: "content: must be a non-empty array"). When an
+  // AIMessage has neither text content nor tool_calls, it must be dropped
+  // before being sent. See #11055.
+  test("drops AIMessage with empty string content and no tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Hi"),
+      new AIMessage({ content: "" }),
+      new HumanMessage("How are you?"),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+    expect(result.converseMessages[0].role).toBe("user");
+    expect(result.converseMessages[1].role).toBe("user");
+  });
+
+  test("drops AIMessage with empty content array and no tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Hi"),
+      new AIMessage({ content: [] }),
+      new HumanMessage("How are you?"),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+  });
+
+  test("keeps AIMessage with empty string content but with tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Get weather"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "getWeather",
+            args: { city: "Berkeley" },
+            id: "call_1",
+          },
+        ],
+      }),
+      new ToolMessage({ tool_call_id: "call_1", content: "70F" }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(3);
+    const assistantMsg = result.converseMessages[1];
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content).toHaveLength(1);
+    expect(assistantMsg.content![0]).toHaveProperty("toolUse");
+  });
+
+  test("keeps AIMessage with empty content array but with tool_calls", () => {
+    const result = convertToConverseMessages([
+      new HumanMessage("Get weather"),
+      new AIMessage({
+        content: [],
+        tool_calls: [
+          {
+            name: "getWeather",
+            args: { city: "Berkeley" },
+            id: "call_1",
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(2);
+    expect(result.converseMessages[1].content![0]).toHaveProperty("toolUse");
+  });
+
+  test("keeps AIMessage with normal text content", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({ content: "Hello back" }),
+    ]);
+
+    expect(result.converseMessages).toHaveLength(1);
+    expect(result.converseMessages[0].content![0]).toEqual({ text: "Hello back" });
+  });
+});

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -574,7 +574,7 @@ function convertSystemMessageToConverseMessage(
   );
 }
 
-function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
+function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message | null {
   if (msg.response_metadata?.output_version === "v1") {
     return {
       role: "assistant",
@@ -648,6 +648,19 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         },
       })),
     ];
+  }
+
+  // Bedrock Converse API rejects messages with empty content arrays
+  // (ValidationException: "content: must be a non-empty array"). This can
+  // happen when an AIMessage has neither text content nor tool_calls — e.g.
+  // an intermediate assistant message that was synthesised by a middleware
+  // hook without text. Drop the message entirely so the rest of the
+  // conversation can still go through.
+  if (
+    (!assistantMsg.content || assistantMsg.content.length === 0) &&
+    (!msg.tool_calls || msg.tool_calls.length === 0)
+  ) {
+    return null;
   }
 
   return assistantMsg;
@@ -767,7 +780,8 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
       } else {
         throw new Error(`Unsupported message type: ${msg.type}`);
       }
-    });
+    })
+    .filter((msg): msg is Bedrock.Message => msg !== null);
 
   // Combine consecutive user tool result messages into a single message
   const combinedConverseMessages = converseMessages.reduce<Bedrock.Message[]>(


### PR DESCRIPTION
Bedrock's `converse` API rejects a message whose `content` is an empty array. When the upstream message stream yields an `AIMessage` with no content and no tool_calls, `formatConverseInputMessages` would forward that empty-content record and the call would fail with `ValidationException: Message: Content blocks are empty`.

This drops the empty `AIMessage` from the formatted input before posting. The provider still synthesizes a normal assistant turn when there is real content, and tool calls are unaffected.

Closes the user-reported failure mode. Adds unit tests covering the empty-AIMessage and the non-empty-AIMessage paths.