### PR TITLE
fix(docs): update 3 broken Anthropic docs links in langchain-anthropic README

### DIFF
--- a/.changeset/fix-anthropic-docs-links.md
+++ b/.changeset/fix-anthropic-docs-links.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(docs): update 3 broken Anthropic docs links in langchain-anthropic README

--- a/libs/providers/langchain-anthropic/README.md
+++ b/libs/providers/langchain-anthropic/README.md
@@ -323,7 +323,7 @@ const response = await llm.invoke(
 );
 ```
 
-For more information, see [Anthropic's Web Fetch Tool documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-fetch-tool).
+For more information, see [Anthropic's Web Fetch Tool documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-fetch-tool).
 
 ### Tool Search Tools
 
@@ -388,7 +388,7 @@ const response = await llm.invoke("What is the weather in San Francisco?", {
 });
 ```
 
-For more information, see [Anthropic's Tool Search documentation](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/tool-search-tool).
+For more information, see [Anthropic's Tool Search documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/tool-search-tool).
 
 ### Text Editor Tool
 
@@ -529,7 +529,7 @@ const computer = tools.computer_20251124({
 });
 ```
 
-For more information, see [Anthropic's Computer Use documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use).
+For more information, see [Anthropic's Computer Use documentation](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool).
 
 ### Code Execution Tool
 


### PR DESCRIPTION
## What

Three links in `libs/providers/langchain-anthropic/README.md` point to Anthropic docs paths that 404. All three replacements were verified with `curl -sL` returning 200.

| Line | Before | After | Reason |
|---|---|---|---|
| 326 | `/build-with-claude/tool-use/web-fetch-tool` | `/agents-and-tools/tool-use/web-fetch-tool` | path segment changed when docs site restructured |
| 391 | `/build-with-claude/tool-use/tool-search-tool` | `/agents-and-tools/tool-use/tool-search-tool` | same path segment change |
| 532 | `/agents-and-tools/tool-use/computer-use` | `/agents-and-tools/tool-use/computer-use-tool` | page renamed with `-tool` suffix to match other tool pages |

## Verification

```
$ for url in \
    'https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-fetch-tool' \
    'https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/tool-search-tool' \
    'https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool'; do
    printf '%s -> ' "$url"
    curl -sL -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0' "$url"
done
https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-fetch-tool -> 200
https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/tool-search-tool -> 200
https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool -> 200
```

The `web-search-tool` link on line 264 still works (the `/build-with-claude/` path was kept as a 301-redirect for that one page), so it was left alone.

## Scope

Pure docs/markdown — no runtime code touched. Total diff: +3 / -3 in 1 file.