### PR TITLE
fix(groq): wire missing constructor params and add interface fields

### DIFF
--- a/libs/providers/langchain-groq/src/chat_models.ts
+++ b/libs/providers/langchain-groq/src/chat_models.ts
@@ -198,7 +198,7 @@ export interface ChatGroqInput extends BaseChatModelParams {
 
   /**
    * The maximum number of tokens that the model can process in a single response.
-   * This limits ensures computational efficiency and resource management.
+   * This limit ensures computational efficiency and resource management.
    */
   maxTokens?: number;
 

--- a/libs/providers/langchain-groq/src/chat_models.ts
+++ b/libs/providers/langchain-groq/src/chat_models.ts
@@ -297,6 +297,20 @@ export interface ChatGroqInput extends BaseChatModelParams {
    * @see https://console.groq.com/docs/reasoning#options-for-reasoning-effort
    */
   reasoningEffort?: "none" | "default" | "low" | "medium" | "high" | null;
+
+  /**
+   * The format of the reasoning content in the response.
+   * Supported values: `"parsed"`, `"streaming_parsed"`, `"raw"`, `"hidden"`.
+   * @see https://console.groq.com/docs/reasoning
+   */
+  reasoningFormat?: ChatCompletionsAPI.ChatCompletionCreateParamsBase["reasoning_format"];
+
+  /**
+   * The service tier to use for the request. Affects cost and latency.
+   * Supported values: `"on_demand"`, `"auto"`.
+   * @see https://console.groq.com/docs/openai
+   */
+  serviceTier?: ChatCompletionsAPI.ChatCompletionCreateParamsBase["service_tier"];
 }
 
 type GroqRoleEnum = "system" | "assistant" | "user" | "function";
@@ -849,7 +863,7 @@ function _oldConvertDeltaToMessageChunk(
  * import { z } from 'zod';
  *
  * const llmForToolCalling = new ChatGroq({
- *   model: "llama3-groq-70b-8192-tool-use-preview",
+ *   model: "llama-3.3-70b-versatile",
  *   temperature: 0,
  *   // other params...
  * });
@@ -1083,6 +1097,9 @@ export class ChatGroq extends BaseChatModel<
     this.logitBias = params.logitBias;
     this.user = params.user;
     this.reasoningEffort = params.reasoningEffort;
+    this.reasoningFormat = params.reasoningFormat;
+    this.serviceTier = params.serviceTier;
+    this.topLogprobs = params.topLogprobs;
   }
 
   getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {

--- a/libs/providers/langchain-groq/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-groq/src/tests/chat_models.test.ts
@@ -91,6 +91,38 @@ describe("reasoningEffort", () => {
   });
 });
 
+describe("constructor params wired through to invocationParams", () => {
+  test("topLogprobs passed in constructor reaches invocationParams", () => {
+    const model = new ChatGroq({
+      apiKey: "foo",
+      model: "llama-3.3-70b-versatile",
+      topLogprobs: 3,
+    });
+    const params = model.invocationParams({});
+    expect(params.top_logprobs).toBe(3);
+  });
+
+  test("reasoningFormat passed in constructor reaches invocationParams", () => {
+    const model = new ChatGroq({
+      apiKey: "foo",
+      model: "qwen/qwen3-32b",
+      reasoningFormat: "parsed",
+    });
+    const params = model.invocationParams({});
+    expect(params.reasoning_format).toBe("parsed");
+  });
+
+  test("serviceTier passed in constructor reaches invocationParams", () => {
+    const model = new ChatGroq({
+      apiKey: "foo",
+      model: "llama-3.3-70b-versatile",
+      serviceTier: "on_demand",
+    });
+    const params = model.invocationParams({});
+    expect(params.service_tier).toBe("on_demand");
+  });
+});
+
 describe("withStructuredOutput - StandardSchema", () => {
   function makeSerializableSchema() {
     return {


### PR DESCRIPTION
## Problem

Three bugs found in the Groq provider that silently break developer expectations:

### Bug 1 — `topLogprobs`, `reasoningFormat`, `serviceTier` silently ignored

These fields are defined as class properties and used in `invocationParams()`, but were **never assigned in the constructor**. A developer passing any of these at construction time gets no error — the values are silently dropped.

```ts
// Before — these did nothing at construction time
const llm = new ChatGroq({ topLogprobs: 5, reasoningFormat: "parsed", serviceTier: "auto" })
// llm.topLogprobs === undefined ❌
```

```ts
// After
// llm.topLogprobs === 5 ✅
```

### Bug 2 — `reasoningFormat` and `serviceTier` missing from `ChatGroqInput`

Both fields are used internally but were not exposed in the public interface, making it impossible for TypeScript users to set them at construction time with type safety.

### Bug 3 — Deprecated model in JSDoc example

The "Bind tools" example used `"llama3-groq-70b-8192-tool-use-preview"` which is deprecated and not in the model registry. Updated to `"llama-3.3-70b-versatile"`.

## Changes

- `chat_models.ts` — Added 3 missing constructor assignments + 2 new `ChatGroqInput` interface fields with JSDoc + updated deprecated model in example
- `chat_models.test.ts` — Added unit tests covering all three constructor param assignments

## Type
- [x] Bug fix (silent data loss on construction)
- [x] Tests added