### PR TITLE
feat(langchain): add tool error middleware

### DIFF
--- a/.changeset/calm-tools-handle.md
+++ b/.changeset/calm-tools-handle.md
@@ -1,5 +1,5 @@
 ---
-"langchain": minor
+"langchain": patch
 ---
 
 feat(langchain): add middleware for handling tool execution errors

--- a/.changeset/calm-tools-handle.md
+++ b/.changeset/calm-tools-handle.md
@@ -1,0 +1,5 @@
+---
+"langchain": minor
+---
+
+feat(langchain): add middleware for handling tool execution errors

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ lib/
 .eslintcache
 .env
 .env.local
+*.pem
+*.key
+*.crt
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ lib/
 .eslintcache
 .env
 .env.local
-*.pem
-*.key
-*.crt
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log

--- a/libs/langchain/src/agents/middleware/index.ts
+++ b/libs/langchain/src/agents/middleware/index.ts
@@ -69,6 +69,11 @@ export {
   type ToolRetryMiddlewareConfig,
 } from "./toolRetry.js";
 export {
+  toolErrorMiddleware,
+  type ToolErrorHandler,
+  type ToolErrorMiddlewareConfig,
+} from "./toolError.js";
+export {
   toolEmulatorMiddleware,
   type ToolEmulatorOptions,
 } from "./toolEmulator.js";

--- a/libs/langchain/src/agents/middleware/tests/toolError.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/toolError.test.ts
@@ -11,6 +11,7 @@ import { createAgent } from "../../index.js";
 import { FakeToolCallingModel } from "../../tests/utils.js";
 import type { ToolCallRequest } from "../types.js";
 import { toolErrorMiddleware } from "../toolError.js";
+import { toolRetryMiddleware } from "../toolRetry.js";
 
 class SecretToolError extends Error {
   constructor(value: string) {
@@ -66,24 +67,74 @@ describe("toolErrorMiddleware", () => {
   });
 
   it("propagates the original error when the handler returns nothing", async () => {
+    const originalError = new SecretToolError("x");
+    const identityTool = tool(
+      async () => {
+        throw originalError;
+      },
+      {
+        name: "failing_tool",
+        description: "Tool that throws a fixed error",
+        schema: z.object({ value: z.string() }),
+      }
+    );
+    const onError = vi.fn((_error: unknown) => undefined);
     const agent = createAgent({
       model: createModel(),
-      tools: [failingTool],
-      middleware: [
-        toolErrorMiddleware({
-          onError: (error) => {
-            if (error instanceof TypeError) {
-              return "handled";
-            }
-            return undefined;
-          },
-        }),
-      ],
+      tools: [identityTool],
+      middleware: [toolErrorMiddleware({ onError })],
     });
 
     await expect(
       agent.invoke({ messages: [new HumanMessage("Use the failing tool")] })
-    ).rejects.toThrow("secret detail: x");
+    ).rejects.toBe(originalError);
+    expect(onError.mock.calls[0][0]).toBe(originalError);
+    expect(originalError).toBeInstanceOf(SecretToolError);
+  });
+
+  it("handles the original error after retries are exhausted", async () => {
+    const originalError = new SecretToolError("retry");
+    const attempts = vi.fn();
+    const retryingTool = tool(
+      async () => {
+        attempts();
+        throw originalError;
+      },
+      {
+        name: "failing_tool",
+        description: "Tool that fails until retries are exhausted",
+        schema: z.object({ value: z.string() }),
+      }
+    );
+    const onError = vi.fn((error: unknown) =>
+      error instanceof SecretToolError ? "handled after retries" : undefined
+    );
+    const agent = createAgent({
+      model: createModel(),
+      tools: [retryingTool],
+      middleware: [
+        toolErrorMiddleware({ onError }),
+        toolRetryMiddleware({
+          maxRetries: 2,
+          initialDelayMs: 0,
+          jitter: false,
+          onFailure: "error",
+        }),
+      ],
+    });
+
+    const result = await agent.invoke({
+      messages: [new HumanMessage("Use the failing tool")],
+    });
+
+    expect(attempts).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBe(originalError);
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+    expect(toolMessages[0]).toMatchObject({
+      content: "handled after retries",
+      status: "error",
+    });
   });
 
   it("supports async handlers and content blocks", async () => {

--- a/libs/langchain/src/agents/middleware/tests/toolError.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/toolError.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for tool error middleware.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { HumanMessage, ToolMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { GraphInterrupt, MemorySaver } from "@langchain/langgraph";
+import { z } from "zod/v3";
+
+import { createAgent } from "../../index.js";
+import { FakeToolCallingModel } from "../../tests/utils.js";
+import type { ToolCallRequest } from "../types.js";
+import { toolErrorMiddleware } from "../toolError.js";
+
+class SecretToolError extends Error {
+  constructor(value: string) {
+    super(`secret detail: ${value}`);
+    this.name = "SecretToolError";
+  }
+}
+
+const failingTool = tool(
+  async ({ value }) => {
+    throw new SecretToolError(value);
+  },
+  {
+    name: "failing_tool",
+    description: "Tool that always fails",
+    schema: z.object({ value: z.string() }),
+  }
+);
+
+function createModel(toolName = "failing_tool") {
+  return new FakeToolCallingModel({
+    toolCalls: [[{ name: toolName, args: { value: "x" }, id: "call_1" }], []],
+  });
+}
+
+describe("toolErrorMiddleware", () => {
+  it("returns handler content as an error ToolMessage", async () => {
+    const onError = vi.fn((error: unknown, _request: ToolCallRequest) => {
+      const errorName = error instanceof Error ? error.name : "UnknownError";
+      return `Tool failed with ${errorName}.`;
+    });
+    const agent = createAgent({
+      model: createModel(),
+      tools: [failingTool],
+      middleware: [toolErrorMiddleware({ onError })],
+    });
+
+    const result = await agent.invoke({
+      messages: [new HumanMessage("Use the failing tool")],
+    });
+
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+    expect(toolMessages).toHaveLength(1);
+    expect(toolMessages[0]).toMatchObject({
+      content: "Tool failed with SecretToolError.",
+      name: "failing_tool",
+      status: "error",
+      tool_call_id: "call_1",
+    });
+    expect(toolMessages[0].content).not.toContain("secret detail");
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][1].toolCall.name).toBe("failing_tool");
+  });
+
+  it("propagates the original error when the handler returns nothing", async () => {
+    const agent = createAgent({
+      model: createModel(),
+      tools: [failingTool],
+      middleware: [
+        toolErrorMiddleware({
+          onError: (error) => {
+            if (error instanceof TypeError) {
+              return "handled";
+            }
+            return undefined;
+          },
+        }),
+      ],
+    });
+
+    await expect(
+      agent.invoke({ messages: [new HumanMessage("Use the failing tool")] })
+    ).rejects.toThrow("secret detail: x");
+  });
+
+  it("supports async handlers and content blocks", async () => {
+    const agent = createAgent({
+      model: createModel(),
+      tools: [failingTool],
+      middleware: [
+        toolErrorMiddleware({
+          onError: async () => [
+            { type: "text", text: "The tool failed safely." },
+          ],
+        }),
+      ],
+    });
+
+    const result = await agent.invoke({
+      messages: [new HumanMessage("Use the failing tool")],
+    });
+
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+    expect(toolMessages[0].content).toEqual([
+      { type: "text", text: "The tool failed safely." },
+    ]);
+    expect(toolMessages[0].status).toBe("error");
+  });
+
+  it("accepts tool instances in the filter", async () => {
+    const agent = createAgent({
+      model: createModel(),
+      tools: [failingTool],
+      middleware: [
+        toolErrorMiddleware({
+          tools: [failingTool],
+          onError: () => "handled",
+        }),
+      ],
+    });
+
+    const result = await agent.invoke({
+      messages: [new HumanMessage("Use the failing tool")],
+    });
+
+    const toolMessages = result.messages.filter(ToolMessage.isInstance);
+    expect(toolMessages[0].content).toBe("handled");
+  });
+
+  it("bypasses tools that are not in the filter", async () => {
+    const onError = vi.fn(() => "handled");
+    const agent = createAgent({
+      model: createModel(),
+      tools: [failingTool],
+      middleware: [toolErrorMiddleware({ tools: ["other_tool"], onError })],
+    });
+
+    await expect(
+      agent.invoke({ messages: [new HumanMessage("Use the failing tool")] })
+    ).rejects.toThrow("secret detail: x");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not pass LangGraph control-flow errors to the handler", async () => {
+    const interruptValue = { action: "approve" };
+    const interruptTool = tool(
+      async () => {
+        throw new GraphInterrupt([{ value: interruptValue }]);
+      },
+      {
+        name: "interrupt_tool",
+        description: "Tool that interrupts",
+        schema: z.object({}),
+      }
+    );
+    const onError = vi.fn(() => "handled");
+    const agent = createAgent({
+      model: new FakeToolCallingModel({
+        toolCalls: [[{ name: "interrupt_tool", args: {}, id: "call_1" }]],
+      }),
+      tools: [interruptTool],
+      middleware: [toolErrorMiddleware({ onError })],
+      checkpointer: new MemorySaver(),
+    });
+
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("Use the interrupt tool")] },
+      { configurable: { thread_id: "tool-error-interrupt" } }
+    );
+
+    expect(result.__interrupt__?.[0].value).toEqual(interruptValue);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/libs/langchain/src/agents/middleware/toolError.ts
+++ b/libs/langchain/src/agents/middleware/toolError.ts
@@ -1,0 +1,107 @@
+/**
+ * Tool error middleware for agents.
+ */
+import { ToolMessage, type MessageContent } from "@langchain/core/messages";
+import type { ClientTool, ServerTool } from "@langchain/core/tools";
+import { isGraphBubbleUp } from "@langchain/langgraph";
+
+import { createMiddleware } from "../middleware.js";
+import type { ToolCallRequest } from "./types.js";
+
+/**
+ * Handler called when tool execution throws.
+ *
+ * Return content to surface the error to the model as an error `ToolMessage`.
+ * Return nothing to propagate the original error.
+ */
+export type ToolErrorHandler = (
+  error: unknown,
+  request: ToolCallRequest
+) => MessageContent | void | Promise<MessageContent | void>;
+
+/**
+ * Configuration for {@link toolErrorMiddleware}.
+ */
+export interface ToolErrorMiddlewareConfig {
+  /**
+   * Handler called when tool execution throws. Return content to convert the
+   * error into an error `ToolMessage`, or return nothing to propagate it.
+   */
+  onError: ToolErrorHandler;
+
+  /**
+   * Optional tools or tool names to handle errors for. Handles all tools when
+   * omitted.
+   */
+  tools?: Array<ClientTool | ServerTool | string>;
+}
+
+/**
+ * Converts selected tool execution errors into error `ToolMessage`s.
+ *
+ * Handling is opt-in: {@link ToolErrorMiddlewareConfig.onError} must return
+ * content for an error to be sent to the model. Returning nothing propagates
+ * the original error unchanged. LangGraph control-flow signals always
+ * propagate and are never passed to `onError`.
+ *
+ * Prefer returning content that identifies the error type without including
+ * the raw error message, which may contain sensitive or internal details.
+ *
+ * This middleware does not retry. To retry before handling an error, place
+ * `toolRetryMiddleware({ onFailure: "error" })` after this middleware.
+ *
+ * @example
+ * ```ts
+ * import { createAgent, toolErrorMiddleware } from "langchain";
+ *
+ * const agent = createAgent({
+ *   model,
+ *   tools: [searchTool],
+ *   middleware: [
+ *     toolErrorMiddleware({
+ *       onError: (error, request) => {
+ *         if (error instanceof TypeError) {
+ *           return `Tool '${request.toolCall.name}' failed with TypeError.`;
+ *         }
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function toolErrorMiddleware(config: ToolErrorMiddlewareConfig) {
+  const toolFilter = config.tools?.map((tool) =>
+    typeof tool === "string" ? tool : tool.name
+  );
+
+  return createMiddleware({
+    name: "toolErrorMiddleware",
+    wrapToolCall: async (request, handler) => {
+      const toolName = request.tool?.name ?? request.toolCall.name;
+
+      if (toolFilter !== undefined && !toolFilter.includes(toolName)) {
+        return handler(request);
+      }
+
+      try {
+        return await handler(request);
+      } catch (error: unknown) {
+        if (isGraphBubbleUp(error)) {
+          throw error;
+        }
+
+        const content = await config.onError(error, request);
+        if (content === undefined) {
+          throw error;
+        }
+
+        return new ToolMessage({
+          content,
+          tool_call_id: request.toolCall.id ?? "",
+          ...(typeof toolName === "string" ? { name: toolName } : {}),
+          status: "error",
+        });
+      }
+    },
+  });
+}

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -843,8 +843,8 @@ describe("middleware", () => {
       expect(error).toBeInstanceOf(MiddlewareError);
       expect(error.name).toBe("Error");
       expect(error.message).toBe("original error");
-      expect(error.cause).toBeInstanceOf(MiddlewareError);
-      expect(error.cause?.cause).toBeInstanceOf(Error);
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.cause).not.toBeInstanceOf(MiddlewareError);
     });
 
     it("should allow middleware to modify tool calls in response", async () => {

--- a/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
+++ b/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
@@ -202,10 +202,11 @@ describe("Middleware Error Handling", () => {
       expect(result.__interrupt__?.[0].value).toBe("subagent-interrupt");
     });
 
-    it("should still wrap non-GraphBubbleUp errors in MiddlewareError", async () => {
+    it("should preserve errors from the downstream handler", async () => {
+      const originalError = new Error("regular error");
       const errorTool = tool(
         async () => {
-          throw new Error("regular error");
+          throw originalError;
         },
         {
           name: "error_tool",
@@ -216,9 +217,7 @@ describe("Middleware Error Handling", () => {
 
       const middleware = createMiddleware({
         name: "testMiddleware",
-        wrapToolCall: async (request, handler) => {
-          return handler(request);
-        },
+        wrapToolCall: async (request, handler) => handler(request),
       });
 
       const model = new FakeToolCallingModel({
@@ -231,14 +230,41 @@ describe("Middleware Error Handling", () => {
         middleware: [middleware],
       });
 
+      await expect(
+        agent.invoke({ messages: [new HumanMessage("test")] })
+      ).rejects.toBe(originalError);
+    });
+
+    it("should wrap errors thrown by middleware", async () => {
+      const middlewareError = new Error("middleware failed");
+      const okTool = tool(async () => "ok", {
+        name: "ok_tool",
+        description: "A tool that succeeds",
+        schema: z.object({}),
+      });
+      const middleware = createMiddleware({
+        name: "testMiddleware",
+        wrapToolCall: async () => {
+          throw middlewareError;
+        },
+      });
+      const agent = createAgent({
+        model: new FakeToolCallingModel({
+          toolCalls: [[{ name: "ok_tool", args: {}, id: "call_1" }]],
+        }),
+        tools: [okTool],
+        middleware: [middleware],
+      });
+
       try {
         await agent.invoke({ messages: [new HumanMessage("test")] });
         expect.fail("Should have thrown MiddlewareError");
-      } catch (error) {
-        // Regular errors should still be wrapped in MiddlewareError
-        expect(error).toBeInstanceOf(MiddlewareError);
-        expect((error as MiddlewareError).message).toBe("regular error");
-        expect((error as MiddlewareError).cause).toBeInstanceOf(Error);
+      } catch (error: unknown) {
+        expect(MiddlewareError.isInstance(error)).toBe(true);
+        if (!MiddlewareError.isInstance(error)) {
+          return;
+        }
+        expect(error.cause).toBe(middlewareError);
       }
     });
 

--- a/libs/langchain/src/agents/utils.ts
+++ b/libs/langchain/src/agents/utils.ts
@@ -573,6 +573,9 @@ export function wrapToolCall(middleware: readonly AnyAgentMiddleware[]) {
          * Create a handler that preserves state parsing for this middleware
          * while allowing tool/toolCall/state modifications from inner middleware
          */
+        // Track exact values thrown by the downstream handler so unchanged
+        // propagation is not misclassified as a failure in this middleware.
+        const downstreamErrors = new Set<unknown>();
         const wrappedInnerHandler: ToolCallHandler = async (passedRequest) => {
           /**
            * Merge the passed request with the original state for parsing.
@@ -583,10 +586,15 @@ export function wrapToolCall(middleware: readonly AnyAgentMiddleware[]) {
             ...originalState,
             ...passedRequest.state,
           };
-          return handler({
-            ...passedRequest,
-            state: mergedState,
-          });
+          try {
+            return await handler({
+              ...passedRequest,
+              state: mergedState,
+            });
+          } catch (error: unknown) {
+            downstreamErrors.add(error);
+            throw error;
+          }
         };
 
         try {
@@ -617,7 +625,10 @@ export function wrapToolCall(middleware: readonly AnyAgentMiddleware[]) {
           }
 
           return result;
-        } catch (error) {
+        } catch (error: unknown) {
+          if (downstreamErrors.has(error)) {
+            throw error;
+          }
           throw MiddlewareError.wrap(error, m.name);
         }
       };


### PR DESCRIPTION
## Summary

Ports `ToolErrorMiddleware` from [langchain-ai/langchain#38781](https://github.com/langchain-ai/langchain/pull/38781) to LangChain.js. The new middleware lets agents selectively convert tool execution failures into model-visible error messages while preserving original exceptions by default.

## Changes

- Add and export `toolErrorMiddleware`, `ToolErrorHandler`, and `ToolErrorMiddlewareConfig` from `langchain`.
- Support synchronous or asynchronous error handlers and structured `ToolMessage` content.
- Allow handling to be restricted by tool name or tool instance.
- Propagate unhandled failures and LangGraph control-flow signals unchanged, avoiding disclosure of raw exception details unless the handler explicitly includes them.
- Add focused coverage for error handling, propagation, filtering, structured content, disclosure control, and graph interrupts.
