### PR TITLE
fix(aws): default missing reasoningText.text to empty string

### DIFF
--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -699,6 +699,57 @@ describe("convertToConverseMessages", () => {
         ],
       },
     },
+    {
+      name: "reasoning_content block with no text field (signature-only, as Bedrock sometimes returns)",
+      input: [
+        new HumanMessage("What is 2+2?"),
+        new AIMessage({
+          content: [
+            {
+              type: "reasoning_content",
+              reasoningText: {
+                signature: "abc123",
+              },
+            },
+          ],
+        }),
+        new HumanMessage("Thanks! What about 3+3?"),
+      ],
+      output: {
+        converseSystem: [],
+        converseMessages: [
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "What is 2+2?",
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.ASSISTANT,
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: {
+                    text: "",
+                    signature: "abc123",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            role: BedrockConversationRole.USER,
+            content: [
+              {
+                text: "Thanks! What about 3+3?",
+              },
+            ],
+          },
+        ],
+      },
+    },
   ];
 
   it.each(testCases.map((tc) => [tc.name, tc]))(

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -801,8 +801,14 @@ export function langchainReasoningBlockToBedrockReasoningBlock(
     throw new Error("Invalid reasoning content");
   }
   if ("reasoningText" in content) {
+    const reasoningText = content.reasoningText as Bedrock.ReasoningTextBlock;
     return {
-      reasoningText: content.reasoningText as Bedrock.ReasoningTextBlock,
+      // Bedrock's Converse API can *return* a reasoning block that's just a
+      // signature with no `text` (e.g. on short turns with no visible
+      // thinking summary), but rejects receiving that same shape back on a
+      // later turn ("Member must not be null"). Default it to an empty
+      // string so replaying history doesn't crash.
+      reasoningText: { ...reasoningText, text: reasoningText.text ?? "" },
     };
   }
   if ("redactedContent" in content) {


### PR DESCRIPTION
Fixes #11164.

## Problem

`ChatBedrockConverse` can crash mid-conversation on any multi-turn tool-calling session with extended thinking enabled:

```
1 validation error detected: Value at 'messages.N.member.content.M.member.reasoningContent.reasoningText.text' failed to satisfy constraint: Member must not be null
```

## Root cause

Bedrock's Converse API can *return* a `reasoning_content` block that's just a signature, with no `text` field at all — e.g. on a short turn with no visible thinking summary:

```json
{ "type": "reasoning_content", "reasoningText": { "signature": "..." } }
```

`langchainReasoningBlockToBedrockReasoningBlock` (`message_inputs.ts`) passes this straight through unmodified when the message is replayed as history on a later turn. Bedrock accepts *producing* this shape but rejects *receiving* it back — its request-side validation requires `text` to be present. It's a response/request schema asymmetry, not related to whether thinking is enabled or disabled.

## Fix

Default the missing `text` to an empty string when converting the outgoing reasoning block, mirroring the existing null-coalescing already used elsewhere in this file (e.g. `concatenateLangchainReasoningBlocks`).

## Testing

- Added a unit test case to `convertToConverseMessages` covering a signature-only `reasoning_content` block with no `text` field.
- All existing tests pass (`pnpm vitest run` in `libs/providers/langchain-aws`: 117 passed).
- Verified against a real multi-turn tool-calling session on Bedrock (`global.anthropic.claude-sonnet-5`, thinking left fully **enabled**, no disable override) that previously crashed on the second turn — with this fix it completes cleanly end-to-end. Details and full repro history are in #11164.
