### PR TITLE
fix(weaviate): set integration header to langchain-typescript

### DIFF
--- a/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-weaviate/src/tests/vectorstores.test.ts
@@ -77,7 +77,7 @@ test("registers the X-Weaviate-Client-Integration header via getConnectionDetail
   // Mutates the live headers object by reference, so subsequent client requests
   // carry the telemetry header on both transports.
   expect(headers["X-Weaviate-Client-Integration"]).toBe(
-    `langchain/${__PKG_VERSION__}`
+    `langchain-typescript/${__PKG_VERSION__}`
   );
 });
 

--- a/libs/providers/langchain-weaviate/src/vectorstores.ts
+++ b/libs/providers/langchain-weaviate/src/vectorstores.ts
@@ -88,12 +88,11 @@ export interface WeaviateLibArgs {
 }
 
 /**
- * Integration identifier reported to Weaviate telemetry. Matches the Python
- * `langchain-weaviate` integration: the value is intentionally just `langchain`
- * (not language-specific) since language disambiguation is already carried by
- * the client's own `X-Weaviate-Client` header.
+ * Integration identifier reported to Weaviate telemetry. The value is
+ * `langchain-typescript` so Weaviate can distinguish the TypeScript integration
+ * from the Python `langchain` integration in telemetry.
  */
-const INTEGRATION_NAME = "langchain";
+const INTEGRATION_NAME = "langchain-typescript";
 
 /**
  * Telemetry header that tags the connection so Weaviate can track langchain
@@ -109,7 +108,8 @@ const INTEGRATION_HEADER = "X-Weaviate-Client-Integration";
  * `integrations.configure(...)` API. However, `getConnectionDetails()` returns
  * the client's live `headers` object by reference, and the client spreads that
  * same object into every HTTP and gRPC request. Mutating it therefore tags all
- * subsequent requests with `X-Weaviate-Client-Integration: langchain/<version>`
+ * subsequent requests with `X-Weaviate-Client-Integration:
+ * langchain-typescript/<version>`
  * without depending on any private internals. The whole thing is wrapped so a
  * future change to the client's shape silently skips registration instead of
  * breaking store construction.


### PR DESCRIPTION
## Description

Changes the Weaviate telemetry integration identifier from `langchain` to `langchain-typescript`.

The `X-Weaviate-Client-Integration` header now reports `langchain-typescript/<version>` instead of `langchain/<version>`, allowing Weaviate to distinguish the TypeScript integration from the Python `langchain` integration in telemetry.

## Changes

- `INTEGRATION_NAME` in `vectorstores.ts` updated to `langchain-typescript`
- Updated the (now stale) doc comments that explained the value was intentionally language-agnostic
- Updated the unit test assertion accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)