### PR TITLE
feat(pgvector): add hybrid search (vector + full-text via RRF)

### DIFF
--- a/.changeset/hybrid-search-pgvector.md
+++ b/.changeset/hybrid-search-pgvector.md
@@ -1,0 +1,5 @@
+---
+"@langchain/pgvector": minor
+---
+
+Added hybrid search to PGVectorStore, combining vector similarity with Postgres full-text search via reciprocal rank fusion. New `hybridSearch` / `hybridSearchWithScore` methods run both branches and the fusion in a single SQL round trip, honoring metadata filters and collections in both branches, and `createHybridSearchIndex` creates the GIN expression index for the full-text branch so it works on existing tables without schema changes.

--- a/libs/providers/langchain-pgvector/src/tests/vectorstores.test.ts
+++ b/libs/providers/langchain-pgvector/src/tests/vectorstores.test.ts
@@ -1004,4 +1004,199 @@ describe("PGVectorStore", () => {
       ).toBe(true);
     });
   });
+
+  describe("hybridSearchWithScore", () => {
+    test("runs both branches and RRF fusion in a single query", async () => {
+      const pool = createMockPool();
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            id: "uuid-1",
+            text: "hello world",
+            metadata: { key: "value" },
+            embedding: "[0.1,0.2,0.3,0.4]",
+            _score: 0.032,
+          },
+        ],
+      });
+
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      const results = await store.hybridSearchWithScore("hello", 5);
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain('WITH "vector_ranks"');
+      expect(sql).toContain('"fulltext_ranks"');
+      expect(sql).toContain("websearch_to_tsquery('english', $2)");
+      expect(sql).toContain("to_tsvector('english', \"text\")");
+      expect(sql).toContain("FULL OUTER JOIN");
+      // [embedding, query, vectorWeight, fullTextWeight, rrfK, fetchK, k]
+      expect(params).toEqual(["[0.1,0.2,0.3,0.4]", "hello", 1, 1, 60, 20, 5]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0][0].pageContent).toBe("hello world");
+      expect(results[0][0].metadata).toEqual({ key: "value" });
+      expect(results[0][0].id).toBe("uuid-1");
+      expect(results[0][1]).toBe(0.032);
+    });
+
+    test("passes custom weights, rrfK, fetchK, and text search config", async () => {
+      const pool = createMockPool();
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      await store.hybridSearchWithScore("hello", 3, {
+        vectorWeight: 0.7,
+        fullTextWeight: 0.3,
+        rrfK: 10,
+        fetchK: 50,
+        textSearchConfig: "simple",
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      expect(sql).toContain("websearch_to_tsquery('simple', $2)");
+      expect(sql).toContain("to_tsvector('simple', \"text\")");
+      expect(params).toEqual([
+        "[0.1,0.2,0.3,0.4]",
+        "hello",
+        0.7,
+        0.3,
+        10,
+        50,
+        3,
+      ]);
+    });
+
+    test("applies metadata filter to both branches", async () => {
+      const pool = createMockPool();
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      await store.hybridSearchWithScore("hello", 5, {
+        filter: { category: "test" },
+      });
+
+      const [sql, params] = pool.query.mock.calls[0];
+      const filterOccurrences = sql.split("metadata ->> $").length - 1;
+      expect(filterOccurrences).toBe(2);
+      expect(params).toContain("test");
+      expect(params).toContain("category");
+    });
+
+    test("scopes both branches to the collection when configured", async () => {
+      const pool = createMockPool();
+      // getOrCreateCollection SELECT returns an existing collection id
+      pool.query.mockResolvedValueOnce({ rows: [{ uuid: "collection-1" }] });
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+        collectionTableName: "collections",
+        collectionName: "test",
+      });
+
+      await store.hybridSearchWithScore("hello", 5);
+
+      const lastCall = pool.query.mock.calls[pool.query.mock.calls.length - 1];
+      const [sql, params] = lastCall;
+      const collectionOccurrences = sql.split("collection_id = $8").length - 1;
+      expect(collectionOccurrences).toBe(2);
+      expect(params).toContain("collection-1");
+    });
+
+    test("rejects an invalid text search configuration", async () => {
+      const store = createStore();
+      await expect(
+        store.hybridSearchWithScore("hello", 5, {
+          textSearchConfig: "english'; DROP TABLE test_table; --",
+        })
+      ).rejects.toThrow("Invalid text search configuration");
+    });
+
+    test("returns an empty list when nothing matches", async () => {
+      const store = createStore();
+      const results = await store.hybridSearchWithScore("hello", 5);
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("hybridSearch", () => {
+    test("returns documents without scores", async () => {
+      const pool = createMockPool();
+      pool.query.mockResolvedValue({
+        rows: [
+          {
+            id: "uuid-1",
+            text: "hello world",
+            metadata: { key: "value" },
+            embedding: "[0.1,0.2,0.3,0.4]",
+            _score: 0.05,
+          },
+        ],
+      });
+
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      const results = await store.hybridSearch("hello", 5);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBeInstanceOf(Document);
+      expect(results[0].pageContent).toBe("hello world");
+    });
+  });
+
+  describe("createHybridSearchIndex", () => {
+    test("creates a GIN expression index over the content column", async () => {
+      const pool = createMockPool();
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      await store.createHybridSearchIndex();
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).toContain("CREATE INDEX IF NOT EXISTS");
+      expect(sql).toContain("USING gin");
+      expect(sql).toContain("to_tsvector('english', \"text\")");
+    });
+
+    test("honors a custom text search config and namespace", async () => {
+      const pool = createMockPool();
+      const store = new PGVectorStore(new MockEmbeddings(), {
+        tableName: "test_table",
+        pool,
+      });
+
+      await store.createHybridSearchIndex({
+        textSearchConfig: "simple",
+        namespace: "myns",
+      });
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).toContain("myns_test_table_text_fulltext_gin_idx");
+      expect(sql).toContain("to_tsvector('simple', \"text\")");
+    });
+
+    test("rejects an invalid text search configuration", async () => {
+      const store = createStore();
+      await expect(
+        store.createHybridSearchIndex({
+          textSearchConfig: "english); DROP TABLE test_table; --",
+        })
+      ).rejects.toThrow("Invalid text search configuration");
+    });
+  });
 });

--- a/libs/providers/langchain-pgvector/src/vectorstores.ts
+++ b/libs/providers/langchain-pgvector/src/vectorstores.ts
@@ -71,6 +71,53 @@ type Metadata = Record<string, unknown>;
 export type DistanceStrategy = "cosine" | "innerProduct" | "euclidean";
 
 /**
+ * Options for hybrid (vector + full-text) search.
+ */
+export interface HybridSearchOptions {
+  /**
+   * Optional metadata filter applied to both the vector and full-text
+   * branches of the search.
+   */
+  filter?: MetadataFilter;
+  /**
+   * Number of candidates each branch (vector and full-text) retrieves
+   * before rank fusion.
+   * @default 20
+   */
+  fetchK?: number;
+  /**
+   * Smoothing constant used by reciprocal rank fusion. Higher values reduce
+   * the influence of top-ranked outliers.
+   * @default 60
+   */
+  rrfK?: number;
+  /**
+   * Weight applied to the vector branch's reciprocal rank contribution.
+   * @default 1
+   */
+  vectorWeight?: number;
+  /**
+   * Weight applied to the full-text branch's reciprocal rank contribution.
+   * @default 1
+   */
+  fullTextWeight?: number;
+  /**
+   * Postgres text search configuration used to parse the document text and
+   * the query (e.g. "english", "simple"). Must match the configuration used
+   * by `createHybridSearchIndex` for the index to be usable.
+   * @default "english"
+   */
+  textSearchConfig?: string;
+}
+
+/**
+ * Text search configurations are interpolated into SQL as literals (a GIN
+ * expression index is only planner-eligible when the query expression uses
+ * the same constant configuration), so restrict them to simple identifiers.
+ */
+const TEXT_SEARCH_CONFIG_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
  * Interface that defines the arguments required to create a
  * `PGVectorStore` instance. It includes Postgres connection options,
  * table name, filter, and verbosity level.
@@ -1200,5 +1247,203 @@ export class PGVectorStore extends VectorStore {
       return docs[index][0];
     });
     return mmrDocs;
+  }
+
+  /**
+   * Hybrid search combining vector similarity with Postgres full-text search
+   * via reciprocal rank fusion (RRF).
+   *
+   * Each branch independently ranks up to `fetchK` candidates (the vector
+   * branch by the configured distance strategy, the full-text branch by
+   * `ts_rank_cd` over a `websearch_to_tsquery` match), and the fused score of
+   * a document is `vectorWeight / (rrfK + vectorRank) + fullTextWeight /
+   * (rrfK + fullTextRank)`, treating a miss in either branch as a zero
+   * contribution. Fusing ranks rather than raw scores avoids mixing
+   * incomparable scales (cosine distance vs. `ts_rank_cd`).
+   *
+   * Runs entirely in a single SQL round trip. For large tables, create a GIN
+   * index for the full-text branch with `createHybridSearchIndex` (the vector
+   * branch uses the HNSW index from `createHnswIndex` as usual).
+   *
+   * @param query Text to look up documents similar to.
+   * @param k Number of documents to return. Defaults to 4.
+   * @param options Hybrid search options (filter, weights, `fetchK`, `rrfK`,
+   *     text search configuration).
+   * @returns List of documents ranked by fused score.
+   */
+  async hybridSearch(
+    query: string,
+    k = 4,
+    options: HybridSearchOptions = {}
+  ): Promise<Document[]> {
+    const results = await this.hybridSearchWithScore(query, k, options);
+    return results.map(([doc]) => doc);
+  }
+
+  /**
+   * Hybrid search combining vector similarity with Postgres full-text search
+   * via reciprocal rank fusion. See {@link hybridSearch} for details.
+   *
+   * The returned score is the fused RRF score (higher = more relevant). It is
+   * a rank-based quantity, so `scoreNormalization` does not apply to it.
+   *
+   * @param query Text to look up documents similar to.
+   * @param k Number of documents to return. Defaults to 4.
+   * @param options Hybrid search options (filter, weights, `fetchK`, `rrfK`,
+   *     text search configuration).
+   * @returns Promise that resolves with an array of tuples, each containing a
+   *     `Document` and its fused RRF score.
+   */
+  async hybridSearchWithScore(
+    query: string,
+    k = 4,
+    options: HybridSearchOptions = {}
+  ): Promise<[Document, number][]> {
+    const {
+      filter,
+      fetchK = 20,
+      rrfK = 60,
+      vectorWeight = 1,
+      fullTextWeight = 1,
+      textSearchConfig = "english",
+    } = options;
+
+    if (!TEXT_SEARCH_CONFIG_REGEX.test(textSearchConfig)) {
+      throw new Error(
+        `Invalid text search configuration: "${textSearchConfig}". Expected a simple identifier such as "english" or "simple".`
+      );
+    }
+
+    const embedding = await this.embeddings.embedQuery(query);
+    const embeddingString = `[${embedding.join(",")}]`;
+    const _filter: this["FilterType"] = filter ?? {};
+
+    let collectionId;
+    if (this.collectionTableName) {
+      collectionId = await this.getOrCreateCollection();
+    }
+
+    const baseParameters: unknown[] = [
+      embeddingString,
+      query,
+      vectorWeight,
+      fullTextWeight,
+      rrfK,
+      fetchK,
+      k,
+    ];
+    const baseClauses: string[] = [];
+    let paramOffset = 7;
+
+    if (collectionId) {
+      paramOffset = 8;
+      baseParameters.push(collectionId);
+      baseClauses.push("collection_id = $8");
+    }
+
+    const { whereClauses, parameters } = this.buildFilterClauses(
+      _filter,
+      paramOffset
+    );
+
+    const allParameters = [...baseParameters, ...parameters];
+    // Both branches see the same collection and filter clauses; the full-text
+    // branch additionally requires a text match. Placeholders can be shared
+    // because both clause lists bind against the same parameter array.
+    const sharedClauses = [...baseClauses, ...whereClauses];
+    const tsVector = `to_tsvector('${textSearchConfig}', "${this.contentColumnName}")`;
+    const tsQuery = `websearch_to_tsquery('${textSearchConfig}', $2)`;
+    const fullTextClauses = [`${tsVector} @@ ${tsQuery}`, ...sharedClauses];
+
+    const vectorWhereClause = sharedClauses.length
+      ? `WHERE ${sharedClauses.join(" AND ")}`
+      : "";
+    const fullTextWhereClause = `WHERE ${fullTextClauses.join(" AND ")}`;
+
+    const queryString = `
+      WITH "vector_ranks" AS (
+        SELECT "${this.idColumnName}" AS "_id",
+          RANK() OVER (ORDER BY "${this.vectorColumnName}" ${this.computedOperatorString} $1) AS "_rank"
+        FROM ${this.computedTableName}
+        ${vectorWhereClause}
+        ORDER BY "_rank" ASC
+        LIMIT $6
+      ),
+      "fulltext_ranks" AS (
+        SELECT "${this.idColumnName}" AS "_id",
+          RANK() OVER (ORDER BY ts_rank_cd(${tsVector}, ${tsQuery}) DESC) AS "_rank"
+        FROM ${this.computedTableName}
+        ${fullTextWhereClause}
+        ORDER BY "_rank" ASC
+        LIMIT $6
+      )
+      SELECT "t".*,
+        COALESCE($3::float8 / ($5::float8 + "vector_ranks"."_rank"), 0) +
+        COALESCE($4::float8 / ($5::float8 + "fulltext_ranks"."_rank"), 0) AS "_score"
+      FROM "vector_ranks"
+      FULL OUTER JOIN "fulltext_ranks"
+        ON "vector_ranks"."_id" = "fulltext_ranks"."_id"
+      JOIN ${this.computedTableName} "t"
+        ON "t"."${this.idColumnName}" = COALESCE("vector_ranks"."_id", "fulltext_ranks"."_id")
+      ORDER BY "_score" DESC
+      LIMIT $7;
+      `;
+
+    const documents = (await this.pool.query(queryString, allParameters)).rows;
+
+    const results = [] as [Document, number][];
+    for (const doc of documents) {
+      if (doc._score != null && doc[this.contentColumnName] != null) {
+        const document = new Document({
+          pageContent: doc[this.contentColumnName],
+          metadata: doc[this.metadataColumnName],
+          id: doc[this.idColumnName],
+        });
+        results.push([document, Number(doc._score)]);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Method to create a GIN index for the full-text branch of
+   * {@link hybridSearch}. The index is built over the same
+   * `to_tsvector(<config>, <content column>)` expression the search uses, so
+   * it applies to existing tables without schema changes — but it is only
+   * usable when searches run with the same `textSearchConfig`.
+   *
+   * @param config.textSearchConfig - Postgres text search configuration to index with. Must match the `textSearchConfig` passed to `hybridSearch`. Defaults to "english".
+   * @param config.namespace - The namespace is used to create the index with a specific name. This is useful when you want to create multiple indexes on the same database schema (within the same schema in PostgreSQL, the index name must be unique across all tables).
+   * @returns Promise that resolves with the query response of creating the index.
+   */
+  async createHybridSearchIndex(
+    config: {
+      textSearchConfig?: string;
+      namespace?: string;
+    } = {}
+  ): Promise<void> {
+    const textSearchConfig = config.textSearchConfig ?? "english";
+    if (!TEXT_SEARCH_CONFIG_REGEX.test(textSearchConfig)) {
+      throw new Error(
+        `Invalid text search configuration: "${textSearchConfig}". Expected a simple identifier such as "english" or "simple".`
+      );
+    }
+    const prefix = config.namespace ? `${config.namespace}_` : "";
+
+    // Index names are schema-global in Postgres, so include the table name in
+    // the default to keep stores on different tables from colliding (the
+    // CREATE INDEX IF NOT EXISTS would otherwise silently no-op).
+    const createIndexQuery = `CREATE INDEX IF NOT EXISTS ${prefix}${this.tableName}_${
+      this.contentColumnName
+    }_fulltext_gin_idx
+        ON ${this.computedTableName} USING gin (to_tsvector('${textSearchConfig}', "${this.contentColumnName}"));`;
+
+    try {
+      await this.pool.query(createIndexQuery);
+    } catch (e) {
+      console.error(
+        `Failed to create full-text GIN index on table ${this.computedTableName}, error: ${e}`
+      );
+    }
   }
 }


### PR DESCRIPTION
Adds hybrid search to `@langchain/pgvector`: `hybridSearch` / `hybridSearchWithScore` combine vector similarity with Postgres full-text search, plus `createHybridSearchIndex` for the full-text side. Pure vector search has poor precision on keyword-heavy queries (error codes, product names, identifiers), and Postgres already ships everything needed to fix that without another dependency.

Fixes #11041

## Design notes

- **Rank fusion, not score blending.** The issue proposed an `alpha` blend of raw scores, but cosine distance and `ts_rank_cd` live on incomparable scales, so a linear blend is dominated by whichever scale happens to be wider. Instead each branch ranks its own top `fetchK` candidates and the fused score is `vectorWeight / (rrfK + vectorRank) + fullTextWeight / (rrfK + fullTextRank)` (weighted reciprocal rank fusion, the approach pgvector's own hybrid search example uses). Weights still let you bias either branch; `rrfK` defaults to the standard 60.
- **One SQL round trip.** Both branches are CTEs over the same table, fused with a `FULL OUTER JOIN`, so a document found by only one branch still scores. Metadata filters and collection scoping apply to both branches through the existing `buildFilterClauses` machinery.
- **`websearch_to_tsquery`** parses the query: it never throws on user input, unlike `to_tsquery`.
- **Works on existing tables.** `createHybridSearchIndex` builds a GIN index over the `to_tsvector(<config>, <content column>)` expression rather than adding a tsvector column, so there is no migration. The text search configuration is validated against a strict identifier pattern and inlined as a constant (a parameterized config would make the expression index unusable by the planner); the default index name includes the table name because index names are schema-global in Postgres and a fixed name would silently no-op via `IF NOT EXISTS` on the second table.
- **Score semantics.** The returned score is the fused RRF value (higher = better). It is rank-based, so `scoreNormalization` intentionally does not apply; this is called out in the JSDoc.
- `fetchK` naming and defaults follow the existing `maxMarginalRelevanceSearch` precedent.

## Testing

- 12 new unit tests in the package's existing mocked-pool style: SQL shape and parameter order, filter and collection clauses present in both branches, config validation (rejects injection attempts), defaults and overrides, row mapping, index DDL.
- Verified end to end against a real `pgvector/pgvector:pg16` container: a keyword query for a unique error code that pure vector search misses is returned first by hybrid search, semantic queries still rank through the vector branch, filters exclude across both branches, and `EXPLAIN` confirms the GIN expression index is used for the full-text branch.

`pnpm vitest run` (81 passed, no type errors), `oxlint`, `oxfmt --check`, and the package build are all green.
