### PR TITLE
[codex] fix Google ToolMessage duplicate Gemini parts

### DIFF
--- a/.changeset/google-toolmessage-function-response.md
+++ b/.changeset/google-toolmessage-function-response.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): avoid duplicate ToolMessage text in Gemini v1 converter

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -16,7 +16,11 @@ import { RequestError } from "../../utils/errors.js";
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { ChatGoogle, ChatGoogleParams } from "../index.js";
 import { ChatGoogle as ChatGoogleNode } from "../node.js";
-import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { LLMResult } from "@langchain/core/outputs";
 import { OutputParserException } from "@langchain/core/output_parsers";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
@@ -317,6 +321,46 @@ describe("Google Mock", () => {
     expect(recorder?.request?.body?.generationConfig?.candidateCount).toEqual(
       1
     );
+  });
+
+  test("ToolMessage v1 request body only includes functionResponse content", async () => {
+    const llm = newChatGoogle({
+      model: "gemini-3-pro-preview",
+      responseFile: "gemini-chat-001.json",
+    });
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "search",
+          args: {},
+          id: "call-1",
+          type: "tool_call",
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+    const messages = [
+      aiMsg,
+      new ToolMessage({
+        content: "TOOL RESULT TEXT",
+        tool_call_id: "call-1",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    await llm.invoke(messages);
+
+    const toolResponseContent = recorder.request.body.contents.find(
+      (content: Gemini.Content) =>
+        content.role === "user" &&
+        content.parts.some((part) => "functionResponse" in part)
+    ) as Gemini.Content;
+
+    expect(toolResponseContent).toBeDefined();
+    expect(toolResponseContent.parts).toHaveLength(1);
+    expect(toolResponseContent.parts[0]).not.toHaveProperty("text");
+    expect(toolResponseContent.parts[0]).toHaveProperty("functionResponse");
   });
 
   test("handleLLMEnd exposes camelCase tokenUsage for invoke", async () => {

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -421,7 +421,7 @@ function convertStandardContentMessageToGeminiContent(
     role = "user";
   }
 
-  const parts: Gemini.Part[] = [];
+  let parts: Gemini.Part[] = [];
 
   // Process standard content blocks
   const contentBlocks = Array.isArray(message.contentBlocks)
@@ -473,6 +473,9 @@ function convertStandardContentMessageToGeminiContent(
         response: { result: responseContent },
       },
     });
+
+    // Tool responses already carry their text in functionResponse.response.result.
+    parts = parts.filter((part) => "functionResponse" in part);
   }
 
   // Only return content if we have parts

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -422,6 +422,41 @@ describe("convertMessagesToGeminiContents", () => {
     expect(functionResponsePart.functionResponse!.name).toBe("get_weather");
   });
 
+  test("ToolMessage only sends functionResponse parts in v1 path", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "search",
+          args: {},
+          id: "call-1",
+          type: "tool_call",
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: "TOOL RESULT TEXT",
+        tool_call_id: "call-1",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+
+    expect(toolResponseContent).toBeDefined();
+    expect(toolResponseContent!.parts).toHaveLength(1);
+    expect(toolResponseContent!.parts[0]).not.toHaveProperty("text");
+    expect(toolResponseContent!.parts[0]).toHaveProperty("functionResponse");
+  });
+
   test("Multiple tool calls name resolution (v1 path)", () => {
     const aiMsg = new AIMessage({
       content: "",


### PR DESCRIPTION
## Summary

Fixes #10459.

The Gemini v1 standard content converter was building text parts from a `ToolMessage`'s content blocks and then appending the `functionResponse` part for the same tool result. That meant the same tool output could be sent twice to Gemini: once as `{ text: ... }` and once as `functionResponse.response.result`.

This matches the legacy converter behavior by keeping only `functionResponse` parts for `ToolMessage`s after the function response is built.

## Tests

- `pnpm --filter @langchain/google build`
- `pnpm --filter @langchain/google test src/converters/tests/messages.test.ts -t 'v1 path|v1 standard path|ToolMessage only sends functionResponse parts'`
- `pnpm --filter @langchain/google test src/chat_models/tests/index.test.ts -t 'ToolMessage v1 request body only includes functionResponse content'`
- `pnpm exec oxfmt --check libs/providers/langchain-google/src/converters/messages.ts libs/providers/langchain-google/src/converters/tests/messages.test.ts libs/providers/langchain-google/src/chat_models/tests/index.test.ts .changeset/google-toolmessage-function-response.md`
- `pnpm exec oxlint libs/providers/langchain-google/src/converters/messages.ts libs/providers/langchain-google/src/converters/tests/messages.test.ts libs/providers/langchain-google/src/chat_models/tests/index.test.ts`
- `git diff --check`

## Notes

- The model-level regression uses `GoogleRequestRecorder` with `MockApiClient`, so it verifies the generated request body without requiring a real Google API key.
- I also checked `src/converters/tests/messages.test.ts` as a full file. It has 3 current-main baseline failures even with this patch stashed, so the targeted v1 ToolMessage tests above are the relevant validation for this fix.
- This picks up the closed #10460 direction and adds the request-body regression suggested later in that thread.
