### PR TITLE
fix(aws): normalize Bedrock reasoning blocks

### DIFF
--- a/.changeset/calm-pandas-reason.md
+++ b/.changeset/calm-pandas-reason.md
@@ -1,0 +1,8 @@
+---
+"@langchain/aws": patch
+"@langchain/core": patch
+---
+
+fix(aws): normalize and safely replay Bedrock reasoning blocks
+
+Emit standard reasoning blocks with preserved signatures, omit incomplete signature-only reasoning during replay, and retain compatibility with legacy and redacted Bedrock reasoning.

--- a/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
+++ b/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
@@ -313,6 +313,19 @@ function convertToV1FromChatBedrockConverseMessage(
         continue;
       } else if (
         _isContentBlock(block, "reasoning_content") &&
+        _isObject(block.reasoningText) &&
+        _isString(block.reasoningText.text)
+      ) {
+        yield {
+          type: "reasoning",
+          reasoning: block.reasoningText.text,
+          ...(_isString(block.reasoningText.signature)
+            ? { signature: block.reasoningText.signature }
+            : {}),
+        };
+        continue;
+      } else if (
+        _isContentBlock(block, "reasoning_content") &&
         _isString(block.reasoningText)
       ) {
         yield {

--- a/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
+++ b/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
@@ -238,7 +238,10 @@ function convertToV1FromChatBedrockConverseMessage(
         ? [{ type: "text", text: message.content }]
         : message.content;
     for (const block of content) {
-      if (_isContentBlock(block, "cache_point")) {
+      if (_isContentBlock(block, "reasoning") && _isString(block.reasoning)) {
+        yield block;
+        continue;
+      } else if (_isContentBlock(block, "cache_point")) {
         yield { type: "non_standard", value: block };
         continue;
       } else if (

--- a/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
+++ b/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts
@@ -239,7 +239,7 @@ function convertToV1FromChatBedrockConverseMessage(
         : message.content;
     for (const block of content) {
       if (_isContentBlock(block, "reasoning") && _isString(block.reasoning)) {
-        yield block;
+        yield { ...block, type: "reasoning", reasoning: block.reasoning };
         continue;
       } else if (_isContentBlock(block, "cache_point")) {
         yield { type: "non_standard", value: block };

--- a/libs/langchain-core/src/messages/block_translators/tests/bedrock_converse.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/bedrock_converse.test.ts
@@ -93,7 +93,14 @@ describe("ChatBedrockConverseTranslator", () => {
         },
         {
           type: "reasoning_content",
-          reasoningText: "foo",
+          reasoningText: {
+            text: "foo",
+            signature: "opaque-signature",
+          },
+        },
+        {
+          type: "reasoning_content",
+          reasoningText: "legacy reasoning",
         },
         {
           type: "reasoning_content",
@@ -197,7 +204,15 @@ describe("ChatBedrockConverseTranslator", () => {
         mimeType: "image/jpeg",
         data: Buffer.from("image_bytes"),
       },
-      { type: "reasoning", reasoning: "foo" },
+      {
+        type: "reasoning",
+        reasoning: "foo",
+        signature: "opaque-signature",
+      },
+      {
+        type: "reasoning",
+        reasoning: "legacy reasoning",
+      },
       {
         type: "non_standard",
         value: {

--- a/libs/langchain-core/src/messages/block_translators/tests/bedrock_converse.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/bedrock_converse.test.ts
@@ -1,4 +1,4 @@
-import { AIMessage } from "../../ai.js";
+import { AIMessage, AIMessageChunk } from "../../ai.js";
 import { ContentBlock } from "../../content/index.js";
 import { convertToV1FromChatBedrockConverseInput } from "../bedrock_converse.js";
 
@@ -257,6 +257,30 @@ describe("ChatBedrockConverseTranslator", () => {
     ];
     expect(message.contentBlocks).toEqual(expectedContent);
   });
+
+  it.each([
+    { name: "AIMessage", MessageClass: AIMessage },
+    { name: "AIMessageChunk", MessageClass: AIMessageChunk },
+  ])(
+    "should preserve standard reasoning blocks in $name contentBlocks",
+    ({ MessageClass }) => {
+      const reasoningBlock: ContentBlock.Reasoning = {
+        type: "reasoning",
+        reasoning: "reasoning text",
+        signature: "opaque-signature",
+        index: 0,
+      };
+      const message = new MessageClass({
+        content: [reasoningBlock],
+        response_metadata: {
+          model_provider: "bedrock-converse",
+        },
+      });
+
+      expect(message.contentBlocks).toEqual([reasoningBlock]);
+    }
+  );
+
   it("should translate ChatBedrockConverse inputs to standard content blocks", () => {
     const message = new AIMessage([
       { type: "text", text: "foo" },

--- a/libs/providers/langchain-aws/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.int.test.ts
@@ -15,8 +15,6 @@ import { tool } from "@langchain/core/tools";
 import { concat } from "@langchain/core/utils/stream";
 
 import { ChatBedrockConverse } from "../chat_models.js";
-import { concatenateLangchainReasoningBlocks } from "../utils/message_inputs.js";
-import { MessageContentReasoningBlockReasoningText } from "../types.js";
 
 // Save the original value of the 'LANGCHAIN_CALLBACKS_BACKGROUND' environment variable
 const originalBackground = process.env.LANGCHAIN_CALLBACKS_BACKGROUND;
@@ -437,7 +435,7 @@ test("Model can handle empty content messages", async () => {
   expect(result.content.length).toBeGreaterThan(1);
 });
 
-test("Test reasoning_content blocks multiturn invoke", async () => {
+test("Test standard reasoning blocks multiturn invoke", async () => {
   const model = new ChatBedrockConverse({
     ...baseConstructorArgs,
     model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -452,22 +450,16 @@ test("Test reasoning_content blocks multiturn invoke", async () => {
 
     expect(Array.isArray(response.content)).toBe(true);
     const content = response.content as MessageContentComplex[];
-    expect(content.some((block) => block.type === "reasoning_content")).toBe(
-      true
-    );
+    expect(content.some((block) => block.type === "reasoning")).toBe(true);
 
     for (const block of content) {
       expect(typeof block).toBe("object");
-      if (block.type === "reasoning_content") {
+      if (block.type === "reasoning") {
         expect(Object.keys(block).sort()).toEqual(
-          ["type", "reasoningText"].sort()
+          ["type", "reasoning", "signature"].sort()
         );
-        expect(block.reasoningText).toBeTruthy();
-        expect(typeof block.reasoningText).toBe("object");
-        expect(block.reasoningText.text).toBeTruthy();
-        expect(typeof block.reasoningText.text).toBe("string");
-        expect(block.reasoningText.signature).toBeTruthy();
-        expect(typeof block.reasoningText.signature).toBe("string");
+        expect(typeof block.reasoning).toBe("string");
+        expect(typeof block.signature).toBe("string");
       }
     }
     return response;
@@ -482,7 +474,7 @@ test("Test reasoning_content blocks multiturn invoke", async () => {
   await model.invoke(invokeMessages);
 });
 
-test("Test reasoning_content blocks multiturn streaming", async () => {
+test("Test standard reasoning blocks multiturn streaming", async () => {
   const model = new ChatBedrockConverse({
     ...baseConstructorArgs,
     model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -499,28 +491,18 @@ test("Test reasoning_content blocks multiturn streaming", async () => {
     }
     expect(full).toBeInstanceOf(AIMessageChunk);
     expect(Array.isArray(full?.content)).toBe(true);
-    const content = concatenateLangchainReasoningBlocks(
-      full?.content as MessageContentComplex[]
-    );
-    expect(content.some((block) => block.type === "reasoning_content")).toBe(
-      true
-    );
+    const content = full?.content as MessageContentComplex[];
+    expect(content.some((block) => block.type === "reasoning")).toBe(true);
 
     for (const block of content) {
       expect(typeof block).toBe("object");
-      if (block.type === "reasoning_content") {
+      if (block.type === "reasoning") {
         expect(Object.keys(block).sort()).toEqual(
-          ["type", "reasoningText"].sort()
+          ["type", "reasoning", "signature", "index"].sort()
         );
-
-        const reasoningBlock =
-          block as MessageContentReasoningBlockReasoningText;
-        expect(reasoningBlock.reasoningText).toBeTruthy();
-        expect(typeof reasoningBlock.reasoningText).toBe("object");
-        expect(reasoningBlock.reasoningText.text).toBeTruthy();
-        expect(typeof reasoningBlock.reasoningText.text).toBe("string");
-        expect(reasoningBlock.reasoningText.signature).toBeTruthy();
-        expect(typeof reasoningBlock.reasoningText.signature).toBe("string");
+        expect(typeof block.reasoning).toBe("string");
+        expect(typeof block.signature).toBe("string");
+        expect(typeof block.index).toBe("number");
       }
     }
     return full as AIMessageChunk;
@@ -587,7 +569,7 @@ test("Test ChatBedrockConverse can respond to tool invocations with thinking ena
 });
 
 describe("AWS Bedrock Reasoning with contentBlocks", () => {
-  test("invoke returns reasoning_content as reasoning in contentBlocks", async () => {
+  test("invoke returns standard reasoning in contentBlocks", async () => {
     const model = new ChatBedrockConverse({
       ...baseConstructorArgs,
       model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -612,7 +594,7 @@ describe("AWS Bedrock Reasoning with contentBlocks", () => {
     expect(textBlocks.length).toBeGreaterThan(0);
   });
 
-  test("stream returns reasoning_content as reasoning in contentBlocks", async () => {
+  test("stream returns standard reasoning in contentBlocks", async () => {
     const model = new ChatBedrockConverse({
       ...baseConstructorArgs,
       model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -713,6 +713,225 @@ describe("convertToConverseMessages", () => {
   );
 });
 
+describe("reasoning content replay", () => {
+  it("omits signature-only standard reasoning and preserves tool use", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning",
+            reasoning: "",
+            signature: "opaque-signature",
+            index: 0,
+          },
+        ],
+        tool_calls: [
+          {
+            id: "tool-call-1",
+            name: "get_weather",
+            args: { location: "San Francisco" },
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: "tool-call-1",
+        content: "72°F and sunny",
+      }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            toolUse: {
+              toolUseId: "tool-call-1",
+              name: "get_weather",
+              input: { location: "San Francisco" },
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            toolResult: {
+              toolUseId: "tool-call-1",
+              content: [{ text: "72°F and sunny" }],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("replays standard reasoning without an output version", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning",
+            reasoning: "Reasoning summary",
+            signature: "opaque-signature",
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: "Reasoning summary",
+            signature: "opaque-signature",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves redacted provider reasoning", () => {
+    const redactedContent = Buffer.from("redacted-reasoning");
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning_content",
+            redactedContent: redactedContent.toString("base64"),
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          redactedContent,
+        },
+      },
+    ]);
+  });
+
+  it("combines streamed redacted reasoning bytes before replay", () => {
+    const firstFragment = Buffer.from("a");
+    const secondFragment = Buffer.from("bc");
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning_content",
+            redactedContent: firstFragment.toString("base64"),
+          },
+          {
+            type: "reasoning_content",
+            redactedContent: secondFragment.toString("base64"),
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          redactedContent: Buffer.concat([firstFragment, secondFragment]),
+        },
+      },
+    ]);
+  });
+
+  it("replays legacy provider-native reasoning", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "reasoning_content",
+            reasoningText: {
+              text: "Reasoning summary",
+              signature: "opaque-signature",
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: "Reasoning summary",
+            signature: "opaque-signature",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("unwraps legacy redacted Bedrock reasoning from standard content", () => {
+    const redactedContent = Buffer.from("redacted-reasoning");
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "non_standard",
+            value: {
+              reasoningContent: {
+                redactedContent,
+              },
+            },
+          },
+        ],
+        response_metadata: {
+          output_version: "v1",
+          model_provider: "bedrock-converse",
+        },
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          redactedContent,
+        },
+      },
+    ]);
+  });
+
+  it("unwraps complete legacy Bedrock reasoning from standard content", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "non_standard",
+            value: {
+              type: "reasoning_content",
+              reasoningText: {
+                text: "Reasoning summary",
+                signature: "opaque-signature",
+              },
+            },
+          },
+        ],
+        response_metadata: {
+          output_version: "v1",
+          model_provider: "bedrock-converse",
+        },
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: {
+            text: "Reasoning summary",
+            signature: "opaque-signature",
+          },
+        },
+      },
+    ]);
+  });
+});
+
 test("Streaming supports empty string chunks", async () => {
   const contentBlocks = [
     {

--- a/libs/providers/langchain-aws/src/utils/compat.ts
+++ b/libs/providers/langchain-aws/src/utils/compat.ts
@@ -1,6 +1,85 @@
 import { AIMessage, ContentBlock } from "@langchain/core/messages";
 import type * as Bedrock from "@aws-sdk/client-bedrock-runtime";
 
+function convertReasoningText(
+  text: unknown,
+  signature: unknown
+): Bedrock.ReasoningContentBlock | undefined {
+  if (typeof text !== "string" || text.length === 0) {
+    return undefined;
+  }
+  return {
+    reasoningText: {
+      text,
+      ...(typeof signature === "string" ? { signature } : {}),
+    },
+  };
+}
+
+function convertLegacyReasoningContent(
+  value: unknown
+): Bedrock.ReasoningContentBlock | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  if (
+    "type" in value &&
+    value.type === "reasoning_content" &&
+    "reasoningText" in value &&
+    typeof value.reasoningText === "object" &&
+    value.reasoningText !== null
+  ) {
+    const reasoningText = value.reasoningText;
+    return convertReasoningText(
+      "text" in reasoningText ? reasoningText.text : undefined,
+      "signature" in reasoningText ? reasoningText.signature : undefined
+    );
+  }
+
+  if (
+    "type" in value &&
+    value.type === "reasoning_content" &&
+    "redactedContent" in value &&
+    typeof value.redactedContent === "string" &&
+    value.redactedContent.length > 0
+  ) {
+    return {
+      redactedContent: Buffer.from(value.redactedContent, "base64"),
+    };
+  }
+
+  if (
+    "reasoningContent" in value &&
+    typeof value.reasoningContent === "object" &&
+    value.reasoningContent !== null
+  ) {
+    if (
+      "reasoningText" in value.reasoningContent &&
+      typeof value.reasoningContent.reasoningText === "object" &&
+      value.reasoningContent.reasoningText !== null
+    ) {
+      const reasoningText = value.reasoningContent.reasoningText;
+      return convertReasoningText(
+        "text" in reasoningText ? reasoningText.text : undefined,
+        "signature" in reasoningText ? reasoningText.signature : undefined
+      );
+    }
+
+    if (
+      "redactedContent" in value.reasoningContent &&
+      value.reasoningContent.redactedContent instanceof Uint8Array &&
+      value.reasoningContent.redactedContent.byteLength > 0
+    ) {
+      return {
+        redactedContent: value.reasoningContent.redactedContent,
+      };
+    }
+  }
+
+  return undefined;
+}
+
 // see `/libs/langchain-core/src/messages/block_translators/bedrock_converse.ts:convertFileFormatToMimeType`
 const formatToMimeType = {
   document(format: string): Bedrock.DocumentFormat {
@@ -170,13 +249,13 @@ export function convertFromV1ToChatBedrockConverseMessage(
         // no-op
         continue;
       } else if (block.type === "reasoning") {
-        yield {
-          reasoningContent: {
-            reasoningText: {
-              text: block.reasoning,
-            },
-          },
-        };
+        const reasoningContent = convertReasoningText(
+          block.reasoning,
+          block.signature
+        );
+        if (reasoningContent) {
+          yield { reasoningContent };
+        }
       } else if (block.type === "server_tool_call") {
         // no-op
         continue;
@@ -232,8 +311,10 @@ export function convertFromV1ToChatBedrockConverseMessage(
         block.type === "non_standard" &&
         modelProvider === "bedrock-converse"
       ) {
-        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-        yield block as any;
+        const reasoningContent = convertLegacyReasoningContent(block.value);
+        if (reasoningContent) {
+          yield { reasoningContent };
+        }
       }
     }
   }

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -22,7 +22,6 @@ import {
   ConverseCommandParams,
   MessageContentReasoningBlock,
   MessageContentReasoningBlockReasoningText,
-  MessageContentReasoningBlockRedacted,
 } from "../types.js";
 import { convertFromV1ToChatBedrockConverseMessage } from "./compat.js";
 
@@ -610,12 +609,15 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
             text: block.text,
           });
         }
-      } else if (block.type === "reasoning_content") {
-        contentBlocks.push({
-          reasoningContent: langchainReasoningBlockToBedrockReasoningBlock(
-            block as MessageContentReasoningBlock
-          ),
-        });
+      } else if (
+        block.type === "reasoning" ||
+        block.type === "reasoning_content"
+      ) {
+        const reasoningContent =
+          langchainReasoningBlockToBedrockReasoningBlock(block);
+        if (reasoningContent) {
+          contentBlocks.push({ reasoningContent });
+        }
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push(convertCachePointBlock(block));
       } else {
@@ -795,22 +797,66 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
 }
 
 export function langchainReasoningBlockToBedrockReasoningBlock(
-  content: MessageContentReasoningBlock
-): Bedrock.ReasoningContentBlock {
-  if (content.type !== "reasoning_content") {
-    throw new Error("Invalid reasoning content");
+  content: unknown
+): Bedrock.ReasoningContentBlock | undefined {
+  if (typeof content !== "object" || content === null || !("type" in content)) {
+    return undefined;
   }
-  if ("reasoningText" in content) {
+
+  if (
+    content.type === "reasoning" &&
+    "reasoning" in content &&
+    typeof content.reasoning === "string" &&
+    content.reasoning.length > 0
+  ) {
+    const signature =
+      "signature" in content && typeof content.signature === "string"
+        ? content.signature
+        : undefined;
     return {
-      reasoningText: content.reasoningText as Bedrock.ReasoningTextBlock,
+      reasoningText: {
+        text: content.reasoning,
+        ...(signature !== undefined ? { signature } : {}),
+      },
     };
   }
-  if ("redactedContent" in content) {
+
+  if (content.type !== "reasoning_content") {
+    return undefined;
+  }
+
+  if (
+    "reasoningText" in content &&
+    typeof content.reasoningText === "object" &&
+    content.reasoningText !== null &&
+    "text" in content.reasoningText &&
+    typeof content.reasoningText.text === "string" &&
+    content.reasoningText.text.length > 0
+  ) {
+    const signature =
+      "signature" in content.reasoningText &&
+      typeof content.reasoningText.signature === "string"
+        ? content.reasoningText.signature
+        : undefined;
+    return {
+      reasoningText: {
+        text: content.reasoningText.text,
+        ...(signature !== undefined ? { signature } : {}),
+      },
+    };
+  }
+
+  if (
+    "redactedContent" in content &&
+    typeof content.redactedContent === "string" &&
+    content.redactedContent.length > 0
+  ) {
     return {
       redactedContent: Buffer.from(content.redactedContent, "base64"),
     };
   }
-  throw new Error("Invalid reasoning content");
+
+  return undefined;
 }
 
 export function concatenateLangchainReasoningBlocks(
@@ -884,14 +930,19 @@ export function concatenateLangchainReasoningBlocks(
         concatenatedBlock = {};
       }
       const { redactedContent } = block;
-      const prevRedactedContent = (
+      const prevRedactedContent =
         "redactedContent" in concatenatedBlock
-          ? concatenatedBlock.redactedContent!
-          : ""
-      ) as Partial<MessageContentReasoningBlockRedacted["redactedContent"]>;
+          ? concatenatedBlock.redactedContent
+          : undefined;
+      const redactedBytes = prevRedactedContent
+        ? Buffer.concat([
+            Buffer.from(prevRedactedContent, "base64"),
+            Buffer.from(redactedContent, "base64"),
+          ])
+        : Buffer.from(redactedContent, "base64");
       concatenatedBlock = {
         type: "reasoning_content",
-        redactedContent: prevRedactedContent + redactedContent,
+        redactedContent: redactedBytes.toString("base64"),
       };
     }
   }

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -4,11 +4,7 @@ import type { ToolCall } from "@langchain/core/messages/tool";
 import type * as Bedrock from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType as __DocumentType } from "@smithy/types";
 import { ChatGenerationChunk } from "@langchain/core/outputs";
-import {
-  MessageContentReasoningBlock,
-  MessageContentReasoningBlockReasoningTextPartial,
-  MessageContentReasoningBlockRedacted,
-} from "../types.js";
+import { MessageContentReasoningBlockRedacted } from "../types.js";
 
 export function convertConverseMessageToLangChainMessage(
   message: Bedrock.Message,
@@ -92,11 +88,9 @@ export function convertConverseMessageToLangChainMessage(
         content.push({ type: "guard_content", guardContent: c.guardContent });
       } else if ("image" in c) {
         content.push({ type: "image", image: c.image });
-      } else if ("reasoningContent" in c) {
+      } else if ("reasoningContent" in c && c.reasoningContent) {
         content.push(
-          bedrockReasoningBlockToLangchainReasoningBlock(
-            c.reasoningContent as Bedrock.ReasoningContentBlock
-          )
+          bedrockReasoningBlockToLangchainReasoningBlock(c.reasoningContent)
         );
       } else if ("text" in c && typeof c.text === "string") {
         content.push({ type: "text", text: c.text });
@@ -166,7 +160,8 @@ export function handleConverseStreamContentBlockDelta(
       message: new AIMessageChunk({
         content: [
           bedrockReasoningDeltaToLangchainPartialReasoningBlock(
-            contentBlockDelta.delta.reasoningContent
+            contentBlockDelta.delta.reasoningContent,
+            contentBlockDelta.contentBlockIndex
           ),
         ],
       }),
@@ -249,21 +244,23 @@ export function handleConverseStreamMetadata(
 }
 
 export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
-  reasoningContent: Bedrock.ReasoningContentBlockDelta
-):
-  | MessageContentReasoningBlockReasoningTextPartial
-  | MessageContentReasoningBlockRedacted {
+  reasoningContent: Bedrock.ReasoningContentBlockDelta,
+  index?: number
+): ContentBlock.Reasoning | MessageContentReasoningBlockRedacted {
   const { text, redactedContent, signature } = reasoningContent;
   if (typeof text === "string") {
     return {
-      type: "reasoning_content",
-      reasoningText: { text },
+      type: "reasoning",
+      reasoning: text,
+      ...(index !== undefined ? { index } : {}),
     };
   }
-  if (signature) {
+  if (typeof signature === "string") {
     return {
-      type: "reasoning_content",
-      reasoningText: { signature },
+      type: "reasoning",
+      reasoning: "",
+      signature,
+      ...(index !== undefined ? { index } : {}),
     };
   }
   if (redactedContent) {
@@ -277,12 +274,15 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
 
 export function bedrockReasoningBlockToLangchainReasoningBlock(
   reasoningContent: Bedrock.ReasoningContentBlock
-): MessageContentReasoningBlock {
+): ContentBlock.Reasoning | MessageContentReasoningBlockRedacted {
   const { reasoningText, redactedContent } = reasoningContent;
-  if (reasoningText) {
+  if (reasoningText && typeof reasoningText.text === "string") {
     return {
-      type: "reasoning_content",
-      reasoningText: reasoningText as Required<Bedrock.ReasoningTextBlock>,
+      type: "reasoning",
+      reasoning: reasoningText.text,
+      ...(typeof reasoningText.signature === "string"
+        ? { signature: reasoningText.signature }
+        : {}),
     };
   }
 

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -1,9 +1,72 @@
 import { describe, expect, test } from "vitest";
 import type * as Bedrock from "@aws-sdk/client-bedrock-runtime";
+import { concat } from "@langchain/core/utils/stream";
 import {
   convertConverseMessageToLangChainMessage,
+  handleConverseStreamContentBlockDelta,
   handleConverseStreamMetadata,
 } from "../message_outputs.js";
+
+describe("reasoning output conversion", () => {
+  test("uses standard reasoning content by default", () => {
+    const result = convertConverseMessageToLangChainMessage(
+      {
+        role: "assistant",
+        content: [
+          {
+            reasoningContent: {
+              reasoningText: {
+                text: "Reasoning summary",
+                signature: "opaque-signature",
+              },
+            },
+          },
+        ],
+      },
+      {
+        stopReason: "end_turn",
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        metrics: { latencyMs: 0 },
+      }
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        signature: "opaque-signature",
+      },
+    ]);
+    expect(result.response_metadata).not.toHaveProperty("output_version");
+  });
+
+  test("merges streaming reasoning and signature into a standard block", () => {
+    const reasoning = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { text: "Reasoning summary" } },
+    });
+    const signature = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { signature: "opaque-signature" } },
+    });
+
+    const result = concat(reasoning.message, signature.message);
+
+    expect(result.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        signature: "opaque-signature",
+        index: 0,
+      },
+    ]);
+    expect(result.response_metadata).not.toHaveProperty("output_version");
+  });
+});
 
 describe("message output usage metadata conversion", () => {
   test("maps Bedrock prompt cache tokens for non-stream responses", () => {


### PR DESCRIPTION
## Summary

Normalize Bedrock Converse reasoning into LangChain's standard reasoning block shape by default, including opaque signatures and streaming block indexes. Prevent incomplete signature-only reasoning from being replayed as an invalid Bedrock `reasoningText` block while preserving tool calls and compatibility with persisted provider-native content.

## Changes

### `@langchain/aws`

- Emit `{ type: "reasoning", reasoning, signature }` for ordinary Bedrock reasoning without requiring `output_version: "v1"`.
- Associate streamed reasoning text and signature deltas by content-block index so they merge into a single standard block.
- Validate reasoning at the Bedrock request boundary and omit signature-only or empty reasoning while retaining subsequent tool-use and tool-result ordering.
- Preserve complete signed reasoning, legacy provider-native reasoning, legacy `non_standard` wrappers, and redacted reasoning.
- Combine streamed redacted reasoning as bytes instead of concatenating independently padded base64 fragments.

### `@langchain/core`

- Recognize Bedrock's object-valued reasoning shape and normalize its text and signature into a standard reasoning block.
- Retain compatibility with the legacy string-valued reasoning representation without changing public core content types.
