### PR TITLE
fix(google): preserve thought and thoughtSignature on resent text/reasoning blocks

### DIFF
--- a/.changeset/preserve-thought-on-text-parts.md
+++ b/.changeset/preserve-thought-on-text-parts.md
@@ -1,0 +1,8 @@
+---
+"@langchain/google": patch
+---
+
+Preserve `thought` and `thoughtSignature` when converting `AIMessage` history back to Gemini API parts. Previously, resending a prior turn's thinking text stripped these markers, so a thinking model's own chain-of-thought was replayed to Gemini as an ordinary, unflagged assistant utterance on the next turn — contradicting Gemini's documented requirement (https://ai.google.dev/gemini-api/docs/thinking) that thought blocks be resent verbatim including their flag/signature. Fixes both content-block shapes a Gemini `AIMessage` can present as:
+
+- The legacy/default `AIMessage.content` array (`{ type: "text", thought: true, ... }`), read directly by `convertLegacyContentMessageToGeminiContent`.
+- The standardized `AIMessage.contentBlocks` getter, which `ChatGoogleTranslator` (`@langchain/core`) normalizes into `{ type: "reasoning", reasoning, thought, ... }` — read by `convertStandardContentMessageToGeminiContent` whenever `response_metadata.model_provider === "google"` (i.e. on every real response this package produces) and `output_version` isn't explicitly `"v1"`.

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1532,6 +1532,62 @@ describe.each(thinkingModelInfo)(
       );
       expect(hasThoughtSignature).toBe(true);
     });
+
+    test("thought/thoughtSignature survive a multi-turn round trip (regression for #10461)", async () => {
+      // Reproduces the production bug: resending a prior thinking AIMessage
+      // as history silently stripped its thought marker/signature before
+      // this fix, either losing the flag (legacy content array) or dropping
+      // the block outright (contentBlocks -> ChatGoogleTranslator ->
+      // "reasoning" -> default: return null in the standard converter).
+      const llm = newChatGoogle({ reasoningEffort: "low" });
+
+      const firstResult = await llm.invoke("Why is the sky blue?");
+      const firstReasoningBlocks = firstResult.contentBlocks.filter(
+        (b) => b.type === "reasoning"
+      );
+      expect(firstReasoningBlocks.length).toBeGreaterThan(0);
+      const firstSignatures = firstResult.contentBlocks
+        .filter((b) => "thoughtSignature" in b)
+        .map((b) => b.thoughtSignature);
+      expect(firstSignatures.length).toBeGreaterThan(0);
+
+      // Feed the thinking AIMessage back in as history and ask a follow-up.
+      // recorder.request captures the actual outbound HTTP body for the
+      // second call — assert the resent turn's `contents` entry still
+      // carries `thought`/`thoughtSignature` on the wire, not just that the
+      // call succeeds (a successful call alone wouldn't catch a silently
+      // dropped/unflagged thought block, since Gemini doesn't require the
+      // resent history to include one).
+      await llm.invoke([
+        new HumanMessage("Why is the sky blue?"),
+        firstResult,
+        new HumanMessage("Now explain it to a 5 year old."),
+      ]);
+
+      const sentContents = recorder.request?.body?.contents ?? [];
+      const modelTurn = sentContents.find(
+        (c: { role?: string }) => c.role === "model"
+      );
+      expect(modelTurn).toBeDefined();
+
+      const sentThoughtParts = (modelTurn?.parts ?? []).filter(
+        (p: { thought?: boolean }) => p.thought === true
+      );
+      expect(sentThoughtParts.length).toBeGreaterThan(0);
+
+      const sentSignatures = (modelTurn?.parts ?? [])
+        .filter((p: { thoughtSignature?: string }) => "thoughtSignature" in p)
+        .map((p: { thoughtSignature?: string }) => p.thoughtSignature);
+      expect(sentSignatures.length).toBeGreaterThan(0);
+      // At least one signature from the first response must round-trip
+      // verbatim — Gemini validates these, so a regenerated/blank value
+      // would defeat the point of preserving the field at all.
+      expect(
+        sentSignatures.some((sig: string | undefined) =>
+          firstSignatures.includes(sig)
+        )
+      ).toBe(true);
+    });
   }
 );
 

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -363,7 +363,28 @@ function convertStandardContentBlockToGeminiPart(
 ): Gemini.Part | null {
   switch (block.type) {
     case "text":
-      return { text: block.text };
+      return {
+        text: block.text,
+        ...("thought" in block ? { thought: block.thought as boolean } : {}),
+        ...("thoughtSignature" in block
+          ? { thoughtSignature: block.thoughtSignature as string }
+          : {}),
+      };
+    case "reasoning":
+      // ChatGoogleTranslator (block_translators/google.ts) normalizes a
+      // Gemini thinking part into `{ type: "reasoning", reasoning, thought,
+      // thoughtSignature, reasoningContentBlock }` for the standard
+      // `contentBlocks` getter. Round-trip it back into the shape Gemini
+      // expects — without this, a thinking model's own chain-of-thought is
+      // silently dropped (hits the `default` branch below) when history
+      // that went through `.contentBlocks` is replayed on the next turn.
+      return {
+        text: block.reasoning,
+        ...("thought" in block ? { thought: block.thought as boolean } : {}),
+        ...("thoughtSignature" in block
+          ? { thoughtSignature: block.thoughtSignature as string }
+          : {}),
+      };
     case "image":
     case "audio":
     case "text-plain":
@@ -714,7 +735,16 @@ function convertLegacyContentMessageToGeminiContent(
         parts.push({ text: item });
       } else if (typeof item === "object" && item !== null) {
         if (isMessageContentText(item)) {
-          parts.push({ text: item.text });
+          const itemRecord = item as Record<string, unknown>;
+          parts.push({
+            text: item.text,
+            ...("thought" in itemRecord
+              ? { thought: itemRecord.thought as boolean }
+              : {}),
+            ...("thoughtSignature" in itemRecord
+              ? { thoughtSignature: itemRecord.thoughtSignature as string }
+              : {}),
+          });
         } else if (isDataContentBlock(item)) {
           parts.push(
             convertToProviderContentBlock(item, geminiContentBlockConverter)

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -740,6 +740,121 @@ describe("convertMessagesToGeminiContents", () => {
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
   });
+
+  test("legacy path: preserves thought and thoughtSignature on a resent text block", () => {
+    // Shape returned by convertGeminiCandidateToAIMessage for a thinking-model
+    // response — a text part with `thought: true` immediately followed by a
+    // functionCall part carrying `thoughtSignature`. When this AIMessage is
+    // fed back in as history on the next turn, the thought text must keep
+    // its `thought`/`thoughtSignature` markers so Gemini can tell it apart
+    // from a real committed utterance (see
+    // https://ai.google.dev/gemini-api/docs/thinking).
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text", text: "internal reasoning", thought: true },
+        {
+          type: "functionCall",
+          functionCall: { name: "get_weather", args: { city: "London" } },
+          thoughtSignature: "sig-abc",
+        },
+      ],
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "call-1",
+          type: "tool_call",
+        },
+      ],
+    });
+
+    const messages = [new HumanMessage("what's the weather?"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("legacy path: a plain text block with no thought key is unaffected", () => {
+    const message = new AIMessage({
+      content: [{ type: "text", text: "Here are your results." }],
+    });
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hi"),
+      message,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toEqual([{ text: "Here are your results." }]);
+  });
+
+  test("v1 contentBlocks (explicit output_version): preserves thought and thoughtSignature on a resent text block", () => {
+    // response_metadata.output_version === "v1" makes AIMessage.contentBlocks
+    // return `content` verbatim (ai.ts:196-202), bypassing ChatGoogleTranslator
+    // entirely — exercises convertStandardContentBlockToGeminiPart's "text" case.
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text" as const, text: "internal reasoning", thought: true },
+      ],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("v1 contentBlocks (via ChatGoogleTranslator): preserves thought on a resent reasoning block", () => {
+    // The real-world shape: every AIMessage this package produces carries
+    // response_metadata.model_provider = "google" (see
+    // convertGeminiCandidateToAIMessage). With no output_version override,
+    // AIMessage.contentBlocks (ai.ts:204-213) routes through
+    // ChatGoogleTranslator, which normalizes a `{ type: "text", thought:
+    // true }` part into `{ type: "reasoning", reasoning, thought,
+    // reasoningContentBlock }` (block_translators/google.ts).
+    // convertStandardContentBlockToGeminiPart must handle that "reasoning"
+    // shape too, or this history is silently dropped on the next turn.
+    const priorAiMessage = new AIMessage({
+      content: [{ text: "internal reasoning", thought: true, type: "text" }],
+      response_metadata: { model_provider: "google" },
+    });
+
+    // Sanity check the premise: this AIMessage's own .contentBlocks getter
+    // really does normalize to "reasoning" via ChatGoogleTranslator.
+    const blocks = priorAiMessage.contentBlocks;
+    expect(blocks.some((b) => b.type === "reasoning")).toBe(true);
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
 });
 
 describe("executableCode and codeExecutionResult round-trip", () => {


### PR DESCRIPTION
## Summary

Fixes #10461.

Both converter paths in `@langchain/google` silently strip `thought` and `thoughtSignature` when resending a prior `AIMessage`'s thinking text as part of a subsequent turn's history:

- **`convertLegacyContentMessageToGeminiContent`**'s `isMessageContentText` branch only copied `.text`, dropping the sibling `thought`/`thoughtSignature` keys that `convertGeminiCandidateToAIMessage` puts directly on a Gemini thinking part (`{ type: "text", thought: true, ... }`) in `AIMessage.content`.
- **`convertStandardContentBlockToGeminiPart`**'s `"text"` case had the same gap, and additionally had **no case at all for `"reasoning"` blocks** — which is the shape `AIMessage.contentBlocks` actually returns for a Gemini thinking part, via `@langchain/core`'s `ChatGoogleTranslator` (every `AIMessage` this package produces sets `response_metadata.model_provider = "google"`, which is exactly the condition that routes `contentBlocks` through that translator). A `"reasoning"` block hit the `default: return null` branch and was dropped entirely.

Per [Gemini's docs](https://ai.google.dev/gemini-api/docs/thinking): *"You should NOT remove or modify thought blocks from the history, as they contain the signatures required for the model to continue its reasoning."* Both gaps mean a thinking model's own prior chain-of-thought either loses its thought marker (legacy path) or disappears outright (standard/`contentBlocks` path) when replayed on the next turn.

## Why this revisits #10462 (closed)

#10462 attempted the same `"text"`-case fix and was closed after @afirstenberg noted thinking parts flow through this package as `"reasoning"` blocks, not `"text"` blocks with `thought=true`. That's correct **for `AIMessage.contentBlocks`** (via `ChatGoogleTranslator`) — but not for `AIMessage.content` itself, which both converters also read directly, and which genuinely does carry `{ type: "text", thought: true }`. I confirmed this against a live production trace (`gemini-3.5-flash` via Vertex):

```json
[
  { "text": "...(real chain-of-thought)...", "thought": true, "type": "text" },
  { "functionCall": { "name": "geo_agent", "args": {...} }, "thoughtSignature": "AY89a19...", "type": "functionCall" }
]
```

This PR fixes **both** shapes rather than picking one — the `"text"` case (legacy path + as a fallback in the standard path when a Gemini part collapses through `originalTextContentBlock`) and a new `"reasoning"` case (standard path, the shape that actually reaches the converter for a real Gemini response with `model_provider: "google"` set and no `output_version` override).

## Changes

Both additions are additive — spread-guarded on key presence — so a plain text/reasoning block with no `thought`/`thoughtSignature` keys serializes identically to before. No behavior change for non-thinking models or non-thought content.

## Test plan

Added 4 unit tests in `converters/tests/messages.test.ts`:
- Legacy path: a `thought:true` text block round-trips with the flag intact
- Legacy path: a plain text block with no `thought` key is unaffected (control case)
- Explicit `output_version: "v1"`: same preservation via the direct `"text"` case
- Real-world `ChatGoogleTranslator` path: asserts (via `.contentBlocks` directly) that the input really does normalize to a `"reasoning"` block, then verifies the converter preserves `thought` through that shape too

All 4 new tests pass. Pre-existing note: 3 unrelated tests in this same file fail in my local environment on unmodified `main` too (confirmed via `git stash`) — a local/CI environment discrepancy unrelated to this change, not something this PR touches.

## AI Disclosure

Investigated and drafted with AI assistance (Claude), including the production trace analysis and the `ChatGoogleTranslator` code trace that explains why #10462's original framing was closed. I reviewed and verified the diagnosis and patch myself before opening this.