### PR TITLE
fix(google): use rep endpoint for Vertex multi-region locations

### DIFF
--- a/.changeset/vertex-multi-region-endpoint.md
+++ b/.changeset/vertex-multi-region-endpoint.md
@@ -1,0 +1,6 @@
+---
+"@langchain/google-common": patch
+"@langchain/google": patch
+---
+
+fix(google): use rep endpoint for Vertex multi-region locations

--- a/libs/providers/langchain-google-common/src/connection.ts
+++ b/libs/providers/langchain-google-common/src/connection.ts
@@ -34,6 +34,14 @@ import {
 } from "./utils/index.js";
 import { getAnthropicAPI } from "./utils/anthropic.js";
 
+// Vertex AI multi-region aliases. Unlike single regions (`us-central1`,
+// `europe-west4`, ...) these are served via regional endpoint proxies
+// (`aiplatform.{location}.rep.googleapis.com`), not a
+// `{location}-aiplatform.googleapis.com` host — the latter does not exist
+// for multi-region aliases. See
+// https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#regional-endpoints
+const VERTEX_MULTI_REGION_LOCATIONS = new Set(["us", "eu"]);
+
 export abstract class GoogleConnection<
   CallOptions extends AsyncCallerCallOptions,
   ResponseType extends GoogleResponse,
@@ -220,6 +228,13 @@ export abstract class GoogleHostConnection<
   get computedEndpoint(): string {
     if (this.location === "global") {
       return "aiplatform.googleapis.com";
+    } else if (VERTEX_MULTI_REGION_LOCATIONS.has(this.location)) {
+      // Multi-region aliases (`us`, `eu`) are served by regional endpoint
+      // proxies, not by a `{location}-aiplatform.googleapis.com` host (which
+      // only exists for single regions like `us-central1`). Using the wrong
+      // host produces `Invalid hostname: us-aiplatform.googleapis.com`.
+      // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#regional-endpoints
+      return `aiplatform.${this.location}.rep.googleapis.com`;
     } else {
       return `${this.location}-aiplatform.googleapis.com`;
     }

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -280,6 +280,56 @@ describe("Mock ChatGoogle - Gemini", () => {
     );
   });
 
+  test("platform endpoint - gcp multi-region us", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gcp",
+      location: "us",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://aiplatform.us.rep.googleapis.com/v1/projects/${projectId}/locations/us/publishers/google/models/gemini-pro:generateContent`
+    );
+  });
+
+  test("platform endpoint - gcp multi-region eu", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+    const model = new ChatGoogle({
+      authOptions,
+      platformType: "gcp",
+      location: "eu",
+    });
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Flip a coin and tell me H for heads and T for tails"),
+      new AIMessage("H"),
+      new HumanMessage("Flip it again"),
+    ];
+    await model.invoke(messages);
+
+    expect(record?.opts.url).toEqual(
+      `https://aiplatform.eu.rep.googleapis.com/v1/projects/${projectId}/locations/eu/publishers/google/models/gemini-pro:generateContent`
+    );
+  });
+
   test("platform endpoint - gai", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -79,6 +79,14 @@ import ServiceTier = Gemini.ServiceTier;
 
 export type GooglePlatformType = "gai" | "gcp";
 
+// Vertex AI multi-region aliases. Unlike single regions (`us-central1`,
+// `europe-west4`, ...) these are served via regional endpoint proxies
+// (`aiplatform.{location}.rep.googleapis.com`), not a
+// `{location}-aiplatform.googleapis.com` host — the latter does not exist
+// for multi-region aliases. See
+// https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#regional-endpoints
+const VERTEX_MULTI_REGION_LOCATIONS = new Set(["us", "eu"]);
+
 export function getPlatformType(
   platform: GooglePlatformType | undefined,
   hasApiKey: boolean
@@ -263,6 +271,13 @@ export abstract class BaseChatGoogle<
     } else if (this.location === "global") {
       // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#use_the_global_endpoint
       return "aiplatform.googleapis.com";
+    } else if (VERTEX_MULTI_REGION_LOCATIONS.has(this.location)) {
+      // Multi-region aliases (`us`, `eu`) are served by regional endpoint
+      // proxies, not by a `{location}-aiplatform.googleapis.com` host (which
+      // only exists for single regions like `us-central1`). Using the wrong
+      // host produces `Invalid hostname: us-aiplatform.googleapis.com`.
+      // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#regional-endpoints
+      return `aiplatform.${this.location}.rep.googleapis.com`;
     } else {
       return `${this.location}-aiplatform.googleapis.com`;
     }


### PR DESCRIPTION
Fixes #11196

## Summary

Vertex AI multi-region aliases (`us`, `eu`) are served by regional endpoint proxies at `aiplatform.{location}.rep.googleapis.com`, not by a `{location}-aiplatform.googleapis.com` host. The current templating only works for single regions like `us-central1`. For the `us` alias it produces the invalid host `us-aiplatform.googleapis.com` and every request fails with `Invalid hostname`.

This blocks anyone who wants to target the `us` (or `eu`) multi-region alias — including reaching Vertex provisioned-throughput (PTU) capacity, which is allocated against the alias rather than a single region — for models that are only available there (e.g. `gemini-3.1-flash-lite`, `gemini-3.5-flash`).

## Reproduction

```ts
import { ChatGoogle } from "@langchain/google";

const model = new ChatGoogle({
  platformType: "gcp",
  location: "us",
  model: "gemini-3.5-flash",
});
await model.invoke([{ role: "user", content: "hi" }]);
```

Fails with:

```
Invalid hostname: us-aiplatform.googleapis.com
```

## Fix

Introduce a `VERTEX_MULTI_REGION_LOCATIONS` set of the multi-region aliases and, when the location matches, return the correct regional endpoint host `aiplatform.{location}.rep.googleapis.com` instead of the single-region template `{location}-aiplatform.googleapis.com`.

Applied to both `langchain-google-common` (`GoogleHostConnection.computedEndpoint`, used by the legacy `vertexai`/`webauth` packages) and the modern `langchain-google` base class (`BaseChatGoogle.endpoint`).

Reference: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#regional-endpoints

## Test plan

- [x] Added mock test: `platform endpoint - gcp multi-region us` → asserts URL `https://aiplatform.us.rep.googleapis.com/v1/projects/{id}/locations/us/publishers/google/models/gemini-pro:generateContent`
- [x] Added mock test: `platform endpoint - gcp multi-region eu` → asserts URL `https://aiplatform.eu.rep.googleapis.com/...`
- [x] Existing single-region test (`luna-central1`) still expects `luna-central1-aiplatform.googleapis.com` — unchanged
- [x] Existing `global` test still expects `aiplatform.googleapis.com` — unchanged
- [x] Verified end-to-end against a real Vertex project: calls to `location: "us"` now reach the correct endpoint and return responses; without the fix they fail immediately at DNS resolution.

## Backwards compatibility

- Users who explicitly set `endpoint` are unaffected — the override branch runs first.
- Single-region strings (`us-central1`, `europe-west4`, `luna-central1`, …) fall through unchanged.
- The only observable behavior change is: `location: "us"` and `location: "eu"` used to fail with `Invalid hostname`, and now succeed.

