### PR TITLE
fix(anthropic): do not send unknown-MIME files as application/pdf documents

### DIFF
--- a/.changeset/anthropic-unknown-mime-not-pdf.md
+++ b/.changeset/anthropic-unknown-mime-not-pdf.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): do not send files with unknown MIME type as application/pdf documents
+
+Files whose MIME type is empty/unknown (e.g. `.pem`, `.keystore`) were encoded as `document.source.base64` blocks with `media_type: "application/pdf"`, which the Anthropic API rejects with a 400. Empty MIME types are now only treated as PDF when the data actually has PDF magic bytes; other unknown binaries raise a clear error instead.

--- a/libs/providers/langchain-anthropic/src/tests/standard_content.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/standard_content.test.ts
@@ -134,6 +134,45 @@ describe("_formatStandardContent", () => {
     });
   });
 
+  it("treats an unlabeled base64 file as a PDF only when it has PDF magic bytes", () => {
+    // "%PDF-1.4" — the PDF header, so an empty MIME type should resolve to a PDF.
+    const pdfData = Uint8Array.from([
+      0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
+    ]);
+    const fileBlock: ContentBlock.Multimodal.File = {
+      type: "file",
+      data: pdfData,
+      mimeType: "",
+    };
+
+    const [content] = _formatStandardContent(
+      createAnthropicMessage([fileBlock])
+    );
+
+    expect(content).toMatchObject({
+      type: "document",
+      source: {
+        type: "base64",
+        data: Buffer.from(pdfData).toString("base64"),
+        media_type: "application/pdf",
+      },
+    });
+  });
+
+  it("throws instead of mislabeling an unknown-MIME binary as a PDF", () => {
+    // Arbitrary binary (e.g. a .pem/.keystore) with no MIME type must not be
+    // sent as an application/pdf document — that yields a 400 from the API.
+    const fileBlock: ContentBlock.Multimodal.File = {
+      type: "file",
+      data: Uint8Array.from([0x00, 0x01, 0x02, 0x03]),
+      mimeType: "",
+    };
+
+    expect(() =>
+      _formatStandardContent(createAnthropicMessage([fileBlock]))
+    ).toThrowError(/unsupported file mime type/i);
+  });
+
   it("throws for unsupported audio blocks", () => {
     const audioBlock: ContentBlock.Multimodal.Audio = {
       type: "audio",

--- a/libs/providers/langchain-anthropic/src/utils/content.ts
+++ b/libs/providers/langchain-anthropic/src/utils/content.ts
@@ -3,6 +3,7 @@ import {
   parseBase64DataUrl,
   type StandardContentBlockConverter,
 } from "@langchain/core/messages";
+import { _looksLikePdf } from "./standard.js";
 
 export function _isAnthropicThinkingBlock(
   block: unknown
@@ -230,7 +231,10 @@ export const standardContentBlockConverter: StandardContentBlockConverter<{
         );
       }
     } else if (block.source_type === "base64") {
-      if (mime_type === "application/pdf" || mime_type === "") {
+      if (
+        mime_type === "application/pdf" ||
+        (mime_type === "" && _looksLikePdf(block.data))
+      ) {
         return {
           type: "document",
           source: {

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -38,7 +38,7 @@ import {
   _isAnthropicCompactionBlock,
   standardContentBlockConverter,
 } from "./content.js";
-import { _formatStandardContent } from "./standard.js";
+import { _formatStandardContent, _looksLikePdf } from "./standard.js";
 
 function _formatImage(imageUrl: string) {
   const parsed = parseBase64DataUrl({ dataUrl: imageUrl });
@@ -274,18 +274,32 @@ function* _formatContentBlocks(
           contentPart.data instanceof Uint8Array)
       ) {
         // File with base64 data (string or Uint8Array)
-        const media_type =
-          "mimeType" in contentPart && typeof contentPart.mimeType === "string"
-            ? contentPart.mimeType
-            : "application/pdf";
         const data =
           typeof contentPart.data === "string"
             ? contentPart.data
             : Buffer.from(contentPart.data).toString("base64");
+        const rawMimeType =
+          "mimeType" in contentPart && typeof contentPart.mimeType === "string"
+            ? contentPart.mimeType
+            : "";
+        const mimeType = rawMimeType.split(";")[0].toLowerCase();
+        // Anthropic base64 document sources only accept application/pdf. Only
+        // emit one for an actual PDF; do not mislabel an unknown/other binary,
+        // which yields a 400 (media_type must be application/pdf).
+        if (
+          mimeType !== "application/pdf" &&
+          !(mimeType === "" && _looksLikePdf(data))
+        ) {
+          throw new Error(
+            `Unsupported file mime type for Anthropic base64 document source: ` +
+              `${rawMimeType || "(none provided)"}. Only application/pdf is ` +
+              `supported for base64 document blocks.`
+          );
+        }
 
         source = {
           type: "base64" as const,
-          media_type,
+          media_type: "application/pdf",
           data,
         };
       } else if (

--- a/libs/providers/langchain-anthropic/src/utils/standard.ts
+++ b/libs/providers/langchain-anthropic/src/utils/standard.ts
@@ -95,6 +95,28 @@ function _normalizeMimeType(mimeType?: string | null): string {
   return (mimeType ?? "").split(";")[0].toLowerCase();
 }
 
+/**
+ * Anthropic base64 document sources only accept `application/pdf`. When a file
+ * arrives with an empty/unknown MIME type we must not blindly label it as a PDF:
+ * doing so yields a 400 (`media_type: Input should be 'application/pdf'`) for
+ * non-PDF binaries such as `.pem` or `.keystore` files. Sniff the PDF magic
+ * bytes ("%PDF", which is "JVBERi" once base64-encoded) so genuinely unlabeled
+ * PDFs still work while other binaries fall through to explicit handling.
+ */
+export function _looksLikePdf(data: string | Uint8Array): boolean {
+  if (typeof data !== "string") {
+    return (
+      data[0] === 0x25 && // %
+      data[1] === 0x50 && // P
+      data[2] === 0x44 && // D
+      data[3] === 0x46 //   F
+    );
+  }
+  // Strip an optional data: URI prefix, then compare the base64 prefix.
+  const base64 = data.includes(",") ? data.slice(data.indexOf(",") + 1) : data;
+  return base64.trimStart().startsWith("JVBERi");
+}
+
 function _extractMetadataValue<T>(
   metadata: unknown,
   key: string
@@ -305,7 +327,10 @@ export function _formatStandardContent(
       }
       if (block.data) {
         const mimeType = _normalizeMimeType(block.mimeType);
-        if (mimeType === "" || mimeType === "application/pdf") {
+        if (
+          mimeType === "application/pdf" ||
+          (mimeType === "" && _looksLikePdf(block.data))
+        ) {
           result.push(
             _applyDocumentMetadata(
               {


### PR DESCRIPTION
Fixes #11139

## Problem

When an agent reads a binary file whose extension has no MIME entry (e.g. `.pem`, `.enc`, `.keystore`), `getMimeType()` returns `""`. Three code paths in `@langchain/anthropic` treated an empty MIME type as equivalent to `application/pdf` and encoded the file as a `document.source.base64` block with `media_type: "application/pdf"`. The Anthropic API validates the content against the declared type and returns:

```
messages.N.content.M.tool_result.content.0.document.source.base64.media_type:
  Input should be 'application/pdf'
```

The run aborts with a 400 and there is no recovery path.

## Root cause

Anthropic base64 **document** sources only accept `media_type: "application/pdf"` (text uses a `text` source, images an `image` content source). An arbitrary binary with an unknown MIME type is not a valid document at all, so labeling it `application/pdf` is incorrect.

## Fix

An empty/unknown MIME type is now treated as a PDF **only when the data actually carries the PDF magic bytes** (`%PDF`, i.e. `JVBERi` once base64-encoded), via a small shared `_looksLikePdf()` helper. This keeps genuinely unlabeled PDFs working while other binaries no longer get mislabeled.

- `utils/standard.ts` — base64 file branch: only route to a PDF document for `application/pdf` or an empty MIME that sniffs as a PDF; other unknown binaries fall through to the existing `Unsupported file mime type` error.
- `utils/content.ts` — same change on the base64 branch of `fromStandardFileBlock`.
- `utils/message_inputs.ts` — previously `media_type = contentPart.mimeType ?? "application/pdf"`, which passed an empty string or any non-PDF MIME straight through into the base64 document block (also a 400). Now it emits a PDF document only for an actual PDF and otherwise raises a clear error.

## Tests

Added two regression tests in `standard_content.test.ts`:
- an unlabeled base64 file with PDF magic bytes still becomes an `application/pdf` document;
- an unknown-MIME binary throws `Unsupported file mime type` instead of being mislabeled.

`pnpm exec vitest run src/tests/standard_content.test.ts` passes (8/8, no type errors). I verified the changed code this way; a few unrelated test files in my local filtered install can't resolve `@langchain/core/*` subpaths (core not built locally) — that's an environment artifact, not from this change.

## Note

The URL document branch (`type: "url"`) still maps an empty MIME to a PDF url source; a remote URL can't be sniffed without fetching, and that path is out of scope for the reported base64 400. Happy to address it separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)