### PR TITLE
fix(openai): emit `output_text` for assistant content in responses input

### DIFF
--- a/.changeset/mighty-hotels-end.md
+++ b/.changeset/mighty-hotels-end.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): emit output_text for assistant content in responses input

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1004,8 +1004,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
 
     // Text parts must match the message role: assistant content uses
     // `output_text` (the Responses API rejects `input_text` for assistant
-    // messages), every other role uses `input_text`. Mirrors Python's
-    // role-dispatched `_construct_responses_api_input`.
+    // messages), every other role uses `input_text`.
     const makeTextPart = (
       text: string
     ): ResponseInputMessageContentList[number] =>

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1002,6 +1002,20 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       }
     });
 
+    // Text parts must match the message role: assistant content uses
+    // `output_text` (the Responses API rejects `input_text` for assistant
+    // messages), every other role uses `input_text`. Mirrors Python's
+    // role-dispatched `_construct_responses_api_input`.
+    const makeTextPart = (
+      text: string
+    ): ResponseInputMessageContentList[number] =>
+      (messageRole === "assistant"
+        ? { type: "output_text", text, annotations: [] }
+        : {
+            type: "input_text",
+            text,
+          }) as unknown as ResponseInputMessageContentList[number];
+
     let currentMessage: OpenAIClient.Responses.EasyInputMessage | undefined =
       undefined;
 
@@ -1044,7 +1058,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       if (typeof currentMessage.content === "string") {
         currentMessage.content =
           currentMessage.content.length > 0
-            ? [{ type: "input_text", text: currentMessage.content }, ...content]
+            ? [makeTextPart(currentMessage.content), ...content]
             : [...content];
       } else {
         currentMessage.content.push(...content);
@@ -1220,7 +1234,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
           return block.extras
             .phase as OpenAIClient.Responses.EasyInputMessage["phase"];
         });
-        pushMessageContent([{ type: "input_text", text: block.text }], phase);
+        pushMessageContent([makeTextPart(block.text)], phase);
       } else if (block.type === "invalid_tool_call") {
         // no-op
       } else if (block.type === "reasoning") {
@@ -1288,12 +1302,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
         }
       } else if (block.type === "text-plain") {
         if (block.text) {
-          pushMessageContent([
-            {
-              type: "input_text",
-              text: block.text,
-            },
-          ]);
+          pushMessageContent([makeTextPart(block.text)]);
         }
       } else if (block.type === "non_standard" && isResponsesMessage) {
         yield* flushMessage();

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1175,6 +1175,34 @@ describe("convertStandardContentMessageToResponsesInput", () => {
   });
 });
 
+describe("convertStandardContentMessageToResponsesInput (role-aware text parts)", () => {
+  it("emits output_text for assistant messages (not input_text)", () => {
+    const items = convertStandardContentMessageToResponsesInput(
+      new AIMessage({ contentBlocks: [{ type: "text", text: "hi" }] })
+    );
+    expect(items).toMatchObject([
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hi" }],
+      },
+    ]);
+  });
+
+  it("emits input_text for user messages", () => {
+    const items = convertStandardContentMessageToResponsesInput(
+      new HumanMessage({ contentBlocks: [{ type: "text", text: "hi" }] })
+    );
+    expect(items).toMatchObject([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      },
+    ]);
+  });
+});
+
 describe("convertMessagesToResponsesInput", () => {
   describe("Regression Tests", () => {
     it("allows file_url without filename metadata and excludes filename from payload", () => {


### PR DESCRIPTION
### Summary

The openai responses converter typed all text content as `input_text` regardless of role. For example, an assistant message became `{ role: "assistant", content: [{ type: "input_text", … }] }` and the API rejected it:

```
400 Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.
```

This bug only affects the native openai responses api and only on multi-turn runs since the bad `input_text` is on a prior assistant turn replayed as input meaning a single first turn never triggers it.

This PR makes the text part role-aware, i.e., `output_text` for assistant, `input_text` otherwise, this matches Python's `_construct_responses_api_input`.

### Tests

Added `convertStandardContentMessageToResponsesInput` regression tests verifying that an assistant message converts to `output_text` and a user message stays `input_text`.
