### PR TITLE
Preserve Google functionCall ids in contentBlocks

### DIFF
--- a/.changeset/curvy-boxes-turn.md
+++ b/.changeset/curvy-boxes-turn.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Preserve Google functionCall ids in contentBlocks.

--- a/libs/langchain-core/src/messages/block_translators/google.ts
+++ b/libs/langchain-core/src/messages/block_translators/google.ts
@@ -71,7 +71,9 @@ function convertToV1FromChatGoogleMessage(
         ) {
           return {
             type: "tool_call",
-            id: message.id,
+            id: _isString(block.functionCall.id)
+              ? block.functionCall.id
+              : message.id,
             name: block.functionCall.name,
             args: block.functionCall.args,
           };

--- a/libs/langchain-core/src/messages/block_translators/google_genai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_genai.ts
@@ -47,7 +47,9 @@ function convertToV1FromChatGoogleMessage(
       ) {
         yield {
           type: "tool_call",
-          id: message.id,
+          id: _isString(block.functionCall.id)
+            ? block.functionCall.id
+            : message.id,
           name: block.functionCall.name,
           args: block.functionCall.args,
         };

--- a/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
@@ -117,6 +117,31 @@ describe("ChatGoogleTranslator", () => {
     ]);
   });
 
+  it("should preserve functionCall ids on tool_call content blocks", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "call_abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "call_abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
   it("should handle array content with only thinking blocks (no text target)", () => {
     // Edge case: all blocks are thinking blocks, no non-thinking text block
     // to attach the signature to. Should fall through gracefully.

--- a/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
@@ -69,6 +69,7 @@ describe("ChatGoogleGenAITranslator", () => {
         {
           type: "functionCall",
           functionCall: {
+            id: "call_123",
             name: "get_weather",
             args: { location: "San Francisco" },
           },
@@ -109,7 +110,7 @@ describe("ChatGoogleGenAITranslator", () => {
       { type: "file", mimeType: "text/plain", data: "Hello from Google" },
       {
         type: "tool_call",
-        id: undefined,
+        id: "call_123",
         name: "get_weather",
         args: { location: "San Francisco" },
       },


### PR DESCRIPTION
## Summary

Fixes #11110.

Google and Google GenAI content block translators were deriving standard `tool_call.id` from `message.id`, which drops provider-supplied Gemini `functionCall.id` values when converting `AIMessage.contentBlocks`. This keeps the previous `message.id` fallback, but prefers `functionCall.id` when it is present.

## Tests

RED before implementation:

```
pnpm --filter @langchain/core test src/messages/block_translators/tests/google_genai.test.ts src/messages/block_translators/tests/google.test.ts
# 2 failed: expected functionCall ids to be preserved
```

GREEN after implementation:

```
pnpm --filter @langchain/core test src/messages/block_translators/tests/google_genai.test.ts src/messages/block_translators/tests/google.test.ts
# Test Files 2 passed; Tests 9 passed; Type Errors no errors

pnpm exec oxfmt --check libs/langchain-core/src/messages/block_translators/google.ts libs/langchain-core/src/messages/block_translators/google_genai.ts libs/langchain-core/src/messages/block_translators/tests/google.test.ts libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
# All matched files use the correct format.

pnpm exec oxlint libs/langchain-core/src/messages/block_translators/google.ts libs/langchain-core/src/messages/block_translators/google_genai.ts libs/langchain-core/src/messages/block_translators/tests/google.test.ts libs/langchain-core/src/messages/block_translators/tests/google_genai.test.ts
# exit 0

pnpm --filter @langchain/core build
# Build complete; attw No problems found; publint No issues found
```