### PR TITLE
fix(docs): update broken docs.langchain.com and oxc.rs links in CONTRIBUTING.md and libs/langchain/README.md

### DIFF
--- a/.changeset/fix-langchain-learn-and-oxc-rs-links.md
+++ b/.changeset/fix-langchain-learn-and-oxc-rs-links.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(docs): update broken langchain.com and oxc.rs links in libs/langchain/README.md and CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Integrations are a core component of LangChain. LangChain provides standard inte
 - **Interoperability**: LangChain components expose a standard interface, allowing developers to easily swap them for each other. If you implement a LangChain integration, any developer using a different component will easily be able to swap yours in.
 - **Best Practices**: Through their standard interface, LangChain components encourage and facilitate best practices (streaming, async, etc.) that improve developer experience and application performance.
 
-See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/langchain/how_to/#custom) in our docs.
+See our dedicated [integration contribution guide](https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md) for specific details and patterns. You can also check out the [guides on extending LangChain.js](https://docs.langchain.com/oss/javascript/Learn) in our docs.
 
 #### Integration Packages
 
@@ -146,8 +146,8 @@ Dev releases are useful for:
 This project uses the following tools, which are worth getting familiar with if you plan to contribute:
 
 - **[pnpm](https://pnpm.io/) (v10.14.0)** - dependency management
-- **[oxlint](https://oxc.rs/docs/guide/usage/linter/)** - enforcing standard lint rules
-- **[oxfmt](https://oxc.rs/docs/guide/usage/formatter/)** - enforcing standard code formatting
+- **[oxlint](https://oxc.rs/docs/guide/usage/linter)** - enforcing standard lint rules
+- **[oxfmt](https://oxc.rs/docs/guide/usage/formatter)** - enforcing standard code formatting
 - **[vitest](https://vitest.dev/)** - testing code
 
 ## 🚀 Quick Start
@@ -195,7 +195,7 @@ pnpm --filter @langchain/core build
 
 ### Linting
 
-We use [oxlint](https://oxc.rs/docs/guide/usage/linter/) to enforce standard lint rules. To run the linter:
+We use [oxlint](https://oxc.rs/docs/guide/usage/linter) to enforce standard lint rules. To run the linter:
 
 ```bash
 pnpm --filter langchain lint
@@ -203,7 +203,7 @@ pnpm --filter langchain lint
 
 ### Formatting
 
-We use [oxfmt](https://oxc.rs/docs/guide/usage/formatter/) to enforce code formatting style. To run the formatter:
+We use [oxfmt](https://oxc.rs/docs/guide/usage/formatter) to enforce code formatting style. To run the formatter:
 
 ```bash
 pnpm format

--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -56,7 +56,7 @@ LangChain.js is written in TypeScript and can be used in:
 ## 📖 Additional Resources
 
 - [Getting started](https://docs.langchain.com/oss/javascript/langchain/overview): Installation, setting up the environment, simple examples
-- [Learn](https://docs.langchain.com/oss/javascript/langchain/learn): Learn about the core concepts of LangChain.
+- [Learn](https://docs.langchain.com/oss/javascript/Learn): Learn about the core concepts of LangChain.
 - [LangChain Forum](https://forum.langchain.com): Connect with the community and share all of your technical questions, ideas, and feedback.
 - [Chat LangChain](https://chat.langchain.com): Ask questions & chat with our documentation.
 


### PR DESCRIPTION
## Summary

Six broken-link fixes across 2 files, plus a changeset:

**`CONTRIBUTING.md` (5 instances):**
- Line 50: `docs.langchain.com/oss/javascript/langchain/how_to/#custom` (404) → `docs.langchain.com/oss/javascript/Learn` (200, the new Learn page that hosts the langchain tutorials)
- Line 149: `oxc.rs/docs/guide/usage/linter/` (404, trailing slash) → `oxc.rs/docs/guide/usage/linter` (200)
- Line 150: `oxc.rs/docs/guide/usage/formatter/` (404, trailing slash) → `oxc.rs/docs/guide/usage/formatter` (200)
- Line 198: same as line 149
- Line 206: same as line 150

**`libs/langchain/README.md` (1 instance):**
- Line 59: `docs.langchain.com/oss/javascript/langchain/learn` (404) → `docs.langchain.com/oss/javascript/Learn` (200, the new Learn page)

3 files changed, +11/-6.

## Verification

All replacements verified with `curl -sL -A 'Mozilla/5.0'`:
- `https://docs.langchain.com/oss/javascript/langchain/learn` → 404
- `https://docs.langchain.com/oss/javascript/Learn` → 200 (title: "Learn - Docs by LangChain")
- `https://docs.langchain.com/oss/javascript/langchain/how_to/#custom` → 404 (the entire `/oss/javascript/langchain/how_to` section is gone)
- `https://oxc.rs/docs/guide/usage/linter/` → 404
- `https://oxc.rs/docs/guide/usage/linter` → 200

## Notes

The langchain docs were restructured — the per-package `langchain/` and `langchain/how_to/` sub-sections were collapsed into a single `/oss/javascript/Learn` landing. The new Learn page covers tutorials, conceptual guides, and "Additional resources" (case studies, etc.) that subsume the previous how_to pages.

The `oxc.rs` URLs reject trailing slashes — both the linter and formatter reference pages are hosted at the bare path (no `/`).