### PR TITLE
fix(anthropic): reject non-PDF base64 file blocks instead of emitting invalid document requests

### DIFF
--- a/.changeset/anthropic-file-block-media-type.md
+++ b/.changeset/anthropic-file-block-media-type.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Fix the legacy `file` content-block converter emitting invalid document requests. A `file` block carrying base64 data with a non-PDF MIME type was passed straight through as the document `media_type`, which the Anthropic API rejects with `document.source.base64.media_type: Input should be 'application/pdf'`. `_convertMessagesToAnthropicPayload` now mirrors the standard-content converter (`utils/standard.ts`): PDF (and empty) MIME types map to a base64 PDF document, `text/plain` maps to a text document source, and any other type throws a clear error instead of sending a request that always returns a 400.

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -1708,6 +1708,73 @@ describe("File ContentBlock handling", () => {
       cache_control: { type: "ephemeral" },
     });
   });
+
+  test("throws for a base64 file whose mime type is not a supported document type", () => {
+    // Office docs (.docx/.pptx/.xlsx) cannot be sent as a base64 Anthropic
+    // document (media_type must be application/pdf). Previously the mime type
+    // was passed straight through, producing a request the API rejects with a
+    // 400. It should now fail fast and consistently with the standard-content
+    // converter instead.
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "file",
+          data: "UEsDBAoAAAAAAA==",
+          mimeType:
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        },
+      ],
+    });
+
+    expect(() => _convertMessagesToAnthropicPayload([message])).toThrow(
+      /Unsupported file mime type for Anthropic base64 source/
+    );
+  });
+
+  test("converts a text/plain base64 file to a text document source", () => {
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "file",
+          data: "aGVsbG8=",
+          mimeType: "text/plain",
+        },
+      ],
+    });
+
+    const payload = _convertMessagesToAnthropicPayload([message]);
+    const content = payload.messages[0].content as AnthropicContentBlockParam[];
+    expect(content[0]).toEqual({
+      type: "document",
+      source: {
+        type: "text",
+        media_type: "text/plain",
+        data: "aGVsbG8=",
+      },
+    });
+  });
+
+  test("defaults to application/pdf when a base64 file has no mime type", () => {
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "file",
+          data: "JVBERi0xLjQK",
+        },
+      ],
+    });
+
+    const payload = _convertMessagesToAnthropicPayload([message]);
+    const content = payload.messages[0].content as AnthropicContentBlockParam[];
+    expect(content[0]).toEqual({
+      type: "document",
+      source: {
+        type: "base64",
+        media_type: "application/pdf",
+        data: "JVBERi0xLjQK",
+      },
+    });
+  });
 });
 
 describe("Opus 4.6", () => {

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -258,6 +258,7 @@ function* _formatContentBlocks(
       let source:
         | { type: "url"; url: string }
         | { type: "base64"; media_type: string; data: string }
+        | { type: "text"; media_type: string; data: string }
         | { type: "file"; file_id: string }
         | undefined;
 
@@ -273,21 +274,42 @@ function* _formatContentBlocks(
           // oxlint-disable-next-line no-instanceof/no-instanceof
           contentPart.data instanceof Uint8Array)
       ) {
-        // File with base64 data (string or Uint8Array)
-        const media_type =
+        // File with base64 data (string or Uint8Array).
+        //
+        // Anthropic's document content block is strict about its source: a
+        // base64 source must be a PDF, and plain text uses a dedicated text
+        // source. Passing any other MIME type straight through as `media_type`
+        // yields a request the API rejects with
+        // `...document.source.base64.media_type: Input should be
+        // 'application/pdf'`. Mirror the standard-content converter (see
+        // ./standard.ts): map PDF and text/plain to their proper sources and
+        // throw on anything else instead of emitting an invalid request.
+        const mimeType =
           "mimeType" in contentPart && typeof contentPart.mimeType === "string"
             ? contentPart.mimeType
-            : "application/pdf";
+            : "";
         const data =
           typeof contentPart.data === "string"
             ? contentPart.data
             : Buffer.from(contentPart.data).toString("base64");
 
-        source = {
-          type: "base64" as const,
-          media_type,
-          data,
-        };
+        if (mimeType === "" || mimeType === "application/pdf") {
+          source = {
+            type: "base64" as const,
+            media_type: "application/pdf",
+            data,
+          };
+        } else if (mimeType === "text/plain") {
+          source = {
+            type: "text" as const,
+            media_type: "text/plain",
+            data,
+          };
+        } else {
+          throw new Error(
+            `Unsupported file mime type for Anthropic base64 source: ${mimeType}`
+          );
+        }
       } else if (
         "fileId" in contentPart &&
         typeof contentPart.fileId === "string"


### PR DESCRIPTION
## Problem

The legacy content converter `_convertMessagesToAnthropicPayload` (`libs/providers/langchain-anthropic/src/utils/message_inputs.ts`) turns a `file` content block carrying base64 data into an Anthropic `document` block, using the block's MIME type verbatim as `media_type`:

```ts
// before
const media_type =
  "mimeType" in contentPart && typeof contentPart.mimeType === "string"
    ? contentPart.mimeType
    : "application/pdf";
source = { type: "base64", media_type, data };
```

Anthropic's base64 **document** source only accepts `application/pdf`. Any other MIME type produces a request the API rejects with a hard 400:

> `messages.N...document.source.base64.media_type: Input should be 'application/pdf'`

This is easy to hit in agent workflows: a tool that reads a `.docx` / `.pptx` / `.xlsx` (e.g. `deepagents`' `read_file`) emits a `file` block with an office MIME type, and the entire call fails.

Notably, the newer **standard-content** converter (`utils/standard.ts`) already handles this correctly — it maps PDF / text / image sources and throws `Unsupported file mime type for Anthropic base64 source: <mime>` for anything else. The two converters were inconsistent.

## Fix

Align `message_inputs.ts` with `standard.ts`:

- `application/pdf` (and empty) → base64 PDF document
- `text/plain` → text document source
- anything else → throw the same clear error instead of emitting an invalid request

## Tests

Added to the `File ContentBlock handling` suite in `chat_models.test.ts`:

- non-PDF base64 file (office doc) → throws `Unsupported file mime type…`
- `text/plain` base64 file → text document source
- base64 file with no MIME type → defaults to `application/pdf`

`vitest run src/tests/chat_models.test.ts` → **112 passed**, no type errors. `oxfmt --check` and `oxlint` clean. Changeset included (`@langchain/anthropic: patch`).
