### PR TITLE
refactor(langchain-ibm): extract authentication and validation into separate modules, use unified `apiKey` etc. props

### DIFF
--- a/libs/providers/langchain-ibm/README.md
+++ b/libs/providers/langchain-ibm/README.md
@@ -22,8 +22,7 @@ const model = new ChatWatsonx({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   projectId: "your-project-id",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
   maxTokens: 200,
 });
 
@@ -83,8 +82,7 @@ const gatewayModel = new ChatWatsonx({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   modelGateway: true,
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
 });
 ```
 
@@ -95,8 +93,7 @@ const deployedModel = new ChatWatsonx({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   idOrName: "your-deployment-id",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
 });
 ```
 
@@ -112,8 +109,7 @@ const llm = new WatsonxLLM({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   projectId: "your-project-id",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
   maxNewTokens: 200,
   temperature: 0.7,
 });
@@ -134,8 +130,7 @@ const embeddings = new WatsonxEmbeddings({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   projectId: "your-project-id",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
 });
 
 const vector = await embeddings.embedQuery("Hello world");
@@ -155,8 +150,7 @@ const reranker = new WatsonxRerank({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
   projectId: "your-project-id",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
 });
 
 const documents = [
@@ -181,8 +175,7 @@ import { WatsonxToolkit } from "@langchain/ibm";
 const toolkit = await WatsonxToolkit.init({
   version: "2024-05-31",
   serviceUrl: "https://us-south.ml.cloud.ibm.com",
-  watsonxAIApikey: "your-api-key",
-  watsonxAIAuthType: "iam",
+  apiKey: "your-api-key",
 });
 
 const tools = toolkit.getTools();
@@ -191,9 +184,48 @@ const searchTool = toolkit.getTool("GoogleSearch", { maxResults: 5 });
 
 ## Authentication
 
-The package supports multiple authentication methods:
+The package supports multiple authentication methods.
 
-### IAM Authentication
+### IAM authentication
+
+```typescript
+{
+  authType: "iam",
+  apiKey: "your-api-key",
+}
+```
+
+Passing only the API key is also supported (defaults to IAM authentication):
+
+```typescript
+{
+  apiKey: "your-api-key",
+}
+```
+
+### Bearer Token authentication
+
+```typescript
+{
+  authType: "bearertoken",
+  bearerToken: "your-token",
+}
+```
+
+### IBM watsonx.ai software authentication
+
+```typescript
+{
+  authType: "cp4d",
+  username: "your-username",
+  password: "your-password",
+  authUrl: "your-cp4d-url",
+}
+```
+
+### Legacy Property Names
+
+For backward compatibility, the original `watsonxAI`-prefixed property names are still supported:
 
 ```typescript
 {
@@ -202,25 +234,7 @@ The package supports multiple authentication methods:
 }
 ```
 
-### Bearer Token Authentication
-
-```typescript
-{
-  watsonxAIAuthType: "bearertoken",
-  watsonxAIBearerToken: "your-token",
-}
-```
-
-### Cloud Pak for Data (CP4D) Authentication
-
-```typescript
-{
-  watsonxAIAuthType: "cp4d",
-  watsonxAIUsername: "your-username",
-  watsonxAIPassword: "your-password",
-  watsonxAIUrl: "your-cp4d-url",
-}
-```
+**Note:** While both naming conventions are supported, we recommend using the shorter property names (`apiKey`, `authType`, etc.) for new code. Avoid mixing both styles for the same property.
 
 ## Related
 

--- a/libs/providers/langchain-ibm/src/agents/toolkits/ibm.ts
+++ b/libs/providers/langchain-ibm/src/agents/toolkits/ibm.ts
@@ -14,7 +14,7 @@ import {
   interopSafeParse,
 } from "@langchain/core/utils/types";
 import {
-  authenticateAndSetInstance,
+  initWatsonxOrGatewayInstance,
   jsonSchemaToZod,
 } from "../../utils/ibm.js";
 import { WatsonxAuth, WatsonxInit } from "../../types.js";
@@ -91,30 +91,8 @@ export class WatsonxToolkit extends BaseToolkit {
 
   constructor(fields: WatsonxAuth & WatsonxInit) {
     super();
-    const {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      version,
-      disableSSL,
-      serviceUrl,
-    } = fields;
 
-    const auth = authenticateAndSetInstance({
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-    });
-    if (auth) this.service = auth;
+    this.service = initWatsonxOrGatewayInstance(fields);
   }
 
   async loadTools() {

--- a/libs/providers/langchain-ibm/src/auth/authenticator.ts
+++ b/libs/providers/langchain-ibm/src/auth/authenticator.ts
@@ -18,30 +18,29 @@ import { WatsonxAuth } from "../types.js";
  * ```typescript
  * // IAM authentication
  * const iamAuth = createAuthenticator({
- *   watsonxAIAuthType: "iam",
- *   watsonxAIApikey: "your-api-key"
+ *   apiKey: "your-api-key"
  * });
  *
  * // Bearer token authentication
  * const bearerAuth = createAuthenticator({
- *   watsonxAIAuthType: "bearertoken",
- *   watsonxAIBearerToken: "your-bearer-token"
+ *   authType: "bearertoken",
+ *   bearerToken: "your-bearer-token"
  * });
  *
  * // Cloud Pak for Data authentication
  * const cp4dAuth = createAuthenticator({
- *   watsonxAIAuthType: "cp4d",
- *   watsonxAIUsername: "your-username",
- *   watsonxAIPassword: "your-password",
- *   watsonxAIUrl: "https://your-cp4d-url.com",
+ *   authType: "cp4d",
+ *   username: "your-username",
+ *   password: "your-password",
+ *   authUrl: "https://your-cp4d-url.com",
  *   serviceUrl: "https://your-service-url.com"
  * });
  *
  * // AWS authentication
  * const awsAuth = createAuthenticator({
- *   watsonxAIAuthType: "aws",
- *   watsonxAIApikey: "your-api-key",
- *   watsonxAIUrl: "https://your-aws-url.com"
+ *   authType: "aws",
+ *   apiKey: "your-api-key",
+ *   authUrl: "https://your-aws-url.com"
  * });
  * ```
  */
@@ -70,9 +69,7 @@ export function createAuthenticator({
           bearerToken,
         });
       }
-      throw new Error(
-        "BearerToken is required for BearerToken auth"
-      );
+      throw new Error("BearerToken is required for BearerToken auth");
 
     case "cp4d":
       if (username && (password || apiKey)) {

--- a/libs/providers/langchain-ibm/src/auth/authenticator.ts
+++ b/libs/providers/langchain-ibm/src/auth/authenticator.ts
@@ -1,0 +1,102 @@
+import {
+  IamAuthenticator,
+  BearerTokenAuthenticator,
+  CloudPakForDataAuthenticator,
+  Authenticator,
+} from "ibm-cloud-sdk-core";
+import { AWSAuthenticator } from "@ibm-cloud/watsonx-ai/authentication";
+import { WatsonxAuth } from "../types.js";
+
+/**
+ * Creates an IBM Cloud SDK authenticator based on the provided authentication configuration.
+ *
+ * @param config - Authentication configuration
+ * @returns Authenticator instance or undefined if no auth type specified
+ * @throws {Error} If required credentials are missing for the specified auth type
+ *
+ * @example
+ * ```typescript
+ * // IAM authentication
+ * const iamAuth = createAuthenticator({
+ *   watsonxAIAuthType: "iam",
+ *   watsonxAIApikey: "your-api-key"
+ * });
+ *
+ * // Bearer token authentication
+ * const bearerAuth = createAuthenticator({
+ *   watsonxAIAuthType: "bearertoken",
+ *   watsonxAIBearerToken: "your-bearer-token"
+ * });
+ *
+ * // Cloud Pak for Data authentication
+ * const cp4dAuth = createAuthenticator({
+ *   watsonxAIAuthType: "cp4d",
+ *   watsonxAIUsername: "your-username",
+ *   watsonxAIPassword: "your-password",
+ *   watsonxAIUrl: "https://your-cp4d-url.com",
+ *   serviceUrl: "https://your-service-url.com"
+ * });
+ *
+ * // AWS authentication
+ * const awsAuth = createAuthenticator({
+ *   watsonxAIAuthType: "aws",
+ *   watsonxAIApikey: "your-api-key",
+ *   watsonxAIUrl: "https://your-aws-url.com"
+ * });
+ * ```
+ */
+export function createAuthenticator({
+  apiKey,
+  authType,
+  bearerToken,
+  username,
+  password,
+  authUrl,
+  disableSSL,
+  serviceUrl,
+}: WatsonxAuth): Authenticator | undefined {
+  switch (authType) {
+    case "iam":
+      if (apiKey) {
+        return new IamAuthenticator({
+          apikey: apiKey,
+        });
+      }
+      throw new Error("ApiKey is required for IAM auth");
+
+    case "bearertoken":
+      if (bearerToken) {
+        return new BearerTokenAuthenticator({
+          bearerToken,
+        });
+      }
+      throw new Error(
+        "BearerToken is required for BearerToken auth"
+      );
+
+    case "cp4d":
+      if (username && (password || apiKey)) {
+        const watsonxCPDAuthUrl = authUrl ?? serviceUrl;
+        return new CloudPakForDataAuthenticator({
+          username,
+          password,
+          url: new URL("/icp4d-api/v1/authorize", watsonxCPDAuthUrl).toString(),
+          apikey: apiKey,
+          disableSslVerification: disableSSL,
+        });
+      }
+      throw new Error(
+        "Username and Password or ApiKey is required for IBM watsonx.ai software auth"
+      );
+
+    case "aws":
+      return new AWSAuthenticator({
+        apikey: apiKey,
+        url: authUrl,
+        disableSslVerification: disableSSL,
+      });
+
+    default:
+      return undefined;
+  }
+}

--- a/libs/providers/langchain-ibm/src/auth/authenticator.ts
+++ b/libs/providers/langchain-ibm/src/auth/authenticator.ts
@@ -59,6 +59,7 @@ export function createAuthenticator({
       if (apiKey) {
         return new IamAuthenticator({
           apikey: apiKey,
+          url: authUrl,
         });
       }
       throw new Error("ApiKey is required for IAM auth");

--- a/libs/providers/langchain-ibm/src/auth/config.ts
+++ b/libs/providers/langchain-ibm/src/auth/config.ts
@@ -63,7 +63,9 @@ export function prepareInstanceConfig({
 }: WatsonxAuth & Omit<WatsonxInit, "authenticator">): InstanceConfig {
   // Auto-detect IAM auth when apiKey is provided without username
   const isIam =
-    (watsonxAIApikey || apiKey) && !watsonxAIUsername ? "iam" : undefined;
+    (watsonxAIApikey || apiKey) && !(watsonxAIUsername || username)
+      ? "iam"
+      : undefined;
 
   const authenticator = createAuthenticator({
     apiKey: watsonxAIApikey ?? apiKey,

--- a/libs/providers/langchain-ibm/src/auth/config.ts
+++ b/libs/providers/langchain-ibm/src/auth/config.ts
@@ -1,0 +1,84 @@
+import { Authenticator } from "ibm-cloud-sdk-core";
+import { WatsonxAuth, WatsonxInit } from "../types.js";
+import { createAuthenticator } from "./authenticator.js";
+
+/**
+ * Configuration object returned by prepareInstanceConfig
+ */
+export interface InstanceConfig {
+  version: string;
+  serviceUrl: string;
+  authenticator?: Authenticator;
+}
+
+/**
+ * Prepares the configuration object for initializing a WatsonX AI instance.
+ * Handles both legacy and new property names, automatically detecting IAM auth when appropriate.
+ *
+ * @param config - Combined authentication and initialization configuration
+ * @returns Configuration object with version, serviceUrl, and optional authenticator
+ *
+ * @example
+ * ```typescript
+ * // Using new property names
+ * const config = prepareInstanceConfig({
+ *   version: "2024-05-31",
+ *   serviceUrl: "https://us-south.ml.cloud.ibm.com",
+ *   authType: "iam",
+ *   apiKey: "your-api-key"
+ * });
+ *
+ * // Using legacy property names (still supported)
+ * const legacyConfig = prepareInstanceConfig({
+ *   version: "2024-05-31",
+ *   serviceUrl: "https://us-south.ml.cloud.ibm.com",
+ *   watsonxAIAuthType: "iam",
+ *   watsonxAIApikey: "your-api-key"
+ * });
+ *
+ * // Auto-detect IAM auth (when apiKey provided without authType)
+ * const autoConfig = prepareInstanceConfig({
+ *   version: "2024-05-31",
+ *   serviceUrl: "https://us-south.ml.cloud.ibm.com",
+ *   apiKey: "your-api-key"
+ * });
+ * ```
+ */
+export function prepareInstanceConfig({
+  watsonxAIApikey,
+  watsonxAIAuthType,
+  watsonxAIBearerToken,
+  watsonxAIUsername,
+  watsonxAIPassword,
+  watsonxAIUrl,
+  disableSSL,
+  version,
+  serviceUrl,
+  apiKey,
+  bearerToken,
+  username,
+  password,
+  authType,
+  authUrl,
+}: WatsonxAuth & Omit<WatsonxInit, "authenticator">): InstanceConfig {
+  // Auto-detect IAM auth when apiKey is provided without username
+  const isIam =
+    (watsonxAIApikey || apiKey) && !watsonxAIUsername ? "iam" : undefined;
+
+  const authenticator = createAuthenticator({
+    apiKey: watsonxAIApikey ?? apiKey,
+    authType: watsonxAIAuthType ?? authType ?? isIam,
+    bearerToken: watsonxAIBearerToken ?? bearerToken,
+    username: watsonxAIUsername ?? username,
+    password: watsonxAIPassword ?? password,
+    authUrl: watsonxAIUrl ?? authUrl,
+    disableSSL,
+    serviceUrl,
+  });
+
+  return {
+    version,
+    serviceUrl,
+    ...(authenticator ? { authenticator } : {}),
+  };
+}

--- a/libs/providers/langchain-ibm/src/auth/index.ts
+++ b/libs/providers/langchain-ibm/src/auth/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Authentication module for IBM watsonx.ai
+ *
+ * This module provides authentication utilities for connecting to IBM watsonx.ai services.
+ * It supports multiple authentication methods:
+ * - IAM (IBM Cloud Identity and Access Management)
+ * - Bearer Token
+ * - Cloud Pak for Data (CP4D)
+ * - AWS
+ *
+ * @module auth
+ */
+
+export { createAuthenticator } from "./authenticator.js";
+export { prepareInstanceConfig } from "./config.js";
+export type { InstanceConfig } from "./config.js";

--- a/libs/providers/langchain-ibm/src/chat_models/ibm.ts
+++ b/libs/providers/langchain-ibm/src/chat_models/ibm.ts
@@ -83,11 +83,9 @@ import {
 import { WatsonxAuth, XOR, WatsonxBaseChatParams } from "../types.js";
 import {
   _convertToolCallIdToMistralCompatible,
-  authenticateAndSetGatewayInstance,
-  authenticateAndSetInstance,
-  checkRequiredProps,
   checkValidProps,
   expectOneOf,
+  initWatsonxOrGatewayInstance,
   WatsonxToolsOutputParser,
 } from "../utils/ibm.js";
 
@@ -682,14 +680,6 @@ export class ChatWatsonx<
     this.modelGateway = fields.modelGateway || this.modelGateway;
     this.spaceId = fields?.spaceId;
 
-    if (this.modelGateway) {
-      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
-    } else if (this.idOrName) {
-      checkRequiredProps(fields, ["serviceUrl", "version"]);
-    } else {
-      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
-    }
-
     this.checkValidProperties(fields);
 
     this.model = fields?.model ?? this.model;
@@ -714,54 +704,17 @@ export class ChatWatsonx<
     this.reasoningEffort = fields?.reasoningEffort;
     this.includeReasoning = fields?.includeReasoning;
 
-    this.modelGateway = fields?.modelGateway ?? this.modelGateway;
-    this.modelGatewayKwargs = fields?.modelGatewayKwargs;
-
-    const {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    } = fields;
-
-    const authData = {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    };
+    if ("modelGateway" in fields) {
+      this.modelGatewayKwargs = fields?.modelGatewayKwargs;
+    } else {
+      this.timeLimit = fields?.timeLimit;
+      this.includeReasoning = fields?.includeReasoning;
+    }
 
     if (this.modelGateway) {
-      const chatGateway = authenticateAndSetGatewayInstance(authData);
-      if (chatGateway) this.gateway = chatGateway;
-      else throw new Error("You have not provided any type of authentication");
+      this.gateway = initWatsonxOrGatewayInstance(fields, true);
     } else {
-      const service = authenticateAndSetInstance(authData);
-
-      if (service) this.service = service;
-      else throw new Error("You have not provided any type of authentication");
+      this.service = initWatsonxOrGatewayInstance(fields);
     }
   }
 

--- a/libs/providers/langchain-ibm/src/chat_models/ibm.ts
+++ b/libs/providers/langchain-ibm/src/chat_models/ibm.ts
@@ -81,7 +81,11 @@ import {
   Gateway,
 } from "@ibm-cloud/watsonx-ai/gateway";
 import { WatsonxAuth, XOR, WatsonxBaseChatParams } from "../types.js";
-import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
+import {
+  PropertyValidator,
+  checkRequiredProps,
+  expectOneOf,
+} from "../utils/validation.js";
 import {
   _convertToolCallIdToMistralCompatible,
   initWatsonxOrGatewayInstance,
@@ -498,8 +502,6 @@ export class ChatWatsonx<
     };
   }
 
-  private validator = new PropertyValidator();
-
   private checkValidProperties(
     fields: this["ParsedCallOptions"] | ChatWatsonxConstructorInput
   ) {
@@ -566,12 +568,10 @@ export class ChatWatsonx<
       modeProps.push(...PROJECT_OR_SPACE);
     }
 
-    this.validator.validateByMode(
+    PropertyValidator.validateByMode(
       fields as Record<string, unknown>,
       modeProps,
-      {
-        includeCommon: true,
-      }
+      true
     );
   }
 
@@ -667,9 +667,7 @@ export class ChatWatsonx<
     this.responseFormat = fields?.responseFormat ?? this.responseFormat;
     this.streaming = fields?.streaming ?? this.streaming;
     this.n = fields?.n ?? this.n;
-    this.timeLimit = fields?.timeLimit;
     this.reasoningEffort = fields?.reasoningEffort;
-    this.includeReasoning = fields?.includeReasoning;
 
     if ("modelGateway" in fields) {
       this.modelGatewayKwargs = fields?.modelGatewayKwargs;

--- a/libs/providers/langchain-ibm/src/chat_models/ibm.ts
+++ b/libs/providers/langchain-ibm/src/chat_models/ibm.ts
@@ -81,10 +81,9 @@ import {
   Gateway,
 } from "@ibm-cloud/watsonx-ai/gateway";
 import { WatsonxAuth, XOR, WatsonxBaseChatParams } from "../types.js";
+import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
 import {
   _convertToolCallIdToMistralCompatible,
-  checkValidProps,
-  expectOneOf,
   initWatsonxOrGatewayInstance,
   WatsonxToolsOutputParser,
 } from "../utils/ibm.js";
@@ -499,121 +498,81 @@ export class ChatWatsonx<
     };
   }
 
+  private validator = new PropertyValidator();
+
   private checkValidProperties(
     fields: this["ParsedCallOptions"] | ChatWatsonxConstructorInput
   ) {
-    const PROPERTY_GROUPS = {
-      ALWAYS_ALLOWED: [
-        "headers",
-        "signal",
-        "tool_choice",
-        "promptIndex",
-        "ls_structured_output_format",
-        "watsonxCallbacks",
-        "writer",
-        "interrupt",
-      ],
-
-      AUTH: [
-        "serviceUrl",
-        "watsonxAIApikey",
-        "watsonxAIBearerToken",
-        "watsonxAIUsername",
-        "watsonxAIPassword",
-        "watsonxAIUrl",
-        "watsonxAIAuthType",
-        "disableSSL",
-        "apiKey",
-        "bearerToken",
-        "username",
-        "password",
-        "authType",
-        "authUrl",
-      ],
-
-      SHARED: [
-        "maxRetries",
-        "authenticator",
-        "serviceUrl",
-        "version",
-        "streaming",
-        "callbackManager",
-        "callbacks",
-        "maxConcurrency",
-        "cache",
-        "metadata",
-        "concurrency",
-        "onFailedAttempt",
-        "verbose",
-        "tags",
-        "headers",
-        "disableStreaming",
-        "timeout",
-        "stopSequences",
-      ],
-
-      GATEWAY: [
-        "tools",
-        "frequencyPenalty",
-        "logitBias",
-        "logprobs",
-        "topLogprobs",
-        "maxTokens",
-        "n",
-        "presencePenalty",
-        "responseFormat",
-        "seed",
-        "stop",
-        "temperature",
-        "topP",
-        "model",
-        "modelGatewayKwargs",
-        "modelGateway",
-        "reasoningEffort",
-      ],
-
-      DEPLOYMENT: ["idOrName"],
-
-      PROJECT_OR_SPACE: [
-        "spaceId",
-        "projectId",
-        "tools",
-        "toolChoiceOption",
-        "frequencyPenalty",
-        "logitBias",
-        "logprobs",
-        "topLogprobs",
-        "maxTokens",
-        "maxCompletionTokens",
-        "n",
-        "presencePenalty",
-        "responseFormat",
-        "seed",
-        "stop",
-        "temperature",
-        "topP",
-        "timeLimit",
-        "model",
-        "reasoningEffort",
-        "includeReasoning",
-      ],
-    };
-
-    const validProps: string[] = [
-      ...PROPERTY_GROUPS.ALWAYS_ALLOWED,
-      ...PROPERTY_GROUPS.AUTH,
-      ...PROPERTY_GROUPS.SHARED,
+    const ALWAYS_ALLOWED_EXTRA = [
+      "tool_choice",
+      "ls_structured_output_format",
+      "watsonxCallbacks",
+      "writer",
+      "interrupt",
     ];
 
+    const GATEWAY = [
+      "tools",
+      "frequencyPenalty",
+      "logitBias",
+      "logprobs",
+      "topLogprobs",
+      "maxTokens",
+      "n",
+      "presencePenalty",
+      "responseFormat",
+      "seed",
+      "stop",
+      "temperature",
+      "topP",
+      "model",
+      "modelGatewayKwargs",
+      "modelGateway",
+      "reasoningEffort",
+    ];
+
+    const DEPLOYMENT = ["idOrName"];
+
+    const PROJECT_OR_SPACE = [
+      "spaceId",
+      "projectId",
+      "tools",
+      "toolChoiceOption",
+      "frequencyPenalty",
+      "logitBias",
+      "logprobs",
+      "topLogprobs",
+      "maxTokens",
+      "maxCompletionTokens",
+      "n",
+      "presencePenalty",
+      "responseFormat",
+      "seed",
+      "stop",
+      "temperature",
+      "topP",
+      "timeLimit",
+      "model",
+      "reasoningEffort",
+      "includeReasoning",
+    ];
+
+    const modeProps: string[] = [...ALWAYS_ALLOWED_EXTRA];
     if (this.modelGateway) {
-      validProps.push(...PROPERTY_GROUPS.GATEWAY);
+      modeProps.push(...GATEWAY);
     } else if (this.idOrName) {
-      validProps.push(...PROPERTY_GROUPS.DEPLOYMENT);
+      modeProps.push(...DEPLOYMENT);
     } else if (this.spaceId || this.projectId) {
-      validProps.push(...PROPERTY_GROUPS.PROJECT_OR_SPACE);
+      modeProps.push(...PROJECT_OR_SPACE);
     }
 
-    checkValidProps(fields, validProps);
+    this.validator.validateByMode(
+      fields as Record<string, unknown>,
+      modeProps,
+      {
+        includeCommon: true,
+      }
+    );
   }
 
   protected service?: WatsonXAI;
@@ -679,6 +638,14 @@ export class ChatWatsonx<
     this.projectId = fields?.projectId;
     this.modelGateway = fields.modelGateway || this.modelGateway;
     this.spaceId = fields?.spaceId;
+
+    if (this.modelGateway) {
+      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
+    } else if (this.idOrName) {
+      checkRequiredProps(fields, ["serviceUrl", "version"]);
+    } else {
+      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
+    }
 
     this.checkValidProperties(fields);
 

--- a/libs/providers/langchain-ibm/src/chat_models/ibm.ts
+++ b/libs/providers/langchain-ibm/src/chat_models/ibm.ts
@@ -465,6 +465,10 @@ export class ChatWatsonx<
       watsonxAIUsername: "WATSONX_AI_USERNAME",
       watsonxAIPassword: "WATSONX_AI_PASSWORD",
       watsonxAIUrl: "WATSONX_AI_URL",
+      authUrl: "WATSONX_AI_URL",
+      bearerToken: "WATSONX_AI_BEARER_TOKEN",
+      username: "WATSONX_AI_USERNAME",
+      password: "WATSONX_AI_PASSWORD",
     };
   }
 
@@ -479,6 +483,10 @@ export class ChatWatsonx<
       watsonxAIUsername: "watsonx_ai_username",
       watsonxAIPassword: "watsonx_ai_password",
       watsonxAIUrl: "watsonx_ai_url",
+      authUrl: "watsonx_ai_url",
+      bearerToken: "watsonx_ai_bearer_token",
+      username: "watsonx_ai_username",
+      password: "watsonx_ai_password",
     };
   }
 
@@ -517,6 +525,12 @@ export class ChatWatsonx<
         "watsonxAIUrl",
         "watsonxAIAuthType",
         "disableSSL",
+        "apiKey",
+        "bearerToken",
+        "username",
+        "password",
+        "authType",
+        "authUrl",
       ],
 
       SHARED: [
@@ -713,6 +727,12 @@ export class ChatWatsonx<
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     } = fields;
 
     const authData = {
@@ -725,6 +745,12 @@ export class ChatWatsonx<
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     };
 
     if (this.modelGateway) {

--- a/libs/providers/langchain-ibm/src/document_compressors/ibm.ts
+++ b/libs/providers/langchain-ibm/src/document_compressors/ibm.ts
@@ -72,9 +72,15 @@ export class WatsonxRerank
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     } = fields;
 
-    const auth = authenticateAndSetInstance({
+    const authData = {
       watsonxAIApikey,
       watsonxAIAuthType,
       watsonxAIBearerToken,
@@ -84,7 +90,15 @@ export class WatsonxRerank
       disableSSL,
       version,
       serviceUrl,
-    });
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
+    };
+
+    const auth = authenticateAndSetInstance(authData);
     if (auth) this.service = auth;
     else throw new Error("You have not provided one type of authentication");
   }

--- a/libs/providers/langchain-ibm/src/document_compressors/ibm.ts
+++ b/libs/providers/langchain-ibm/src/document_compressors/ibm.ts
@@ -4,7 +4,7 @@ import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import { TextRerankParams } from "@ibm-cloud/watsonx-ai/dist/watsonx-ai-ml/vml_v1.js";
 import { WatsonxAuth, WatsonxRerankBasicOptions } from "../types.js";
-import { authenticateAndSetInstance } from "../utils/ibm.js";
+import { initWatsonxOrGatewayInstance } from "../utils/ibm.js";
 
 export interface WatsonxInputRerank
   extends
@@ -62,45 +62,7 @@ export class WatsonxRerank
     this.truncateInputTokens = fields.truncateInputTokens;
     this.returnOptions = fields.returnOptions;
 
-    const {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    } = fields;
-
-    const authData = {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    };
-
-    const auth = authenticateAndSetInstance(authData);
-    if (auth) this.service = auth;
-    else throw new Error("You have not provided one type of authentication");
+    this.service = initWatsonxOrGatewayInstance(fields);
   }
 
   scopeId() {

--- a/libs/providers/langchain-ibm/src/embeddings/ibm.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/ibm.ts
@@ -3,9 +3,12 @@ import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import { CreateEmbeddingsParams, Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR } from "../types.js";
-import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
-import {  initWatsonxOrGatewayInstance } from "../utils/ibm.js";
+import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR,  } from "../types.js";
+import {
+  expectOneOf,
+  initWatsonxOrGatewayInstance,
+} from "../utils/ibm.js";
+import { checkRequiredProps, PropertyValidator } from "../utils/validation.js";
 
 export interface WatsonxEmbeddingsParams
   extends
@@ -122,6 +125,13 @@ export class WatsonxEmbeddings
     checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
 
     this.checkValidProperties(fields);
+
+    if ("modelGateway" in fields)
+      this.modelGatewayKwargs = fields.modelGatewayKwargs;
+    else {
+      this.truncateInputTokens = fields.truncateInputTokens;
+      this.returnOptions = fields.returnOptions;
+    }
 
     this.model = fields.model;
     this.version = fields.version;

--- a/libs/providers/langchain-ibm/src/embeddings/ibm.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/ibm.ts
@@ -3,11 +3,8 @@ import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import { CreateEmbeddingsParams, Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR,  } from "../types.js";
-import {
-  expectOneOf,
-  initWatsonxOrGatewayInstance,
-} from "../utils/ibm.js";
+import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR } from "../types.js";
+import { expectOneOf, initWatsonxOrGatewayInstance } from "../utils/ibm.js";
 import { checkRequiredProps, PropertyValidator } from "../utils/validation.js";
 
 export interface WatsonxEmbeddingsParams
@@ -86,8 +83,6 @@ export class WatsonxEmbeddings
 
   protected gateway?: Gateway;
 
-  private validator = new PropertyValidator();
-
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   private checkValidProperties(fields: any, includeCommonProps = true) {
     const projectOrSpaceProps = [
@@ -106,12 +101,10 @@ export class WatsonxEmbeddings
       modeProps = projectOrSpaceProps;
     }
 
-    this.validator.validateByMode(
+    PropertyValidator.validateByMode(
       fields as Record<string, unknown>,
       modeProps,
-      {
-        includeCommon: includeCommonProps,
-      }
+      includeCommonProps
     );
   }
 

--- a/libs/providers/langchain-ibm/src/embeddings/ibm.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/ibm.ts
@@ -101,6 +101,12 @@ export class WatsonxEmbeddings
       "watsonxAIUrl",
       "watsonxAIAuthType",
       "disableSSL",
+      "apiKey",
+      "bearerToken",
+      "username",
+      "password",
+      "authType",
+      "authUrl",
     ];
 
     const sharedProps = [
@@ -176,6 +182,12 @@ export class WatsonxEmbeddings
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     } = fields;
 
     const authData = {
@@ -188,7 +200,14 @@ export class WatsonxEmbeddings
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     };
+
     if (this.modelGateway) {
       const auth = authenticateAndSetGatewayInstance(authData);
       if (auth) this.gateway = auth;

--- a/libs/providers/langchain-ibm/src/embeddings/ibm.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/ibm.ts
@@ -5,11 +5,9 @@ import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import { CreateEmbeddingsParams, Gateway } from "@ibm-cloud/watsonx-ai/gateway";
 import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR } from "../types.js";
 import {
-  authenticateAndSetGatewayInstance,
-  authenticateAndSetInstance,
-  checkRequiredProps,
   checkValidProps,
   expectOneOf,
+  initWatsonxOrGatewayInstance,
 } from "../utils/ibm.js";
 
 export interface WatsonxEmbeddingsParams
@@ -158,8 +156,6 @@ export class WatsonxEmbeddings
     this.spaceId = fields?.spaceId;
     this.modelGateway = fields.modelGateway ?? this.modelGateway;
 
-    checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
-
     this.checkValidProperties(fields);
 
     this.model = fields.model;
@@ -170,52 +166,11 @@ export class WatsonxEmbeddings
     this.maxConcurrency = fields.maxConcurrency ?? this.maxConcurrency;
     this.maxRetries = fields.maxRetries ?? 0;
     this.serviceUrl = fields?.serviceUrl;
-    this.modelGatewayKwargs = fields.modelGatewayKwargs;
-
-    const {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    } = fields;
-
-    const authData = {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    };
 
     if (this.modelGateway) {
-      const auth = authenticateAndSetGatewayInstance(authData);
-      if (auth) this.gateway = auth;
-      else throw new Error("You have not provided one type of authentication");
+      this.gateway = initWatsonxOrGatewayInstance(fields, true);
     } else {
-      const auth = authenticateAndSetInstance(authData);
-      if (auth) this.service = auth;
-      else throw new Error("You have not provided one type of authentication");
+      this.service = initWatsonxOrGatewayInstance(fields);
     }
   }
 

--- a/libs/providers/langchain-ibm/src/embeddings/ibm.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/ibm.ts
@@ -4,11 +4,8 @@ import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { AsyncCaller } from "@langchain/core/utils/async_caller";
 import { CreateEmbeddingsParams, Gateway } from "@ibm-cloud/watsonx-ai/gateway";
 import { WatsonxAuth, WatsonxEmbeddingsBasicOptions, XOR } from "../types.js";
-import {
-  checkValidProps,
-  expectOneOf,
-  initWatsonxOrGatewayInstance,
-} from "../utils/ibm.js";
+import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
+import {  initWatsonxOrGatewayInstance } from "../utils/ibm.js";
 
 export interface WatsonxEmbeddingsParams
   extends
@@ -86,49 +83,10 @@ export class WatsonxEmbeddings
 
   protected gateway?: Gateway;
 
+  private validator = new PropertyValidator();
+
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   private checkValidProperties(fields: any, includeCommonProps = true) {
-    const alwaysAllowedProps = ["headers", "signal", "promptIndex"];
-
-    const authProps = [
-      "serviceUrl",
-      "watsonxAIApikey",
-      "watsonxAIBearerToken",
-      "watsonxAIUsername",
-      "watsonxAIPassword",
-      "watsonxAIUrl",
-      "watsonxAIAuthType",
-      "disableSSL",
-      "apiKey",
-      "bearerToken",
-      "username",
-      "password",
-      "authType",
-      "authUrl",
-    ];
-
-    const sharedProps = [
-      "maxRetries",
-      "watsonxCallbacks",
-      "authenticator",
-      "serviceUrl",
-      "version",
-      "streaming",
-      "callbackManager",
-      "callbacks",
-      "maxConcurrency",
-      "cache",
-      "metadata",
-      "concurrency",
-      "onFailedAttempt",
-      "concurrency",
-      "verbose",
-      "tags",
-      "headers",
-      "signal",
-      "disableStreaming",
-    ];
-
     const projectOrSpaceProps = [
       "truncateInputTokens",
       "returnOptions",
@@ -137,16 +95,21 @@ export class WatsonxEmbeddings
       "spaceId",
     ];
     const gatewayProps = ["model", "modelGatewayKwargs", "modelGateway"];
-    const validProps: string[] = [...alwaysAllowedProps];
-    if (includeCommonProps) validProps.push(...authProps, ...sharedProps);
 
+    let modeProps: string[] = [];
     if (this.modelGateway) {
-      validProps.push(...gatewayProps);
+      modeProps = gatewayProps;
     } else if (this.spaceId || this.projectId) {
-      validProps.push(...projectOrSpaceProps);
+      modeProps = projectOrSpaceProps;
     }
 
-    checkValidProps(fields, validProps);
+    this.validator.validateByMode(
+      fields as Record<string, unknown>,
+      modeProps,
+      {
+        includeCommon: includeCommonProps,
+      }
+    );
   }
 
   constructor(fields: WatsonxEmbeddingsConstructor) {
@@ -155,6 +118,8 @@ export class WatsonxEmbeddings
     this.projectId = fields?.projectId;
     this.spaceId = fields?.spaceId;
     this.modelGateway = fields.modelGateway ?? this.modelGateway;
+
+    checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
 
     this.checkValidProperties(fields);
 

--- a/libs/providers/langchain-ibm/src/embeddings/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/tests/ibm.test.ts
@@ -206,7 +206,6 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
-        // @ts-expect-error Passing wrong props with modelGateway
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,
@@ -225,7 +224,6 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
-        // @ts-expect-error Passing wrong props with projectid
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,
@@ -242,7 +240,6 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
-        // @ts-expect-error Passing wrong props with modelGateway
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,

--- a/libs/providers/langchain-ibm/src/embeddings/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/embeddings/tests/ibm.test.ts
@@ -206,6 +206,7 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
+        // @ts-expect-error invalid props
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,
@@ -224,6 +225,7 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
+        // @ts-expect-error invalid props
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,
@@ -240,6 +242,7 @@ describe("Negative tests", () => {
     };
     expect(
       () =>
+        // @ts-expect-error invalid props
         new WatsonxEmbeddings({
           ...testProps,
           ...fakeAuthProp,

--- a/libs/providers/langchain-ibm/src/index.ts
+++ b/libs/providers/langchain-ibm/src/index.ts
@@ -10,19 +10,10 @@ export type {
   WatsonxLLMBasicOptions,
   WatsonxRerankBasicOptions,
   WatsonxEmbeddingsBasicOptions,
-  WatsonxToolChoice,
+  WatsonxTooChoice,
   WatsonxBaseChatParams,
   GenerationInfo,
   ResponseChunk,
-} from "./types.js";
-
-// Re-export error classes
-export {
-  WatsonxError,
-  Error,
-  WatsonxValidationError,
-  WatsonxConfigurationError,
-  WatsonxUnsupportedOperationError,
 } from "./types.js";
 
 // Re-export auth utilities
@@ -35,7 +26,6 @@ export {
   WatsonxToolsOutputParser,
   jsonSchemaToZod,
   expectOneOf,
-  checkValidProps,
 } from "./utils/ibm.js";
 
 export {

--- a/libs/providers/langchain-ibm/src/index.ts
+++ b/libs/providers/langchain-ibm/src/index.ts
@@ -1,8 +1,35 @@
-export * from "./types.js";
+// Re-export all types
+export type {
+  WatsonxAuth,
+  WatsonxInit,
+  Neverify,
+  XOR,
+  TokenUsage,
+  WatsonxRequestBasicOptions,
+  WatsonxChatBasicOptions,
+  WatsonxLLMBasicOptions,
+  WatsonxRerankBasicOptions,
+  WatsonxEmbeddingsBasicOptions,
+  WatsonxToolChoice,
+  WatsonxBaseChatParams,
+  GenerationInfo,
+  ResponseChunk,
+} from "./types.js";
+
+// Re-export error classes
+export {
+  WatsonxError,
+  Error,
+  WatsonxValidationError,
+  WatsonxConfigurationError,
+  WatsonxUnsupportedOperationError,
+} from "./types.js";
+
+// Re-export auth utilities
+export { createAuthenticator, prepareInstanceConfig } from "./auth/index.js";
+export type { InstanceConfig } from "./auth/index.js";
 
 export {
-  authenticateAndSetInstance,
-  authenticateAndSetGatewayInstance,
   _isValidMistralToolCallId,
   _convertToolCallIdToMistralCompatible,
   WatsonxToolsOutputParser,

--- a/libs/providers/langchain-ibm/src/llms/ibm.ts
+++ b/libs/providers/langchain-ibm/src/llms/ibm.ts
@@ -21,11 +21,7 @@ import {
   Gateway,
   TextCompletionStream,
 } from "@ibm-cloud/watsonx-ai/gateway";
-import {
-  checkValidProps,
-  expectOneOf,
-  initWatsonxOrGatewayInstance,
-} from "../utils/ibm.js";
+import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
 import {
   GenerationInfo,
   ResponseChunk,
@@ -35,6 +31,7 @@ import {
   WatsonxLLMBasicOptions,
   XOR,
 } from "../types.js";
+import {  initWatsonxOrGatewayInstance } from "../utils/ibm.js";
 
 export interface WatsonxLLMParams {
   maxNewTokens?: number;
@@ -175,48 +172,14 @@ export class WatsonxLLM<
 
   protected gateway?: Gateway;
 
+  private validator = new PropertyValidator();
+
   private checkValidProperties(
     fields:
       | WatsonxLLMConstructor
       | XOR<Partial<WatsonxLLMParams>, Partial<WatsonxLLMGatewayParams>>,
     includeCommonProps = true
   ) {
-    const authProps = [
-      "serviceUrl",
-      "watsonxAIApikey",
-      "watsonxAIBearerToken",
-      "watsonxAIUsername",
-      "watsonxAIPassword",
-      "watsonxAIUrl",
-      "watsonxAIAuthType",
-      "disableSSL",
-      "apiKey",
-      "bearerToken",
-      "username",
-      "password",
-      "authType",
-      "authUrl",
-    ];
-
-    const sharedProps = [
-      "maxRetries",
-      "watsonxCallbacks",
-      "authenticator",
-      "serviceUrl",
-      "version",
-      "streaming",
-      "callbackManager",
-      "callbacks",
-      "maxConcurrency",
-      "cache",
-      "metadata",
-      "concurrency",
-      "onFailedAttempt",
-      "concurrency",
-      "verbose",
-      "tags",
-    ];
-
     const gatewayProps = [
       "temperature",
       "topP",
@@ -250,17 +213,22 @@ export class WatsonxLLM<
       "includeStopSequence",
     ];
 
-    const validProps: string[] = [];
-    if (includeCommonProps) validProps.push(...authProps, ...sharedProps);
-
+    let modeProps: string[] = [];
     if (this.modelGateway) {
-      validProps.push(...gatewayProps);
+      modeProps = gatewayProps;
     } else if (this.idOrName) {
-      validProps.push(...deploymentProps);
+      modeProps = deploymentProps;
     } else if (this.spaceId || this.projectId) {
-      validProps.push(...projectOrSpaceProps);
+      modeProps = projectOrSpaceProps;
     }
-    checkValidProps(fields, validProps);
+
+    this.validator.validateByMode(
+      fields as Record<string, unknown>,
+      modeProps,
+      {
+        includeCommon: includeCommonProps,
+      }
+    );  
   }
 
   constructor(fields: WatsonxLLMConstructor) {
@@ -274,6 +242,14 @@ export class WatsonxLLM<
     this.projectId = fields?.projectId;
     this.modelGateway = fields.modelGateway || this.modelGateway;
     this.spaceId = fields?.spaceId;
+
+    if (this.modelGateway) {
+      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
+    } else if (this.idOrName) {
+      checkRequiredProps(fields, ["serviceUrl", "version"]);
+    } else {
+      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
+    }
 
     this.checkValidProperties(fields);
 

--- a/libs/providers/langchain-ibm/src/llms/ibm.ts
+++ b/libs/providers/langchain-ibm/src/llms/ibm.ts
@@ -22,11 +22,9 @@ import {
   TextCompletionStream,
 } from "@ibm-cloud/watsonx-ai/gateway";
 import {
-  authenticateAndSetGatewayInstance,
-  authenticateAndSetInstance,
-  checkRequiredProps,
   checkValidProps,
   expectOneOf,
+  initWatsonxOrGatewayInstance,
 } from "../utils/ibm.js";
 import {
   GenerationInfo,
@@ -277,14 +275,6 @@ export class WatsonxLLM<
     this.modelGateway = fields.modelGateway || this.modelGateway;
     this.spaceId = fields?.spaceId;
 
-    if (this.modelGateway) {
-      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
-    } else if (this.idOrName) {
-      checkRequiredProps(fields, ["serviceUrl", "version"]);
-    } else {
-      checkRequiredProps(fields, ["model", "serviceUrl", "version"]);
-    }
-
     this.checkValidProperties(fields);
 
     this.model = fields.model ?? this.model;
@@ -315,52 +305,10 @@ export class WatsonxLLM<
     this.streaming = fields.streaming || this.streaming;
     this.watsonxCallbacks = fields.watsonxCallbacks || this.watsonxCallbacks;
 
-    const {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    } = fields;
-
-    const authData = {
-      watsonxAIApikey,
-      watsonxAIAuthType,
-      watsonxAIBearerToken,
-      watsonxAIUsername,
-      watsonxAIPassword,
-      watsonxAIUrl,
-      disableSSL,
-      version,
-      serviceUrl,
-      apiKey,
-      bearerToken,
-      username,
-      password,
-      authType,
-      authUrl,
-    };
-
     if (this.modelGateway) {
-      const gateway = authenticateAndSetGatewayInstance(authData);
-
-      if (gateway) this.gateway = gateway;
-      else throw new Error("You have not provided any type of authentication");
+      this.gateway = initWatsonxOrGatewayInstance(fields, true);
     } else {
-      const service = authenticateAndSetInstance(authData);
-
-      if (service) this.service = service;
-      else throw new Error("You have not provided any type of authentication");
+      this.service = initWatsonxOrGatewayInstance(fields);
     }
   }
 

--- a/libs/providers/langchain-ibm/src/llms/ibm.ts
+++ b/libs/providers/langchain-ibm/src/llms/ibm.ts
@@ -192,6 +192,12 @@ export class WatsonxLLM<
       "watsonxAIUrl",
       "watsonxAIAuthType",
       "disableSSL",
+      "apiKey",
+      "bearerToken",
+      "username",
+      "password",
+      "authType",
+      "authUrl",
     ];
 
     const sharedProps = [
@@ -319,6 +325,12 @@ export class WatsonxLLM<
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     } = fields;
 
     const authData = {
@@ -331,6 +343,12 @@ export class WatsonxLLM<
       disableSSL,
       version,
       serviceUrl,
+      apiKey,
+      bearerToken,
+      username,
+      password,
+      authType,
+      authUrl,
     };
 
     if (this.modelGateway) {
@@ -357,6 +375,11 @@ export class WatsonxLLM<
       watsonxAIUsername: "WATSONX_AI_USERNAME",
       watsonxAIPassword: "WATSONX_AI_PASSWORD",
       watsonxAIUrl: "WATSONX_AI_URL",
+      authUrl: "WATSONX_AI_URL",
+      bearerToken: "WATSONX_AI_BEARER_TOKEN",
+      username: "WATSONX_AI_USERNAME",
+      password: "WATSONX_AI_PASSWORD",
+      authType: "WATSONX_AI_AUTH_TYPE",
     };
   }
 
@@ -371,6 +394,11 @@ export class WatsonxLLM<
       watsonxAIUsername: "watsonx_ai_username",
       watsonxAIPassword: "watsonx_ai_password",
       watsonxAIUrl: "watsonx_ai_url",
+      authUrl: "watsonx_ai_url",
+      bearerToken: "watsonx_ai_bearer_token",
+      username: "watsonx_ai_username",
+      password: "watsonx_ai_password",
+      authType: "watsonx_ai_auth_type",
     };
   }
 

--- a/libs/providers/langchain-ibm/src/llms/ibm.ts
+++ b/libs/providers/langchain-ibm/src/llms/ibm.ts
@@ -21,7 +21,11 @@ import {
   Gateway,
   TextCompletionStream,
 } from "@ibm-cloud/watsonx-ai/gateway";
-import { PropertyValidator, checkRequiredProps, expectOneOf } from "../utils/validation.js";
+import {
+  PropertyValidator,
+  checkRequiredProps,
+  expectOneOf,
+} from "../utils/validation.js";
 import {
   GenerationInfo,
   ResponseChunk,
@@ -31,7 +35,7 @@ import {
   WatsonxLLMBasicOptions,
   XOR,
 } from "../types.js";
-import {  initWatsonxOrGatewayInstance } from "../utils/ibm.js";
+import { initWatsonxOrGatewayInstance } from "../utils/ibm.js";
 
 export interface WatsonxLLMParams {
   maxNewTokens?: number;
@@ -172,8 +176,6 @@ export class WatsonxLLM<
 
   protected gateway?: Gateway;
 
-  private validator = new PropertyValidator();
-
   private checkValidProperties(
     fields:
       | WatsonxLLMConstructor
@@ -222,13 +224,11 @@ export class WatsonxLLM<
       modeProps = projectOrSpaceProps;
     }
 
-    this.validator.validateByMode(
+    PropertyValidator.validateByMode(
       fields as Record<string, unknown>,
       modeProps,
-      {
-        includeCommon: includeCommonProps,
-      }
-    );  
+      includeCommonProps
+    );
   }
 
   constructor(fields: WatsonxLLMConstructor) {

--- a/libs/providers/langchain-ibm/src/llms/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/llms/tests/ibm.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@ibm-cloud/watsonx-ai";
 import { IterableReadableStream } from "@langchain/core/utils/stream";
 import { WatsonxLLM, WatsonxInputLLM, WatsonxLLMConstructor } from "../ibm.js";
-import { authenticateAndSetInstance } from "../../utils/ibm.js";
+import { initWatsonxOrGatewayInstance } from "../../utils/ibm.js";
 import {
   WatsonxEmbeddings,
   WatsonxEmbeddingsConstructor,
@@ -71,7 +71,7 @@ export const testProperties = (
 describe("LLM unit tests", () => {
   describe("Positive tests with default mode", () => {
     test("Test authentication function", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         ...fakeAuthProp,

--- a/libs/providers/langchain-ibm/src/types.ts
+++ b/libs/providers/langchain-ibm/src/types.ts
@@ -26,6 +26,13 @@ export interface WatsonxAuth {
   watsonxAIAuthType?: string;
   disableSSL?: boolean;
   serviceUrl: string;
+  // new fields
+  apiKey?: string;
+  bearerToken?: string;
+  username?: string;
+  password?: string;
+  authType?: string;
+  authUrl?: string;
 }
 
 export interface WatsonxInit {

--- a/libs/providers/langchain-ibm/src/types.ts
+++ b/libs/providers/langchain-ibm/src/types.ts
@@ -3,7 +3,6 @@ import { ChatsToolChoice } from "@ibm-cloud/watsonx-ai/gateway";
 import { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
 import { BaseLLMParams } from "@langchain/core/language_models/llms";
 
-
 /**
  * Utility type that makes all properties of T optional and never.
  * Useful for creating mutually exclusive type unions.

--- a/libs/providers/langchain-ibm/src/types.ts
+++ b/libs/providers/langchain-ibm/src/types.ts
@@ -3,6 +3,11 @@ import { ChatsToolChoice } from "@ibm-cloud/watsonx-ai/gateway";
 import { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
 import { BaseLLMParams } from "@langchain/core/language_models/llms";
 
+
+/**
+ * Utility type that makes all properties of T optional and never.
+ * Useful for creating mutually exclusive type unions.
+ */
 export type Neverify<T> = {
   [K in keyof T]?: never;
 };

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -21,6 +21,7 @@ import {
 } from "@langchain/core/utils/types";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
 import { WatsonxAuth, WatsonxInit } from "../types.js";
+import { AWSAuthenticator } from "@ibm-cloud/watsonx-ai/authentication";
 
 const createAuthenticator = ({
   watsonxAIApikey,
@@ -32,81 +33,45 @@ const createAuthenticator = ({
   disableSSL,
   serviceUrl,
 }: WatsonxAuth): Authenticator | undefined => {
-  if (watsonxAIAuthType === "iam" && watsonxAIApikey) {
-    return new IamAuthenticator({
-      apikey: watsonxAIApikey,
-    });
-  } else if (watsonxAIAuthType === "bearertoken" && watsonxAIBearerToken) {
-    return new BearerTokenAuthenticator({
-      bearerToken: watsonxAIBearerToken,
-    });
-  } else if (watsonxAIAuthType === "cp4d") {
-    if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-      const watsonxCPDAuthUrl = watsonxAIUrl ?? serviceUrl;
-      return new CloudPakForDataAuthenticator({
-        username: watsonxAIUsername,
-        password: watsonxAIPassword,
-        url: watsonxCPDAuthUrl.concat("/icp4d-api/v1/authorize"),
-        apikey: watsonxAIApikey,
-        disableSslVerification: disableSSL,
-      });
-    }
-  }
-  return undefined;
-};
-
-export const authenticateAndSetInstance = ({
-  watsonxAIApikey,
-  watsonxAIAuthType,
-  watsonxAIBearerToken,
-  watsonxAIUsername,
-  watsonxAIPassword,
-  watsonxAIUrl,
-  disableSSL,
-  version,
-  serviceUrl,
-}: WatsonxAuth & Omit<WatsonxInit, "authenticator">): WatsonXAI | undefined => {
-  if (watsonxAIAuthType === "iam" && watsonxAIApikey) {
-    return WatsonXAI.newInstance({
-      version,
-      serviceUrl,
-      authenticator: new IamAuthenticator({
-        apikey: watsonxAIApikey,
-      }),
-    });
-  } else if (watsonxAIAuthType === "bearertoken" && watsonxAIBearerToken) {
-    return WatsonXAI.newInstance({
-      version,
-      serviceUrl,
-      authenticator: new BearerTokenAuthenticator({
-        bearerToken: watsonxAIBearerToken,
-      }),
-    });
-  } else if (watsonxAIAuthType === "cp4d") {
-    if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-      const watsonxCPDAuthUrl = watsonxAIUrl ?? serviceUrl;
-      return WatsonXAI.newInstance({
-        version,
-        serviceUrl,
-        disableSslVerification: disableSSL,
-        authenticator: new CloudPakForDataAuthenticator({
+  switch (watsonxAIAuthType) {
+    case "iam":
+      if (watsonxAIApikey)
+        return new IamAuthenticator({
+          apikey: watsonxAIApikey,
+        });
+      throw new Error("ApiKey is required for IAM auth");
+    case "bearertoken":
+      if (watsonxAIBearerToken)
+        return new BearerTokenAuthenticator({
+          bearerToken: watsonxAIBearerToken,
+        });
+      throw new Error("BearerToken is required for BearerToken auth");
+    case "cp4d":
+      if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
+        const watsonxCPDAuthUrl = watsonxAIUrl ?? serviceUrl;
+        return new CloudPakForDataAuthenticator({
           username: watsonxAIUsername,
           password: watsonxAIPassword,
           url: watsonxCPDAuthUrl.concat("/icp4d-api/v1/authorize"),
           apikey: watsonxAIApikey,
           disableSslVerification: disableSSL,
-        }),
+        });
+      }
+      throw new Error(
+        "Username and Password or ApiKey is required for IBM watsonx.ai software auth",
+      );
+    case "aws":
+      return new AWSAuthenticator({
+        apikey: watsonxAIApikey,
+        url: watsonxAIUrl,
+        disableSslVerification: disableSSL,
       });
-    }
-  } else
-    return WatsonXAI.newInstance({
-      version,
-      serviceUrl,
-    });
-  return undefined;
+    default:
+      return undefined;
+  }
 };
 
-export function authenticateAndSetGatewayInstance({
+const prepareInstanceConfig = ({
   watsonxAIApikey,
   watsonxAIAuthType,
   watsonxAIBearerToken,
@@ -116,23 +81,42 @@ export function authenticateAndSetGatewayInstance({
   disableSSL,
   version,
   serviceUrl,
-}: WatsonxAuth & Omit<WatsonxInit, "authenticator">) {
+  apiKey,
+  bearerToken,
+  username,
+  password,
+  authType,
+  authUrl,
+}: WatsonxAuth & Omit<WatsonxInit, "authenticator">) => {
+  const isIam =
+    (watsonxAIApikey || apiKey) && !watsonxAIUsername ? "iam" : undefined;
   const authenticator = createAuthenticator({
-    watsonxAIApikey,
-    watsonxAIAuthType,
-    watsonxAIBearerToken,
-    watsonxAIUsername,
-    watsonxAIPassword,
-    watsonxAIUrl,
+    watsonxAIApikey: watsonxAIApikey ?? apiKey,
+    watsonxAIAuthType: watsonxAIAuthType ?? authType ?? isIam,
+    watsonxAIBearerToken: watsonxAIBearerToken ?? bearerToken,
+    watsonxAIUsername: watsonxAIUsername ?? username,
+    watsonxAIPassword: watsonxAIPassword ?? password,
+    watsonxAIUrl: watsonxAIUrl ?? authUrl,
     disableSSL,
     serviceUrl,
   });
-
-  return new Gateway({
+  return {
     version,
     serviceUrl,
-    authenticator,
-  });
+    ...(authenticator ? { authenticator } : {}),
+  };
+};
+
+export const authenticateAndSetInstance = (
+  params: WatsonxAuth & Omit<WatsonxInit, "authenticator">,
+) => {
+  return new WatsonXAI(prepareInstanceConfig(params));
+};
+
+export function authenticateAndSetGatewayInstance(
+  params: WatsonxAuth & Omit<WatsonxInit, "authenticator">,
+) {
+  return new Gateway(prepareInstanceConfig(params));
 }
 
 const TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9]{9}$/;

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -58,7 +58,7 @@ const createAuthenticator = ({
         });
       }
       throw new Error(
-        "Username and Password or ApiKey is required for IBM watsonx.ai software auth",
+        "Username and Password or ApiKey is required for IBM watsonx.ai software auth"
       );
     case "aws":
       return new AWSAuthenticator({
@@ -107,16 +107,31 @@ const prepareInstanceConfig = ({
   };
 };
 
-export const authenticateAndSetInstance = (
+/**
+ * Initializes and returns a WatsonX AI or Gateway instance with authentication.
+ *
+ * @param params - Initialization and authentication parameters
+ * @param useGateway - If true, returns Gateway instance; otherwise returns WatsonXAI instance
+ * @returns Configured WatsonXAI or Gateway instance
+ */
+export function initWatsonxOrGatewayInstance(
   params: WatsonxAuth & Omit<WatsonxInit, "authenticator">,
-) => {
-  return new WatsonXAI(prepareInstanceConfig(params));
-};
-
-export function authenticateAndSetGatewayInstance(
+  useGateway: true
+): Gateway;
+export function initWatsonxOrGatewayInstance(
   params: WatsonxAuth & Omit<WatsonxInit, "authenticator">,
-) {
-  return new Gateway(prepareInstanceConfig(params));
+  useGateway?: false
+): WatsonXAI;
+export function initWatsonxOrGatewayInstance(
+  params: WatsonxAuth & Omit<WatsonxInit, "authenticator">,
+  useGateway = false
+): WatsonXAI | Gateway {
+  const config = prepareInstanceConfig(params);
+  try {
+    return useGateway ? new Gateway(config) : new WatsonXAI(config);
+  } catch (_e) {
+    throw new Error("You have not provided any type of authentication");
+  }
 }
 
 const TOOL_CALL_ID_PATTERN = /^[a-zA-Z0-9]{9}$/;

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -1,12 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import {
-  IamAuthenticator,
-  BearerTokenAuthenticator,
-  CloudPakForDataAuthenticator,
-  Authenticator,
-} from "ibm-cloud-sdk-core";
-import {
   JsonOutputKeyToolsParserParamsInterop,
   JsonOutputToolsParser,
 } from "@langchain/core/output_parsers/openai_tools";
@@ -20,95 +14,15 @@ import {
   interopSafeParseAsync,
 } from "@langchain/core/utils/types";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import { WatsonxAuth, WatsonxInit } from "../types.js";
-import { AWSAuthenticator } from "@ibm-cloud/watsonx-ai/authentication";
-
-const createAuthenticator = ({
-  watsonxAIApikey,
-  watsonxAIAuthType,
-  watsonxAIBearerToken,
-  watsonxAIUsername,
-  watsonxAIPassword,
-  watsonxAIUrl,
-  disableSSL,
-  serviceUrl,
-}: WatsonxAuth): Authenticator | undefined => {
-  switch (watsonxAIAuthType) {
-    case "iam":
-      if (watsonxAIApikey)
-        return new IamAuthenticator({
-          apikey: watsonxAIApikey,
-        });
-      throw new Error("ApiKey is required for IAM auth");
-    case "bearertoken":
-      if (watsonxAIBearerToken)
-        return new BearerTokenAuthenticator({
-          bearerToken: watsonxAIBearerToken,
-        });
-      throw new Error("BearerToken is required for BearerToken auth");
-    case "cp4d":
-      if (watsonxAIUsername && (watsonxAIPassword || watsonxAIApikey)) {
-        const watsonxCPDAuthUrl = watsonxAIUrl ?? serviceUrl;
-        return new CloudPakForDataAuthenticator({
-          username: watsonxAIUsername,
-          password: watsonxAIPassword,
-          url: watsonxCPDAuthUrl.concat("/icp4d-api/v1/authorize"),
-          apikey: watsonxAIApikey,
-          disableSslVerification: disableSSL,
-        });
-      }
-      throw new Error(
-        "Username and Password or ApiKey is required for IBM watsonx.ai software auth"
-      );
-    case "aws":
-      return new AWSAuthenticator({
-        apikey: watsonxAIApikey,
-        url: watsonxAIUrl,
-        disableSslVerification: disableSSL,
-      });
-    default:
-      return undefined;
-  }
-};
-
-const prepareInstanceConfig = ({
-  watsonxAIApikey,
-  watsonxAIAuthType,
-  watsonxAIBearerToken,
-  watsonxAIUsername,
-  watsonxAIPassword,
-  watsonxAIUrl,
-  disableSSL,
-  version,
-  serviceUrl,
-  apiKey,
-  bearerToken,
-  username,
-  password,
-  authType,
-  authUrl,
-}: WatsonxAuth & Omit<WatsonxInit, "authenticator">) => {
-  const isIam =
-    (watsonxAIApikey || apiKey) && !watsonxAIUsername ? "iam" : undefined;
-  const authenticator = createAuthenticator({
-    watsonxAIApikey: watsonxAIApikey ?? apiKey,
-    watsonxAIAuthType: watsonxAIAuthType ?? authType ?? isIam,
-    watsonxAIBearerToken: watsonxAIBearerToken ?? bearerToken,
-    watsonxAIUsername: watsonxAIUsername ?? username,
-    watsonxAIPassword: watsonxAIPassword ?? password,
-    watsonxAIUrl: watsonxAIUrl ?? authUrl,
-    disableSSL,
-    serviceUrl,
-  });
-  return {
-    version,
-    serviceUrl,
-    ...(authenticator ? { authenticator } : {}),
-  };
-};
+import {
+  WatsonxAuth,
+  WatsonxInit,
+} from "../types.js";
+import { prepareInstanceConfig } from "../auth/config.js";
 
 /**
  * Initializes and returns a WatsonX AI or Gateway instance with authentication.
+ *
  *
  * @param params - Initialization and authentication parameters
  * @param useGateway - If true, returns Gateway instance; otherwise returns WatsonXAI instance

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -363,15 +363,3 @@ export const checkValidProps = (
     );
   }
 };
-
-export const checkRequiredProps = (
-  params: Record<string, any>,
-  requiredKeys: string[]
-) => {
-  const missing = requiredKeys.filter(
-    (key) => !(key in params) || params[key] === undefined
-  );
-  if (missing.length > 0) {
-    throw new Error(`Missing required properties: ${missing.join(", ")}.`);
-  }
-};

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -14,11 +14,9 @@ import {
   interopSafeParseAsync,
 } from "@langchain/core/utils/types";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import {
-  WatsonxAuth,
-  WatsonxInit,
-} from "../types.js";
+import { WatsonxAuth, WatsonxInit } from "../types.js";
 import { prepareInstanceConfig } from "../auth/config.js";
+export { checkValidProps, expectOneOf } from "./validation.js";
 
 /**
  * Initializes and returns a WatsonX AI or Gateway instance with authentication.
@@ -242,38 +240,3 @@ export function jsonSchemaToZod(obj: WatsonXAI.JsonObject | undefined) {
   }
   throw new Error("Unsupported root schema type");
 }
-
-export const expectOneOf = (
-  params: Record<string, any>,
-  keys: string[],
-  exactlyOneOf = false
-) => {
-  const provided = keys.filter(
-    (key) => key in params && params[key] !== undefined
-  );
-  if (exactlyOneOf && provided.length !== 1) {
-    throw new Error(
-      `Expected exactly one of: ${keys.join(", ")}. Got: ${provided.join(", ")}`
-    );
-  } else if (!exactlyOneOf && provided.length > 1) {
-    throw new Error(
-      `Expected one of: ${keys.join(", ")} or none. Got: ${provided.join(", ")}`
-    );
-  }
-};
-
-export const checkValidProps = (
-  params: Record<string, any>,
-  allowedKeys: string[]
-) => {
-  const unexpected = Object.keys(params).filter(
-    (key) => !allowedKeys.includes(key)
-  );
-  if (unexpected.length > 0) {
-    throw new Error(
-      `Unexpected properties: ${unexpected.join(
-        ", "
-      )}. Expected only: ${allowedKeys.join(", ")}.`
-    );
-  }
-};

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -404,7 +404,7 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
       const authenticator = instance["authenticator"];
       expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
-      expect(authenticator.url).toBe(`${serviceUrl}/icp4d-api/v1/authorize`);
+      expect(authenticator.url).toBe(`${serviceUrl}icp4d-api/v1/authorize`);
     });
 
     test("uses authUrl as alternative to watsonxAIUrl", () => {

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -1,6 +1,11 @@
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import { describe, test, expect } from "vitest";
+import {
+  IamAuthenticator,
+  BearerTokenAuthenticator,
+  CloudPakForDataAuthenticator,
+} from "ibm-cloud-sdk-core";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
   authenticateAndSetInstance,
   authenticateAndSetGatewayInstance,
@@ -58,13 +63,492 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetInstance with cp4d auth returns undefined without credentials", () => {
+    test("authenticateAndSetGatewayInstance with bearer token", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "bearertoken",
+        watsonxAIBearerToken: "fake_token",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+    });
+
+    test("authenticateAndSetGatewayInstance with cp4d auth", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+    });
+  });
+
+  describe("Authentication with alternative prop names", () => {
+    test("authenticateAndSetInstance with apiKey instead of watsonxAIApikey", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "iam",
+        apiKey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetInstance with apiKey instead of watsonxAIApikey and 'iam' as default authType", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        apiKey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetInstance with bearerToken instead of watsonxAIBearerToken", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "bearertoken",
+        bearerToken: "fake_token",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetInstance with username/password instead of watsonxAI prefixed", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "cp4d",
+        username: "user",
+        password: "pass",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetGatewayInstance with alternative prop names", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "iam",
+        apiKey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+    });
+  });
+
+  describe("Authentication fallback to environment variables", () => {
+    test("authenticateAndSetInstance without explicit auth creates instance (env fallback)", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetGatewayInstance without explicit auth creates instance (env fallback)", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+      });
+
+      expect(instance).toBeInstanceOf(Gateway);
+    });
+  });
+
+  describe("Authenticator type verification", () => {
+    test("creates IamAuthenticator when authType is 'iam' with apiKey", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "iam",
+        watsonxAIApikey: "fake_key",
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    });
+
+    test("creates BearerTokenAuthenticator when authType is 'bearertoken'", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "bearertoken",
+        watsonxAIBearerToken: "fake_token",
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(BearerTokenAuthenticator);
+    });
+
+    test("creates CloudPakForDataAuthenticator when authType is 'cp4d' with username and password", () => {
       const instance = authenticateAndSetInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
       });
-      expect(instance).toBeUndefined();
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+    });
+
+    test("creates CloudPakForDataAuthenticator when authType is 'cp4d' with username and apikey", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIApikey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+    });
+
+    test("creates IamAuthenticator with alternative prop names (apiKey)", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "iam",
+        apiKey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    });
+
+    test("creates BearerTokenAuthenticator with alternative prop names (bearerToken)", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "bearertoken",
+        bearerToken: "fake_token",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(BearerTokenAuthenticator);
+    });
+
+    test("creates CloudPakForDataAuthenticator with alternative prop names (username/password)", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        username: "user",
+        password: "pass",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+    });
+
+    test("defaults to 'iam' authType when only apiKey is provided", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        apiKey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    });
+
+    test("Gateway instance creates IamAuthenticator", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "iam",
+        watsonxAIApikey: "fake_key",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(IamAuthenticator);
+    });
+
+    test("Gateway instance creates BearerTokenAuthenticator", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "bearertoken",
+        watsonxAIBearerToken: "fake_token",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(BearerTokenAuthenticator);
+    });
+
+    test("Gateway instance creates CloudPakForDataAuthenticator", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+    });
+  });
+
+  describe("Environment variable fallback behavior", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      // Reset environment before each test
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      // Restore original environment
+      process.env = originalEnv;
+    });
+
+    test("falls back to environment variables when no auth params provided", () => {
+      // Set environment variables that the IBM SDK would use
+      process.env.WATSONX_AI_APIKEY = "env_api_key";
+
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      // When no authenticator is explicitly provided, SDK uses env vars
+      // The instance should still be created successfully
+    });
+
+    test("explicit params override environment variables", () => {
+      // Set environment variables
+      process.env.WATSONX_AI_APIKEY = "env_api_key";
+
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "iam",
+        watsonxAIApikey: "explicit_key",
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(IamAuthenticator);
+      expect(authenticator.apikey).toBe("explicit_key");
+    });
+
+    test("creates instance when no explicit credentials provided (relies on SDK env fallback)", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+  });
+
+  describe("CP4D authentication with custom URL", () => {
+    test("uses watsonxAIUrl for CP4D authentication URL", () => {
+      const customUrl = "https://custom.cp4d.url";
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+        watsonxAIUrl: customUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+      expect(authenticator.url).toBe(`${customUrl}/icp4d-api/v1/authorize`);
+    });
+
+    test("falls back to serviceUrl for CP4D authentication URL when watsonxAIUrl not provided", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+      expect(authenticator.url).toBe(`${serviceUrl}/icp4d-api/v1/authorize`);
+    });
+
+    test("uses authUrl as alternative to watsonxAIUrl", () => {
+      const customUrl = "https://custom.auth.url";
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        username: "user",
+        password: "pass",
+        authUrl: customUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+      expect(authenticator.url).toBe(`${customUrl}/icp4d-api/v1/authorize`);
+    });
+
+    test("watsonxAIUrl takes precedence over authUrl", () => {
+      const primaryUrl = "https://primary.url";
+      const fallbackUrl = "https://fallback.url";
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+        watsonxAIUrl: primaryUrl,
+        authUrl: fallbackUrl,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+      expect(authenticator.url).toBe(`${primaryUrl}/icp4d-api/v1/authorize`);
+    });
+
+    test("CP4D with disableSSL option", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "cp4d",
+        watsonxAIUsername: "user",
+        watsonxAIPassword: "pass",
+        disableSSL: true,
+      });
+
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
+      expect(authenticator.disableSslVerification).toBe(true);
+    });
+  });
+
+  describe("Invalid authentication configurations", () => {
+    test("IAM without apikey throws error", () => {
+      expect(() => {
+        authenticateAndSetInstance({
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "iam",
+        });
+      }).toThrow(/ApiKey is required for IAM auth/);
+    });
+
+    test("bearertoken without token throws error", () => {
+      expect(() => {
+        authenticateAndSetInstance({
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "bearertoken",
+        });
+      }).toThrow(/BearerToken is required for BearerToken auth/);
+    });
+
+    test("CP4D without username throws error", () => {
+      expect(() => {
+        authenticateAndSetInstance({
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "cp4d",
+          watsonxAIPassword: "pass",
+        });
+      }).toThrow(/Username and Password or ApiKey is required/);
+    });
+
+    test("CP4D without password or apikey throws error", () => {
+      expect(() => {
+        authenticateAndSetInstance({
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "cp4d",
+          watsonxAIUsername: "user",
+        });
+      }).toThrow(/Username and Password or ApiKey is required/);
+    });
+
+    test("CP4D with username but no password or apikey throws error", () => {
+      expect(() => {
+        authenticateAndSetInstance({
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "cp4d",
+          watsonxAIUsername: "user",
+        });
+      }).toThrow(/Username and Password or ApiKey is required/);
+    });
+  });
+
+  describe("AWS authentication", () => {
+    test("creates AWS authenticator with apikey and url", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "aws",
+        watsonxAIApikey: "fake_key",
+        watsonxAIUrl: "https://aws.url",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeDefined();
+      // AWS authenticator is a custom type from the SDK
+      expect(authenticator.constructor.name).toBe("AWSAuthenticator");
+    });
+
+    test("creates AWS authenticator with alternative prop names", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        authType: "aws",
+        apiKey: "fake_key",
+        authUrl: "https://aws.url",
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeDefined();
+      expect(authenticator.constructor.name).toBe("AWSAuthenticator");
+    });
+
+    test("AWS authenticator with disableSSL option", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "aws",
+        watsonxAIApikey: "fake_key",
+        watsonxAIUrl: "https://aws.url",
+        disableSSL: true,
+      });
+      expect(instance).toBeInstanceOf(WatsonXAI);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeDefined();
+      expect(authenticator.disableSslVerification).toBe(true);
+    });
+
+    test("Gateway instance creates AWS authenticator", () => {
+      const instance = authenticateAndSetGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        watsonxAIAuthType: "aws",
+        watsonxAIApikey: "fake_key",
+        watsonxAIUrl: "https://aws.url",
+      });
+      expect(instance).toBeInstanceOf(Gateway);
+      const authenticator = instance["authenticator"];
+      expect(authenticator).toBeDefined();
+      expect(authenticator.constructor.name).toBe("AWSAuthenticator");
     });
   });
 

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -7,13 +7,12 @@ import {
 } from "ibm-cloud-sdk-core";
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import {
-  authenticateAndSetInstance,
-  authenticateAndSetGatewayInstance,
   _isValidMistralToolCallId,
   _convertToolCallIdToMistralCompatible,
   jsonSchemaToZod,
   expectOneOf,
   checkValidProps,
+  initWatsonxOrGatewayInstance,
 } from "../ibm.js";
 
 const fakeAuthProp = {
@@ -24,8 +23,8 @@ const serviceUrl = "https://fake.url/";
 
 describe("Utils tests", () => {
   describe("Authentication", () => {
-    test("authenticateAndSetInstance creates WatsonXAI with IAM", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance creates WatsonXAI with IAM", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         ...fakeAuthProp,
@@ -33,17 +32,20 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetGatewayInstance creates Gateway with IAM", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        ...fakeAuthProp,
-      });
+    test("initWatsonxOrGatewayInstance creates Gateway with IAM", () => {
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          ...fakeAuthProp,
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
     });
 
-    test("authenticateAndSetInstance with bearer token", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with bearer token", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "bearertoken",
@@ -52,8 +54,8 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetInstance with cp4d auth", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with cp4d auth", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -63,31 +65,37 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetGatewayInstance with bearer token", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "bearertoken",
-        watsonxAIBearerToken: "fake_token",
-      });
+    test("initWatsonxOrGatewayInstance Gateway with bearer token", () => {
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "bearertoken",
+          watsonxAIBearerToken: "fake_token",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
     });
 
-    test("authenticateAndSetGatewayInstance with cp4d auth", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "cp4d",
-        watsonxAIUsername: "user",
-        watsonxAIPassword: "pass",
-      });
+    test("initWatsonxOrGatewayInstance Gateway with cp4d auth", () => {
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "cp4d",
+          watsonxAIUsername: "user",
+          watsonxAIPassword: "pass",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
     });
   });
 
   describe("Authentication with alternative prop names", () => {
-    test("authenticateAndSetInstance with apiKey instead of watsonxAIApikey", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with apiKey instead of watsonxAIApikey", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         authType: "iam",
@@ -96,8 +104,8 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetInstance with apiKey instead of watsonxAIApikey and 'iam' as default authType", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with apiKey instead of watsonxAIApikey and 'iam' as default authType", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         apiKey: "fake_key",
@@ -105,8 +113,8 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetInstance with bearerToken instead of watsonxAIBearerToken", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with bearerToken instead of watsonxAIBearerToken", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         authType: "bearertoken",
@@ -115,8 +123,8 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetInstance with username/password instead of watsonxAI prefixed", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance with username/password instead of watsonxAI prefixed", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         authType: "cp4d",
@@ -126,20 +134,23 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetGatewayInstance with alternative prop names", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        authType: "iam",
-        apiKey: "fake_key",
-      });
+    test("initWatsonxOrGatewayInstance Gateway with alternative prop names", () => {
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          authType: "iam",
+          apiKey: "fake_key",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
     });
   });
 
   describe("Authentication fallback to environment variables", () => {
-    test("authenticateAndSetInstance without explicit auth creates instance (env fallback)", () => {
-      const instance = authenticateAndSetInstance({
+    test("initWatsonxOrGatewayInstance without explicit auth creates instance (env fallback)", () => {
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
       });
@@ -147,11 +158,14 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(WatsonXAI);
     });
 
-    test("authenticateAndSetGatewayInstance without explicit auth creates instance (env fallback)", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-      });
+    test("initWatsonxOrGatewayInstance Gateway without explicit auth creates instance (env fallback)", () => {
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+        },
+        true
+      );
 
       expect(instance).toBeInstanceOf(Gateway);
     });
@@ -159,7 +173,7 @@ describe("Utils tests", () => {
 
   describe("Authenticator type verification", () => {
     test("creates IamAuthenticator when authType is 'iam' with apiKey", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "iam",
@@ -172,7 +186,7 @@ describe("Utils tests", () => {
     });
 
     test("creates BearerTokenAuthenticator when authType is 'bearertoken'", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "bearertoken",
@@ -185,7 +199,7 @@ describe("Utils tests", () => {
     });
 
     test("creates CloudPakForDataAuthenticator when authType is 'cp4d' with username and password", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -199,7 +213,7 @@ describe("Utils tests", () => {
     });
 
     test("creates CloudPakForDataAuthenticator when authType is 'cp4d' with username and apikey", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -212,7 +226,7 @@ describe("Utils tests", () => {
     });
 
     test("creates IamAuthenticator with alternative prop names (apiKey)", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         authType: "iam",
@@ -224,7 +238,7 @@ describe("Utils tests", () => {
     });
 
     test("creates BearerTokenAuthenticator with alternative prop names (bearerToken)", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "bearertoken",
@@ -236,7 +250,7 @@ describe("Utils tests", () => {
     });
 
     test("creates CloudPakForDataAuthenticator with alternative prop names (username/password)", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -249,7 +263,7 @@ describe("Utils tests", () => {
     });
 
     test("defaults to 'iam' authType when only apiKey is provided", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         apiKey: "fake_key",
@@ -260,37 +274,46 @@ describe("Utils tests", () => {
     });
 
     test("Gateway instance creates IamAuthenticator", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "iam",
-        watsonxAIApikey: "fake_key",
-      });
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "iam",
+          watsonxAIApikey: "fake_key",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
       const authenticator = instance["authenticator"];
       expect(authenticator).toBeInstanceOf(IamAuthenticator);
     });
 
     test("Gateway instance creates BearerTokenAuthenticator", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "bearertoken",
-        watsonxAIBearerToken: "fake_token",
-      });
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "bearertoken",
+          watsonxAIBearerToken: "fake_token",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
       const authenticator = instance["authenticator"];
       expect(authenticator).toBeInstanceOf(BearerTokenAuthenticator);
     });
 
     test("Gateway instance creates CloudPakForDataAuthenticator", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "cp4d",
-        watsonxAIUsername: "user",
-        watsonxAIPassword: "pass",
-      });
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "cp4d",
+          watsonxAIUsername: "user",
+          watsonxAIPassword: "pass",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
       const authenticator = instance["authenticator"];
       expect(authenticator).toBeInstanceOf(CloudPakForDataAuthenticator);
@@ -314,7 +337,7 @@ describe("Utils tests", () => {
       // Set environment variables that the IBM SDK would use
       process.env.WATSONX_AI_APIKEY = "env_api_key";
 
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
       });
@@ -328,7 +351,7 @@ describe("Utils tests", () => {
       // Set environment variables
       process.env.WATSONX_AI_APIKEY = "env_api_key";
 
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "iam",
@@ -342,7 +365,7 @@ describe("Utils tests", () => {
     });
 
     test("creates instance when no explicit credentials provided (relies on SDK env fallback)", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
       });
@@ -354,7 +377,7 @@ describe("Utils tests", () => {
   describe("CP4D authentication with custom URL", () => {
     test("uses watsonxAIUrl for CP4D authentication URL", () => {
       const customUrl = "https://custom.cp4d.url";
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -370,7 +393,7 @@ describe("Utils tests", () => {
     });
 
     test("falls back to serviceUrl for CP4D authentication URL when watsonxAIUrl not provided", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -386,7 +409,7 @@ describe("Utils tests", () => {
 
     test("uses authUrl as alternative to watsonxAIUrl", () => {
       const customUrl = "https://custom.auth.url";
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -404,7 +427,7 @@ describe("Utils tests", () => {
     test("watsonxAIUrl takes precedence over authUrl", () => {
       const primaryUrl = "https://primary.url";
       const fallbackUrl = "https://fallback.url";
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -421,7 +444,7 @@ describe("Utils tests", () => {
     });
 
     test("CP4D with disableSSL option", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "cp4d",
@@ -440,7 +463,7 @@ describe("Utils tests", () => {
   describe("Invalid authentication configurations", () => {
     test("IAM without apikey throws error", () => {
       expect(() => {
-        authenticateAndSetInstance({
+        initWatsonxOrGatewayInstance({
           version: "2024-05-31",
           serviceUrl,
           watsonxAIAuthType: "iam",
@@ -450,7 +473,7 @@ describe("Utils tests", () => {
 
     test("bearertoken without token throws error", () => {
       expect(() => {
-        authenticateAndSetInstance({
+        initWatsonxOrGatewayInstance({
           version: "2024-05-31",
           serviceUrl,
           watsonxAIAuthType: "bearertoken",
@@ -460,7 +483,7 @@ describe("Utils tests", () => {
 
     test("CP4D without username throws error", () => {
       expect(() => {
-        authenticateAndSetInstance({
+        initWatsonxOrGatewayInstance({
           version: "2024-05-31",
           serviceUrl,
           watsonxAIAuthType: "cp4d",
@@ -471,7 +494,7 @@ describe("Utils tests", () => {
 
     test("CP4D without password or apikey throws error", () => {
       expect(() => {
-        authenticateAndSetInstance({
+        initWatsonxOrGatewayInstance({
           version: "2024-05-31",
           serviceUrl,
           watsonxAIAuthType: "cp4d",
@@ -482,7 +505,7 @@ describe("Utils tests", () => {
 
     test("CP4D with username but no password or apikey throws error", () => {
       expect(() => {
-        authenticateAndSetInstance({
+        initWatsonxOrGatewayInstance({
           version: "2024-05-31",
           serviceUrl,
           watsonxAIAuthType: "cp4d",
@@ -494,7 +517,7 @@ describe("Utils tests", () => {
 
   describe("AWS authentication", () => {
     test("creates AWS authenticator with apikey and url", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "aws",
@@ -509,7 +532,7 @@ describe("Utils tests", () => {
     });
 
     test("creates AWS authenticator with alternative prop names", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         authType: "aws",
@@ -523,7 +546,7 @@ describe("Utils tests", () => {
     });
 
     test("AWS authenticator with disableSSL option", () => {
-      const instance = authenticateAndSetInstance({
+      const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",
         serviceUrl,
         watsonxAIAuthType: "aws",
@@ -538,13 +561,16 @@ describe("Utils tests", () => {
     });
 
     test("Gateway instance creates AWS authenticator", () => {
-      const instance = authenticateAndSetGatewayInstance({
-        version: "2024-05-31",
-        serviceUrl,
-        watsonxAIAuthType: "aws",
-        watsonxAIApikey: "fake_key",
-        watsonxAIUrl: "https://aws.url",
-      });
+      const instance = initWatsonxOrGatewayInstance(
+        {
+          version: "2024-05-31",
+          serviceUrl,
+          watsonxAIAuthType: "aws",
+          watsonxAIApikey: "fake_key",
+          watsonxAIUrl: "https://aws.url",
+        },
+        true
+      );
       expect(instance).toBeInstanceOf(Gateway);
       const authenticator = instance["authenticator"];
       expect(authenticator).toBeDefined();

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -44,6 +44,32 @@ describe("Utils tests", () => {
       expect(instance).toBeInstanceOf(Gateway);
     });
 
+    test("authenticateAndSetInstance IAM forwards watsonxAIUrl to IamAuthenticator", () => {
+      const privateIamUrl = "https://private.iam.cloud.ibm.com";
+      const instance = initWatsonxOrGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        ...fakeAuthProp,
+        watsonxAIUrl: privateIamUrl,
+      });
+      expect(instance).toBeDefined();
+      const auth = instance?.["authenticator"] as IamAuthenticator;
+      const tokenManagerUrl = auth["tokenManager"]["url"];
+      expect(tokenManagerUrl).toBe(privateIamUrl);
+    });
+
+    test("authenticateAndSetInstance IAM uses default IAM URL when watsonxAIUrl is absent", () => {
+      const instance = initWatsonxOrGatewayInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        ...fakeAuthProp,
+      })!;
+      expect(instance).toBeDefined();
+      const auth = instance?.["authenticator"] as IamAuthenticator;
+      const tokenManagerUrl = auth["tokenManager"]["url"];
+      expect(tokenManagerUrl).toBe("https://iam.cloud.ibm.com");
+    });
+
     test("initWatsonxOrGatewayInstance with bearer token", () => {
       const instance = initWatsonxOrGatewayInstance({
         version: "2024-05-31",

--- a/libs/providers/langchain-ibm/src/utils/validation.ts
+++ b/libs/providers/langchain-ibm/src/utils/validation.ts
@@ -1,0 +1,224 @@
+/**
+ * Validation utilities for IBM watsonx.ai parameters
+ * @module utils/validation
+ */
+
+/* oxlint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Shared property validator for IBM watsonx.ai configurations.
+ * Provides centralized validation logic for common patterns.
+ *
+ * @example
+ * ```typescript
+ * const validator = new PropertyValidator();
+ *
+ * // Validate that only allowed properties are present
+ * validator.checkAllowed(
+ *   { model: "granite", temperature: 0.7 },
+ *   ["model", "temperature", "maxTokens"]
+ * );
+ *
+ * // Validate exactly one of multiple options
+ * validator.expectExactlyOne(
+ *   { projectId: "123" },
+ *   ["projectId", "spaceId"]
+ * );
+ *
+ * // Validate at most one of multiple options
+ * validator.expectAtMostOne(
+ *   { projectId: "123" },
+ *   ["projectId", "spaceId", "idOrName"]
+ * );
+ * ```
+ */
+export class PropertyValidator {
+  private static readonly ALWAYS_ALLOWED = ["headers", "signal", "promptIndex"];
+  private static readonly AUTH_PROPS = [
+    "serviceUrl",
+    "apiKey",
+    "bearerToken",
+    "username",
+    "password",
+    "authType",
+    "authUrl",
+    "disableSSL",
+    // Legacy props
+    "watsonxAIApikey",
+    "watsonxAIBearerToken",
+    "watsonxAIUsername",
+    "watsonxAIPassword",
+    "watsonxAIUrl",
+    "watsonxAIAuthType",
+  ];
+
+  private static readonly SHARED_PROPS = [
+    "maxRetries",
+    "watsonxCallbacks",
+    "authenticator",
+    "serviceUrl",
+    "version",
+    "streaming",
+    "callbackManager",
+    "callbacks",
+    "maxConcurrency",
+    "cache",
+    "metadata",
+    "concurrency",
+    "onFailedAttempt",
+    "verbose",
+    "tags",
+    "headers",
+    "signal",
+    "disableStreaming",
+    "timeout",
+    "stopSequences",
+  ];
+
+  /**
+   * Validates properties based on deployment mode (gateway, deployment, or project/space).
+   * This method automatically determines which properties are allowed based on the mode.
+   *
+   * @param fields - The object to validate
+   * @param modeProps - Properties specific to the current deployment mode
+   * @param options - Validation options
+   * @throws {Error} If unexpected properties are found
+   *
+   * @example
+   * ```typescript
+   * // For gateway mode
+   * validator.validateByMode(
+   *   fields,
+   *   ["model", "modelGateway", "modelGatewayKwargs"],
+   *   { includeCommon: true }
+   * );
+   *
+   * // For project/space mode
+   * validator.validateByMode(
+   *   fields,
+   *   ["projectId", "spaceId", "model", "temperature"],
+   *   { includeCommon: true }
+   * );
+   * ```
+   */
+  validateByMode(
+    fields: Record<string, unknown>,
+    modeProps: string[],
+    options: { includeCommon?: boolean } = {}
+  ): void {
+    const { includeCommon = true } = options;
+
+    const allowed = [
+      ...modeProps,
+      ...(includeCommon
+        ? [
+            ...PropertyValidator.ALWAYS_ALLOWED,
+            ...PropertyValidator.AUTH_PROPS,
+            ...PropertyValidator.SHARED_PROPS,
+          ]
+        : []),
+    ];
+
+    checkValidProps(fields, allowed);
+  }
+}
+
+/**
+ * Validates that exactly one or at most one of the specified keys is provided.
+ *
+ * @param params - The parameters object to validate
+ * @param keys - Array of key names to check
+ * @param exactlyOneOf - If true, requires exactly one key; if false, allows zero or one key
+ * @throws {Error} If validation fails
+ *
+ * @example
+ * ```typescript
+ * // Require exactly one of projectId or spaceId
+ * expectOneOf({ projectId: "123" }, ["projectId", "spaceId"], true);
+ *
+ * // Allow at most one of projectId or spaceId
+ * expectOneOf({ projectId: "123" }, ["projectId", "spaceId"], false);
+ * ```
+ */
+export function expectOneOf(
+  params: Record<string, any>,
+  keys: string[],
+  exactlyOneOf = false
+): void {
+  const provided = keys.filter(
+    (key) => key in params && params[key] !== undefined
+  );
+
+  if (exactlyOneOf && provided.length !== 1) {
+    throw new Error(
+      `Expected exactly one of: ${keys.join(", ")}. Got: ${provided.join(", ")}`
+    );
+  }
+
+  if (!exactlyOneOf && provided.length > 1) {
+    throw new Error(
+      `Expected one of: ${keys.join(", ")} or none. Got: ${provided.join(", ")}`
+    );
+  }
+}
+
+/**
+ * Validates that only allowed properties are present in the parameters object.
+ *
+ * @param params - The parameters object to validate
+ * @param allowedKeys - Array of allowed key names
+ * @throws {Error} If unexpected properties are found
+ *
+ * @example
+ * ```typescript
+ * checkValidProps(
+ *   { model: "granite", temperature: 0.7 },
+ *   ["model", "temperature", "maxTokens"]
+ * );
+ * ```
+ */
+export function checkValidProps(
+  params: Record<string, any>,
+  allowedKeys: string[]
+): void {
+  const unexpected = Object.keys(params).filter(
+    (key) => !allowedKeys.includes(key)
+  );
+
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Unexpected properties: ${unexpected.join(", ")}. Expected only: ${allowedKeys.join(", ")}.`
+    );
+  }
+}
+
+/**
+ * Validates that all required properties are present and not undefined or null.
+ *
+ * @param params - The parameters object to validate
+ * @param requiredKeys - Array of required property names
+ * @throws {WatsonxValidationError} If any required properties are missing or null/undefined
+ *
+ * @example
+ * ```typescript
+ * checkRequiredProps(
+ *   { model: "granite", serviceUrl: "https://api.example.com" },
+ *   ["model", "serviceUrl", "version"]
+ * );
+ * // Throws: Missing required properties: version.
+ * ```
+ */
+export function checkRequiredProps(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Record<string, any>,
+  requiredKeys: string[]
+): void {
+  const missing = requiredKeys.filter(
+    (key) => !(key in params) || params[key] === undefined || params[key] === null
+  );
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required properties: ${missing.join(", ")}.`
+    );
+  }
+}

--- a/libs/providers/langchain-ibm/src/utils/validation.ts
+++ b/libs/providers/langchain-ibm/src/utils/validation.ts
@@ -100,13 +100,11 @@ export class PropertyValidator {
    * );
    * ```
    */
-  validateByMode(
+  static validateByMode(
     fields: Record<string, unknown>,
     modeProps: string[],
-    options: { includeCommon?: boolean } = {}
+    includeCommon = true
   ): void {
-    const { includeCommon = true } = options;
-
     const allowed = [
       ...modeProps,
       ...(includeCommon
@@ -213,12 +211,11 @@ export function checkRequiredProps(
   requiredKeys: string[]
 ): void {
   const missing = requiredKeys.filter(
-    (key) => !(key in params) || params[key] === undefined || params[key] === null
+    (key) =>
+      !(key in params) || params[key] === undefined || params[key] === null
   );
 
   if (missing.length > 0) {
-    throw new Error(
-      `Missing required properties: ${missing.join(", ")}.`
-    );
+    throw new Error(`Missing required properties: ${missing.join(", ")}.`);
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Refactor: Extract Authentication and Validation into Separate Modules (langchain-ibm)

This PR restructures the internal architecture of the @langchain/ibm provider package by breaking up the monolithic [utils/ibm.ts](vscode-webview://0uspb7cuqnol0qssj2iom7qta9o4ekc8sd7ght11q5g5mfdkhvbe/libs/providers/langchain-ibm/src/utils/ibm.ts) file into focused, single-responsibility modules.

Key Changes
1. New auth/ module — Authentication logic is extracted into two dedicated files:
[auth/authenticator.ts](vscode-webview://0uspb7cuqnol0qssj2iom7qta9o4ekc8sd7ght11q5g5mfdkhvbe/libs/providers/langchain-ibm/src/auth/authenticator.ts): A createAuthenticator() factory that creates the appropriate IBM SDK authenticator (IAM, BearerToken, CP4D, AWS) based on config.
[auth/config.ts](vscode-webview://0uspb7cuqnol0qssj2iom7qta9o4ekc8sd7ght11q5g5mfdkhvbe/libs/providers/langchain-ibm/src/auth/config.ts): A prepareInstanceConfig() helper that normalises legacy vs. new property names and assembles the final instance config.

2. New utils/validation.ts — Validation utilities (checkValidProps, checkRequiredProps, expectOneOf) and a new PropertyValidator class with centralised, mode-aware validation logic are extracted here from ibm.ts.

3. Unified instance initialisation — The two separate authenticateAndSetInstance / authenticateAndSetGatewayInstance functions in ibm.ts are replaced by a single overloaded initWatsonxOrGatewayInstance().

4. New shorthand credential properties — WatsonxAuth gains shorter aliases (apiKey, bearerToken, username, password, authType, authUrl) alongside the existing watsonxAI* legacy names, with matching env-var mappings added to all model classes.

5. Expanded test coverage — utils/tests/ibm.test.ts grows significantly (+540 lines) to cover the new validation and auth logic.