### PR TITLE
fix(core): coerce string v1 AIMessage content to text blocks

### DIFF
--- a/.changeset/fix-aimessage-v1-string-content.md
+++ b/.changeset/fix-aimessage-v1-string-content.md
@@ -1,0 +1,9 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): coerce string v1 AIMessage content to text blocks
+
+Prevent `contentBlocks.push is not a function` when constructing an
+`AIMessage` with `response_metadata.output_version === "v1"` and string
+`content` (common in serialized LangGraph stream payloads).

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -22,6 +22,19 @@ import {
 } from "./tool.js";
 import { collapseToolCallChunks, Constructor } from "./utils.js";
 
+function coerceToContentBlocks(value: unknown): Array<ContentBlock.Standard> {
+  if (typeof value === "string") {
+    return value.length > 0 ? [{ type: "text", text: value }] : [];
+  }
+  if (Array.isArray(value)) {
+    return value as Array<ContentBlock.Standard>;
+  }
+  if (value == null) {
+    return [];
+  }
+  return [value as ContentBlock.Standard];
+}
+
 export interface AIMessageFields<
   TStructure extends MessageStructure = MessageStructure,
 > extends BaseMessageFields<TStructure, "ai"> {
@@ -98,19 +111,25 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
         initParams.invalid_tool_calls = [];
       }
 
-      // Convert content to content blocks if output version is v1
+      // Convert content to content blocks if output version is v1.
+      // Serialized LangGraph payloads often still carry string `content` even
+      // when `output_version` is "v1"; normalize to an array before mutating.
       if (
         initParams.response_metadata !== undefined &&
         "output_version" in initParams.response_metadata &&
         initParams.response_metadata.output_version === "v1" &&
         initParams.content !== undefined
       ) {
-        initParams.contentBlocks =
-          initParams.content as Array<ContentBlock.Standard>;
+        initParams.contentBlocks = coerceToContentBlocks(initParams.content);
         initParams.content = undefined;
       }
 
       if (initParams.contentBlocks !== undefined) {
+        if (!Array.isArray(initParams.contentBlocks)) {
+          initParams.contentBlocks = coerceToContentBlocks(
+            initParams.contentBlocks
+          );
+        }
         // Add constructor tool calls as content blocks only when they are not
         // already represented in the v1 content payload.
         if (initParams.tool_calls) {

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -22,7 +22,7 @@ import {
 } from "./tool.js";
 import { collapseToolCallChunks, Constructor } from "./utils.js";
 
-function coerceToContentBlocks(value: unknown): Array<ContentBlock.Standard> {
+function coerceToContentBlocks(value: unknown): ContentBlock.Standard[] {
   if (typeof value === "string") {
     return value.length > 0 ? [{ type: "text", text: value }] : [];
   }

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -80,6 +80,70 @@ describe("AIMessage", () => {
     ]);
   });
 
+  it("should coerce string content to text blocks when output version is v1", () => {
+    const message = new AIMessage({
+      content: "Hi there!",
+      response_metadata: {
+        output_version: "v1",
+      },
+    });
+
+    expect(message.content).toEqual([{ type: "text", text: "Hi there!" }]);
+    expect(message.contentBlocks).toEqual([
+      { type: "text", text: "Hi there!" },
+    ]);
+  });
+
+  it("should coerce string content and merge tool_calls when output version is v1", () => {
+    const message = new AIMessage({
+      content: "Hi there!",
+      tool_calls: [
+        {
+          id: "123",
+          name: "get_weather",
+          args: {
+            location: "San Francisco",
+          },
+        },
+      ],
+      response_metadata: {
+        output_version: "v1",
+      },
+    });
+
+    expect(message.content).toEqual([
+      { type: "text", text: "Hi there!" },
+      {
+        type: "tool_call",
+        id: "123",
+        name: "get_weather",
+        args: {
+          location: "San Francisco",
+        },
+      },
+    ]);
+    expect(message.contentBlocks).toEqual([
+      { type: "text", text: "Hi there!" },
+      {
+        type: "tool_call",
+        id: "123",
+        name: "get_weather",
+        args: {
+          location: "San Francisco",
+        },
+      },
+    ]);
+    expect(message.tool_calls).toEqual([
+      {
+        id: "123",
+        name: "get_weather",
+        args: {
+          location: "San Francisco",
+        },
+      },
+    ]);
+  });
+
   describe(".contentBlocks", () => {
     it("should have tool call content blocks from .tool_calls", () => {
       const message = new AIMessage({


### PR DESCRIPTION
## Summary
- Normalize string (and other non-array) `content` to content-block arrays when constructing `AIMessage` with `response_metadata.output_version === "v1"`.
- Prevents `TypeError: initParams.contentBlocks.push is not a function`, which shows up when LangGraph stream/history payloads still carry string `content` under v1 metadata (e.g. Fleet agent creation).
- Adds regression coverage for string content with and without `tool_calls`.

No existing open PR covers this. Related merged work: #11047 (preserve existing `contentBlocks`), which does not handle string `content`.

## Test plan
- [x] `pnpm test src/messages/tests/ai.test.ts` in `libs/langchain-core` (17 passed)
- [ ] Confirm agent-creation chat no longer throws after bumping `@langchain/core` in langchainplus
