### PR TITLE
fix(google-common): recover Gemini 3.x thought signatures dropped on streamed tool calls

### DIFF
--- a/.changeset/tidy-signatures-recover.md
+++ b/.changeset/tidy-signatures-recover.md
@@ -1,0 +1,7 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): recover Gemini 3.x thought signatures dropped by streamed chunk-merge misalignment
+
+When a tool-calling turn is streamed, chunk merging can leave the `signatures` array longer than the re-serialized parts (e.g. `["sig", ""]` for a single `functionCall` part). The exact-length guard then dropped every signature, so the replayed `functionCall` carried no `thoughtSignature` and Gemini 3.x rejected the next turn with `400 INVALID_ARGUMENT`. Falls back to mapping the non-empty signatures onto the `functionCall` parts in order when lengths do not match. Fixes #9624.

--- a/libs/providers/langchain-google-common/src/tests/utils.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/utils.test.ts
@@ -16,6 +16,7 @@ import { schemaToGeminiParameters } from "../utils/zod_to_gemini_parameters.js";
 import { getGeminiAPI } from "../utils/gemini.js";
 import { getAnthropicAPI } from "../utils/anthropic.js";
 import {
+  GeminiPart,
   GeminiPartFileData,
   GeminiPartInlineData,
   GeminiPartText,
@@ -1090,5 +1091,104 @@ describe("gemini empty text content handling", () => {
 
     const textPart = modelContent?.parts[0] as GeminiPartText;
     expect(textPart.text).toBe("I am doing well");
+  });
+});
+
+describe("gemini thought signature handling", () => {
+  test("applies signatures positionally when they align with parts", async () => {
+    const api = getGeminiAPI();
+    const messages = [
+      new HumanMessage("Search for LangChain"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "search", args: { query: "LangChain" } },
+        ],
+        additional_kwargs: { signatures: ["decafe42"] },
+      }),
+    ];
+
+    const formatted = (await api.formatData(messages, {})) as GeminiRequest;
+
+    const modelContent = formatted.contents?.find((c) => c.role === "model");
+    const part = modelContent?.parts[0] as GeminiPart;
+    expect(part).toHaveProperty("functionCall");
+    expect(part.thoughtSignature).toBe("decafe42");
+  });
+
+  // Regression for https://github.com/langchain-ai/langchainjs/issues/9624:
+  // streamed chunk merging can leave the `signatures` array longer than the
+  // re-serialized parts (e.g. `["sig", ""]` for a single functionCall part).
+  // The exact-length guard used to drop every signature, so the replayed
+  // functionCall carried none and Gemini 3.x rejected the next turn with 400.
+  test("recovers signatures dropped by streamed chunk-merge misalignment", async () => {
+    const api = getGeminiAPI();
+    const messages = [
+      new HumanMessage("Search for LangChain"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "search", args: { query: "LangChain" } },
+        ],
+        // one functionCall part, but streaming produced a trailing empty entry
+        additional_kwargs: { signatures: ["decafe42", ""] },
+      }),
+    ];
+
+    const formatted = (await api.formatData(messages, {})) as GeminiRequest;
+
+    const modelContent = formatted.contents?.find((c) => c.role === "model");
+    expect(modelContent?.parts.length).toBe(1);
+    const part = modelContent?.parts[0] as GeminiPart;
+    expect(part).toHaveProperty("functionCall");
+    expect(part.thoughtSignature).toBe("decafe42");
+  });
+
+  test("maps misaligned signatures onto multiple functionCall parts in order", async () => {
+    const api = getGeminiAPI();
+    const messages = [
+      new HumanMessage("Search two things"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "search", args: { query: "a" } },
+          { id: "call_2", name: "search", args: { query: "b" } },
+        ],
+        additional_kwargs: { signatures: ["sig_a", "sig_b", ""] },
+      }),
+    ];
+
+    const formatted = (await api.formatData(messages, {})) as GeminiRequest;
+
+    const modelContent = formatted.contents?.find((c) => c.role === "model");
+    const parts = (modelContent?.parts ?? []) as GeminiPart[];
+    expect(parts.length).toBe(2);
+    expect(parts[0].thoughtSignature).toBe("sig_a");
+    expect(parts[1].thoughtSignature).toBe("sig_b");
+  });
+
+  test("leaves parts untouched when the non-empty count cannot be matched", async () => {
+    const api = getGeminiAPI();
+    const messages = [
+      new HumanMessage("Search two things"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          { id: "call_1", name: "search", args: { query: "a" } },
+          { id: "call_2", name: "search", args: { query: "b" } },
+        ],
+        // only one non-empty signature for two functionCall parts — ambiguous,
+        // so we do not guess
+        additional_kwargs: { signatures: ["sig_a", "", ""] },
+      }),
+    ];
+
+    const formatted = (await api.formatData(messages, {})) as GeminiRequest;
+
+    const modelContent = formatted.contents?.find((c) => c.role === "model");
+    const parts = (modelContent?.parts ?? []) as GeminiPart[];
+    expect(parts.length).toBe(2);
+    expect(parts[0].thoughtSignature).toBeUndefined();
+    expect(parts[1].thoughtSignature).toBeUndefined();
   });
 });

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -855,6 +855,25 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
           parts[co].thoughtSignature = signature;
         }
       }
+    } else {
+      // Streaming can misalign the merged `signatures` array against the
+      // re-serialized parts (e.g. `[sig, ""]` for a single functionCall part),
+      // which fails the exact-length check above and drops every signature.
+      // Gemini 3.x then rejects the next turn with 400 INVALID_ARGUMENT because
+      // the replayed functionCall carries no thoughtSignature. Fall back to
+      // mapping the non-empty signatures onto the functionCall parts in order,
+      // which is the shape the non-streaming path already produces.
+      // See https://github.com/langchain-ai/langchainjs/issues/9624
+      const nonEmptySignatures = signatures.filter((s) => s && s.length > 0);
+      const functionCallParts = parts.filter((part) => part.functionCall);
+      if (
+        nonEmptySignatures.length > 0 &&
+        nonEmptySignatures.length === functionCallParts.length
+      ) {
+        functionCallParts.forEach((part, co) => {
+          part.thoughtSignature = nonEmptySignatures[co];
+        });
+      }
     }
 
     return [


### PR DESCRIPTION
_(Disclosure: Code and writeup by Claude Fable 5)_

Fixes #9624

## Problem

Gemini 3.x requires every replayed `functionCall` part to carry back the `thoughtSignature` it was issued with. When the tool-calling turn is **streamed**, chunk merging in `@langchain/google-common` concatenates the per-chunk signature arrays out of alignment with the re-serialized parts — you end up with e.g. `signatures = ["sig", ""]` against a single `functionCall` part.

`roleMessageToContent` then applies the signatures with an exact-length guard:

```ts
if (signatures.length === parts.length) {
  for (let co = 0; co < signatures.length; co += 1) {
    const signature = signatures[co];
    if (signature && signature.length > 0) {
      parts[co].thoughtSignature = signature;
    }
  }
}
```

On the streamed mismatch (`2 !== 1`) the loop is skipped entirely, so **every** signature is dropped. The replayed `functionCall` carries no `thoughtSignature` and Vertex/GenAI rejects the *next* turn with `400 INVALID_ARGUMENT`. The first turn (including the tool call) works; the second turn fails. Non-streaming (`invoke`) is unaffected because it doesn't hit the misaligned merge.

This has been reproduced independently by several people on #9624 across Vertex and web-auth on `google-vertexai@2.2.0`.

## Fix

Keep the aligned path exactly as-is (so thinking-model thought-part signatures are unchanged), and add a fallback for the mismatch case: map the non-empty signatures onto the `functionCall` parts in order — the same shape the non-streaming path already produces. Only applied when the non-empty-signature count equals the `functionCall`-part count, so ambiguous shapes are left untouched.

## Tests

Adds a `gemini thought signature handling` block to `utils.test.ts` covering:
- aligned signatures still applied positionally (regression guard),
- signatures recovered when a trailing empty entry misaligns the array (the #9624 case),
- multiple tool calls mapped in order,
- ambiguous counts left untouched (no guessing).

All existing google-common tests pass, including the mock round-trip `4-5. Functions - conversation with signature`.
