### PR TITLE
fix(ollama): fire handleLLMNewToken for the final usage_metadata chunk

### DIFF
--- a/libs/providers/langchain-ollama/src/chat_models.ts
+++ b/libs/providers/langchain-ollama/src/chat_models.ts
@@ -827,7 +827,7 @@ export class ChatOllama
     }
 
     // Yield the `response_metadata` as the final chunk.
-    yield new ChatGenerationChunk({
+    const finalChunk = new ChatGenerationChunk({
       text: "",
       message: new AIMessageChunk({
         content: "",
@@ -838,6 +838,19 @@ export class ChatOllama
         usage_metadata: usageMetadata,
       }),
     });
+    yield finalChunk;
+    // Fire the callback for the final chunk too: on_chat_model_stream events
+    // (streamEvents, LangGraph's "messages" stream mode) are built from
+    // handleLLMNewToken, so without this the usage_metadata never reaches
+    // streaming consumers.
+    await runManager?.handleLLMNewToken(
+      "",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { chunk: finalChunk }
+    );
   }
 
   withStructuredOutput<

--- a/libs/providers/langchain-ollama/src/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-ollama/src/tests/chat_models_stream_events.test.ts
@@ -96,4 +96,52 @@ describe("ChatOllama.streamEvents", () => {
       total_tokens: 13,
     });
   });
+
+  test("passes the final usage chunk to handleLLMNewToken callbacks", async () => {
+    const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
+    process.env.LANGCHAIN_CALLBACKS_BACKGROUND = "false";
+
+    try {
+      const model = mockOllama(ollamaUsageChunks());
+
+      const callbackChunks: unknown[] = [];
+
+      await model.invoke("Hello", {
+        callbacks: [
+          {
+            handleLLMNewToken(
+              _token: string,
+              _idx,
+              _runId,
+              _parentRunId,
+              _tags,
+              fields
+            ) {
+              callbackChunks.push(fields?.chunk);
+            },
+          },
+        ],
+      });
+
+      // The final content-empty chunk carries the aggregated usage_metadata.
+      // on_chat_model_stream events (streamEvents v2, LangGraph's "messages"
+      // stream mode) are built from these callbacks, so without it usage is
+      // invisible to streaming consumers.
+      expect(callbackChunks.length).toBeGreaterThan(0);
+      expect(callbackChunks).toContainEqual(
+        expect.objectContaining({
+          text: "",
+          message: expect.objectContaining({
+            usage_metadata: {
+              input_tokens: 10,
+              output_tokens: 3,
+              total_tokens: 13,
+            },
+          }),
+        })
+      );
+    } finally {
+      process.env.LANGCHAIN_CALLBACKS_BACKGROUND = originalBackground;
+    }
+  });
 });


### PR DESCRIPTION
`ChatOllama._streamResponseChunks()` fires `handleLLMNewToken` for every content chunk inside its loop, but the final content-empty chunk it yields afterwards, the one carrying the aggregated `usage_metadata` and `response_metadata`, never gets a matching callback. `on_chat_model_stream` events are built from `handleLLMNewToken`'s `fields.chunk`, so token usage is invisible to `.streamEvents()` and to LangGraph's `streamMode: "messages"`, while the same call's `.invoke()` result carries it fine.

The fix fires the callback for the final chunk with an empty token, the same shape the loop already uses. This mirrors #11103, which fixes the same callback gap for google-genai's reasoning chunks.

Added a regression test in `chat_models_stream_events.test.ts` that collects `handleLLMNewToken` chunks off the mocked client and asserts one of them carries the aggregated usage. It fails on main and passes with this change; the rest of the suite (32 unit tests), build, oxlint, and oxfmt are green.

Fixes #11155
