### PR TITLE
fix(langchain): recover from invalid tool args when middleware is present

### DIFF
--- a/.changeset/spotty-lamps-feel.md
+++ b/.changeset/spotty-lamps-feel.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): recover from invalid tool args when middleware is present. ToolInvocationError is now converted to a ToolMessage (per the documented handleToolErrors default) even when a wrapToolCall middleware is registered, instead of fatally aborting the agent run.

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -104,6 +104,26 @@ const isSendInput = (
   typeof input === "object" && input != null && "lg_tool_call" in input;
 
 /**
+ * Find a ToolInvocationError in an error's cause chain.
+ *
+ * Errors thrown by the base handler inside wrapToolCall middleware are
+ * wrapped in MiddlewareError (possibly nested once per middleware layer),
+ * with the original error preserved as `cause`.
+ */
+function findToolInvocationError(
+  error: unknown
+): ToolInvocationError | undefined {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    if (current instanceof ToolInvocationError) {
+      return current;
+    }
+    current = current.cause;
+  }
+  return undefined;
+}
+
+/**
  * Default error handler for tool errors.
  *
  * This is applied to errors from baseHandler (tool execution).
@@ -246,10 +266,23 @@ export class ToolNode<
     }
 
     /**
+     * ToolInvocationError originates from the model producing invalid tool
+     * arguments (thrown by baseHandler), not from middleware logic - even
+     * when it surfaces through wrapToolCall wrapped in a MiddlewareError.
+     * The documented default converts it to a ToolMessage so the model can
+     * retry, regardless of middleware presence, so unwrap it here.
+     */
+    const toolInvocationError = findToolInvocationError(error);
+
+    /**
      * If error is from middleware and handleToolErrors is not true, bubble up
      * (default handler and false both re-raise middleware errors)
      */
-    if (isMiddlewareError && this.handleToolErrors !== true) {
+    if (
+      isMiddlewareError &&
+      this.handleToolErrors !== true &&
+      toolInvocationError === undefined
+    ) {
       throw error;
     }
 
@@ -264,7 +297,7 @@ export class ToolNode<
      * Apply handleToolErrors to the error
      */
     if (typeof this.handleToolErrors === "function") {
-      const result = this.handleToolErrors(error, call);
+      const result = this.handleToolErrors(toolInvocationError ?? error, call);
       if (result && ToolMessage.isInstance(result)) {
         return result;
       }

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -113,12 +113,11 @@ const isSendInput = (
 function findToolInvocationError(
   error: unknown
 ): ToolInvocationError | undefined {
-  let current: unknown = error;
-  while (current instanceof Error) {
-    if (current instanceof ToolInvocationError) {
-      return current;
-    }
-    current = current.cause;
+  if (error instanceof ToolInvocationError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return findToolInvocationError(error.cause);
   }
   return undefined;
 }

--- a/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
+++ b/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
@@ -242,6 +242,53 @@ describe("Middleware Error Handling", () => {
       }
     });
 
+    it("should convert invalid tool arguments to a ToolMessage when middleware is present", async () => {
+      const strictTool = tool(
+        async ({ value }: { value: string }) => `got ${value}`,
+        {
+          name: "strict_tool",
+          description: "A tool with a required string argument",
+          schema: z.object({ value: z.string() }),
+        }
+      );
+
+      const middleware = createMiddleware({
+        name: "testMiddleware",
+        wrapToolCall: async (request, handler) => {
+          return handler(request);
+        },
+      });
+
+      // First turn: model emits invalid args (missing `value`).
+      // Second turn: model recovers and finishes without tool calls.
+      const model = new FakeToolCallingModel({
+        toolCalls: [[{ name: "strict_tool", args: {}, id: "call_1" }], []],
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [strictTool],
+        middleware: [middleware],
+      });
+
+      // Without the ToolInvocationError exemption this rejects with a
+      // MiddlewareError instead of feeding the error back to the model.
+      const result = await agent.invoke({
+        messages: [new HumanMessage("test")],
+      });
+
+      const toolMessages = result.messages.filter(
+        (m) => m.getType() === "tool"
+      );
+      expect(toolMessages).toHaveLength(1);
+      expect(toolMessages[0].content).toContain(
+        "Error invoking tool 'strict_tool'"
+      );
+      expect(toolMessages[0].content).toContain(
+        "Please fix the error and try again."
+      );
+    });
+
     it("should handle GraphInterrupt with checkpointer for resume flow", async () => {
       const checkpointer = new MemorySaver();
       const toolCalled = vi.fn();


### PR DESCRIPTION
## Problem

`ToolNode`'s documented default for `handleToolErrors` says it "Catches only `ToolInvocationError` (invalid arguments from model) and converts to ToolMessage" so the model can see the validation error and retry.

That holds without middleware. But when any `wrapToolCall` middleware is registered, the `ToolInvocationError` thrown by the base handler propagates through the middleware call, gets wrapped in `MiddlewareError` (once per middleware layer), and hits this branch in `ToolNode.#handleError`:

```ts
if (isMiddlewareError && this.handleToolErrors !== true) {
  throw error;
}
```

so it is re-thrown as fatal before the documented default ever applies. One malformed tool call from the model kills the entire agent run.

This bites any `createAgent`/DeepAgents user in practice: DeepAgents always registers a `wrapToolCall` middleware, so agents built on it (e.g. OpenWiki) hard-abort whenever the model emits a tool call with a missing required field, instead of retrying. Repro observed repeatedly with claude-sonnet-5 emitting a todo item without `status` in OpenWiki 0.0.1: the run dies with `Error invoking tool 'write_todos' ... Received tool input did not match expected schema`.

## Fix

- Add `findToolInvocationError()` that walks the `cause` chain (the `MiddlewareError` wrapping preserves the original error as `cause`, and stacked middleware can nest wrappers).
- Exempt `ToolInvocationError` from the middleware bubble-up, so the existing default/function handlers convert it to a `ToolMessage` exactly as they already do in the no-middleware path.
- Pass the unwrapped error to a function-valued `handleToolErrors` so `instanceof ToolInvocationError` checks in user handlers keep working.

Genuine middleware errors are unaffected: they still bubble up unless `handleToolErrors === true` (the existing test "should still wrap non-GraphBubbleUp errors in MiddlewareError" still passes).

## Test

Added a regression test: a passthrough `wrapToolCall` middleware plus a model that first emits invalid tool args. Before the fix the invoke rejects with `MiddlewareError`; after, the model receives a ToolMessage with the validation error and recovers. Verified red without the fix, green with it; all 331 agents unit tests pass.