### PR TITLE
fix(core): align server tool result content block type to `server_tool_result`

### DIFF
--- a/.changeset/align-server-tool-result-type.md
+++ b/.changeset/align-server-tool-result-type.md
@@ -1,0 +1,16 @@
+---
+"@langchain/core": patch
+"@langchain/anthropic": patch
+"@langchain/aws": patch
+"@langchain/openai": patch
+---
+
+fix(core): align server tool result content block `type` to `server_tool_result`
+
+Rename the server tool result discriminator literal from
+`server_tool_call_result` to `server_tool_result` to match the canonical value
+documented in the LangChain reference and emitted by `langchain-core` (Python),
+where the TS and Python `type` literals previously diverged only on this block.
+The `Tools.ServerToolCallResult` interface is renamed to `Tools.ServerToolResult`
+with a deprecated `ServerToolCallResult` type alias kept for backward
+compatibility.

--- a/.changeset/align-server-tool-result-type.md
+++ b/.changeset/align-server-tool-result-type.md
@@ -7,10 +7,7 @@
 
 fix(core): align server tool result content block `type` to `server_tool_result`
 
-Rename the server tool result discriminator literal from
-`server_tool_call_result` to `server_tool_result` to match the canonical value
-documented in the LangChain reference and emitted by `langchain-core` (Python),
-where the TS and Python `type` literals previously diverged only on this block.
-The `Tools.ServerToolCallResult` interface is renamed to `Tools.ServerToolResult`
-with a deprecated `ServerToolCallResult` type alias kept for backward
-compatibility.
+Rename the server tool result content block `type` from `server_tool_call_result`
+to `server_tool_result`, matching `langchain-core` (Python). Renames
+`Tools.ServerToolCallResult` to `Tools.ServerToolResult`, keeping a deprecated
+`ServerToolCallResult` alias for backward compatibility.

--- a/libs/langchain-core/src/messages/block_translators/anthropic.ts
+++ b/libs/langchain-core/src/messages/block_translators/anthropic.ts
@@ -438,7 +438,7 @@ export function convertToV1FromAnthropicMessage(
           return acc;
         }, []);
         yield {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           name: "web_search",
           toolCallId: tool_use_id,
           status: "success",
@@ -455,7 +455,7 @@ export function convertToV1FromAnthropicMessage(
         _isObject(block.content)
       ) {
         yield {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           name: "code_execution",
           toolCallId: block.tool_use_id,
           status: "success",
@@ -480,7 +480,7 @@ export function convertToV1FromAnthropicMessage(
         _isObject(block.content)
       ) {
         yield {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           name: "mcp_tool_use",
           toolCallId: block.tool_use_id,
           status: "success",

--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -236,14 +236,14 @@ function* mapToolOutputToV1Blocks(
       name: "web_search",
       args: webSearchArgs,
     };
-    // Emit a server_tool_call_result when the search has completed or failed
+    // Emit a server_tool_result when the search has completed or failed
     if (toolOutput.status === "completed" || toolOutput.status === "failed") {
       const output: Record<string, unknown> = {};
       if (_isObject(toolOutput.action)) {
         output.action = toolOutput.action;
       }
       yield {
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
         status: toolOutput.status === "completed" ? "success" : "error",
         output,
@@ -260,10 +260,10 @@ function* mapToolOutputToV1Blocks(
         queries: _isArray(toolOutput.queries) ? toolOutput.queries : [],
       },
     };
-    // Emit a server_tool_call_result when results are available
+    // Emit a server_tool_result when results are available
     if (toolOutput.status === "completed" || toolOutput.status === "failed") {
       yield {
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
         status: toolOutput.status === "completed" ? "success" : "error",
         output: _isArray(toolOutput.results)
@@ -298,7 +298,7 @@ function* mapToolOutputToV1Blocks(
       for (const output of toolOutput.outputs) {
         if (_isContentBlock(output, "logs")) {
           yield {
-            type: "server_tool_call_result",
+            type: "server_tool_result",
             toolCallId: toolOutput.id ?? "",
             status: "success",
             output: {
@@ -373,7 +373,7 @@ function* mapToolOutputToV1Blocks(
       toolSearchOutputExtras.execution = toolOutput.execution;
     }
     yield {
-      type: "server_tool_call_result",
+      type: "server_tool_result",
       toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
       status:
         toolOutput.status === "completed"
@@ -453,7 +453,7 @@ function* mapToolOutputToV1Blocks(
  * //   { type: "text", text: "Hello world", annotations: [] },
  * //   { type: "tool_call", id: "123", name: "calculator", args: { a: 1, b: 2 } },
  * //   { type: "server_tool_call", name: "code_interpreter", args: { code: "print('hello')" } },
- * //   { type: "server_tool_call_result", toolCallId: "", status: "success", output: { type: "code_interpreter_output", returnCode: 0, stdout: "hello" } }
+ * //   { type: "server_tool_result", toolCallId: "", status: "success", output: { type: "code_interpreter_output", returnCode: 0, stdout: "hello" } }
  * // ]
  * ```
  */

--- a/libs/langchain-core/src/messages/block_translators/tests/anthropic.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/anthropic.test.ts
@@ -138,7 +138,7 @@ describe("anthropicTranslator", () => {
         args: { query: "web search query" },
       },
       {
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         name: "web_search",
         toolCallId: "srvtoolu_abc123",
         status: "success",
@@ -153,7 +153,7 @@ describe("anthropicTranslator", () => {
         args: { code: "import numpy as np..." },
       },
       {
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         name: "code_execution",
         toolCallId: "srvtoolu_def456",
         status: "success",

--- a/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
@@ -229,7 +229,7 @@ describe("openaiTranslator", () => {
           args: { code: "print('hello')" },
         },
         {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           toolCallId: "call_456",
           status: "success",
           output: {
@@ -355,7 +355,7 @@ describe("openaiTranslator", () => {
           args: {},
         },
         {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           toolCallId: "ws_abc123",
           status: "success",
           output: {},
@@ -394,7 +394,7 @@ describe("openaiTranslator", () => {
           args: { query: "melbourne australia news today" },
         },
         {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           toolCallId: "ws_abc456",
           status: "success",
           output: {
@@ -435,7 +435,7 @@ describe("openaiTranslator", () => {
         (b) => b.type === "server_tool_call"
       );
       const serverToolCallResults = blocks.filter(
-        (b) => b.type === "server_tool_call_result"
+        (b) => b.type === "server_tool_result"
       );
 
       expect(serverToolCalls).toHaveLength(2);
@@ -483,7 +483,7 @@ describe("openaiTranslator", () => {
           args: { queries: ["quarterly report", "revenue 2025"] },
         },
         {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           toolCallId: "fs_abc123",
           status: "success",
           output: {
@@ -521,7 +521,7 @@ describe("openaiTranslator", () => {
       const blocks = message.contentBlocks;
       const serverToolCall = blocks.find((b) => b.type === "server_tool_call");
       const serverToolCallResult = blocks.find(
-        (b) => b.type === "server_tool_call_result"
+        (b) => b.type === "server_tool_result"
       );
 
       expect(serverToolCall).toEqual({
@@ -531,7 +531,7 @@ describe("openaiTranslator", () => {
         args: { queries: ["test query"] },
       });
       expect(serverToolCallResult).toEqual({
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         toolCallId: "fs_abc456",
         status: "success",
         output: {},
@@ -554,17 +554,17 @@ describe("openaiTranslator", () => {
       });
 
       const blocks = message.contentBlocks;
-      const result = blocks.find((b) => b.type === "server_tool_call_result");
+      const result = blocks.find((b) => b.type === "server_tool_result");
 
       expect(result).toEqual({
-        type: "server_tool_call_result",
+        type: "server_tool_result",
         toolCallId: "ws_fail",
         status: "error",
         output: {},
       });
     });
 
-    it("should not emit server_tool_call_result for in_progress web_search_call", () => {
+    it("should not emit server_tool_result for in_progress web_search_call", () => {
       const message = new AIMessage({
         content: [],
         additional_kwargs: {
@@ -581,7 +581,7 @@ describe("openaiTranslator", () => {
 
       const blocks = message.contentBlocks;
       const serverToolCall = blocks.find((b) => b.type === "server_tool_call");
-      const result = blocks.find((b) => b.type === "server_tool_call_result");
+      const result = blocks.find((b) => b.type === "server_tool_result");
 
       expect(serverToolCall).toBeDefined();
       expect(result).toBeUndefined();
@@ -651,7 +651,7 @@ describe("openaiTranslator", () => {
       });
     });
 
-    it("should translate tool_search_output to server_tool_call_result", () => {
+    it("should translate tool_search_output to server_tool_result", () => {
       const message = new AIMessage({
         content: [],
         additional_kwargs: {
@@ -679,8 +679,8 @@ describe("openaiTranslator", () => {
 
       const blocks = message.contentBlocks;
       const result = blocks.find(
-        (b) => b.type === "server_tool_call_result"
-      ) as ContentBlock.Tools.ServerToolCallResult;
+        (b) => b.type === "server_tool_result"
+      ) as ContentBlock.Tools.ServerToolResult;
       expect(result).toBeDefined();
       expect(result.status).toBe("success");
       expect(result.toolCallId).toBe("tso_001");

--- a/libs/langchain-core/src/messages/content/tools.ts
+++ b/libs/langchain-core/src/messages/content/tools.ts
@@ -151,9 +151,7 @@ export declare namespace Tools {
   }
 
   /**
-   * @deprecated Renamed to {@link ServerToolResult} to align the block `type`
-   * literal with `langchain-core` (Python). This alias will be removed in a
-   * future major release.
+   * @deprecated Renamed to {@link ServerToolResult}.
    */
   export type ServerToolCallResult<TOutput = Record<string, unknown>> =
     ServerToolResult<TOutput>;

--- a/libs/langchain-core/src/messages/content/tools.ts
+++ b/libs/langchain-core/src/messages/content/tools.ts
@@ -8,7 +8,7 @@ export const KNOWN_BLOCK_TYPES = [
   "invalid_tool_call",
   "server_tool_call",
   "server_tool_call_chunk",
-  "server_tool_call_result",
+  "server_tool_result",
 ];
 
 // oxlint-disable-next-line @typescript-eslint/no-namespace
@@ -129,13 +129,13 @@ export declare namespace Tools {
     args?: string;
   }
 
-  export interface ServerToolCallResult<
+  export interface ServerToolResult<
     TOutput = Record<string, unknown>,
   > extends BaseContentBlock {
     /**
      * Type of the content block
      */
-    readonly type: "server_tool_call_result";
+    readonly type: "server_tool_result";
     /**
      * The unique identifier of the tool call that this result corresponds to
      */
@@ -150,11 +150,19 @@ export declare namespace Tools {
     output: TOutput;
   }
 
+  /**
+   * @deprecated Renamed to {@link ServerToolResult} to align the block `type`
+   * literal with `langchain-core` (Python). This alias will be removed in a
+   * future major release.
+   */
+  export type ServerToolCallResult<TOutput = Record<string, unknown>> =
+    ServerToolResult<TOutput>;
+
   export type Standard =
     | ToolCall
     | ToolCallChunk
     | InvalidToolCall
     | ServerToolCall
     | ServerToolCallChunk
-    | ServerToolCallResult;
+    | ServerToolResult;
 }

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -347,7 +347,7 @@ function _contentBlockToString(
     case "invalid_tool_call":
     case "server_tool_call":
     case "server_tool_call_chunk":
-    case "server_tool_call_result":
+    case "server_tool_result":
     case "non_standard":
       return "";
     default:

--- a/libs/providers/langchain-anthropic/src/utils/standard.ts
+++ b/libs/providers/langchain-anthropic/src/utils/standard.ts
@@ -238,7 +238,7 @@ export function _formatStandardContent(
           input: block.args,
         });
       }
-    } else if (block.type === "server_tool_call_result" && isAnthropicMessage) {
+    } else if (block.type === "server_tool_result" && isAnthropicMessage) {
       if (block.name === "web_search" && Array.isArray(block.output.urls)) {
         const content = block.output.urls.map((url) => ({
           type: "web_search_result" as const,

--- a/libs/providers/langchain-aws/src/utils/compat.ts
+++ b/libs/providers/langchain-aws/src/utils/compat.ts
@@ -262,7 +262,7 @@ export function convertFromV1ToChatBedrockConverseMessage(
       } else if (block.type === "server_tool_call_chunk") {
         // no-op
         continue;
-      } else if (block.type === "server_tool_call_result") {
+      } else if (block.type === "server_tool_result") {
         // no-op
         continue;
       } else if (block.type === "text-plain") {

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
@@ -1509,8 +1509,8 @@ describe("tool search", () => {
       (b) => b.type === "server_tool_call"
     ) as ContentBlock.Tools.ServerToolCall[];
     const serverToolResults = blocks.filter(
-      (b) => b.type === "server_tool_call_result"
-    ) as ContentBlock.Tools.ServerToolCallResult[];
+      (b) => b.type === "server_tool_result"
+    ) as ContentBlock.Tools.ServerToolResult[];
 
     const toolSearchCall = serverToolCalls.find(
       (b) => b.name === "tool_search"

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1227,7 +1227,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
     });
 
     const convertFunctionCallOutput = (
-      block: ContentBlock.Tools.ServerToolCallResult
+      block: ContentBlock.Tools.ServerToolResult
     ): OpenAIClient.Responses.ResponseInputItem.FunctionCallOutput => {
       const output = toJsonString(block.output);
       const status =
@@ -1305,7 +1305,7 @@ export const convertStandardContentMessageToResponsesInput: Converter<
           if (block.args) existing.args.push(block.args);
           pendingServerFunctionChunks.set(block.id, existing);
         }
-      } else if (block.type === "server_tool_call_result") {
+      } else if (block.type === "server_tool_result") {
         yield* flushMessage();
         yield convertFunctionCallOutput(block);
       } else if (block.type === "audio") {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1038,7 +1038,7 @@ describe("convertStandardContentMessageToResponsesInput", () => {
     const message = new AIMessage({
       contentBlocks: [
         {
-          type: "server_tool_call_result",
+          type: "server_tool_result",
           toolCallId: "call-2",
           status: "success",
           output: { foo: "bar" },


### PR DESCRIPTION
### Summary

`@langchain/core` uses `server_tool_call_result` as the content block `type`, while [`langchain-core` (Python)](https://github.com/langchain-ai/langchain/blob/233e02a8223234de731dda8f47152fa6c6a40535/libs/core/langchain_core/messages/content.py#L425-L428) and the [document](https://reference.langchain.com/python/langchain-core/messages/content/ServerToolResult) use `server_tool_result`.

Renames `Tools.ServerToolCallResult` → `Tools.ServerToolResult` (deprecated alias kept for backward compatibility) and updates the core block translators and provider consumers (`@langchain/anthropic`, `@langchain/aws`, `@langchain/openai`).

### Tests

Unit tests; existing block-translator and openai converter snapshots updated to assert `server_tool_result`.
