### PR TITLE
fix(core): avoid stream tool call block collisions

### DIFF
--- a/.changeset/stream-tool-call-indexes.md
+++ b/.changeset/stream-tool-call-indexes.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Fix legacy stream conversion when text and tool call chunks share provider indexes.

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -154,6 +154,7 @@ export async function* convertChunksToEvents(
     | undefined;
   let audioStream: AudioStreamState | undefined;
   const emittedImageKeys = new Set<string>();
+  const toolCallBlockIndexes = new Map<string, number>();
 
   for await (const chunk of chunks) {
     options?.signal?.throwIfAborted();
@@ -239,10 +240,22 @@ export async function* convertChunksToEvents(
       msg.tool_call_chunks.length > 0
     ) {
       for (const toolChunk of msg.tool_call_chunks) {
-        const blockIndex =
+        const blockKeys = [
           typeof toolChunk.index === "number"
-            ? toolChunk.index
-            : activeBlocks.size;
+            ? `index:${toolChunk.index}`
+            : undefined,
+          typeof toolChunk.id === "string" ? `id:${toolChunk.id}` : undefined,
+        ].filter((key): key is string => key != null);
+        let blockIndex = blockKeys
+          .map((key) => toolCallBlockIndexes.get(key))
+          .find((index): index is number => index != null);
+
+        if (blockIndex == null) {
+          blockIndex = nextBlockIndex(activeBlocks);
+        }
+        for (const key of blockKeys) {
+          toolCallBlockIndexes.set(key, blockIndex);
+        }
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {
@@ -250,7 +263,10 @@ export async function* convertChunksToEvents(
             id: toolChunk.id,
             name: toolChunk.name,
             args: "",
-            index: blockIndex,
+            index:
+              typeof toolChunk.index === "number"
+                ? toolChunk.index
+                : blockIndex,
           };
           activeBlocks.set(blockIndex, {
             type: "tool_call_chunk",

--- a/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
@@ -169,6 +169,44 @@ class FakeToolCallStreamModel extends BaseChatModel {
   }
 }
 
+class FakeTextAndToolCallStreamModel extends BaseChatModel {
+  _llmType() {
+    return "fake-text-and-tool-stream";
+  }
+
+  async _generate(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return { generations: [] };
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: "Checking",
+        id: "msg_text_and_tools",
+        tool_call_chunks: [
+          { id: "call_1", name: "search", args: "", index: 0 },
+        ],
+      }),
+      text: "Checking",
+    });
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: "",
+        tool_call_chunks: [{ args: '{"q":"hello"}', index: 0 }],
+      }),
+      text: "",
+    });
+  }
+}
+
 /**
  * A model that yields chunks with usage_metadata.
  */
@@ -488,6 +526,28 @@ describe("_streamChatModelEvents bridge", () => {
       expect(toolFinish).toBeDefined();
       expect(toolFinish!.content.name).toBe("search");
       expect(toolFinish!.content.args).toEqual({ q: "hello" });
+    });
+
+    test("keeps text and tool call chunks in separate content blocks", async () => {
+      const model = new FakeTextAndToolCallStreamModel({});
+      const message = await model.streamEvents("Hello");
+
+      expect(message.tool_calls).toHaveLength(1);
+      expect(message.tool_calls?.[0]).toMatchObject({
+        id: "call_1",
+        name: "search",
+        args: { q: "hello" },
+      });
+
+      const content = message.content as ContentBlock[];
+      expect(content).toHaveLength(2);
+      expect(content[0]).toMatchObject({ type: "text", text: "Checking" });
+      expect(content[1]).toMatchObject({
+        type: "tool_call",
+        id: "call_1",
+        name: "search",
+        args: { q: "hello" },
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #11074.

## Summary
- map legacy `tool_call_chunks` provider indexes to independent content block indexes
- keep streamed text and tool calls in separate content blocks when their indexes overlap
- add regression coverage and a patch changeset for `@langchain/core`

## Testing
- `pnpm --filter @langchain/core test src/language_models/tests/stream_bridge.test.ts`
- `pnpm --filter @langchain/core build`
- `pnpm exec oxfmt --check libs/langchain-core/src/language_models/compat.ts libs/langchain-core/src/language_models/tests/stream_bridge.test.ts .changeset/stream-tool-call-indexes.md`
- `pnpm exec oxlint libs/langchain-core/src/language_models/compat.ts libs/langchain-core/src/language_models/tests/stream_bridge.test.ts`
- `git diff --check`
- `pnpm changeset status --since main`