### PR TITLE
fix(openai): normalize provider tool call blocks

### DIFF
--- a/.changeset/proud-actors-run.md
+++ b/.changeset/proud-actors-run.md
@@ -1,0 +1,6 @@
+---
+"@langchain/google-genai": patch
+"@langchain/openai": patch
+---
+
+Prevent provider-specific tool call content blocks from leaking into OpenAI Chat Completions requests.

--- a/libs/providers/langchain-google-genai/src/tests/common.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/common.test.ts
@@ -129,6 +129,40 @@ describe("Thinking content handling", () => {
     expect(typeof result.generations[0].message.content).toBe("string");
     expect(result.generations[0].message.content).toBe("Regular response");
   });
+
+  test("should mark non-streaming function calls with the provider metadata", () => {
+    const mockResponse = createMockResponse([
+      {
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                name: "lookup",
+                args: { city: "Paris" },
+              },
+            },
+          ] as GoogleGenerativeAIPart[],
+        },
+        finishReason: "STOP" as FinishReason,
+        index: 0,
+        safetyRatings: [],
+      },
+    ]);
+
+    const result = mapGenerateContentResultToChatResult(mockResponse);
+    const message = result.generations[0].message;
+
+    expect(message.response_metadata.model_provider).toBe("google-genai");
+    expect(message.tool_calls).toHaveLength(1);
+    expect(message.tool_calls?.[0]).toEqual(
+      expect.objectContaining({
+        type: "tool_call",
+        name: "lookup",
+        args: { city: "Paris" },
+      })
+    );
+  });
 });
 
 describe("Streaming thinking content handling", () => {

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -753,6 +753,9 @@ export function mapGenerateContentResultToChatResult(
         ...generationInfo,
         [_FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY]: functionThoughtSignatures,
       },
+      response_metadata: {
+        model_provider: "google-genai",
+      },
       usage_metadata: extra?.usageMetadata,
     }),
     generationInfo,

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -787,8 +787,11 @@ export const convertMessagesToCompletionsMessageParams: Converter<
 > = ({ messages, model }) => {
   return messages.flatMap((message) => {
     if (
-      "output_version" in message.response_metadata &&
-      message.response_metadata?.output_version === "v1"
+      ("output_version" in message.response_metadata &&
+        message.response_metadata?.output_version === "v1") ||
+      (Array.isArray(message.content) &&
+        "model_provider" in message.response_metadata &&
+        typeof message.response_metadata.model_provider === "string")
     ) {
       return convertStandardContentMessageToCompletionsMessage({ message });
     }

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -363,6 +363,50 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
+    it("should normalize provider-specific tool call content blocks", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "functionCall",
+            functionCall: {
+              name: "greet",
+              args: { name: "John" },
+            },
+          },
+        ],
+        tool_calls: [
+          {
+            id: "call_123",
+            name: "greet",
+            args: { name: "John" },
+          },
+        ],
+        response_metadata: {
+          model_provider: "google-genai",
+        },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        role: "assistant",
+        content: [],
+        tool_calls: [
+          {
+            id: "call_123",
+            type: "function",
+            function: {
+              name: "greet",
+              arguments: '{"name":"John"}',
+            },
+          },
+        ],
+      });
+    });
+
     it("should preserve content with function_call in additional_kwargs", () => {
       const message = new AIMessage({
         content: "Let me call a function for you.",


### PR DESCRIPTION
Fixes #9705

## Summary
- tag non-streaming Google GenAI chat results with provider metadata
- route provider-tagged structured assistant content through the standard content converter before OpenAI Chat Completions serialization
- add regression coverage for the mapper metadata and OpenAI tool-call request payload

## Testing
- pnpm --filter @langchain/openai test src/converters/tests/completions.test.ts
- pnpm --filter @langchain/google-genai test src/tests/common.test.ts
- pnpm --filter @langchain/openai build
- pnpm --filter @langchain/google-genai build
- pnpm exec oxlint libs/providers/langchain-openai/src/converters/completions.ts libs/providers/langchain-openai/src/converters/tests/completions.test.ts libs/providers/langchain-google-genai/src/utils/common.ts libs/providers/langchain-google-genai/src/tests/common.test.ts
- pnpm exec oxfmt --check libs/providers/langchain-openai/src/converters/completions.ts libs/providers/langchain-openai/src/converters/tests/completions.test.ts libs/providers/langchain-google-genai/src/utils/common.ts libs/providers/langchain-google-genai/src/tests/common.test.ts .changeset/proud-actors-run.md
- git diff --check