### PR TITLE
fix(openai): filter out content blocks the chat completions api rejects as input

### DIFF
--- a/.changeset/curvy-buckets-itch.md
+++ b/.changeset/curvy-buckets-itch.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): filter out content blocks the chat completions api rejects as input

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -807,14 +807,21 @@ export const convertMessagesToCompletionsMessageParams: Converter<
                 completionsApiContentBlockConverter
               );
             }
-            // Drop Anthropic tool_use blocks from content — these are
-            // already represented in message.tool_calls and would cause
-            // an API error if passed through to OpenAI.
+            // Drop content blocks the Chat Completions API rejects as input:
+            //  - `tool_use` is already carried in message.tool_calls, so
+            //    resending it as content would be a duplicate/invalid part.
+            //  - Reasoning traces (`reasoning`, `reasoning_content`,
+            //    `thinking`) are output-only; echoing them back in the request
+            //    history is rejected by strict openai-compatible providers,
+            //    e.g. DeepSeek: "unknown variant `reasoning`, expected `text`".
             if (
               typeof m === "object" &&
               m !== null &&
               "type" in m &&
-              m.type === "tool_use"
+              (m.type === "tool_use" ||
+                m.type === "reasoning" ||
+                m.type === "reasoning_content" ||
+                m.type === "thinking")
             ) {
               return [];
             }

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -554,13 +554,37 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
 
       expect(result).toHaveLength(1);
-      // tool_use is dropped; thinking and text pass through (thinking is
-      // unrecognised by OpenAI but that's a separate concern)
+      // Both tool_use and thinking are dropped; only text remains. Reasoning
+      // traces are output-only and are rejected when echoed back to strict
+      // openai-compatible providers (e.g. DeepSeek).
       const contentArr = result[0].content as any[];
       expect(contentArr.some((c: any) => c.type === "tool_use")).toBe(false);
+      expect(contentArr.some((c: any) => c.type === "thinking")).toBe(false);
       expect(contentArr.some((c: any) => c.type === "text")).toBe(true);
       // tool_calls should still be present
       expect((result[0] as any).tool_calls).toHaveLength(1);
+    });
+
+    it("should drop reasoning and reasoning_content blocks from content", () => {
+      // Regression: reasoning traces held in message history were echoed back
+      // into the request, which strict openai-compatible providers reject
+      // (e.g. DeepSeek: "unknown variant `reasoning`, expected `text`").
+      const message = new AIMessage({
+        content: [
+          { type: "reasoning", reasoning: "Let me think about this..." },
+          { type: "reasoning_content", reasoning_content: "more thoughts" },
+          { type: "text", text: "The answer is 42." },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toEqual([
+        { type: "text", text: "The answer is 42." },
+      ]);
     });
   });
 });


### PR DESCRIPTION
### Summary

The Chat Completions outbound converter (`convertMessagesToCompletionsMessageParams`) forwarded provider reasoning content blocks back into the request history. Strict openai-compatible providers reject them, for example DeepSeek returns `400 unknown variant 'reasoning', expected 'text'`. Short requests worked, but longer agent runs failed once a reasoning block accumulated in history.

The converter already dropped `tool_use` blocks. This extends that guard to also drop `reasoning`, `reasoning_content`, and `thinking` blocks, which are output-only and not valid Chat Completions input content.

Reference issue: https://github.com/langchain-ai/openwiki/issues/231

### Tests

Unit tests