### PR TITLE
fix(google-genai): preserve Gemini signatures in stream events

### DIFF
--- a/.changeset/calm-tools-remember.md
+++ b/.changeset/calm-tools-remember.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+Preserve Gemini thought signatures and tool call IDs when using chat model stream events.

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -510,14 +510,28 @@ export function convertMessageContentToParts(
   if (Array.isArray(message.content)) {
     messageParts.push(
       ...(message.content
-        .map((c) => _convertLangChainContentToPart(c, isMultimodalModel))
+        .map((c) => {
+          if (
+            isAIMessage(message) &&
+            c.type === "tool_call" &&
+            message.tool_calls?.some(
+              (toolCall) => toolCall.id === c.id && toolCall.name === c.name
+            )
+          ) {
+            return undefined;
+          }
+          return _convertLangChainContentToPart(c, isMultimodalModel);
+        })
         .filter((p) => p !== undefined) as Part[])
     );
   }
 
-  const functionThoughtSignatures = message.additional_kwargs?.[
+  const functionThoughtSignatures = (message.additional_kwargs?.[
     _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY
-  ] as Record<string, string>;
+  ] ??
+    message.response_metadata?.[_FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY]) as
+    | Record<string, string>
+    | undefined;
 
   if (isAIMessage(message) && message.tool_calls?.length) {
     functionCalls = message.tool_calls.map((tc) => {

--- a/libs/providers/langchain-google-genai/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google-genai/src/utils/stream_events.ts
@@ -11,7 +11,11 @@ import type {
   FinishReason,
 } from "@langchain/core/language_models/event";
 import type { ContentBlock, UsageMetadata } from "@langchain/core/messages";
-import { convertUsageMetadata } from "./common.js";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
+import {
+  _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY,
+  convertUsageMetadata,
+} from "./common.js";
 
 export interface ConvertGoogleGenAIStreamOptions {
   streamUsage?: boolean;
@@ -31,6 +35,7 @@ export async function* convertGoogleGenAIStream(
     Record<string, any>
   >();
   const blockKeyToIndex = new Map<BlockKey, number>();
+  const functionThoughtSignatures: Record<string, string> = {};
   let nextBlockIndex = 0;
   let messageStarted = false;
   let usageSnapshot: UsageMetadata | undefined;
@@ -84,15 +89,21 @@ export async function* convertGoogleGenAIStream(
           const { index, isNew } = getOrCreateBlockIndex(key, {
             type: "reasoning",
             reasoning: "",
+            ...(part.thoughtSignature
+              ? { signature: part.thoughtSignature }
+              : {}),
           });
+          const acc = blockAccumulators.get(index)!;
+          if (part.thoughtSignature) {
+            acc.signature = part.thoughtSignature;
+          }
           if (isNew) {
             yield {
               event: "content-block-start" as const,
               index,
-              content: { type: "reasoning", reasoning: "" } as ContentBlock,
+              content: { ...acc } as ContentBlock,
             };
           }
-          const acc = blockAccumulators.get(index)!;
           acc.reasoning = (acc.reasoning ?? "") + part.text;
           yield {
             event: "content-block-delta" as const,
@@ -123,25 +134,30 @@ export async function* convertGoogleGenAIStream(
       } else if ("functionCall" in part && part.functionCall) {
         const key: BlockKey = `tool:${toolIdx}`;
         const args = JSON.stringify(part.functionCall.args ?? {});
+        const functionCallId =
+          "id" in part.functionCall &&
+          typeof part.functionCall.id === "string" &&
+          part.functionCall.id
+            ? part.functionCall.id
+            : uuidv4();
         const { index, isNew } = getOrCreateBlockIndex(key, {
           type: "tool_call_chunk",
+          id: functionCallId,
           name: part.functionCall.name,
           args: "",
           index: toolIdx,
         });
+        const acc = blockAccumulators.get(index)!;
+        if (part.thoughtSignature) {
+          functionThoughtSignatures[acc.id] = part.thoughtSignature;
+        }
         if (isNew) {
           yield {
             event: "content-block-start" as const,
             index,
-            content: {
-              type: "tool_call_chunk",
-              name: part.functionCall.name,
-              args: "",
-              index: toolIdx,
-            } as ContentBlock,
+            content: { ...acc } as ContentBlock,
           };
         }
-        const acc = blockAccumulators.get(index)!;
         acc.args = args;
         yield {
           event: "content-block-delta" as const,
@@ -150,6 +166,7 @@ export async function* convertGoogleGenAIStream(
             type: "block-delta" as const,
             fields: {
               type: "tool_call_chunk",
+              id: acc.id,
               name: acc.name,
               args: acc.args,
             },
@@ -172,7 +189,15 @@ export async function* convertGoogleGenAIStream(
     event: "message-finish" as const,
     reason: finishReason,
     ...(usageSnapshot ? { usage: usageSnapshot } : {}),
-    responseMetadata: { model_provider: "google-genai" },
+    responseMetadata: {
+      model_provider: "google-genai",
+      ...(Object.keys(functionThoughtSignatures).length
+        ? {
+            [_FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY]:
+              functionThoughtSignatures,
+          }
+        : {}),
+    },
   };
 }
 

--- a/libs/providers/langchain-google-genai/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-google-genai/src/utils/tests/stream_events.test.ts
@@ -1,18 +1,27 @@
 import { describe, test, expect } from "vitest";
 import type { EnhancedGenerateContentResponse } from "@google/generative-ai";
 import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
+import { ChatModelStream } from "@langchain/core/language_models/stream";
 import { convertGoogleGenAIStream } from "../stream_events.js";
+import {
+  _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY,
+  convertMessageContentToParts,
+} from "../common.js";
 
-async function collectEvents(
-  chunks: Record<string, unknown>[]
-): Promise<ChatModelStreamEvent[]> {
-  const out: ChatModelStreamEvent[] = [];
+function streamResponses(chunks: Record<string, unknown>[]) {
   async function* source() {
     for (const chunk of chunks) {
       yield chunk as unknown as EnhancedGenerateContentResponse;
     }
   }
-  for await (const event of convertGoogleGenAIStream(source())) {
+  return convertGoogleGenAIStream(source());
+}
+
+async function collectEvents(
+  chunks: Record<string, unknown>[]
+): Promise<ChatModelStreamEvent[]> {
+  const out: ChatModelStreamEvent[] = [];
+  for await (const event of streamResponses(chunks)) {
     out.push(event);
   }
   return out;
@@ -85,5 +94,94 @@ describe("convertGoogleGenAIStream", () => {
     ).toMatchObject({
       content: { reasoning: "Let me think" },
     });
+  });
+
+  test("preserves thought signatures and tool call ids", async () => {
+    const message = await new ChatModelStream(
+      streamResponses([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: "planning",
+                    thought: true,
+                    thoughtSignature: "THOUGHT_SIG",
+                  },
+                  {
+                    functionCall: {
+                      name: "get_weather",
+                      args: { city: "Paris" },
+                    },
+                    thoughtSignature: "FC_SIG",
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ])
+    );
+
+    expect(message.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "planning",
+        signature: "THOUGHT_SIG",
+      },
+      {
+        type: "tool_call",
+        id: expect.any(String),
+        name: "get_weather",
+        args: { city: "Paris" },
+      },
+    ]);
+
+    const toolCallId = message.tool_calls?.[0]?.id;
+    expect(toolCallId).toEqual(expect.any(String));
+    expect(message.response_metadata).toMatchObject({
+      [_FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY]: {
+        [toolCallId!]: "FC_SIG",
+      },
+    });
+  });
+
+  test("replays streamed tool calls with their thought signature", async () => {
+    const message = await new ChatModelStream(
+      streamResponses([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      name: "get_weather",
+                      args: { city: "Paris" },
+                    },
+                    thoughtSignature: "FC_SIG",
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ])
+    );
+
+    expect(
+      convertMessageContentToParts(message, false, [], "gemini-3.1-pro-preview")
+    ).toEqual([
+      {
+        functionCall: {
+          name: "get_weather",
+          args: { city: "Paris" },
+        },
+        thoughtSignature: "FC_SIG",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #11181

## Summary

The native chat model event path in `@langchain/google-genai` was not carrying Gemini thought signatures or tool call IDs into the assembled message. As a result, replaying a streamed Gemini 3 tool call used the fallback dummy signature instead of the signature returned by Gemini.

This change:

- preserves signatures on streamed reasoning blocks;
- assigns a stable ID to each streamed tool call and keeps its signature mapped to that ID in response metadata;
- reads that metadata when replaying the assembled message; and
- avoids serializing the same standardized tool call from both `content` and `tool_calls`.

## Validation

- Reproduced the missing signatures, missing tool call ID, and dummy-signature replay before the change with a stubbed SSE response.
- Manually verified the same provider entrypoint after the change: both signatures survive, the tool call has an ID, and replay sends one function call with the real signature.
- `pnpm --filter @langchain/google-genai test` (77 passed)
- `pnpm --filter @langchain/google-genai build`
- `pnpm format:check`
- `pnpm lint`
