### PR TITLE
fix(anthropic): fix streaming with server tools producing invalid_tool_calls

### DIFF
--- a/.changeset/fix-anthropic-server-tool-streaming.md
+++ b/.changeset/fix-anthropic-server-tool-streaming.md
@@ -1,0 +1,14 @@
+---
+"@langchain/anthropic": patch
+"@langchain/core": patch
+---
+
+fix(anthropic): fix streaming with server tools producing invalid_tool_calls
+
+- Track content block types by index during streaming so input_json_delta
+  events for server_tool_use blocks do not emit tool_call_chunks (which
+  lack id/name and fail validation in collapseToolCallChunks)
+- Add web_fetch_tool_result, code_execution_tool_result, mcp_tool_result,
+  mcp_tool_use, and other missing server tool result types to streaming
+  and round-trip whitelists
+- Fix double-JSON encoding of server_tool_use args when input is a string

--- a/libs/langchain-core/src/messages/block_translators/anthropic.ts
+++ b/libs/langchain-core/src/messages/block_translators/anthropic.ts
@@ -381,6 +381,12 @@ export function convertToV1FromAnthropicMessage(
         if (name === "web_search") {
           const query = iife(() => {
             if (typeof block.input === "string") {
+              // During streaming accumulation, input is a JSON string like
+              // '{"query": "..."}' that needs parsing to extract the field.
+              const parsed = safeParseJson<{ query?: string }>(block.input);
+              if (parsed?.query) {
+                return parsed.query;
+              }
               return block.input;
             } else if (_isObject(block.input) && _isString(block.input.query)) {
               return block.input.query;
@@ -404,6 +410,12 @@ export function convertToV1FromAnthropicMessage(
         } else if (block.name === "code_execution") {
           const code = iife(() => {
             if (typeof block.input === "string") {
+              // During streaming accumulation, input is a JSON string like
+              // '{"code": "..."}' that needs parsing to extract the field.
+              const parsed = safeParseJson<{ code?: string }>(block.input);
+              if (parsed?.code) {
+                return parsed.code;
+              }
               return block.input;
             } else if (_isObject(block.input) && _isString(block.input.code)) {
               return block.input.code;

--- a/libs/langchain-core/src/messages/block_translators/tests/anthropic.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/anthropic.test.ts
@@ -383,6 +383,62 @@ describe("anthropicTranslator", () => {
     expect(full?.contentBlocks).toEqual(expectedContentBlocks);
   });
 
+  it("should correctly parse string input for web_search server_tool_use (no double-JSON encoding)", () => {
+    // During streaming accumulation, input can be a JSON string like '{"query": "..."}'
+    // instead of a parsed object. The translator should parse it correctly.
+    const message = new AIMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srvtoolu_stream_001",
+          name: "web_search",
+          input: '{"query": "weather NYC today"}',
+        },
+      ],
+      response_metadata: {
+        model_provider: "anthropic",
+      },
+    });
+
+    const expectedContent: Array<ContentBlock.Standard> = [
+      {
+        type: "server_tool_call",
+        name: "web_search",
+        id: "srvtoolu_stream_001",
+        args: { query: "weather NYC today" },
+      },
+    ];
+
+    expect(message.contentBlocks).toEqual(expectedContent);
+  });
+
+  it("should correctly parse string input for code_execution server_tool_use (no double-JSON encoding)", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srvtoolu_code_001",
+          name: "code_execution",
+          input: '{"code": "print(42)"}',
+        },
+      ],
+      response_metadata: {
+        model_provider: "anthropic",
+      },
+    });
+
+    const expectedContent: Array<ContentBlock.Standard> = [
+      {
+        type: "server_tool_call",
+        name: "code_execution",
+        id: "srvtoolu_code_001",
+        args: { code: "print(42)" },
+      },
+    ];
+
+    expect(message.contentBlocks).toEqual(expectedContent);
+  });
+
   it("should translate anthropic input to standard content blocks", () => {
     const message = new HumanMessage({
       content: [

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1342,6 +1342,12 @@ export class ChatAnthropicMessages<
       signal: options.signal,
     });
 
+    // Track content block types by index so that input_json_delta events
+    // for server_tool_use blocks are not emitted as tool_call_chunks. This
+    // map is populated inside _makeMessageChunkFromAnthropicEvent on
+    // content_block_start events and read on input_json_delta events.
+    const blockTypesByIndex = new Map<number, string>();
+
     for await (const data of stream) {
       if (options.signal?.aborted) {
         stream.controller.abort();
@@ -1351,6 +1357,7 @@ export class ChatAnthropicMessages<
       const result = _makeMessageChunkFromAnthropicEvent(data, {
         streamUsage: shouldStreamUsage,
         coerceContentToString,
+        blockTypesByIndex,
       });
       if (!result) continue;
 

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -159,11 +159,15 @@ function* _formatContentBlocks(
 ): Generator<Anthropic.Beta.BetaContentBlockParam> {
   const toolTypes = [
     "bash_code_execution_tool_result",
+    "code_execution_tool_result",
     "input_json_delta",
+    "mcp_tool_result",
+    "mcp_tool_use",
     "server_tool_use",
     "text_editor_code_execution_tool_result",
     "tool_result",
     "tool_use",
+    "web_fetch_tool_result",
     "web_search_result",
     "web_search_tool_result",
   ];

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -18,6 +18,7 @@ export function _makeMessageChunkFromAnthropicEvent(
   fields: {
     streamUsage: boolean;
     coerceContentToString: boolean;
+    blockTypesByIndex?: Map<number, string>;
   }
 ): {
   chunk: AIMessageChunk;
@@ -75,8 +76,17 @@ export function _makeMessageChunkFromAnthropicEvent(
       "document",
       "server_tool_use",
       "web_search_tool_result",
+      "web_fetch_tool_result",
+      "code_execution_tool_result",
+      "bash_code_execution_tool_result",
+      "text_editor_code_execution_tool_result",
+      "mcp_tool_result",
+      "mcp_tool_use",
     ].includes(data.content_block.type)
   ) {
+    // Track the block type by index so that input_json_delta can distinguish
+    // between tool_use (client) and server_tool_use blocks.
+    fields.blockTypesByIndex?.set(data.index, data.content_block.type);
     const contentBlock = data.content_block;
     let toolCallChunks: ToolCallChunk[];
     if (contentBlock.type === "tool_use") {
@@ -156,6 +166,13 @@ export function _makeMessageChunkFromAnthropicEvent(
     data.type === "content_block_delta" &&
     data.delta.type === "input_json_delta"
   ) {
+    // Only emit tool_call_chunks for actual tool_use (client tool) blocks.
+    // server_tool_use blocks also stream input_json_delta events, but those
+    // should NOT produce tool_call_chunks since they lack id/name and would
+    // fail validation in collapseToolCallChunks(), producing invalid_tool_calls.
+    const blockType = fields.blockTypesByIndex?.get(data.index);
+    const isClientToolUse = blockType === undefined || blockType === "tool_use";
+
     return {
       chunk: new AIMessageChunk({
         content: fields.coerceContentToString
@@ -169,12 +186,14 @@ export function _makeMessageChunkFromAnthropicEvent(
             ],
         response_metadata,
         additional_kwargs: {},
-        tool_call_chunks: [
-          {
-            index: data.index,
-            args: data.delta.partial_json,
-          },
-        ],
+        tool_call_chunks: isClientToolUse
+          ? [
+              {
+                index: data.index,
+                args: data.delta.partial_json,
+              },
+            ]
+          : [],
       }),
     };
   } else if (


### PR DESCRIPTION
Fixes three related bugs that cause streaming with Anthropic server tools (`web_search`, `web_fetch`, `code_execution`) to produce `invalid_tool_calls` entries and silently drop content blocks.

This recreates #10013, which a maintainer approved in direction ("The direction of the fix seems valid… Feel free to recreate it and I am happy to review.") but closed for author inactivity. Rebased onto current `main` and re-verified. Fixes #9911.

## Root causes & fixes

### 1. `input_json_delta` emits `tool_call_chunks` for `server_tool_use` blocks

The streaming handler in `message_outputs.ts` created `tool_call_chunks` for every `input_json_delta` event regardless of whether the parent block is a client `tool_use` or a `server_tool_use`. Server-tool deltas have no `id`/`name`, so `collapseToolCallChunks()` flags them as malformed and pushes them into `invalid_tool_calls`.

Fix: track content-block types by index (`blockTypesByIndex`) as they arrive on `content_block_start`, and only emit `tool_call_chunks` for client `tool_use` blocks. For `server_tool_use`, emit `[]`.

> Re: the review note on the earlier PR ("It doesn't seem we use this anywhere after?") — the map is consumed inside `_makeMessageChunkFromAnthropicEvent`: it's populated on `content_block_start` and read on `input_json_delta` to decide whether to emit `tool_call_chunks`. `chat_models.ts` owns it so it persists across the per-event calls within a single stream.

### 2. Missing content-block types in streaming and round-trip whitelists

`web_fetch_tool_result`, `code_execution_tool_result`, `bash_code_execution_tool_result`, `text_editor_code_execution_tool_result`, `mcp_tool_result`, and `mcp_tool_use` were absent from the whitelists in `message_outputs.ts` (streaming) and `message_inputs.ts` (serialization), so they were silently dropped during streaming and multi-turn conversations. Added them to both.

### 3. Double-JSON encoding of `server_tool_use` args when `input` is a string

During streaming accumulation, `input` is a JSON string like `'{"query": "..."}'`. The `web_search`/`code_execution` handlers in `block_translators/anthropic.ts` returned that raw string as the field value, producing `{ query: '{"query": "..."}' }`. Now the string branch parses the JSON first and falls back to the raw string if parsing fails.

## Test plan

- Added unit tests: `input_json_delta` for `server_tool_use` does NOT emit `tool_call_chunks`; regular `tool_use` still does; mixed streams handled; `web_search_tool_result`/`web_fetch_tool_result` `content_block_start` not dropped; `web_fetch_tool_result` round-trips through message formatting; string `input` for `web_search`/`code_execution` parses correctly (no double-JSON).
- Verified failing → passing: reverting each source change reproduces the failures the new tests assert.
- Full `@langchain/anthropic` unit suite green (207 tests); `@langchain/core` messages suite green (336 tests); no type errors; `oxfmt`/`oxlint` clean.

## Backward compatibility

`blockTypesByIndex` is optional (defaults to `undefined`); when absent the handler falls back to the previous behavior, so existing callers are unaffected. The whitelist additions only restore previously-dropped block types.
