### PR TITLE
fix(core): type ToolRuntime.store as unknown

### DIFF
--- a/.changeset/tool-runtime-store-unknown.md
+++ b/.changeset/tool-runtime-store-unknown.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Type `ToolRuntime.store` as `unknown` so it reflects the shape actually injected at runtime (e.g. LangGraph's `BaseStore`, which uses `get`/`put`) instead of the unrelated `mget`/`mset` `BaseStore` from `@langchain/core/stores`. Callers should narrow to the store type provided by their runtime.

--- a/libs/langchain-core/src/tools/tests/types.test-d.ts
+++ b/libs/langchain-core/src/tools/tests/types.test-d.ts
@@ -89,6 +89,23 @@ describe("tool() literal name type inference", () => {
     // Name should still be inferred as literal even with ToolRuntime
     expectTypeOf(myTool.name).toEqualTypeOf<"greetUser">();
   });
+
+  it("should type ToolRuntime.store as unknown so callers narrow it", () => {
+    // The concrete store shape is decided by the runtime that injects it
+    // (e.g. LangGraph's `BaseStore`, which exposes `get`/`put`, not core's
+    // `mget`/`mset`). Typing it as `unknown` forces callers to narrow.
+    tool(
+      (_input, runtime: ToolRuntime) => {
+        expectTypeOf(runtime.store).toEqualTypeOf<unknown>();
+        return "ok";
+      },
+      {
+        name: "storeTypeCheck",
+        description: "verifies store type",
+        schema: z.object({}),
+      }
+    );
+  });
 });
 
 describe("tool() async generator type inference", () => {

--- a/libs/langchain-core/src/tools/types.ts
+++ b/libs/langchain-core/src/tools/types.ts
@@ -25,7 +25,6 @@ import {
 } from "../utils/types/zod.js";
 
 import { JSONSchema } from "../utils/json_schema.js";
-import type { BaseStore } from "../stores.js";
 
 export type ResponseFormat = "content" | "content_and_artifact" | string;
 
@@ -481,7 +480,7 @@ export function isLangChainTool(tool?: unknown): tool is StructuredToolParams {
  * - `toolCallId`: The ID of the current tool call
  * - `config`: `RunnableConfig` for the current execution
  * - `context`: Runtime context
- * - `store`: `BaseStore` instance for persistent storage
+ * - `store`: Persistent store injected by the runtime (e.g. LangGraph's `BaseStore`)
  * - `writer`: Stream writer for streaming output
  *
  * No `Annotated` wrapper is needed - just use `runtime: ToolRuntime`
@@ -511,8 +510,9 @@ export function isLangChainTool(tool?: unknown): tool is StructuredToolParams {
  *     // Access runtime context
  *     const userId = runtime.context?.userId;
  *
- *     // Access store
- *     await runtime.store?.mset([["key", "value"]]);
+ *     // Access store (narrow to the store your runtime provides — e.g.
+ *     // LangGraph's `BaseStore` from `@langchain/langgraph`).
+ *     await (runtime.store as BaseStore | null)?.put(["ns"], "key", { hello: "world" });
  *
  *     // Stream output
  *     runtime.writer?.("Processing...");
@@ -571,9 +571,14 @@ export type ToolRuntime<
       ? TContext
       : unknown;
   /**
-   * BaseStore instance for persistent storage (from langgraph `Runtime`).
+   * Persistent store injected by the runtime that hosts the tool call
+   * (e.g. the `BaseStore` LangGraph attaches to its `Runtime`). The concrete
+   * shape is decided by the runtime — LangGraph's store, for example, exposes
+   * `get`/`put`/`search`, not the `mget`/`mset` API of `@langchain/core`'s
+   * `BaseStore` — so this is left as `unknown` and callers should narrow it
+   * to their expected type. `null` when no store is configured.
    */
-  store: BaseStore<string, unknown> | null;
+  store: unknown;
   /**
    * Stream writer for streaming output (from langgraph `Runtime`).
    */

--- a/libs/langchain/src/agents/tests/tools.test.ts
+++ b/libs/langchain/src/agents/tests/tools.test.ts
@@ -36,7 +36,10 @@ describe("tools", () => {
         expect(runtime.toolCallId).toEqual("1");
         expect(runtime.config.recursionLimit).toEqual(25);
         expect(typeof runtime.writer).toBe("function");
-        expect(runtime.store?.constructor.name).toEqual("AsyncBatchedStore");
+        expect(
+          (runtime.store as { constructor: { name: string } } | null)
+            ?.constructor.name
+        ).toEqual("AsyncBatchedStore");
         return `The weather in ${input.city} is sunny. The foo is ${runtime.context.foo} and the bar is ${runtime.state.bar}.`;
       },
       {


### PR DESCRIPTION
## Summary

`ToolRuntime.store` was typed as `BaseStore<string, unknown> | null` from `@langchain/core/stores`, but at runtime LangGraph injects its own `BaseStore` (`AsyncBatchedStore`, `InMemoryStore`, etc.) whose surface is `get`/`put`/`search` — not `mget`/`mset`. So user code like this compiles but crashes:

```ts
tool(async (input, runtime: ToolRuntime) => {
  await runtime.store?.mget(["k"]); // TypeError: store.mget is not a function
});
```

Typing it as `unknown` makes the misalignment visible at compile time and lets callers narrow to whatever the runtime actually provides (e.g. `import { BaseStore } from "@langchain/langgraph"`). Fixes #10521.

## Notes

- The one in-repo caller of `runtime.store` (`libs/langchain/src/agents/tests/tools.test.ts`) already relied on the LangGraph shape (`.constructor.name === "AsyncBatchedStore"`) and just needed a narrow to keep compiling.
- Added a `types.test-d.ts` case pinning `runtime.store` to `unknown`.

## Test plan

- `pnpm --filter @langchain/core test src/tools` — 71 passed, 0 type errors
- `pnpm --filter langchain test src/agents/tests/tools.test.ts` — 4 passed
- `pnpm format:check` / `pnpm lint` on touched files — clean