### PR TITLE
fix(openai): surface prompt-cache write tokens in usage_metadata (LiteLLM/Anthropic-style gateways)

### DIFF
--- a/.changeset/openai-cache-creation-usage.md
+++ b/.changeset/openai-cache-creation-usage.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): surface prompt-cache write tokens in usage_metadata. LiteLLM-based gateways and Anthropic-style providers report cache writes as `prompt_tokens_details.cache_creation_tokens` or top-level `cache_creation_input_tokens`; these are now mapped to `usage_metadata.input_token_details.cache_creation` in both the invoke and streaming paths.

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -254,9 +254,18 @@ export class ChatOpenAICompletions<
           (usageMetadata.total_tokens ?? 0) + totalTokens;
       }
 
+      const cacheCreation =
+        (
+          promptTokensDetails as
+            | { cache_creation_tokens?: number | null }
+            | undefined
+        )?.cache_creation_tokens ??
+        (data?.usage as { cache_creation_input_tokens?: number | null })
+          ?.cache_creation_input_tokens;
       if (
         promptTokensDetails?.audio_tokens !== null ||
-        promptTokensDetails?.cached_tokens !== null
+        promptTokensDetails?.cached_tokens !== null ||
+        cacheCreation != null
       ) {
         usageMetadata.input_token_details = {
           ...(promptTokensDetails?.audio_tokens !== null && {
@@ -264,6 +273,9 @@ export class ChatOpenAICompletions<
           }),
           ...(promptTokensDetails?.cached_tokens !== null && {
             cache_read: promptTokensDetails?.cached_tokens,
+          }),
+          ...(cacheCreation != null && {
+            cache_creation: cacheCreation,
           }),
         };
       }
@@ -458,12 +470,23 @@ export class ChatOpenAICompletions<
       );
     }
     if (usage) {
+      const cacheCreation =
+        (
+          usage.prompt_tokens_details as
+            | { cache_creation_tokens?: number | null }
+            | undefined
+        )?.cache_creation_tokens ??
+        (usage as { cache_creation_input_tokens?: number | null })
+          ?.cache_creation_input_tokens;
       const inputTokenDetails = {
         ...(usage.prompt_tokens_details?.audio_tokens !== null && {
           audio: usage.prompt_tokens_details?.audio_tokens,
         }),
         ...(usage.prompt_tokens_details?.cached_tokens !== null && {
           cache_read: usage.prompt_tokens_details?.cached_tokens,
+        }),
+        ...(cacheCreation != null && {
+          cache_creation: cacheCreation,
         }),
       };
       const outputTokenDetails = {


### PR DESCRIPTION
## Problem

`ChatOpenAI` maps prompt-cache **reads** into `usage_metadata.input_token_details.cache_read` (from the standard `prompt_tokens_details.cached_tokens`), but **cache writes are dropped entirely** — there is no mapping for them in either the `_generate` (non-streaming) or streaming final-usage paths in `libs/providers/langchain-openai/src/chat_models/completions.ts`.

OpenAI's own API has no explicit cache-write concept, but the OpenAI-*compatible* ecosystem does: **LiteLLM** (and gateways built on it) normalizes Anthropic/Bedrock prompt-caching stats into OpenAI-format usage as:

```jsonc
{
  "prompt_tokens": 10032,
  "prompt_tokens_details": {
    "cached_tokens": 0,
    "cache_creation_tokens": 10017   // write count (details alias)
  },
  "cache_creation_input_tokens": 10017,  // write count (Anthropic-style top level)
  "cache_read_input_tokens": 0
}
```

Because neither field is recognized, `input_token_details` ends up as `{ cache_read: 0 }` and downstream consumers (e.g. LibreChat's token accounting/UI, cost trackers) can never display or bill cache writes — even though the provider charged the 1.25x write premium. Reads working while writes silently vanish also makes this hard to notice: users see `cache_read` on the second request and assume everything is plumbed.

## Fix

Map `cache_creation` in `input_token_details` from, in order of preference:

1. `prompt_tokens_details.cache_creation_tokens` (LiteLLM details alias)
2. top-level `usage.cache_creation_input_tokens` (Anthropic-style, also emitted by LiteLLM)

applied to both the `_generate` and streaming usage-mapping sites. `cache_creation` already exists in `UsageMetadata.input_token_details` (the Anthropic integration populates it), so this only fills an existing, typed slot for OpenAI-compatible endpoints. No behavior change for providers that emit neither field.

## Verification

Real end-to-end against AWS Bedrock through a LiteLLM-based proxy — 4-way matrix (fresh vs hot cache prefix, streaming vs non-streaming). Before the fix `cache_creation` was absent in all four; after:

| call | transport | prefix | input_token_details |
|---|---|---|---|
| 1 | stream  | fresh | `{"cache_read":0,"cache_creation":10019}` |
| 2 | stream  | hot   | `{"cache_read":10019,"cache_creation":0}` |
| 3 | invoke  | hot   | `{"cache_read":10019,"cache_creation":0}` |
| 4 | invoke  | fresh | `{"cache_read":0,"cache_creation":10024}` |

Surfaced numbers match the provider-billed `cache_creation_input_tokens` / `cache_read_input_tokens` exactly. Happy to add a mocked unit test if you can point me at the preferred harness for the completions usage path (existing tests cover the Responses converter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
