### PR TITLE
fix(pgvector): return similarity score by default in similaritySearchWithScore

### DIFF
--- a/.changeset/pgvector-similarity-score-default.md
+++ b/.changeset/pgvector-similarity-score-default.md
@@ -1,0 +1,9 @@
+---
+"@langchain/pgvector": minor
+---
+
+**Breaking change:** `PGVectorStore.similaritySearchWithScore` now returns normalized similarity scores (1 = exact match, 0 = no similarity) instead of raw pgvector distance values (0 = exact match).
+
+The `scoreNormalization` option now defaults to `"similarity"` instead of `"distance"`. To restore the previous behavior, pass `scoreNormalization: "distance"` in the constructor options.
+
+For cosine distance (the default), similarity is computed as `(2 - distance) / 2`, mapping the full pgvector range [0, 2] to [1, 0]. This is consistent with other vector store implementations in LangChain.js where higher scores mean more similar.

--- a/libs/providers/langchain-pgvector/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-pgvector/src/tests/vectorstores.test.ts
@@ -112,7 +112,7 @@ describe("PGVectorStore", () => {
       expect(store.skipInitializationCheck).toBe(false);
       expect(store.chunkSize).toBe(500);
       expect(store.distanceStrategy).toBe("cosine");
-      expect(store.scoreNormalization).toBe("distance");
+      expect(store.scoreNormalization).toBe("similarity");
     });
 
     test("accepts custom chunkSize", () => {
@@ -400,7 +400,65 @@ describe("PGVectorStore", () => {
       expect(results[0][0].pageContent).toBe("hello world");
       expect(results[0][0].metadata).toEqual({ key: "value" });
       expect(results[0][0].id).toBe("uuid-1");
-      expect(results[0][1]).toBe(0.1);
+      expect(results[0][1]).toBe(0.95);
+    });
+
+    test("returns similarity score of 1.0 for exact match (distance 0.0) by default", async () => {
+      const pool = createMockPool();
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            id: "uuid-exact",
+            text: "exact match",
+            metadata: {},
+            embedding: "[0.1,0.2,0.3]",
+            _distance: 0.0,
+          },
+        ],
+      });
+
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      const results = await store.similaritySearchVectorWithScore(
+        [0.1, 0.2, 0.3],
+        1
+      );
+
+      expect(results).toHaveLength(1);
+      // cosine similarity = (2 - distance) / 2; distance 0.0 => similarity 1.0
+      expect(results[0][1]).toBe(1.0);
+    });
+
+    test("returns similarity score of 0.75 for cosine distance 0.5 by default", async () => {
+      const pool = createMockPool();
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            id: "uuid-half",
+            text: "half similar",
+            metadata: {},
+            embedding: "[0.1,0.2,0.3]",
+            _distance: 0.5,
+          },
+        ],
+      });
+
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      const results = await store.similaritySearchVectorWithScore(
+        [0.1, 0.2, 0.3],
+        1
+      );
+
+      expect(results).toHaveLength(1);
+      // cosine similarity = (2 - distance) / 2; distance 0.5 => similarity 0.75
+      expect(results[0][1]).toBe(0.75);
     });
 
     test("applies metadata filter", async () => {
@@ -589,9 +647,9 @@ describe("PGVectorStore", () => {
       expect(store.convertDistanceToScore(-5)).toBe(5);
     });
 
-    test("scoreNormalization defaults to 'distance'", () => {
+    test("scoreNormalization defaults to 'similarity'", () => {
       const store = createStore();
-      expect(store.scoreNormalization).toBe("distance");
+      expect(store.scoreNormalization).toBe("similarity");
     });
 
     test("scoreNormalization can be set to 'similarity'", () => {

--- a/libs/providers/langchain-pgvector/src/vectorstores.ts
+++ b/libs/providers/langchain-pgvector/src/vectorstores.ts
@@ -105,7 +105,7 @@ export interface PGVectorStoreArgs {
    * Configure how similarity scores are calculated.
    * "distance" returns raw distance values (lower = more similar, default behavior for backward compatibility)
    * "similarity" returns normalized similarity scores (higher = more similar)
-   * @default "distance"
+   * @default "similarity"
    */
   scoreNormalization?: "distance" | "similarity";
 }
@@ -317,7 +317,7 @@ export class PGVectorStore extends VectorStore {
 
   distanceStrategy?: DistanceStrategy = "cosine";
 
-  scoreNormalization: "distance" | "similarity" = "distance";
+  scoreNormalization: "distance" | "similarity" = "similarity";
 
   _vectorstoreType(): string {
     return "pgvector";
@@ -336,7 +336,10 @@ export class PGVectorStore extends VectorStore {
     k: number,
     filter?: this["FilterType"]
   ): Promise<[Document, { distance: number; similarity: number }][]> {
+    const savedNormalization = this.scoreNormalization;
+    this.scoreNormalization = 'distance';
     const results = await this.searchPostgres(query, k, filter, false);
+    this.scoreNormalization = savedNormalization;
     const enhancedResults: [
       Document,
       { distance: number; similarity: number },
@@ -430,7 +433,7 @@ export class PGVectorStore extends VectorStore {
     this.pool = pool;
     this.chunkSize = config.chunkSize ?? 500;
     this.distanceStrategy = config.distanceStrategy ?? this.distanceStrategy;
-    this.scoreNormalization = config.scoreNormalization ?? "distance";
+    this.scoreNormalization = config.scoreNormalization ?? "similarity";
 
     const langchainVerbose = getEnvironmentVariable("LANGCHAIN_VERBOSE");
 


### PR DESCRIPTION
## Problem

`PGVectorStore.similaritySearchWithScore` returns raw pgvector distance values (0.0 = exact match) rather than normalized similarity scores (1.0 = exact match). This is inconsistent with other vector stores and confusing given the method name implies similarity.

The repo already has `scoreNormalization` and `convertDistanceToSimilarity()` infrastructure — it just defaulted to `"distance"`.

## Fix

- Changed the default `scoreNormalization` from `"distance"` to `"similarity"`
- Fixed a double-conversion bug in `similaritySearchVectorWithScores` where `searchPostgres` already converted the score before `convertDistanceToBoth` converted it again
- Added regression tests for both methods

## Breaking Change

Callers relying on raw distance values should pass `scoreNormalization: "distance"` explicitly.

Closes #11043