### PR TITLE
fix(openai): stop persisting echoed request fields in streamed response_metadata

### DIFF
--- a/.changeset/streamed-response-metadata-echo.md
+++ b/.changeset/streamed-response-metadata-echo.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Stop persisting echoed request fields (tools, instructions) in streamed Responses `response_metadata`

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -800,15 +800,15 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
         // and let the caller fall back to msg.text or retry. See #10894.
       }
     }
-    for (const [key, value] of Object.entries(event.response)) {
+    // Reuse the allowlisted metadata from the converted message rather than
+    // copying every key of event.response. The raw response echoes the
+    // request (tools, instructions, ...), which would otherwise bloat every
+    // streamed message's response_metadata (see #11162). This also keeps the
+    // cleaned output so SDK-only fields like parsed_arguments are not
+    // persisted.
+    for (const [key, value] of Object.entries(msg.response_metadata)) {
       if (key === "id") continue;
-      // Use the cleaned output from the converted message so that
-      // SDK-only fields like parsed_arguments are not persisted.
-      if (key === "output") {
-        response_metadata[key] = msg.response_metadata.output;
-      } else {
-        response_metadata[key] = value;
-      }
+      response_metadata[key] = value;
     }
   } else if (
     event.type === "response.function_call_arguments.delta" ||

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -800,12 +800,11 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
         // and let the caller fall back to msg.text or retry. See #10894.
       }
     }
-    // Reuse the allowlisted metadata from the converted message rather than
-    // copying every key of event.response. The raw response echoes the
-    // request (tools, instructions, ...), which would otherwise bloat every
-    // streamed message's response_metadata (see #11162). This also keeps the
-    // cleaned output so SDK-only fields like parsed_arguments are not
-    // persisted.
+    // reuse the converted message's allowlisted metadata instead of copying
+    // every key of event.response — the raw response echoes the request
+    // (tools, instructions, ...) and would bloat every streamed message's
+    // response_metadata (#11162). also drops sdk-only fields like
+    // parsed_arguments.
     for (const [key, value] of Object.entries(msg.response_metadata)) {
       if (key === "id") continue;
       response_metadata[key] = value;

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -382,6 +382,44 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
     expect(aggregated.response_metadata.id).toBe("resp_top_level");
   });
 
+  it("does not persist echoed request fields (tools, instructions) in response_metadata", () => {
+    const completed = convertResponsesDeltaToChatGenerationChunk({
+      type: "response.completed",
+      response: {
+        id: "resp_top_level",
+        model: "gpt-4o",
+        created_at: 1234567890,
+        object: "response",
+        status: "completed",
+        instructions: "a very long system prompt".repeat(100),
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+        output: [
+          {
+            type: "message",
+            id: "msg_nested",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Hi", annotations: [] }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+      },
+    } as any);
+
+    const metadata = completed!.message.response_metadata;
+    expect(metadata.tools).toBeUndefined();
+    expect(metadata.instructions).toBeUndefined();
+    // The allowlisted fields are still present.
+    expect(metadata.model).toBe("gpt-4o");
+    expect(metadata.status).toBe("completed");
+    expect(metadata.created_at).toBe(1234567890);
+  });
+
   describe("custom tool streaming delta handling", () => {
     it("should preserve custom tool metadata from response.output_item.added events", () => {
       const customToolStart = {


### PR DESCRIPTION
Fixes #11162

In the streamed Responses path, the `response.completed` / `response.incomplete` handler in `convertResponsesDeltaToChatGenerationChunk` copied every key of `event.response` into `response_metadata`. The raw response echoes the request, so `tools`, `instructions`, and other request fields (tens of KB of JSON schemas for a `bindTools` call) were persisted on every streamed message's `response_metadata`, which bloats long LangGraph threads. The non-streaming `convertResponsesMessageToAIMessage` already builds an allowlisted `response_metadata` for the same response, and the streaming handler already computes that message (`msg`) a few lines above.

This reuses `msg.response_metadata` (the allowlisted set, which already includes the cleaned `output`) instead of copying the raw echo, keeping the existing top-level `id`. The streamed `response_metadata` now matches the non-streaming shape.

Added a regression test to `convertResponsesDeltaToChatGenerationChunk` asserting that a `response.completed` event carrying `tools` and `instructions` produces `response_metadata` without those keys while retaining the allowlisted fields (`model`, `status`, `created_at`).

Note: I was unable to run the package's vitest suite locally: `@langchain/core`'s build and this repo's vitest both fail in my environment on a missing native binary (`@rolldown/binding-darwin-*` / the pnpm optional-dependency issue in npm/cli#4828), unrelated to this change. The diff is minimal and the added test is self-contained, so CI should exercise it; happy to adjust based on CI.
