### PR TITLE
[codex] fix core contentBlocks stored message round trip

### DIFF
--- a/.changeset/content-blocks-roundtrip.md
+++ b/.changeset/content-blocks-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Preserve `contentBlocks` when converting messages through stored message helpers.

--- a/libs/langchain-core/src/messages/tests/message_utils.test.ts
+++ b/libs/langchain-core/src/messages/tests/message_utils.test.ts
@@ -783,4 +783,17 @@ describe("chat message conversions", () => {
 
     expect(convertedBackMessages).toEqual(originalMessages);
   });
+
+  it("preserves AIMessage contentBlocks when converting through stored messages", () => {
+    const contentBlocks = [{ type: "text" as const, text: "hello" }];
+    const originalMessage = new AIMessage({ contentBlocks });
+
+    const [storedMessage] = mapChatMessagesToStoredMessages([originalMessage]);
+    const [convertedBackMessage] = mapStoredMessagesToChatMessages([
+      storedMessage,
+    ]);
+
+    expect(convertedBackMessage.content).toEqual(contentBlocks);
+    expect(convertedBackMessage.text).toBe("hello");
+  });
 });

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -447,30 +447,51 @@ function mapV1MessageToStoredMessage(
   }
 }
 
+type StoredMessageDataWithContentBlocks = StoredMessage["data"] & {
+  contentBlocks?: BaseMessageFields["contentBlocks"];
+  content_blocks?: BaseMessageFields["contentBlocks"];
+};
+
+function mapStoredMessageDataToFields(
+  data: StoredMessage["data"]
+): StoredMessageDataWithContentBlocks {
+  const { content_blocks: contentBlocks, ...fields } =
+    data as StoredMessageDataWithContentBlocks;
+  if (
+    fields.content === undefined &&
+    fields.contentBlocks === undefined &&
+    contentBlocks !== undefined
+  ) {
+    return { ...fields, contentBlocks };
+  }
+  return fields;
+}
+
 export function mapStoredMessageToChatMessage(message: StoredMessage) {
   const storedMessage = mapV1MessageToStoredMessage(message);
+  const fields = mapStoredMessageDataToFields(storedMessage.data);
   switch (storedMessage.type) {
     case "human":
-      return new HumanMessage(storedMessage.data);
+      return new HumanMessage(fields);
     case "ai":
-      return new AIMessage(storedMessage.data);
+      return new AIMessage(fields);
     case "system":
-      return new SystemMessage(storedMessage.data);
+      return new SystemMessage(fields);
     case "function":
-      if (storedMessage.data.name === undefined) {
+      if (fields.name === undefined) {
         throw new Error("Name must be defined for function messages");
       }
-      return new FunctionMessage(storedMessage.data as FunctionMessageFields);
+      return new FunctionMessage(fields as FunctionMessageFields);
     case "tool":
-      if (storedMessage.data.tool_call_id === undefined) {
+      if (fields.tool_call_id === undefined) {
         throw new Error("Tool call ID must be defined for tool messages");
       }
-      return new ToolMessage(storedMessage.data as ToolMessageFields);
+      return new ToolMessage(fields as ToolMessageFields);
     case "generic": {
-      if (storedMessage.data.role === undefined) {
+      if (fields.role === undefined) {
         throw new Error("Role must be defined for chat messages");
       }
-      return new ChatMessage(storedMessage.data as ChatMessageFields);
+      return new ChatMessage(fields as ChatMessageFields);
     }
     default:
       throw new Error(`Got unexpected type: ${storedMessage.type}`);


### PR DESCRIPTION
## Summary

Fixes #11096.

`mapChatMessagesToStoredMessages()` serializes messages constructed with `contentBlocks` as `content_blocks`, but `mapStoredMessagesToChatMessages()` passed stored data directly back into message constructors. Since constructors understand `contentBlocks` but not `content_blocks`, the stored-message helper round trip rebuilt the message with empty content.

This normalizes only the stored-message `content_blocks` field back to `contentBlocks` before construction, without applying a broad snake_case-to-camelCase conversion that would change constructor fields such as `additional_kwargs`.

## Tests

- `pnpm --filter @langchain/core test src/messages/tests/message_utils.test.ts src/messages/tests/base_message.test.ts`
- `pnpm exec oxfmt --check libs/langchain-core/src/messages/utils.ts libs/langchain-core/src/messages/tests/message_utils.test.ts .changeset/content-blocks-roundtrip.md`
- `pnpm exec oxlint libs/langchain-core/src/messages/utils.ts libs/langchain-core/src/messages/tests/message_utils.test.ts`
- `pnpm --filter @langchain/core build`
