### PR TITLE
fix(core): bind splitText to textSplitter instance in trimMessages

### DIFF
--- a/.changeset/little-regions-appear.md
+++ b/.changeset/little-regions-appear.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): bind splitText to textSplitter instance in trimMessages

--- a/libs/langchain-core/src/messages/transformers.ts
+++ b/libs/langchain-core/src/messages/transformers.ts
@@ -684,7 +684,7 @@ async function _trimMessagesHelper(
     defaultTextSplitter;
   if (textSplitter) {
     if ("splitText" in textSplitter) {
-      textSplitterFunc = textSplitter.splitText;
+      textSplitterFunc = textSplitter.splitText.bind(textSplitter);
     } else {
       textSplitterFunc = async (text: string): Promise<string[]> =>
         textSplitter(text);


### PR DESCRIPTION
Fix trimMessages losing textSplitter context

Hey team, I ran into an issue where `trimMessages` was throwing a TypeError when passing a `TextSplitter` instance. It looks like `splitText` was losing its context when assigned to `textSplitterFunc`. I just bound it to the instance so it works correctly now. Let me know if you need any tests added or changes made.
