### PR TITLE
feat(google): surface Vertex trafficType and modelVersion on response_metadata

### DIFF
--- a/.changeset/vertex-traffic-type.md
+++ b/.changeset/vertex-traffic-type.md
@@ -1,0 +1,6 @@
+---
+"@langchain/google-common": patch
+"@langchain/google": patch
+---
+
+feat(google): surface Vertex trafficType and modelVersion on response_metadata

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -3456,6 +3456,23 @@ test("Invoke usage_metadata maps token details", async () => {
   expect(result.usage_metadata?.output_token_details?.reasoning).toBe(4);
 });
 
+test("Invoke surfaces Vertex traffic_type and model_version on response_metadata", async () => {
+  const record: Record<string, unknown> = {};
+  const projectId = mockId();
+  const model = new ChatGoogle({
+    authOptions: {
+      record,
+      projectId,
+      resultFile: "chat-traffic-type-mock.json",
+    },
+  });
+
+  const result = await model.invoke("Hello?");
+
+  expect(result.response_metadata?.traffic_type).toBe("PROVISIONED_THROUGHPUT");
+  expect(result.response_metadata?.model_version).toBe("gemini-2.0-flash-001");
+});
+
 test("Stream usage_metadata includes cache_read", async () => {
   const record: Record<string, unknown> = {};
   const projectId = mockId();

--- a/libs/providers/langchain-google-common/src/tests/data/chat-traffic-type-mock.json
+++ b/libs/providers/langchain-google-common/src/tests/data/chat-traffic-type-mock.json
@@ -1,0 +1,25 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "OK"
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "modelVersion": "gemini-2.0-flash-001",
+  "promptFeedback": {
+    "safetyRatings": []
+  },
+  "usageMetadata": {
+    "promptTokenCount": 10,
+    "candidatesTokenCount": 4,
+    "totalTokenCount": 14,
+    "trafficType": "PROVISIONED_THROUGHPUT"
+  }
+}

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1288,6 +1288,15 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
 
     const finish_reason = data.candidates[0]?.finishReason;
 
+    // Vertex response provenance. Not in the OpenAPI spec but present on both
+    // streaming (final chunk) and non-streaming responses. Surface them so
+    // callers can observe PTU consumption (`PROVISIONED_THROUGHPUT`) vs
+    // on-demand (`ON_DEMAND` / `ON_DEMAND_PRIORITY`) and the exact served
+    // model version — useful when PTU is version-bound.
+    const traffic_type = (data.usageMetadata as { trafficType?: string })
+      ?.trafficType;
+    const model_version = (data as { modelVersion?: string })?.modelVersion;
+
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     const ret: Record<string, any> = {
       safety_ratings: data.candidates[0]?.safetyRatings?.map((rating) => ({
@@ -1304,6 +1313,8 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       url_context_metadata: candidateToUrlContextMetadata(data.candidates[0]),
       avgLogprobs: data.candidates[0]?.avgLogprobs,
       logprobs: candidateToLogprobs(data.candidates[0]),
+      ...(traffic_type !== undefined ? { traffic_type } : {}),
+      ...(model_version !== undefined ? { model_version } : {}),
     };
 
     // Only add the usage_metadata on the last chunk
@@ -1542,12 +1553,22 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     //   kwargs.reasoning_content = combineContent(gen.reasoning, true);
     // }
 
+    // Surface Vertex response provenance on the message. See
+    // responseToGenerationInfo for the same treatment on per-generation info.
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const responseData = (response.data as any) ?? {};
+    const traffic_type: string | undefined =
+      responseData?.usageMetadata?.trafficType;
+    const model_version: string | undefined = responseData?.modelVersion;
+
     // Build the message and the generation chunk to return
     const message = new AIMessageChunk({
       content: combinedContent,
       additional_kwargs: kwargs,
       response_metadata: {
         model_provider: "google-vertexai",
+        ...(traffic_type !== undefined ? { traffic_type } : {}),
+        ...(model_version !== undefined ? { model_version } : {}),
       },
       usage_metadata,
       tool_calls: combinedToolCalls.tool_calls,

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1288,15 +1288,6 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
 
     const finish_reason = data.candidates[0]?.finishReason;
 
-    // Vertex response provenance. Not in the OpenAPI spec but present on both
-    // streaming (final chunk) and non-streaming responses. Surface them so
-    // callers can observe PTU consumption (`PROVISIONED_THROUGHPUT`) vs
-    // on-demand (`ON_DEMAND` / `ON_DEMAND_PRIORITY`) and the exact served
-    // model version — useful when PTU is version-bound.
-    const traffic_type = (data.usageMetadata as { trafficType?: string })
-      ?.trafficType;
-    const model_version = (data as { modelVersion?: string })?.modelVersion;
-
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     const ret: Record<string, any> = {
       safety_ratings: data.candidates[0]?.safetyRatings?.map((rating) => ({
@@ -1313,14 +1304,19 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       url_context_metadata: candidateToUrlContextMetadata(data.candidates[0]),
       avgLogprobs: data.candidates[0]?.avgLogprobs,
       logprobs: candidateToLogprobs(data.candidates[0]),
-      ...(traffic_type !== undefined ? { traffic_type } : {}),
-      ...(model_version !== undefined ? { model_version } : {}),
     };
 
-    // Only add the usage_metadata on the last chunk
-    // sent while streaming (see issue 8102).
+    // Vertex response provenance (trafficType / modelVersion) + usage_metadata
+    // ONLY on the last chunk. Avoids AIMessageChunk.concat string-appending
+    // the same value across every streaming chunk. Not in the OpenAPI spec
+    // but present on real Vertex responses.
     if (typeof finish_reason === "string") {
       ret.usage_metadata = responseToUsageMetadata(response);
+      const traffic_type = (data.usageMetadata as { trafficType?: string })
+        ?.trafficType;
+      const model_version = (data as { modelVersion?: string })?.modelVersion;
+      if (traffic_type !== undefined) ret.traffic_type = traffic_type;
+      if (model_version !== undefined) ret.model_version = model_version;
     }
 
     return ret;

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -761,24 +761,31 @@ export abstract class BaseChatGoogle<
 
               // Only emit if we have content
               if (parts.length > 0 || candidate.finishReason) {
+                // Surface Vertex response provenance the same way the
+                // non-streaming path does. Attach ONLY on the terminal chunk
+                // (finishReason set) — AIMessageChunk.concat string-appends
+                // response_metadata values across chunks, so putting the same
+                // value on every chunk produces e.g.
+                // "PROVISIONED_THROUGHPUTPROVISIONED_THROUGHPUT" on the merged
+                // AIMessage. Non-terminal chunks don't carry these fields
+                // reliably anyway.
                 // @ts-expect-error - trafficType is defined on Vertex, so isn't in the OpenAPI spec
-                const chunkTrafficType: string | undefined =
-                  chunk?.usageMetadata?.trafficType;
+                const chunkTrafficType: string | undefined = candidate.finishReason
+                  ? chunk?.usageMetadata?.trafficType
+                  : undefined;
+                const chunkModelVersion: string | undefined = candidate.finishReason
+                  ? chunk?.modelVersion
+                  : undefined;
                 const messageChunkParams: AIMessageChunkFields = {
                   content: message.content,
                   tool_calls: toolCalls,
                   response_metadata: {
                     model_provider: "google",
-                    // Surface Vertex response provenance the same way the
-                    // non-streaming path does. Only present on chunks that
-                    // actually carry these fields (typically the terminal
-                    // chunk with usageMetadata) — merged into the final
-                    // AIMessage by AIMessageChunk.concat.
                     ...(chunkTrafficType !== undefined
                       ? { traffic_type: chunkTrafficType }
                       : {}),
-                    ...(chunk?.modelVersion !== undefined
-                      ? { model_version: chunk.modelVersion }
+                    ...(chunkModelVersion !== undefined
+                      ? { model_version: chunkModelVersion }
                       : {}),
                   },
                   additional_kwargs: {

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -536,10 +536,24 @@ export abstract class BaseChatGoogle<
       convertGeminiGenerateContentResponseToUsageMetadata(data);
     message.usage_metadata = usageMetadata;
 
-    const serviceTier: ServiceTier = iife((): ServiceTier => {
-      // @ts-expect-error - trafficType is defined on Vertex, so isn't in the OpenAPI spec
-      const trafficType: string | undefined = data.usageMetadata?.trafficType;
+    // @ts-expect-error - trafficType is defined on Vertex, so isn't in the OpenAPI spec
+    const trafficType: string | undefined = data.usageMetadata?.trafficType;
 
+    // Surface Vertex response provenance on the message so callers can
+    // observe PTU consumption (`PROVISIONED_THROUGHPUT`) vs on-demand
+    // (`ON_DEMAND` / `ON_DEMAND_PRIORITY`) without dropping to the raw HTTP
+    // envelope via the `google-response-*` custom event. `modelVersion`
+    // captures the exact served version (e.g. gemini-3.1-flash-lite vs a
+    // preview variant), useful when PTU is version-bound.
+    message.response_metadata = {
+      ...message.response_metadata,
+      ...(trafficType !== undefined ? { traffic_type: trafficType } : {}),
+      ...(data.modelVersion !== undefined
+        ? { model_version: data.modelVersion }
+        : {}),
+    };
+
+    const serviceTier: ServiceTier = iife((): ServiceTier => {
       // AI Studio replies with actual service type in the header
       const serviceTierHeader: string | null = response.headers.get(
         "x-gemini-service-tier"
@@ -747,11 +761,25 @@ export abstract class BaseChatGoogle<
 
               // Only emit if we have content
               if (parts.length > 0 || candidate.finishReason) {
+                // @ts-expect-error - trafficType is defined on Vertex, so isn't in the OpenAPI spec
+                const chunkTrafficType: string | undefined =
+                  chunk?.usageMetadata?.trafficType;
                 const messageChunkParams: AIMessageChunkFields = {
                   content: message.content,
                   tool_calls: toolCalls,
                   response_metadata: {
                     model_provider: "google",
+                    // Surface Vertex response provenance the same way the
+                    // non-streaming path does. Only present on chunks that
+                    // actually carry these fields (typically the terminal
+                    // chunk with usageMetadata) — merged into the final
+                    // AIMessage by AIMessageChunk.concat.
+                    ...(chunkTrafficType !== undefined
+                      ? { traffic_type: chunkTrafficType }
+                      : {}),
+                    ...(chunk?.modelVersion !== undefined
+                      ? { model_version: chunk.modelVersion }
+                      : {}),
                   },
                   additional_kwargs: {
                     ...(message.additional_kwargs.originalTextContentBlock

--- a/libs/providers/langchain-google/src/chat_models/tests/data/mock/gemini-chat-traffic-type.json
+++ b/libs/providers/langchain-google/src/chat_models/tests/data/mock/gemini-chat-traffic-type.json
@@ -1,0 +1,24 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "1 + 1 = 2"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 9,
+    "candidatesTokenCount": 7,
+    "totalTokenCount": 16,
+    "trafficType": "PROVISIONED_THROUGHPUT"
+  },
+  "modelVersion": "gemini-3-flash-preview",
+  "responseId": "ZFtQaYfhHvnm_uMPzdv0iAk"
+}

--- a/libs/providers/langchain-google/src/chat_models/tests/data/mock/gemini-stream-traffic-type.txt
+++ b/libs/providers/langchain-google/src/chat_models/tests/data/mock/gemini-stream-traffic-type.txt
@@ -1,0 +1,4 @@
+data: {"candidates":[{"content":{"parts":[{"text":"The"}],"role":"model"}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1,"totalTokenCount":11},"modelVersion":"gemini-2.5-flash"}
+
+data: {"candidates":[{"content":{"parts":[{"text":" sky is blue."}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":12,"totalTokenCount":22,"trafficType":"PROVISIONED_THROUGHPUT"},"modelVersion":"gemini-2.5-flash"}
+

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -353,6 +353,38 @@ describe("Google Mock", () => {
     );
   });
 
+  test("invoke surfaces Vertex traffic_type and model_version on response_metadata", async () => {
+    const llm = newChatGoogle({
+      model: "gemini-3-flash-preview",
+      responseFile: "gemini-chat-traffic-type.json",
+    });
+    const result = await llm.invoke("What is 1+1?");
+    expect(result.response_metadata.traffic_type).toBe(
+      "PROVISIONED_THROUGHPUT"
+    );
+    expect(result.response_metadata.model_version).toBe(
+      "gemini-3-flash-preview"
+    );
+  });
+
+  test("stream surfaces Vertex traffic_type and model_version on the final concatenated chunk", async () => {
+    const llm = newChatGoogle({
+      model: "gemini-2.5-flash",
+      responseFile: "gemini-stream-traffic-type.txt",
+      streaming: true,
+    });
+    const stream = await llm.stream("What color is the sky?");
+    let finalChunk: AIMessageChunk | undefined;
+    for await (const chunk of stream) {
+      finalChunk = finalChunk ? finalChunk.concat(chunk) : chunk;
+    }
+    expect(finalChunk).toBeDefined();
+    expect(finalChunk?.response_metadata.traffic_type).toBe(
+      "PROVISIONED_THROUGHPUT"
+    );
+    expect(finalChunk?.response_metadata.model_version).toBe("gemini-2.5-flash");
+  });
+
   test("mediaResolution uses scalar generation config value from constructor fields", async () => {
     const params: ChatGoogleParams = {
       model: "gemini-3-pro-preview",


### PR DESCRIPTION
Closes #11197

## Summary

Vertex AI returns two useful fields on every generate response that the SDK currently drops:

- **`usageMetadata.trafficType`** — `PROVISIONED_THROUGHPUT`, `ON_DEMAND`, or `ON_DEMAND_PRIORITY`. Tells you whether the request actually consumed Provisioned Throughput (PTU) capacity or spilled to on-demand.
- **`modelVersion`** — the exact served model version, which matters when PTU is version-bound.

Today a caller can only see token counts via `usage_metadata`. There's no supported way to observe PTU consumption from the client — you have to intercept the raw HTTP body (e.g. via the `google-response-*` custom event) to get `trafficType` at all, and on **streaming** responses even that is awkward because the field only arrives on the terminal chunk.

This surfaces both fields on the returned message's `response_metadata`, on both streaming and non-streaming paths, in both `@langchain/google` and `@langchain/google-common`.

## Motivation

We run Gemini on Vertex Provisioned Throughput. After pinning traffic to a PTU-eligible region we needed to confirm requests were actually consuming PTU (not silently billing on-demand). The only signal is `trafficType`, and it wasn't reachable from the `AIMessage` — non-streaming or streaming. This change makes it a first-class part of the response.

## Changes

- **`@langchain/google`**
  - `_generate` (non-streaming): add `traffic_type` + `model_version` to `message.response_metadata`. The path already read `trafficType` to derive `serviceTier`; now it's also exposed directly.
  - `_streamResponseChunks` (streaming): add them to each chunk's `response_metadata` when present (terminal chunk carries `usageMetadata`), so they land on the final concatenated `AIMessage`.
- **`@langchain/google-common`**
  - `responseToGenerationInfo` + `combineGenerations`: same fields on `generationInfo` and the message's `response_metadata`.

Both fields are omitted when absent (e.g. AI Studio responses without `trafficType`), so no shape change for non-Vertex callers.

## Test plan

- [x] `@langchain/google`: new mock fixtures + tests — `invoke surfaces Vertex traffic_type and model_version on response_metadata`, and `stream surfaces ... on the final concatenated chunk`.
- [x] `@langchain/google-common`: new fixture + `Invoke surfaces Vertex traffic_type and model_version on response_metadata`.
- [x] Existing usage-metadata and streaming tests unchanged.

## Example

```ts
const model = new ChatGoogle({ platformType: "gcp", location: "us", model: "gemini-3.1-flash-lite" });
const res = await model.invoke("hi");
console.log(res.response_metadata.traffic_type);  // "PROVISIONED_THROUGHPUT"
console.log(res.response_metadata.model_version); // "gemini-3.1-flash-lite"

// streaming
let final;
for await (const c of await model.stream("hi")) final = final ? final.concat(c) : c;
console.log(final.response_metadata.traffic_type); // "PROVISIONED_THROUGHPUT"
```

