### PR TITLE
fix(perplexity): serialize text content blocks

### DIFF
--- a/.changeset/thin-socks-whisper.md
+++ b/.changeset/thin-socks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Fix ChatPerplexity serialization for text content blocks.

--- a/libs/providers/langchain-perplexity/src/chat_models.ts
+++ b/libs/providers/langchain-perplexity/src/chat_models.ts
@@ -227,6 +227,21 @@ function _useResponsesApi(payload: Record<string, unknown>): boolean {
   return Boolean(usesBuiltin || hasResponsesOnly);
 }
 
+function messageContentToString(message: BaseMessage): string {
+  if (typeof message.content === "string") return message.content;
+
+  const textParts: string[] = [];
+  for (const block of message.contentBlocks) {
+    if (block.type !== "text") {
+      throw new Error(
+        `ChatPerplexity only supports text content blocks. Received block type: ${block.type}`
+      );
+    }
+    textParts.push(block.text);
+  }
+  return textParts.join("");
+}
+
 /**
  * Map a Perplexity Agent API (Responses-compatible) response to a `ChatResult`.
  */
@@ -549,17 +564,17 @@ export class ChatPerplexity
     if (message._getType() === "human") {
       return {
         role: "user",
-        content: message.content.toString(),
+        content: messageContentToString(message),
       };
     } else if (message._getType() === "ai") {
       return {
         role: "assistant",
-        content: message.content.toString(),
+        content: messageContentToString(message),
       };
     } else if (message._getType() === "system") {
       return {
         role: "system",
-        content: message.content.toString(),
+        content: messageContentToString(message),
       };
     }
     throw new Error(`Unknown message type: ${message}`);

--- a/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
@@ -289,6 +289,39 @@ describe("ChatPerplexity", () => {
       );
     });
 
+    test("serializes text content blocks as text", async () => {
+      const model = new ChatPerplexity({
+        model: "sonar",
+        apiKey: "test-key",
+      });
+
+      const createSpy = vi
+        .spyOn(
+          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+          (model as any).client.chat.completions,
+          "create"
+        )
+        .mockResolvedValue({
+          choices: [{ message: { role: "assistant", content: "4" } }],
+          citations: [],
+        });
+
+      await model._generate(
+        [
+          new HumanMessage({
+            contentBlocks: [{ type: "text", text: "What is 2+2?" }],
+          }),
+        ],
+        {}
+      );
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [{ role: "user", content: "What is 2+2?" }],
+        })
+      );
+    });
+
     test("throws on unknown message type", async () => {
       const model = new ChatPerplexity({
         model: "sonar",


### PR DESCRIPTION
Fixes #9913.

## Summary
- serialize text content blocks to plain text before sending Chat Completions requests
- avoid sending `[object Object]` for `HumanMessage({ contentBlocks: [...] })`
- add a regression test for the outgoing request payload

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @langchain/core build`
- `pnpm --filter @langchain/perplexity test src/tests/chat_models.test.ts`
- `pnpm --filter @langchain/perplexity build`
- `pnpm exec oxlint libs/providers/langchain-perplexity/src/chat_models.ts libs/providers/langchain-perplexity/src/tests/chat_models.test.ts`
- `pnpm exec oxfmt --check libs/providers/langchain-perplexity/src/chat_models.ts libs/providers/langchain-perplexity/src/tests/chat_models.test.ts .changeset/thin-socks-whisper.md`
- `git diff --check`
