### PR TITLE
fix(anthropic): honor cumulative message_delta usage (input + cache fields) from Anthropic-compatible gateways

### DIFF
--- a/.changeset/anthropic-delta-cache-usage.md
+++ b/.changeset/anthropic-delta-cache-usage.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): honor cumulative `message_delta.usage` fields (input_tokens, cache_creation_input_tokens, cache_read_input_tokens) in streaming usage metadata. Anthropic-compatible gateways backed by OpenAI-style upstreams (LiteLLM, Bedrock proxies) can only report usage at stream end via `message_delta`; previously those fields were discarded and streamed `usage_metadata` reported `input_tokens: 0` with no cache details.

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -51,10 +51,31 @@ export function _makeMessageChunkFromAnthropicEvent(
       }),
     };
   } else if (data.type === "message_delta") {
+    // `message_delta.usage` is cumulative and may carry input-side fields
+    // (input_tokens, cache_creation_input_tokens, cache_read_input_tokens) —
+    // notably from OpenAI-backed Anthropic-compatible gateways (LiteLLM,
+    // Bedrock proxies), which only know usage at stream end.
+    const deltaUsage = data.usage as typeof data.usage & {
+      input_tokens?: number | null;
+      cache_creation_input_tokens?: number | null;
+      cache_read_input_tokens?: number | null;
+    };
+    const cacheCreation = deltaUsage.cache_creation_input_tokens;
+    const cacheRead = deltaUsage.cache_read_input_tokens;
+    const inputTokens =
+      (deltaUsage.input_tokens ?? 0) + (cacheCreation ?? 0) + (cacheRead ?? 0);
     const usageMetadata: UsageMetadata = {
-      input_tokens: 0,
+      input_tokens: inputTokens,
       output_tokens: data.usage.output_tokens,
-      total_tokens: data.usage.output_tokens,
+      total_tokens: inputTokens + data.usage.output_tokens,
+      ...(cacheCreation != null || cacheRead != null
+        ? {
+            input_token_details: {
+              ...(cacheCreation != null && { cache_creation: cacheCreation }),
+              ...(cacheRead != null && { cache_read: cacheRead }),
+            },
+          }
+        : {}),
     };
     const responseMetadata =
       "context_management" in data.delta

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -63,7 +63,28 @@ export async function* convertAnthropicStream(
       case "message_delta": {
         stopReason = data.delta.stop_reason;
         if (shouldStreamUsage && data.usage) {
-          if (!usageSnapshot) {
+          // Cumulative delta usage may carry input-side fields (input_tokens,
+          // cache_creation_input_tokens, cache_read_input_tokens) — notably
+          // from OpenAI-backed Anthropic-compatible gateways, which only know
+          // usage at stream end.
+          const deltaUsage = data.usage as typeof data.usage & {
+            input_tokens?: number | null;
+            cache_creation_input_tokens?: number | null;
+            cache_read_input_tokens?: number | null;
+          };
+          if (
+            deltaUsage.input_tokens != null ||
+            deltaUsage.cache_creation_input_tokens != null ||
+            deltaUsage.cache_read_input_tokens != null
+          ) {
+            usageSnapshot = buildUsageSnapshot({
+              input_tokens: deltaUsage.input_tokens ?? 0,
+              output_tokens: deltaUsage.output_tokens ?? 0,
+              cache_creation_input_tokens:
+                deltaUsage.cache_creation_input_tokens ?? 0,
+              cache_read_input_tokens: deltaUsage.cache_read_input_tokens ?? 0,
+            } as Parameters<typeof buildUsageSnapshot>[0]);
+          } else if (!usageSnapshot) {
             usageSnapshot = {
               input_tokens: 0,
               output_tokens: data.usage.output_tokens,


### PR DESCRIPTION
## Problem

Both `message_delta` usage handlers in `@langchain/anthropic` — `utils/message_outputs.ts` (used by `ChatAnthropic` streaming) and `utils/stream_events.ts` (events API) — hardcode `input_tokens: 0` and read only `output_tokens`, discarding any other fields present in `message_delta.usage`.

Anthropic's streaming protocol defines `message_delta.usage` as **cumulative** usage, and it may carry input-side fields: `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`. This matters in practice for **Anthropic-compatible gateways backed by OpenAI-style upstreams** (LiteLLM, AWS Bedrock proxies): those upstreams only deliver usage at stream end, so the gateway's only spec-compliant place to report input/cache usage is `message_delta.usage`. With the current handlers, streamed `usage_metadata` from such endpoints reports `input_tokens: 0` and no cache details — cache reads/writes that the provider billed become invisible to LangChain consumers (cost trackers, UIs such as LibreChat).

Notably, the Anthropic SDK's own client (e.g. Claude Code) merges `message_delta.usage` fields cumulatively, so it reports these gateways correctly — LangChain is the outlier.

## Fix

In both handlers: when `message_delta.usage` carries input-side fields, build the usage snapshot from them (including `input_token_details.cache_creation` / `cache_read`); otherwise keep the existing output-only behavior byte-for-byte. No behavior change for responses where `message_delta.usage` has only `output_tokens` (the direct Anthropic API today).

## Verification

Real end-to-end against AWS Bedrock through an Anthropic-compatible gateway (`/v1/messages` in, Bedrock `cachePoint` caching), `ChatAnthropic.stream()` with `streamUsage: true`:

| call | before | after |
|---|---|---|
| fresh cache prefix | `input_tokens: 0`, no details | `input=7225, input_token_details={"cache_creation":7210,"cache_read":0}` |
| hot cache prefix | `input_tokens: 0`, no details | `input=7225, input_token_details={"cache_creation":0,"cache_read":7210}` |

Surfaced numbers match the provider-billed cache fields exactly.

Related: #11194 (same class of gap on the OpenAI side — cache write fields from LiteLLM-style gateways).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
