### PR TITLE
fix(core): stop pinning string chunks to block index 0 in convertChunksToEvents

### DIFF
--- a/.changeset/string-chunks-block-index.md
+++ b/.changeset/string-chunks-block-index.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): stop pinning string chunks to block index 0 in convertChunksToEvents and carry response_metadata on message-finish

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -43,6 +43,25 @@ function nextBlockIndex(activeBlocks: Map<number, unknown>): number {
   return next;
 }
 
+/**
+ * Block types that stream as incremental continuations of a single logical
+ * block. Discrete payloads (images, audio, files) must never be merged this
+ * way — concatenating two images would corrupt both.
+ */
+const CONTINUABLE_BLOCK_TYPES = new Set(["text", "thinking", "reasoning"]);
+
+function lastBlockEntry(
+  activeBlocks: Map<number, { type: string; accumulated: ContentBlock }>
+): { index: number; type: string } | undefined {
+  let entry: { index: number; type: string } | undefined;
+  for (const [index, block] of activeBlocks) {
+    if (entry === undefined || index > entry.index) {
+      entry = { index, type: block.type };
+    }
+  }
+  return entry;
+}
+
 function getAdditionalKwargs(message: unknown): Record<string, unknown> {
   const additional = (message as { additional_kwargs?: unknown })
     .additional_kwargs;
@@ -152,6 +171,7 @@ export async function* convertChunksToEvents(
   let lastUsage:
     | { input_tokens: number; output_tokens: number; total_tokens: number }
     | undefined;
+  let responseMetadata: Record<string, unknown> | undefined;
   let audioStream: AudioStreamState | undefined;
   const emittedImageKeys = new Set<string>();
 
@@ -180,7 +200,12 @@ export async function* convertChunksToEvents(
     const content = msg.content;
     if (typeof content === "string") {
       if (content !== "") {
-        const blockIndex = 0;
+        // Continue the trailing text block if there is one; otherwise open a
+        // new block. String chunks must not mutate whatever lives at index 0
+        // (e.g. a thinking block streamed first as array content).
+        const last = lastBlockEntry(activeBlocks);
+        const blockIndex =
+          last?.type === "text" ? last.index : nextBlockIndex(activeBlocks);
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock.Text = { type: "text", text: "" };
           activeBlocks.set(blockIndex, {
@@ -206,8 +231,19 @@ export async function* convertChunksToEvents(
       }
     } else if (Array.isArray(content)) {
       for (const part of content) {
-        const blockIndex =
-          typeof part.index === "number" ? part.index : activeBlocks.size;
+        let blockIndex: number;
+        if (typeof part.index === "number") {
+          blockIndex = part.index;
+        } else {
+          // Un-indexed parts continue the trailing block when it streams the
+          // same continuable type; otherwise they open a new block at a free
+          // index (`activeBlocks.size` can collide with explicit indexes).
+          const last = lastBlockEntry(activeBlocks);
+          blockIndex =
+            last?.type === part.type && CONTINUABLE_BLOCK_TYPES.has(part.type)
+              ? last.index
+              : nextBlockIndex(activeBlocks);
+        }
 
         if (!activeBlocks.has(blockIndex)) {
           activeBlocks.set(blockIndex, {
@@ -242,7 +278,7 @@ export async function* convertChunksToEvents(
         const blockIndex =
           typeof toolChunk.index === "number"
             ? toolChunk.index
-            : activeBlocks.size;
+            : nextBlockIndex(activeBlocks);
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {
@@ -384,6 +420,17 @@ export async function* convertChunksToEvents(
       };
     }
 
+    // Response metadata (model name, finish reason, response id, ...)
+    const chunkResponseMetadata = (
+      msg as { response_metadata?: Record<string, unknown> }
+    ).response_metadata;
+    if (
+      chunkResponseMetadata != null &&
+      Object.keys(chunkResponseMetadata).length > 0
+    ) {
+      responseMetadata = { ...responseMetadata, ...chunkResponseMetadata };
+    }
+
     // Usage
     if (
       !usageHandledInStart &&
@@ -418,6 +465,7 @@ export async function* convertChunksToEvents(
     event: "message-finish" as const,
     reason: "stop" as const,
     ...(lastUsage ? { usage: lastUsage } : {}),
+    ...(responseMetadata ? { responseMetadata } : {}),
   };
 }
 

--- a/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream_bridge.test.ts
@@ -129,6 +129,90 @@ class FakeThinkingStreamModel extends BaseChatModel {
 }
 
 /**
+ * A model that streams a thinking block as array content followed by the
+ * answer as a plain string chunk, the way `@langchain/google-genai` does
+ * when Gemini thinking is enabled.
+ */
+class FakeThinkingThenStringModel extends BaseChatModel {
+  _llmType() {
+    return "fake-thinking-then-string";
+  }
+
+  async _generate(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return { generations: [] };
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: [
+          { type: "thinking", thinking: "let me think " },
+        ] as unknown as ContentBlock[],
+        id: "msg_thinking_string",
+      }),
+      text: "",
+    });
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: "THE ANSWER",
+        response_metadata: { finishReason: "STOP", model_name: "gemini-test" },
+      }),
+      text: "THE ANSWER",
+    });
+  }
+}
+
+/**
+ * A model that streams continuations of one thinking block as un-indexed
+ * array parts across chunks.
+ */
+class FakeUnindexedThinkingModel extends BaseChatModel {
+  _llmType() {
+    return "fake-unindexed-thinking";
+  }
+
+  async _generate(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return { generations: [] };
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: [
+          { type: "thinking", thinking: "Thinking" },
+        ] as unknown as ContentBlock[],
+        id: "msg_unindexed_thinking",
+      }),
+      text: "",
+    });
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: [
+          { type: "thinking", thinking: " hard..." },
+        ] as unknown as ContentBlock[],
+      }),
+      text: "",
+    });
+  }
+}
+
+/**
  * A model that yields tool call chunks via _streamResponseChunks.
  */
 class FakeToolCallStreamModel extends BaseChatModel {
@@ -452,6 +536,105 @@ describe("_streamChatModelEvents bridge", () => {
           (e as { index: number }).index === 0
       ) as { content: { type: string; thinking?: string } };
 
+      expect(finish.content.type).toBe("thinking");
+      expect(finish.content.thinking).toBe("Thinking hard...");
+    });
+
+    test("string chunk after a thinking block opens its own text block", async () => {
+      const model = new FakeThinkingThenStringModel({});
+      const events: ChatModelStreamEvent[] = [];
+      for await (const event of model._streamChatModelEvents(
+        [],
+        {} as BaseChatModelCallOptions
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.event === "content-block-start");
+      expect(starts.length).toBe(2);
+      expect((starts[0] as { content: ContentBlock }).content.type).toBe(
+        "thinking"
+      );
+      expect((starts[0] as { index: number }).index).toBe(0);
+      expect((starts[1] as { content: ContentBlock }).content.type).toBe(
+        "text"
+      );
+      expect((starts[1] as { index: number }).index).toBe(1);
+
+      const finishes = events.filter((e) => e.event === "content-block-finish");
+      expect(finishes.length).toBe(2);
+      const thinkingFinish = finishes[0] as {
+        content: { type: string; thinking?: string; text?: string };
+      };
+      expect(thinkingFinish.content.thinking).toBe("let me think ");
+      // The answer must not leak into the thinking block.
+      expect(thinkingFinish.content.text).toBeUndefined();
+      const textFinish = finishes[1] as {
+        content: { type: string; text?: string };
+      };
+      expect(textFinish.content.type).toBe("text");
+      expect(textFinish.content.text).toBe("THE ANSWER");
+    });
+
+    test("assembled message keeps the answer text and response metadata", async () => {
+      const model = new FakeThinkingThenStringModel({});
+      const message = await model.streamEvents("Hello");
+
+      const content = message.content as Array<{
+        type: string;
+        thinking?: string;
+        text?: string;
+      }>;
+      expect(content.length).toBe(2);
+      expect(content[0]!.type).toBe("thinking");
+      expect(content[0]!.thinking).toBe("let me think ");
+      expect(content[0]!.text).toBeUndefined();
+      expect(content[1]!.type).toBe("text");
+      expect(content[1]!.text).toBe("THE ANSWER");
+
+      expect(message.response_metadata.finishReason).toBe("STOP");
+      expect(message.response_metadata.model_name).toBe("gemini-test");
+    });
+
+    test("message-finish carries accumulated response metadata", async () => {
+      const model = new FakeThinkingThenStringModel({});
+      const events: ChatModelStreamEvent[] = [];
+      for await (const event of model._streamChatModelEvents(
+        [],
+        {} as BaseChatModelCallOptions
+      )) {
+        events.push(event);
+      }
+
+      const msgFinish = events[events.length - 1] as {
+        event: string;
+        responseMetadata?: Record<string, unknown>;
+      };
+      expect(msgFinish.event).toBe("message-finish");
+      expect(msgFinish.responseMetadata).toEqual({
+        finishReason: "STOP",
+        model_name: "gemini-test",
+      });
+    });
+
+    test("un-indexed parts of the same type continue one block across chunks", async () => {
+      const model = new FakeUnindexedThinkingModel({});
+      const events: ChatModelStreamEvent[] = [];
+      for await (const event of model._streamChatModelEvents(
+        [],
+        {} as BaseChatModelCallOptions
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.event === "content-block-start");
+      expect(starts.length).toBe(1);
+
+      const finishes = events.filter((e) => e.event === "content-block-finish");
+      expect(finishes.length).toBe(1);
+      const finish = finishes[0] as {
+        content: { type: string; thinking?: string };
+      };
       expect(finish.content.type).toBe("thinking");
       expect(finish.content.thinking).toBe("Thinking hard...");
     });


### PR DESCRIPTION
Fixes #11182

## Problem

`convertChunksToEvents` (`language_models/compat`) hardcodes `blockIndex = 0` for string-content chunks. When a stream opens a non-text block first – e.g. a thinking block streamed as array content, which is exactly what `@langchain/google-genai` emits with Gemini thinking enabled – the answer's `text-delta` events are applied to that block. `ChatModelStream._assembleMessage` then merges the visible answer into the thinking block and the final message has no `text` block at all, so downstream consumers render a blank assistant reply.

Two related problems in the same path:

- Un-indexed array parts were assigned `blockIndex = activeBlocks.size`, which fragments continuations of one logical block across chunks and can collide with explicitly indexed blocks.
- The `message-finish` event never carried `responseMetadata`, so anything a provider stored on `response_metadata` of the chunks was dropped during assembly (the `MessageFinishEvent.responseMetadata` field and the assembly side in `stream.ts` already exist – the bridge just never populated it).

## Fix

- A string chunk now continues the trailing **text** block when one is active, and otherwise opens a new block at a collision-free index. It never mutates whatever happens to live at index 0.
- An un-indexed array part continues the trailing block when it streams the same continuable type (`text`, `thinking`, `reasoning`). Discrete payloads (images, audio, files) are never merged this way – concatenating two images would corrupt both. New blocks are allocated via `nextBlockIndex` instead of `activeBlocks.size`.
- `response_metadata` from the chunk stream is accumulated (shallow-merged) and emitted on `message-finish`, so `_assembleMessage` preserves it on the final message.

## Tests

Added four tests to `stream_bridge.test.ts` mirroring the google-genai shape from the issue (thinking as array content, answer as a plain string chunk with `response_metadata`):

- string chunk after a thinking block opens its own text block (event-level)
- assembled message keeps the answer text and `response_metadata` (the issue's repro, end to end)
- `message-finish` carries accumulated `responseMetadata`
- un-indexed same-type parts continue one block across chunks instead of fragmenting

`vitest` on `libs/langchain-core`: 97 files, 1453 passed / 1 skipped, no type errors. `oxlint` and `oxfmt --check` clean. Changeset included (`@langchain/core` patch).