### PR TITLE
fix(core): avoid duplicate v1 AI message content

### DIFF
--- a/.changeset/calm-maps-smile.md
+++ b/.changeset/calm-maps-smile.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Avoid duplicating v1 AI message content blocks during serialization.

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -105,9 +105,10 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
         initParams.response_metadata.output_version === "v1" &&
         initParams.content !== undefined
       ) {
-        initParams.contentBlocks =
+        const contentBlocks =
           initParams.content as Array<ContentBlock.Standard>;
-        initParams.content = undefined;
+        delete initParams.content;
+        initParams.contentBlocks = contentBlocks;
       }
 
       if (initParams.contentBlocks !== undefined) {

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -80,6 +80,27 @@ describe("AIMessage", () => {
     ]);
   });
 
+  it("should serialize v1 content blocks once", () => {
+    const message = new AIMessage({
+      content: [{ type: "text", text: "Hi there!" }],
+      response_metadata: {
+        output_version: "v1",
+      },
+    });
+    const serialized = message.toJSON();
+
+    expect(serialized.type).toBe("constructor");
+    if (serialized.type !== "constructor") {
+      throw new Error("Expected AIMessage to serialize as a constructor");
+    }
+    expect(serialized.kwargs).not.toHaveProperty("content");
+    expect(serialized.kwargs).toMatchObject({
+      content_blocks: [{ type: "text", text: "Hi there!" }],
+      response_metadata: { output_version: "v1" },
+    });
+    expect(JSON.stringify(serialized).match(/Hi there!/g)).toHaveLength(1);
+  });
+
   describe(".contentBlocks", () => {
     it("should have tool call content blocks from .tool_calls", () => {
       const message = new AIMessage({


### PR DESCRIPTION
Fixes #10558

## Description

`AIMessage` with `response_metadata.output_version === "v1"` converts `content` into `contentBlocks` before serialization. The constructor was leaving a `content` key in `lc_kwargs`, so `.toJSON()` emitted the same block as both `content` and `content_blocks`.

This removes the migrated constructor `content` key before serialization captures kwargs, preserving `content_blocks` as the single serialized v1 payload.

## Testing

- `pnpm --filter @langchain/core test src/messages/tests/ai.test.ts`
- `pnpm --filter @langchain/core build`
- Repro: v1 `AIMessage.toJSON()` now reports `occurrences 1` and kwargs omit `content`.