### PR TITLE
fix(langchain): malformed tool input schemas are unrecoverable

### DIFF
--- a/.changeset/bold-peas-happen.md
+++ b/.changeset/bold-peas-happen.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): malformed tool input schemas are unrecoverable

--- a/libs/langchain/src/agents/errors.ts
+++ b/libs/langchain/src/agents/errors.ts
@@ -52,6 +52,8 @@ export class StructuredOutputParsingError extends Error {
  * Raised when a tool call is throwing an error.
  */
 export class ToolInvocationError extends Error {
+  readonly "~brand" = "ToolInvocationError";
+
   public readonly toolCall: ToolCall;
 
   public readonly toolError: Error;
@@ -67,6 +69,19 @@ export class ToolInvocationError extends Error {
     this.toolCall = toolCall;
     this.toolError = error;
   }
+
+  /**
+   * Check if the error is a ToolInvocationError.
+   * @param error - The error to check
+   * @returns Whether the error is a ToolInvocationError
+   */
+  static isInstance(error: unknown): error is ToolInvocationError {
+    return (
+      error instanceof Error &&
+      "~brand" in error &&
+      error["~brand"] === "ToolInvocationError"
+    );
+  }
 }
 
 /**
@@ -76,7 +91,7 @@ export class ToolInvocationError extends Error {
  * to ensure that GraphBubbleUp errors (like GraphInterrupt) are never wrapped.
  */
 export class MiddlewareError extends Error {
-  static readonly "~brand" = "MiddlewareError";
+  readonly "~brand" = "MiddlewareError";
 
   private constructor(error: unknown, middlewareName: string) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -247,20 +247,23 @@ export class ToolNode<
 
     /**
      * A recoverable tool error (e.g. tool-input schema validation) can be
-     * rewrapped by the middleware composer as a {@link MiddlewareError} with the
-     * original error on `.cause`. Unwrap it so the intended `handleToolErrors`
-     * self-correction path still applies, while genuine middleware errors stay
-     * fatal by default.
+     * rewrapped as a {@link MiddlewareError} with the original error on `.cause`
+     * — once per `wrapToolCall` middleware, so it may be nested several layers
+     * deep. Walk the cause chain to the root; if it's a {@link ToolInvocationError},
+     * unwrap it so the intended `handleToolErrors` self-correction path still
+     * applies. Genuine middleware errors stay fatal by default.
      */
     let effectiveError = error;
     let errorFromMiddleware = isMiddlewareError;
-    if (
-      isMiddlewareError &&
-      error instanceof MiddlewareError &&
-      error.cause instanceof ToolInvocationError
-    ) {
-      effectiveError = error.cause;
-      errorFromMiddleware = false;
+    if (isMiddlewareError) {
+      let unwrapped: unknown = error;
+      while (unwrapped instanceof MiddlewareError) {
+        unwrapped = unwrapped.cause;
+      }
+      if (unwrapped instanceof ToolInvocationError) {
+        effectiveError = unwrapped;
+        errorFromMiddleware = false;
+      }
     }
 
     /**

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -20,7 +20,7 @@ import {
 
 import { RunnableCallable } from "../RunnableCallable.js";
 import { mergeAbortSignals } from "./utils.js";
-import { ToolInvocationError } from "../errors.js";
+import { MiddlewareError, ToolInvocationError } from "../errors.js";
 import type {
   WrapToolCallHook,
   ToolCallRequest,
@@ -246,25 +246,43 @@ export class ToolNode<
     }
 
     /**
+     * A recoverable tool error (e.g. tool-input schema validation) can be
+     * rewrapped by the middleware composer as a {@link MiddlewareError} with the
+     * original error on `.cause`. Unwrap it so the intended `handleToolErrors`
+     * self-correction path still applies, while genuine middleware errors stay
+     * fatal by default.
+     */
+    let effectiveError = error;
+    let errorFromMiddleware = isMiddlewareError;
+    if (
+      isMiddlewareError &&
+      error instanceof MiddlewareError &&
+      error.cause instanceof ToolInvocationError
+    ) {
+      effectiveError = error.cause;
+      errorFromMiddleware = false;
+    }
+
+    /**
      * If error is from middleware and handleToolErrors is not true, bubble up
      * (default handler and false both re-raise middleware errors)
      */
-    if (isMiddlewareError && this.handleToolErrors !== true) {
-      throw error;
+    if (errorFromMiddleware && this.handleToolErrors !== true) {
+      throw effectiveError;
     }
 
     /**
      * If handleToolErrors is false, throw all errors
      */
     if (!this.handleToolErrors) {
-      throw error;
+      throw effectiveError;
     }
 
     /**
      * Apply handleToolErrors to the error
      */
     if (typeof this.handleToolErrors === "function") {
-      const result = this.handleToolErrors(error, call);
+      const result = this.handleToolErrors(effectiveError, call);
       if (result && ToolMessage.isInstance(result)) {
         return result;
       }
@@ -272,11 +290,11 @@ export class ToolNode<
       /**
        * `handleToolErrors` returned undefined - re-raise
        */
-      throw error;
+      throw effectiveError;
     } else if (this.handleToolErrors) {
       return new ToolMessage({
         name: call.name,
-        content: `${error}\n Please fix your mistakes.`,
+        content: `${effectiveError}\n Please fix your mistakes.`,
         tool_call_id: call.id!,
       });
     }
@@ -284,7 +302,7 @@ export class ToolNode<
     /**
      * Shouldn't reach here, but throw as fallback
      */
-    throw error;
+    throw effectiveError;
   }
 
   protected async runTool(

--- a/libs/langchain/src/agents/nodes/ToolNode.ts
+++ b/libs/langchain/src/agents/nodes/ToolNode.ts
@@ -117,7 +117,7 @@ function defaultHandleToolErrors(
   error: unknown,
   toolCall: ToolCall
 ): ToolMessage | undefined {
-  if (error instanceof ToolInvocationError) {
+  if (ToolInvocationError.isInstance(error)) {
     return new ToolMessage({
       content: error.message,
       tool_call_id: toolCall.id!,
@@ -257,10 +257,10 @@ export class ToolNode<
     let errorFromMiddleware = isMiddlewareError;
     if (isMiddlewareError) {
       let unwrapped: unknown = error;
-      while (unwrapped instanceof MiddlewareError) {
+      while (MiddlewareError.isInstance(unwrapped)) {
         unwrapped = unwrapped.cause;
       }
-      if (unwrapped instanceof ToolInvocationError) {
+      if (ToolInvocationError.isInstance(unwrapped)) {
         effectiveError = unwrapped;
         errorFromMiddleware = false;
       }

--- a/libs/langchain/src/agents/nodes/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/nodes/tests/ToolNode.test.ts
@@ -823,21 +823,25 @@ describe("ToolNode error handling", () => {
     );
   });
 
-  it("recovers a schema error rewrapped by wrapToolCall middleware", async () => {
+  it("recovers a schema error nested under multiple MiddlewareError wrappers", async () => {
     // A tool whose args must satisfy a schema.
     const strictTool = tool(async () => "ok", {
       name: "strict_tool",
       description: "requires a field",
       schema: z.object({ required_field: z.string() }),
     });
-    // Simulate the middleware composer: rethrow any tool error as a
-    // MiddlewareError (keeping the original on `.cause`).
+    // Simulate two stacked wrapToolCall middlewares: the composer wraps once
+    // per middleware, so the recoverable error is nested
+    // MiddlewareError -> MiddlewareError -> ToolInvocationError.
     const toolNode = new ToolNode([strictTool], {
       wrapToolCall: async (request, handler) => {
         try {
           return await handler(request);
         } catch (error) {
-          throw MiddlewareError.wrap(error, "test_middleware");
+          throw MiddlewareError.wrap(
+            MiddlewareError.wrap(error, "inner_middleware"),
+            "outer_middleware"
+          );
         }
       },
     });

--- a/libs/langchain/src/agents/nodes/tests/ToolNode.test.ts
+++ b/libs/langchain/src/agents/nodes/tests/ToolNode.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@langchain/langgraph";
 
 import { ToolNode } from "../ToolNode.js";
+import { MiddlewareError } from "../../errors.js";
 
 import {
   _AnyIdAIMessage,
@@ -820,6 +821,68 @@ describe("ToolNode error handling", () => {
     expect(result.messages[0].content).toBe(
       "Error: some error\n Please fix your mistakes."
     );
+  });
+
+  it("recovers a schema error rewrapped by wrapToolCall middleware", async () => {
+    // A tool whose args must satisfy a schema.
+    const strictTool = tool(async () => "ok", {
+      name: "strict_tool",
+      description: "requires a field",
+      schema: z.object({ required_field: z.string() }),
+    });
+    // Simulate the middleware composer: rethrow any tool error as a
+    // MiddlewareError (keeping the original on `.cause`).
+    const toolNode = new ToolNode([strictTool], {
+      wrapToolCall: async (request, handler) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          throw MiddlewareError.wrap(error, "test_middleware");
+        }
+      },
+    });
+
+    // Invalid args → ToolInputParsingException → ToolInvocationError →
+    // wrapped as MiddlewareError. It should still be recovered into a
+    // ToolMessage rather than aborting the run.
+    const result = await toolNode.invoke({
+      messages: [
+        new AIMessage({
+          content: "",
+          tool_calls: [{ name: "strict_tool", args: {}, id: "testid" }],
+        }),
+      ],
+    });
+
+    expect(ToolMessage.isInstance(result.messages[0])).toBe(true);
+    expect(result.messages[0].content).toContain(
+      "did not match expected schema"
+    );
+  });
+
+  it("still throws non-recoverable middleware errors by default", async () => {
+    const okTool = tool(async () => "ok", {
+      name: "ok_tool",
+      description: "a tool",
+      schema: z.object({}),
+    });
+    // A genuine middleware failure (cause is not a ToolInvocationError).
+    const toolNode = new ToolNode([okTool], {
+      wrapToolCall: async () => {
+        throw MiddlewareError.wrap(new Error("boom"), "test_middleware");
+      },
+    });
+
+    await expect(
+      toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: "",
+            tool_calls: [{ name: "ok_tool", args: {}, id: "testid" }],
+          }),
+        ],
+      })
+    ).rejects.toThrow();
   });
 
   it("should throw if handleToolErrors is false", async () => {


### PR DESCRIPTION
### Summary
When a `wrapToolCall` middleware is present, a recoverable tool-input error never reaches the model to self-correct and instead the whole run aborts instead.

The root cause is `baseHandler` correctly turns a `ToolInputParsingException` into a `ToolInvocationError`. The `defaultHandleToolErrors` knows how to convert into a retryable `ToolMessage`, but the middleware composer then
rewraps it as a `MiddlewareError`. `#handleError`'s guard re-raises middleware errors unless `handleToolErrors === true` and never looks at .cause, so the recoverable error is treated as fatal. Since middleware always wraps tool calls in deepagents, the self-correction path is unreachable.

This PR unwraps that one case, i.e., if a `MiddlewareError`'s .cause is a `ToolInvocationError` we treat the cause as the error passed to `handleToolErrors` so the existing recovery path applies. Genuine middleware failures stay fatal by default.

This has been heavily reported downstream in openwiki where long --init runs die the first time the model fumbles a tool call.

### Tests

Added two cases to `ToolNode.test.ts`. Both include a `wrapToolCall` middleware that rewraps errors as `MiddlewareError`