### PR TITLE
feat(anthropic): support eager_input_streaming tool extra

### DIFF
--- a/.changeset/eager-otters-stream.md
+++ b/.changeset/eager-otters-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Add `eager_input_streaming` to the supported Anthropic tool extras, allowing it to be set per-tool via the `extras` parameter and passed through to the Anthropic API.

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -742,6 +742,40 @@ describe("Tool extras", () => {
     expect(toolDef).toHaveProperty("cache_control", { type: "ephemeral" });
     expect(toolDef).toHaveProperty("input_examples");
   });
+
+  test("eager_input_streaming is passed through to the tool definition", () => {
+    const streamingTool = tool(
+      async (input: { query: string }) => {
+        return `Results for ${input.query}`;
+      },
+      {
+        name: "eager_search",
+        description: "Search with eager input streaming.",
+        schema: z.object({
+          query: z.string(),
+        }),
+        extras: {
+          eager_input_streaming: true,
+        },
+      }
+    );
+
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+
+    const formattedTools = model.formatStructuredToolToAnthropic([
+      streamingTool,
+    ]);
+
+    expect(formattedTools).toBeDefined();
+    const toolDef = formattedTools?.find(
+      (t) => "name" in t && t.name === "eager_search"
+    );
+    expect(toolDef).toBeDefined();
+    expect(toolDef).toHaveProperty("eager_input_streaming", true);
+  });
 });
 
 describe("Tool extras validation", () => {
@@ -754,6 +788,21 @@ describe("Tool extras validation", () => {
   test("input_examples with wrong type throws error", () => {
     expect(() => {
       AnthropicToolExtrasSchema.parse({ input_examples: "not a list" });
+    }).toThrow(z4.ZodError);
+  });
+
+  test("eager_input_streaming accepts boolean and null", () => {
+    expect(
+      AnthropicToolExtrasSchema.parse({ eager_input_streaming: true })
+    ).toEqual({ eager_input_streaming: true });
+    expect(
+      AnthropicToolExtrasSchema.parse({ eager_input_streaming: null })
+    ).toEqual({ eager_input_streaming: null });
+  });
+
+  test("eager_input_streaming with wrong type throws error", () => {
+    expect(() => {
+      AnthropicToolExtrasSchema.parse({ eager_input_streaming: "not a bool" });
     }).toThrow(z4.ZodError);
   });
 });

--- a/libs/providers/langchain-anthropic/src/utils/tools.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tools.ts
@@ -41,6 +41,7 @@ export const AnthropicToolExtrasSchema = z.object({
     .optional()
     .nullable(),
   defer_loading: z.boolean().optional(),
+  eager_input_streaming: z.boolean().optional().nullable(),
   input_examples: z.array(z.unknown()).optional(),
   allowed_callers: z.array(z.unknown()).optional(),
   strict: z.boolean().optional(),


### PR DESCRIPTION
Adds support for the `eager_input_streaming` extra field on Anthropic tool definitions, so it can be set per-tool via the `extras` parameter and passed through to the Anthropic API.

## Motivation

The Anthropic API supports enabling fine-grained/eager input streaming on a per-tool basis. The Anthropic TypeScript SDK already types `eager_input_streaming` on the tool definition ([messages.ts#L1862-L1869](https://github.com/anthropics/anthropic-sdk-typescript/blob/4f2eb8071993780d79610b9eda26db96f7653843/src/resources/messages/messages.ts#L1862-L1869)), but `@langchain/anthropic` validated tool extras against `AnthropicToolExtrasSchema`, which did not include this field — so it was stripped before reaching the API.

## Changes

- Add `eager_input_streaming` to `AnthropicToolExtrasSchema` in `utils/tools.ts`. The SDK types the field as `boolean | null`, so the Zod field is `z.boolean().optional().nullable()` (matching the existing `cache_control` treatment).
- No changes needed in `chat_models.ts`: validated extras are already spread into the tool definition, so the field passes through automatically once accepted by the schema.
- Add unit tests covering schema validation (accepts `boolean`/`null`, rejects wrong types) and passthrough into the formatted tool definition.
- Add a changeset (`@langchain/anthropic`: patch).

## Usage

```typescript
import { tool } from "@langchain/core/tools";
import { z } from "zod";

const myTool = tool(async (input) => { /* ... */ }, {
  name: "my_tool",
  description: "A tool with eager input streaming",
  schema: z.object({ /* ... */ }),
  extras: { eager_input_streaming: true },
});
```

## Testing

- `pnpm --filter @langchain/anthropic test` — 204 passed, no type errors
- `pnpm format:check` and `oxlint` on changed files — clean

This is a minimal, non-breaking change that only adds one new optional field to the schema validation.
