### PR TITLE
fix(openai): drop `tool_call` content blocks from chat completions input

### DIFF
--- a/.changeset/lovely-houses-tease.md
+++ b/.changeset/lovely-houses-tease.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): drop tool_call content blocks from chat completions input

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -808,17 +808,20 @@ export const convertMessagesToCompletionsMessageParams: Converter<
               );
             }
             // Drop content blocks the Chat Completions API rejects as input:
-            //  - `tool_use` is already carried in message.tool_calls, so
-            //    resending it as content would be a duplicate/invalid part.
+            //  - Tool-call blocks (`tool_use`, `tool_call`) are already
+            //    carried in message.tool_calls, so resending them as content
+            //    would be a duplicate/invalid part.
             //  - Reasoning traces (`reasoning`, `reasoning_content`,
-            //    `thinking`) are output-only; echoing them back in the request
-            //    history is rejected by strict openai-compatible providers,
-            //    e.g. DeepSeek: "unknown variant `reasoning`, expected `text`".
+            //    `thinking`) are output-only.
+            // Echoing any of these back in the request history is rejected by
+            // strict openai-compatible providers, e.g. DeepSeek:
+            // "unknown variant `reasoning`, expected `text`".
             if (
               typeof m === "object" &&
               m !== null &&
               "type" in m &&
               (m.type === "tool_use" ||
+                m.type === "tool_call" ||
                 m.type === "reasoning" ||
                 m.type === "reasoning_content" ||
                 m.type === "thinking")

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -565,14 +565,21 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       expect((result[0] as any).tool_calls).toHaveLength(1);
     });
 
-    it("should drop reasoning and reasoning_content blocks from content", () => {
-      // Regression: reasoning traces held in message history were echoed back
-      // into the request, which strict openai-compatible providers reject
-      // (e.g. DeepSeek: "unknown variant `reasoning`, expected `text`").
+    it("should drop reasoning, reasoning_content, and tool_call blocks from content", () => {
+      // Regression: standard reasoning/tool-call blocks held in message
+      // history were echoed back into the request, which strict
+      // openai-compatible providers reject (e.g. DeepSeek:
+      // "unknown variant `reasoning`/`tool_call`, expected `text`").
       const message = new AIMessage({
         content: [
           { type: "reasoning", reasoning: "Let me think about this..." },
           { type: "reasoning_content", reasoning_content: "more thoughts" },
+          {
+            type: "tool_call",
+            id: "call_1",
+            name: "search",
+            args: { q: "langchain" },
+          },
           { type: "text", text: "The answer is 42." },
         ],
       });


### PR DESCRIPTION
### Summary

Follow-up to the reasoning-block fix. The chat completions outbound converter (`convertMessagesToCompletionsMessageParams`) also forwarded `tool_call` content blocks back into the request history. Strict openai-compatible providers reject them, for example DeepSeek returns `400 unknown variant 'tool_call', expected 'text'` on longer agent runs.

Reference: https://github.com/langchain-ai/openwiki/issues/231

### Tests

Unit tests