### PR TITLE
fix(cohere): serialize streaming tool-call arguments as JSON

### DIFF
--- a/.changeset/cohere-stream-tool-call-args.md
+++ b/.changeset/cohere-stream-tool-call-args.md
@@ -1,0 +1,5 @@
+---
+"@langchain/cohere": patch
+---
+
+fix(cohere): serialize streaming tool-call arguments as JSON

--- a/libs/providers/langchain-cohere/src/chat_models.ts
+++ b/libs/providers/langchain-cohere/src/chat_models.ts
@@ -1235,7 +1235,7 @@ export class ChatCohere<
         if (toolCalls.length > 0) {
           toolCallChunks = toolCalls.map((toolCall: any) => ({
             name: toolCall.function.name,
-            args: toolCall.function.arguments,
+            args: JSON.stringify(toolCall.function.arguments),
             id: toolCall.id,
             index: toolCall.index,
             type: "tool_call_chunk",


### PR DESCRIPTION
## What
In `ChatCohere._streamResponseChunks`, streaming tool calls set `ToolCallChunk.args` to the raw Cohere `parameters` object instead of a JSON string.

## Why
`ToolCallChunk.args` is typed `string` (a JSON substring of the arguments). `_formatCohereToolCalls` returns `arguments` as the raw `parameters` object, and the stream-end handler assigns it straight to `args`. When `AIMessageChunk` collapses the tool-call chunks, `args` is coerced to `"[object Object]"`, fails to parse, and the call is dropped from `tool_calls` into `invalid_tool_calls`.

So any tool call obtained via streaming — e.g. `new ChatCohere({ streaming: true }).bindTools([...]).invoke(...)`, which routes through `_streamResponseChunks` — comes back with empty `tool_calls` and a garbage `invalid_tool_calls` entry. The streamEvents path (`utils/stream_events.ts`) already stringifies this exact field; this aligns the classic streaming path with it.

## How
`JSON.stringify(toolCall.function.arguments)` when building the tool_call_chunk.

## Reproduction
`ChatCohere` with `streaming: true` + `bindTools`, a prompt that triggers a tool call: `tool_calls` is empty and `invalid_tool_calls[0].args` is `"[object Object]"`. With this change, `tool_calls[0].args` is the parsed arguments object.
