### PR TITLE
fix(core): preserve function call ids in content blocks

### DIFF
--- a/.changeset/clever-calls-remember.md
+++ b/.changeset/clever-calls-remember.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Preserve native function call ids when translating provider function call parts into standard tool call content blocks.

--- a/libs/langchain-core/src/messages/block_translators/google.ts
+++ b/libs/langchain-core/src/messages/block_translators/google.ts
@@ -71,7 +71,9 @@ function convertToV1FromChatGoogleMessage(
         ) {
           return {
             type: "tool_call",
-            id: message.id,
+            id: _isString(block.functionCall.id)
+              ? block.functionCall.id
+              : message.id,
             name: block.functionCall.name,
             args: block.functionCall.args,
           };

--- a/libs/langchain-core/src/messages/block_translators/google_genai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_genai.ts
@@ -47,7 +47,9 @@ function convertToV1FromChatGoogleMessage(
       ) {
         yield {
           type: "tool_call",
-          id: message.id,
+          id: _isString(block.functionCall.id)
+            ? block.functionCall.id
+            : message.id,
           name: block.functionCall.name,
           args: block.functionCall.args,
         };

--- a/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
@@ -62,8 +62,7 @@ describe("ChatGoogleTranslator", () => {
   });
 
   it("should merge thoughtSignature from originalTextContentBlock into array content", () => {
-    // This is THE BUG FIX scenario: streaming with thinking models causes
-    // content to be an array, but thoughtSignature only ends up in
+    // Streaming with thinking models can keep thoughtSignature in
     // originalTextContentBlock, not in the content blocks themselves.
     const message = new AIMessage({
       content: [
@@ -114,6 +113,57 @@ describe("ChatGoogleTranslator", () => {
 
     expect(message.contentBlocks).toEqual([
       { type: "text", text: "Hello world" },
+    ]);
+  });
+
+  it("should preserve function call ids in tool call content blocks", () => {
+    const message = new AIMessage({
+      id: "message-id",
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "call-abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "call-abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
+  it("should fall back to the message id when function call ids are missing", () => {
+    const message = new AIMessage({
+      id: "message-id",
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "message-id",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
     ]);
   });
 

--- a/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
@@ -150,4 +150,55 @@ describe("ChatGoogleGenAITranslator", () => {
       },
     ]);
   });
+
+  it("should preserve function call ids in tool call content blocks", () => {
+    const message = new AIMessage({
+      id: "message-id",
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "call-abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google-genai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "call-abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
+  it("should fall back to the message id when function call ids are missing", () => {
+    const message = new AIMessage({
+      id: "message-id",
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google-genai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "message-id",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve provider function call ids when translating function call parts into standard tool call content blocks
- keep the existing message id fallback when a function call part has no id
- add regression coverage for both affected translators

Fixes #11110

## Testing
- `pnpm --filter @langchain/core test src/messages/block_translators/tests/google.test.ts src/messages/block_translators/tests/google_genai.test.ts`
- `pnpm --filter @langchain/core build`
- `pnpm format:check libs/langchain-core/src/messages/block_translators/google.ts libs/langchain-core/src/messages/block_translators/google_genai.ts libs/langchain-core/src/messages/block_translators/tests/google.test.ts libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts .changeset/clever-calls-remember.md`
- `pnpm lint libs/langchain-core/src/messages/block_translators/google.ts libs/langchain-core/src/messages/block_translators/google_genai.ts libs/langchain-core/src/messages/block_translators/tests/google.test.ts libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts`
- `git diff --check`