### PR TITLE
fix(google-genai): serialize standard v1 reasoning content blocks

### DIFF
--- a/.changeset/fix-google-genai-reasoning-blocks.md
+++ b/.changeset/fix-google-genai-reasoning-blocks.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): serialize standard v1 `reasoning` content blocks back to Gemini thought parts instead of throwing "Unknown content type reasoning", so multi-turn agents replaying v1 message history (for example langgraph checkpoints) no longer crash on the second model call

--- a/libs/providers/langchain-google-genai/src/tests/common.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/common.test.ts
@@ -376,3 +376,83 @@ describe("Round-trip thinking content handling", () => {
     });
   });
 });
+
+// https://github.com/langchain-ai/langchainjs/issues/11180
+describe("Round-trip standard v1 reasoning content handling", () => {
+  test("reasoning block converts back to Gemini thought part", () => {
+    const message = new AIMessage({
+      content: [
+        { type: "reasoning", reasoning: "Let me reason about this..." },
+        { type: "text", text: "The answer is 42." },
+      ],
+    });
+
+    const parts = convertMessageContentToParts(message, true, []);
+
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({
+      text: "Let me reason about this...",
+      thought: true,
+    });
+    expect(parts[0]).not.toHaveProperty("thoughtSignature");
+    expect(parts[1]).toEqual({ text: "The answer is 42." });
+  });
+
+  test("reasoning block with signature keeps thoughtSignature", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "reasoning",
+          reasoning: "Signed reasoning",
+          signature: "sig456",
+        },
+      ],
+    });
+
+    const parts = convertMessageContentToParts(message, true, []);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({
+      text: "Signed reasoning",
+      thought: true,
+      thoughtSignature: "sig456",
+    });
+  });
+
+  test("multi-turn replay: v1 AIMessage with reasoning and tool_call serializes", () => {
+    // Shape produced by core's v1 output pipeline (output_version: "v1"),
+    // e.g. when replaying checkpointed agent history.
+    const message = new AIMessage({
+      content: [
+        { type: "reasoning", reasoning: "thinking about it" },
+        {
+          type: "tool_call",
+          id: "tc-1",
+          name: "get_weather",
+          args: { city: "Paris" },
+        },
+      ],
+      tool_calls: [
+        { name: "get_weather", args: { city: "Paris" }, id: "tc-1" },
+      ],
+      response_metadata: {
+        output_version: "v1",
+        model_provider: "google-genai",
+        finish_reason: "stop",
+      },
+    });
+
+    const parts = convertMessageContentToParts(message, true, []);
+
+    expect(parts[0]).toEqual({
+      text: "thinking about it",
+      thought: true,
+    });
+    const functionCallParts = parts.filter((p) => "functionCall" in p);
+    expect(functionCallParts.length).toBeGreaterThanOrEqual(1);
+    expect(
+      (functionCallParts[0] as { functionCall: { name: string } }).functionCall
+        .name
+    ).toBe("get_weather");
+  });
+});

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -442,6 +442,22 @@ function _convertLangChainContentToPart(
         ? { thoughtSignature: thinkingContent.signature }
         : {}),
     } as Part;
+  } else if (content.type === "reasoning") {
+    // Standard v1 reasoning content block (e.g. produced by core's v1 output
+    // pipeline). Convert back to a Gemini thought part, mirroring the
+    // provider-specific "thinking" block handling above.
+    const reasoningContent = content as {
+      type: "reasoning";
+      reasoning: string;
+      signature?: string;
+    };
+    return {
+      text: reasoningContent.reasoning,
+      thought: true,
+      ...(reasoningContent.signature
+        ? { thoughtSignature: reasoningContent.signature }
+        : {}),
+    } as Part;
   } else if ("functionCall" in content) {
     // No action needed here — function calls will be added later from message.tool_calls
     return undefined;


### PR DESCRIPTION
Fixes #11180

## Problem

The request serializer (`_convertLangChainContentToPart` in `libs/providers/langchain-google-genai/src/utils/common.ts`) throws `Unknown content type reasoning` when the history contains the standard v1 `reasoning` content block. That block shape is produced by `@langchain/core`'s own v1 output pipeline (`output_version: "v1"`), so any multi-turn agent that stores v1 messages (for example langgraph checkpoints) crashes on the second model call when the history is replayed.

This is the standard-block sibling of #10103, which fixed the same failure for the provider-specific `thinking` shape.

## Fix

Handle `type: "reasoning"` in `_convertLangChainContentToPart` and convert it back to a Gemini thought part (`{ text, thought: true, thoughtSignature? }`), mirroring the existing `thinking` branch. The `signature` field is read directly from the block, which matches the shape core's own Google block translator emits (`block_translators/google_vertexai.ts`).

## Tests

Three new unit tests in `src/tests/common.test.ts` (no network):
- reasoning block converts to `{ text, thought: true }` and does not gain a `thoughtSignature`
- reasoning block with a `signature` keeps it as `thoughtSignature`
- the exact multi-turn replay shape from the issue (v1 `AIMessage` with `reasoning` + `tool_call` blocks) serializes without throwing

Package checks: `vitest run` for the package passes (75 tests, no type errors), `oxfmt --check` and `oxlint` clean on the touched files, package build passes. Changeset included (patch on `@langchain/google-genai`).
