### PR TITLE
fix(@langchain/google): omit native functionCall.id and functionResponse.id on Vertex, keep them on gai

### DIFF
--- a/.changeset/vertex-function-response-id-passthrough.md
+++ b/.changeset/vertex-function-response-id-passthrough.md
@@ -1,0 +1,9 @@
+---
+"@langchain/google": patch
+---
+
+fix: omit native functionResponse.id for Vertex AI, preserve it for the Gemini Developer API
+
+#10292 stripped a LangChain-generated `tool_call_id` from `functionResponse.id` to fix Vertex AI's rejection of that field, but only checked for the `lc-tool-call-` prefix. When Gemini/Vertex supplies its own native `functionCall.id`, that id is not generated, so it still round-trips into `functionResponse.id` and Vertex rejects the request with the same `Unknown name "id" ... Cannot find field` error #10292 was meant to fix.
+
+Vertex rejects `functionResponse.id` unconditionally (native or generated), while the Gemini Developer API accepts it and needs it to disambiguate parallel calls to the same tool name. This now threads the resolved `platformType` through `convertMessagesToGeminiContents` and only omits a native id when the platform is Vertex (`gcp`).

--- a/.changeset/vertex-function-response-id-passthrough.md
+++ b/.changeset/vertex-function-response-id-passthrough.md
@@ -2,8 +2,10 @@
 "@langchain/google": patch
 ---
 
-fix: omit native functionResponse.id for Vertex AI, preserve it for the Gemini Developer API
+fix: omit native functionCall.id / functionResponse.id for Vertex AI, preserve them for the Gemini Developer API
 
 #10292 stripped a LangChain-generated `tool_call_id` from `functionResponse.id` to fix Vertex AI's rejection of that field, but only checked for the `lc-tool-call-` prefix. When Gemini/Vertex supplies its own native `functionCall.id`, that id is not generated, so it still round-trips into `functionResponse.id` and Vertex rejects the request with the same `Unknown name "id" ... Cannot find field` error #10292 was meant to fix.
 
 Vertex rejects `functionResponse.id` unconditionally (native or generated), while the Gemini Developer API accepts it and needs it to disambiguate parallel calls to the same tool name. This now threads the resolved `platformType` through `convertMessagesToGeminiContents` and only omits a native id when the platform is Vertex (`gcp`).
+
+The same leak affects `functionCall.id` in the opposite direction. `convertGeminiPartToContentBlock` stores the model's `functionCall` object verbatim — including a native `id` — and the legacy converter spreads it straight back onto the wire, so replaying a prior tool call 400s with `Unknown name "id" at 'contents[N].parts[0].function_call'`. Vertex began populating `functionCall.id` on 2026-07-24, turning every multi-turn tool-calling conversation into a failure with no client-side change. Both part types are now gated on `platformType` (#11209).

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -468,7 +468,7 @@ export abstract class BaseChatGoogle<
     const body = {
       ...this.invocationParams(options),
       systemInstruction: convertMessagesToGeminiSystemInstruction(messages),
-      contents: convertMessagesToGeminiContents(messages),
+      contents: convertMessagesToGeminiContents(messages, this.platform),
     };
 
     const moduleName = this.constructor.name;
@@ -583,7 +583,7 @@ export abstract class BaseChatGoogle<
     const body = {
       ...this.invocationParams(options),
       systemInstruction: convertMessagesToGeminiSystemInstruction(messages),
-      contents: convertMessagesToGeminiContents(messages),
+      contents: convertMessagesToGeminiContents(messages, this.platform),
     };
 
     const url = await this.buildUrl("streamGenerateContent?alt=sse");
@@ -657,7 +657,7 @@ export abstract class BaseChatGoogle<
     const body = {
       ...this.invocationParams(options),
       systemInstruction: convertMessagesToGeminiSystemInstruction(messages),
-      contents: convertMessagesToGeminiContents(messages),
+      contents: convertMessagesToGeminiContents(messages, this.platform),
     };
 
     const url = await this.buildUrl("streamGenerateContent?alt=sse");

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -21,7 +21,7 @@ import {
 } from "@langchain/core/messages";
 import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import { Converter } from "@langchain/core/utils/format";
-import type { Gemini } from "../chat_models/types.js";
+import type { Gemini, GooglePlatformType } from "../chat_models/types.js";
 import { iife } from "../utils/misc.js";
 import { InvalidInputError, ToolCallNotFoundError } from "../utils/errors.js";
 
@@ -384,7 +384,8 @@ function convertStandardContentBlockToGeminiPart(
  */
 function convertStandardContentMessageToGeminiContent(
   message: BaseMessage,
-  messages: BaseMessage[]
+  messages: BaseMessage[],
+  platformType?: GooglePlatformType
 ): Gemini.Content | null {
   // Skip system messages - they're handled separately
   if (SystemMessage.isInstance(message)) {
@@ -466,9 +467,17 @@ function convertStandardContentMessageToGeminiContent(
       (tc) => tc.id === message.tool_call_id
     );
     const isGeneratedId = message.tool_call_id.startsWith("lc-tool-call-");
+    // Vertex AI's generateContent endpoint rejects an "id" field on
+    // functionResponse outright (see #10266), even when the id is one
+    // Vertex itself supplied natively rather than a LangChain-generated
+    // one. The Gemini Developer API accepts a native id and needs it to
+    // disambiguate parallel calls to the same tool name, so only omit a
+    // native id for Vertex; a generated id is never sent to either.
     parts.push({
       functionResponse: {
-        ...(isGeneratedId ? {} : { id: message.tool_call_id }),
+        ...(isGeneratedId || platformType === "gcp"
+          ? {}
+          : { id: message.tool_call_id }),
         name: matchedToolCall?.name ?? message.name ?? "unknown",
         response: { result: responseContent },
       },
@@ -491,7 +500,8 @@ function convertStandardContentMessageToGeminiContent(
  */
 function convertLegacyContentMessageToGeminiContent(
   message: BaseMessage,
-  messages: BaseMessage[]
+  messages: BaseMessage[],
+  platformType?: GooglePlatformType
 ): Gemini.Content | null {
   // Skip system messages - they're handled separately
   if (SystemMessage.isInstance(message)) {
@@ -767,9 +777,15 @@ function convertLegacyContentMessageToGeminiContent(
     const matchedToolCall = aiMsg.tool_calls?.find(
       (tc) => tc.id === message.tool_call_id
     );
+    // See the comment in convertStandardContentMessageToGeminiContent:
+    // Vertex rejects a native functionResponse.id outright; gai relies on
+    // a native id to disambiguate parallel calls to the same tool name. A
+    // generated id is never meaningful to the model, so it's never sent.
     parts.push({
       functionResponse: {
-        ...(isGeneratedId ? {} : { id: message.tool_call_id }),
+        ...(isGeneratedId || platformType === "gcp"
+          ? {}
+          : { id: message.tool_call_id }),
         name: matchedToolCall?.name ?? message.name ?? "unknown",
         response: { result: responseContent },
       },
@@ -823,10 +839,10 @@ function convertLegacyContentMessageToGeminiContent(
  * // ]
  * ```
  */
-export const convertMessagesToGeminiContents: Converter<
-  BaseMessage[],
-  Gemini.GenerateContentRequest["contents"]
-> = (messages) => {
+export const convertMessagesToGeminiContents = (
+  messages: BaseMessage[],
+  platformType?: GooglePlatformType
+): Gemini.GenerateContentRequest["contents"] => {
   const contents: Gemini.Content[] = [];
 
   for (const message of messages) {
@@ -840,11 +856,16 @@ export const convertMessagesToGeminiContents: Converter<
         case "v1":
           return convertStandardContentMessageToGeminiContent(
             message,
-            messages
+            messages,
+            platformType
           );
         case "v0":
         default:
-          return convertLegacyContentMessageToGeminiContent(message, messages);
+          return convertLegacyContentMessageToGeminiContent(
+            message,
+            messages,
+            platformType
+          );
       }
     });
     if (content) {

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -377,6 +377,27 @@ function convertStandardContentBlockToGeminiPart(
 }
 
 /**
+ * Returns `functionCall` without its `id` when targeting Vertex, which rejects
+ * that field even though it populates it on the way out. Copies rather than
+ * mutates: the block is shared with the caller's message history.
+ */
+function stripNativeFunctionCallId<T>(
+  functionCall: T,
+  platformType?: GooglePlatformType
+): T {
+  if (
+    platformType !== "gcp" ||
+    typeof functionCall !== "object" ||
+    functionCall === null ||
+    !("id" in functionCall)
+  ) {
+    return functionCall;
+  }
+  const { id, ...rest } = functionCall as Record<string, unknown>;
+  return rest as T;
+}
+
+/**
  * Converts a single LangChain message with standard content blocks (v1 format) to Gemini Content.
  * This handles messages that have `response_metadata.output_version === "v1"`.
  *
@@ -731,9 +752,14 @@ function convertLegacyContentMessageToGeminiContent(
           );
         } else if (item?.type === "functionCall") {
           const { type, functionCall, ...etc } = item;
+          // Vertex rejects a native `id` inside function_call for the same
+          // reason it rejects one on functionResponse (see the comments in
+          // the ToolMessage branches). The stored block is pushed by
+          // reference, so copy rather than delete the key — mutating it
+          // would strip the id from the caller's message history too.
           parts.push({
             ...etc,
-            functionCall,
+            functionCall: stripNativeFunctionCallId(functionCall, platformType),
           } as Gemini.Part.FunctionCall);
         } else if (item?.type === "executableCode") {
           const { type, executableCode, ...etc } = item;

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -588,6 +588,159 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBeUndefined();
   });
 
+  test("omits a native tool_call_id from functionResponse.id when platformType is gcp (Vertex) (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { query: "test" },
+            id: "native-vertex-id-123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: "result",
+        tool_call_id: "native-vertex-id-123",
+        name: "my_tool",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gcp");
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts!.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    );
+    expect(functionResponsePart).toBeDefined();
+    expect(
+      (functionResponsePart as Gemini.Part.FunctionResponse).functionResponse!
+        .id
+    ).toBeUndefined();
+  });
+
+  test("omits a native tool_call_id from functionResponse.id when platformType is gcp (Vertex) (v1 standard path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { query: "test" },
+            id: "native-vertex-id-456",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: "result",
+        tool_call_id: "native-vertex-id-456",
+        name: "my_tool",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gcp");
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts!.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    );
+    expect(functionResponsePart).toBeDefined();
+    expect(
+      (functionResponsePart as Gemini.Part.FunctionResponse).functionResponse!
+        .id
+    ).toBeUndefined();
+  });
+
+  test("preserves a native tool_call_id in functionResponse.id when platformType is gai (Developer API) (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { query: "test" },
+            id: "native-gai-id-123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: "result",
+        tool_call_id: "native-gai-id-123",
+        name: "my_tool",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gai");
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts!.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    );
+    expect(functionResponsePart).toBeDefined();
+    expect(
+      (functionResponsePart as Gemini.Part.FunctionResponse).functionResponse!
+        .id
+    ).toBe("native-gai-id-123");
+  });
+
+  test("still omits a generated tool_call_id from functionResponse.id when platformType is gai (Developer API)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "my_tool",
+            args: { query: "test" },
+            id: "lc-tool-call-gai",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: "result",
+        tool_call_id: "lc-tool-call-gai",
+        name: "my_tool",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gai");
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts!.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    );
+    expect(functionResponsePart).toBeDefined();
+    expect(
+      (functionResponsePart as Gemini.Part.FunctionResponse).functionResponse!
+        .id
+    ).toBeUndefined();
+  });
+
   test("v1 contentBlocks: text-plain block produces fileData part", () => {
     const messages = [
       new HumanMessage({

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -741,6 +741,97 @@ describe("convertMessagesToGeminiContents", () => {
     ).toBeUndefined();
   });
 
+  // Vertex began populating functionCall.id on 2026-07-24 20:33 UTC and
+  // rejects the same field on the way back in, 400ing any multi-turn
+  // tool-calling conversation once a prior functionCall is replayed. The
+  // content blocks below are the real production wire shape (see #11209).
+  const nativeFunctionCallBlock = (id: string) => ({
+    type: "functionCall" as const,
+    functionCall: { name: "get_fares", args: { flightKey: "UA485" }, id },
+    thoughtSignature: "AY89a19oJM6nWmBqSbgAk0C9",
+  });
+
+  test("omits a native functionCall.id when platformType is gcp (Vertex)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: [nativeFunctionCallBlock("a323kt5y")],
+        tool_calls: [
+          {
+            name: "get_fares",
+            args: { flightKey: "UA485" },
+            id: "a323kt5y",
+            type: "tool_call",
+          },
+        ],
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gcp");
+
+    const functionCallPart = contents
+      .flatMap((c) => c.parts ?? [])
+      .find((p) => "functionCall" in p && p.functionCall);
+    expect(functionCallPart).toBeDefined();
+    const { functionCall } = functionCallPart as Gemini.Part.FunctionCall;
+    expect(functionCall).not.toHaveProperty("id");
+    // The rest of the part must survive — name/args are load-bearing, and
+    // thoughtSignature is required for the model to continue its reasoning.
+    expect(functionCall!.name).toBe("get_fares");
+    expect(functionCall!.args).toEqual({ flightKey: "UA485" });
+    expect(functionCallPart).toHaveProperty(
+      "thoughtSignature",
+      "AY89a19oJM6nWmBqSbgAk0C9"
+    );
+  });
+
+  test("preserves a native functionCall.id when platformType is gai (Developer API)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: [nativeFunctionCallBlock("m4v7k35n")],
+        tool_calls: [
+          {
+            name: "get_fares",
+            args: { flightKey: "UA485" },
+            id: "m4v7k35n",
+            type: "tool_call",
+          },
+        ],
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages, "gai");
+
+    const functionCallPart = contents
+      .flatMap((c) => c.parts ?? [])
+      .find((p) => "functionCall" in p && p.functionCall);
+    expect(
+      (functionCallPart as Gemini.Part.FunctionCall).functionCall
+    ).toHaveProperty("id", "m4v7k35n");
+  });
+
+  test("does not mutate the caller's message history when stripping functionCall.id", () => {
+    const block = nativeFunctionCallBlock("dontmutate");
+    const messages = [
+      new AIMessage({
+        content: [block],
+        tool_calls: [
+          {
+            name: "get_fares",
+            args: { flightKey: "UA485" },
+            id: "dontmutate",
+            type: "tool_call",
+          },
+        ],
+      }),
+    ];
+
+    convertMessagesToGeminiContents(messages, "gcp");
+
+    expect(block.functionCall).toHaveProperty("id", "dontmutate");
+  });
+
   test("v1 contentBlocks: text-plain block produces fileData part", () => {
     const messages = [
       new HumanMessage({


### PR DESCRIPTION
Fixes #11209

## Problem

#10292 fixed Vertex AI's `generateContent` rejecting a `functionResponse.id` field (`Unknown name "id" ... Cannot find field`) by omitting `id` whenever `message.tool_call_id.startsWith("lc-tool-call-")` — i.e. only when the id was LangChain-synthesized.

That check doesn't cover ids Gemini/Vertex supplies natively. `convertGeminiPartsToToolCalls` only falls back to a synthetic `lc-tool-call-*` id when the model doesn't supply its own `functionCall.id`:

```ts
id:
  functionCallPart.functionCall.id ??
  `lc-tool-call-${uuidv4().replace(/-/g, "")}`,
```

When Vertex supplies a native id (common, not an edge case), that id round-trips into `functionResponse.id` on the next turn, `isGeneratedId` is `false`, and Vertex 400s with the exact error #10292 was meant to fix:

```
Invalid JSON payload received. Unknown name "id" at 'contents[2].parts[0].function_response': Cannot find field.
```

This is a real regression of #10292's own intent, hit in production against Vertex with multi-turn tool-calling.

## Why not just strip `id` everywhere

I initially assumed a blanket strip was correct, but verified empirically against the Gemini Developer API (`platformType: "gai"`) that a native `functionResponse.id` **is** load-bearing there: when a turn produces two parallel `functionCall`s to the *same* tool name (so name alone can't disambiguate) and the `functionResponse`s are sent back out of order, the model only pairs them correctly when `id` is present — without it, responses are matched positionally and produce a wrong/swapped answer. The existing test `"passes tool_call_id through as functionResponse.id (legacy path)"` already locks this behavior in for the no-platform-specified path.

So the fix is platform-gated: still omit a **generated** id everywhere (unchanged from #10292 — it's never meaningful to the model), but also omit a **native** id specifically when the platform is Vertex (`gcp`), since Vertex rejects `functionResponse.id` regardless of the id's origin.

## Fix

Threads `platformType` through `convertMessagesToGeminiContents` → `convertStandardContentMessageToGeminiContent` / `convertLegacyContentMessageToGeminiContent`, and combines it with the existing `isGeneratedId` check:

```ts
// before
const isGeneratedId = message.tool_call_id.startsWith("lc-tool-call-");
parts.push({
  functionResponse: {
    ...(isGeneratedId ? {} : { id: message.tool_call_id }),
    ...
  },
});

// after
const isGeneratedId = message.tool_call_id.startsWith("lc-tool-call-");
parts.push({
  functionResponse: {
    ...(isGeneratedId || platformType === "gcp"
      ? {}
      : { id: message.tool_call_id }),
    ...
  },
});
```

`platformType` is available at all 3 call sites of `convertMessagesToGeminiContents` in `chat_models/base.ts` via `this.platform`.

Also switched `convertMessagesToGeminiContents`'s type annotation from `Converter<BaseMessage[], ...>` (a strict 1-arg function alias) to an explicit 2-param signature, since the `Converter` type couldn't express the new optional parameter.

## Tests

All existing tests pass unchanged (none of them pass a `platformType`, so default/no-platform behavior — preserve a native id, omit a generated id — is untouched). Added 4 new tests covering the platform-gated cases:

- native id + `gcp` → omitted (Vertex rejects it)
- native id + `gai` → preserved (needed for parallel-call disambiguation)
- generated id + `gcp` → omitted (unchanged)
- generated id + `gai` → omitted (unchanged — a generated id is never meaningful to the model on either platform)

Verified against a local patch-package equivalent of this fix with a live end-to-end run against Vertex (multi-turn tool-calling, matching the production failure depth) and an empirical test directly against the Gemini Developer API confirming the parallel-call disambiguation behavior described above.
