### PR TITLE
fix(langchain): keep structured-output tool name stable across model requests

### DIFF
--- a/.changeset/stable-extract-tool-name.md
+++ b/.changeset/stable-extract-tool-name.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): keep structured-output tool name stable across model requests

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -146,6 +146,24 @@ export class AgentNode<
   #options: AgentNodeOptions<StructuredResponseFormat, ContextSchema>;
   #systemMessage: SystemMessage;
 
+  /**
+   * Memoized result of {@link AgentNode.#getResponseFormat}, keyed by the
+   * `model` and `responseFormat` references it was derived from.
+   *
+   * `#getResponseFormat` runs on every model request. Recomputing it rebuilds
+   * the structured-output strategies from scratch, and an unnamed schema is
+   * assigned a fresh `extract-<n>` tool name from a module-global counter each
+   * time. That makes the model see a different tool definition on every call,
+   * which defeats provider prompt caching (e.g. Anthropic, Gemini). Reusing the
+   * previous result whenever the inputs are unchanged keeps the tool definition
+   * stable across the agent loop.
+   */
+  #responseFormatCache?: {
+    model: string | LanguageModelLike;
+    responseFormat: ResponseFormatInput | undefined;
+    result: ResponseFormat | undefined;
+  };
+
   constructor(
     options: AgentNodeOptions<StructuredResponseFormat, ContextSchema>
   ) {
@@ -179,6 +197,20 @@ export class AgentNode<
       return undefined;
     }
 
+    /**
+     * Reuse the previously computed response format when neither the model nor
+     * the responseFormat reference has changed, so the structured-output tool
+     * keeps a stable name across model requests within an agent loop.
+     */
+    const cached = this.#responseFormatCache;
+    if (
+      cached &&
+      cached.model === model &&
+      cached.responseFormat === responseFormat
+    ) {
+      return cached.result;
+    }
+
     let resolvedModel: LanguageModelLike | undefined;
     if (isConfigurableModel(model)) {
       resolvedModel = await (
@@ -196,22 +228,19 @@ export class AgentNode<
       resolvedModel
     );
 
+    let result: ResponseFormat | undefined;
     if (strategies.length === 0) {
-      return undefined;
-    }
-
-    /**
-     * we either define a list of provider strategies or a list of tool strategies
-     */
-    const isProviderStrategy = strategies.every(
-      (format) => format instanceof ProviderStrategy
-    );
-
-    /**
-     * Populate a list of structured tool info.
-     */
-    if (!isProviderStrategy) {
-      return {
+      result = undefined;
+    } else if (
+      /**
+       * we either define a list of provider strategies or a list of tool strategies
+       */
+      !strategies.every((format) => format instanceof ProviderStrategy)
+    ) {
+      /**
+       * Populate a list of structured tool info.
+       */
+      result = {
         type: "tool",
         tools: (
           strategies.filter(
@@ -225,15 +254,18 @@ export class AgentNode<
           {} as Record<string, ToolStrategy>
         ),
       };
+    } else {
+      result = {
+        type: "native",
+        /**
+         * there can only be one provider strategy
+         */
+        strategy: strategies[0] as ProviderStrategy,
+      };
     }
 
-    return {
-      type: "native",
-      /**
-       * there can only be one provider strategy
-       */
-      strategy: strategies[0] as ProviderStrategy,
-    };
+    this.#responseFormatCache = { model, responseFormat, result };
+    return result;
   }
 
   async #run(

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -843,3 +843,52 @@ describe("native structured output does not force strict tools", () => {
     expect(opts.strict).toBeUndefined();
   });
 });
+
+describe("structured-output tool name stability", () => {
+  it("binds the same generated tool name on every model request in an agent loop", async () => {
+    // A model that supports tool calling but not native JSON-schema output, so
+    // structured output is routed through the tool strategy (which generates
+    // the `extract-<n>` tool name from an unnamed schema).
+    const model = new FakeToolCallingModel({
+      toolCalls: [
+        [{ name: "get_weather", args: { city: "London" }, id: "call_1" }],
+        [],
+      ],
+    });
+    const bindTools = vi.spyOn(model, "bindTools");
+
+    const getWeather = tool(async () => "sunny", {
+      name: "get_weather",
+      description: "Get the weather for a city.",
+      schema: z.object({ city: z.string() }),
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [getWeather],
+      // Raw schema with no explicit name — the structured-output tool name is
+      // generated internally and must stay stable across model requests.
+      responseFormat: z.object({ answer: z.string() }),
+    });
+
+    await agent.invoke({
+      messages: [new HumanMessage("What is the weather in London?")],
+    });
+
+    const extractNames = bindTools.mock.calls
+      .map(([toolClasses]) =>
+        (toolClasses as { type?: string; function?: { name?: string } }[])
+          .map((t) => t.function?.name)
+          .find((name) => name?.startsWith("extract-"))
+      )
+      .filter((name): name is string => name !== undefined);
+
+    // The agent runs a tool and calls the model again, so the structured-output
+    // tool is bound on more than one request.
+    expect(extractNames.length).toBeGreaterThan(1);
+    // Every binding must use the same generated name. A name that changes per
+    // request rewrites the tool definitions the model sees and defeats provider
+    // prompt caching (the tool block is part of the cached prefix).
+    expect(new Set(extractNames).size).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #11151

## What

Memoizes the structured-output response format inside `AgentNode` so the generated tool keeps a stable name across the model requests of a single agent loop.

## Why

`AgentNode.#getResponseFormat` runs on every model request (via `baseHandler`). When `responseFormat` is a schema with no explicit name, `transformResponseFormat` → `ToolStrategy.fromSchema` derives the tool name from a module-global counter (`extract-${++bindingIdentifier}` in `libs/langchain/src/agents/responses.ts`). Rebuilding on every call therefore produces a new tool name (`extract-89`, `extract-90`, `extract-91`, …) for the same schema, so the model sees a different tool definition on each request.

Because tool definitions are part of the cached prefix for providers that support prompt caching, an unstable tool name turns every request in the agent loop into a cache miss (`cache_read_input_tokens` stays 0). The instability degrades implicit caching on other providers for the same reason.

## How

The strategies for a given `(model, responseFormat)` pair can't change between iterations of one agent loop, so `#getResponseFormat` now caches its result keyed on the `model` and `responseFormat` references it was built from and returns the cached value when both are unchanged. A middleware that swaps the model or response format still produces a fresh result (the references differ), so behavior is unchanged in that case. I traced the rebuild path through `AgentNode.#getResponseFormat` → `transformResponseFormat` → `ToolStrategy.fromSchema` and confirmed the tool name is the only value that varies between otherwise-identical calls. I kept the `extract-` naming scheme intact since it's relied on elsewhere (e.g. routing in `ReactAgent` and `piiRedaction` check `name.startsWith("extract-")`).

## Testing

Added a unit test in `libs/langchain/src/agents/tests/responses.test.ts` that spies on `bindTools` and asserts the structured-output tool is bound with the same generated name on every model request of a multi-step agent loop. It fails before the change (two different `extract-<n>` names) and passes after.

```
$ npx vitest run src/agents/tests/responses.test.ts
 Test Files  1 passed (1)
      Tests  37 passed (37)

$ npx vitest run src/agents/tests/reactAgent.test.ts
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

Also ran the full `src/agents/tests` unit suite (25 files, 390 tests) — all pass. `oxlint` and `oxfmt --check` are clean on the changed files.