### PR TITLE
fix(aws): support Bedrock guard content blocks

### DIFF
--- a/.changeset/bedrock-guard-content.md
+++ b/.changeset/bedrock-guard-content.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): pass Bedrock guard content blocks through Converse message conversion

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -711,6 +711,35 @@ describe("convertToConverseMessages", () => {
       expect(converseSystem).toEqual(tc.output.converseSystem);
     }
   );
+
+  test("preserves Bedrock guard content blocks from user messages", () => {
+    const guardContent = {
+      text: {
+        text: "What is the enrollment target?",
+      },
+    };
+
+    const result = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: "text", text: "Untrusted RAG context" },
+          { guardContent },
+          { type: "guard_content", guardContent },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      {
+        role: BedrockConversationRole.USER,
+        content: [
+          { text: "Untrusted RAG context" },
+          { guardContent },
+          { guardContent },
+        ],
+      },
+    ]);
+  });
 });
 
 describe("reasoning content replay", () => {

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -71,6 +71,17 @@ function isConverseCachePoint(block: unknown): boolean {
   );
 }
 
+function isGuardContentBlock(
+  block: unknown
+): block is Bedrock.ContentBlock.GuardContentMember {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    "guardContent" in block &&
+    block.guardContent !== undefined
+  );
+}
+
 function createConverseCachePointBlock(
   cacheControl: BedrockPromptCacheControl,
   isNovaModel: boolean
@@ -493,6 +504,10 @@ function convertLangChainContentBlockToConverseContentBlock<
 
   if (isDataContentBlock(block)) {
     return convertToProviderContentBlock(block, standardContentBlockConverter);
+  }
+
+  if (isGuardContentBlock(block)) {
+    return { guardContent: block.guardContent };
   }
 
   if (block.type === "text") {


### PR DESCRIPTION
Fixes #11217.

## Summary

Allow `ChatBedrockConverse` to preserve Bedrock `guardContent` blocks in user messages.

The converter already handled this block on responses, but rejected it while building a Converse request. As a result, applications could not use selective guardrail coverage for a chosen portion of a message.

## Changes

- Pass through raw Bedrock `{ guardContent: ... }` blocks.
- Preserve the typed `guard_content` representation used when replaying content.
- Add a patch changeset for `@langchain/aws`.

## Validation

- `pnpm --filter @langchain/aws build`
- `pnpm --filter @langchain/aws exec vitest run src/tests/chat_models.test.ts` (67 passed)
- `pnpm exec oxlint …`
- `pnpm exec oxfmt --check …`
- `git diff --check`
