### PR TITLE
fix(core): don't drop streamed list items that straddle chunk boundaries

### DIFF
--- a/libs/langchain-core/src/output_parsers/list.ts
+++ b/libs/langchain-core/src/output_parsers/list.ts
@@ -42,7 +42,11 @@ export abstract class ListOutputParser extends BaseTransformOutputParser<
           // if there are multiple matches, yield all but the last one
           for (const match of matches.slice(0, -1)) {
             yield [match[1]];
-            doneIdx += (match.index ?? 0) + match[0].length;
+            // `match.index` is an absolute offset into `buffer`, so track the
+            // end of the last yielded match directly rather than accumulating
+            // (accumulating overshoots once >1 match is yielded and drops the
+            // buffered text for an item straddling a chunk boundary).
+            doneIdx = (match.index ?? 0) + match[0].length;
           }
           // keep the last match in the buffer
           buffer = buffer.slice(doneIdx);

--- a/libs/langchain-core/src/output_parsers/tests/output_parser.test.ts
+++ b/libs/langchain-core/src/output_parsers/tests/output_parser.test.ts
@@ -83,3 +83,16 @@ for (const [Parser, input, output] of listTestCases) {
     await expect(parser.parse(input)).resolves.toEqual(output);
   });
 }
+
+test("NumberedListOutputParser streams items that straddle multi-char chunks", async () => {
+  // Realistic LLM streaming emits multi-character chunks. Here "4. data" is
+  // split across the two chunks; it must not be dropped from the stream.
+  async function* generator() {
+    for (const chunk of ["1. a\n2. b\n3. c\n4. da", "ta\n5. e\n"]) {
+      yield chunk;
+    }
+  }
+  const parser = new NumberedListOutputParser();
+  const chunks = await acc(parser.transform(generator(), {}));
+  expect(chunks).toEqual([["a"], ["b"], ["c"], ["data"], ["e"]]);
+});


### PR DESCRIPTION
Fixes a streaming bug in `ListOutputParser` where list items that straddle a chunk boundary are silently dropped.

### Problem

`ListOutputParser._transform` (the regex branch used by `NumberedListOutputParser` and `MarkdownListOutputParser`) computes how much of the buffer to discard after yielding completed matches:

```ts
let doneIdx = 0;
for (const match of matches.slice(0, -1)) {
  yield [match[1]];
  doneIdx += (match.index ?? 0) + match[0].length;   // bug
}
buffer = buffer.slice(doneIdx);
```

`match.index` is an **absolute** offset into `buffer`, so `+=` accumulates absolute offsets across iterations. Once more than one match is yielded, `doneIdx` overshoots the true end of the last yielded match, and `buffer.slice(doneIdx)` discards buffered text belonging to the next, not-yet-complete item — so that item is lost.

This is masked by the existing streaming test, which feeds input **one character at a time** (so ≥2 complete matches plus a straddling partial never coexist in the buffer). Real LLM streaming emits multi-character chunks.

Reproduction (numbered list streamed in two chunks, `"4. data"` split across the boundary):

```
non-streaming parse : [["a"],["b"],["c"],["data"],["e"]]
streamed (before)   : [["a"],["b"],["c"],["e"]]        // "data" dropped
```

### Fix

`match.index` already gives the absolute end of the current match, so assign it rather than accumulate:

```ts
doneIdx = (match.index ?? 0) + match[0].length;
```

After the fix the straddling item is preserved, and the existing char-by-char behavior is unchanged.

### Tests

Added a streaming test in `libs/langchain-core/src/output_parsers/tests/output_parser.test.ts` that feeds multi-character chunks with a list item split across the boundary and asserts no item is dropped. Fails before the fix, passes after.
