### PR TITLE
fix(classic): yield final output from AgentExecutor.stream() when a tool has returnDirect

### DIFF
--- a/.changeset/wise-agents-return.md
+++ b/.changeset/wise-agents-return.md
@@ -1,0 +1,5 @@
+---
+"@langchain/classic": patch
+---
+
+fix(classic): yield final output from AgentExecutor.stream() when a tool has returnDirect

--- a/libs/langchain-classic/src/agents/executor.ts
+++ b/libs/langchain-classic/src/agents/executor.ts
@@ -205,6 +205,12 @@ export class AgentExecutorIterator
   /**
    * Process the output of the next step,
    * handling AgentFinish and tool return cases.
+   *
+   * When the step resolves to an `AgentFinish`, or the single executed tool
+   * has `returnDirect` set, the final output is stored and returned
+   * immediately so it is yielded to stream consumers as the last chunk.
+   * Otherwise the step is wrapped in `{ intermediateSteps }` and iteration
+   * continues.
    */
   async _processNextStepOutput(
     nextStepOutput: AgentFinish | AgentStep[],

--- a/libs/langchain-classic/src/agents/executor.ts
+++ b/libs/langchain-classic/src/agents/executor.ts
@@ -239,6 +239,7 @@ export class AgentExecutorIterator
         );
         await this.runManager?.handleChainEnd(output);
         await this.setFinalOutputs(output);
+        return output;
       }
     }
     output = { intermediateSteps: nextStepOutput as AgentStep[] };

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -1,0 +1,37 @@
+import { AgentAction } from "@langchain/core/agents";
+import { RunnableLambda } from "@langchain/core/runnables";
+import { DynamicTool } from "@langchain/core/tools";
+import { AgentExecutor } from "../executor.js";
+import { RunnableSingleActionAgent } from "../agent.js";
+
+// Regression test for https://github.com/langchain-ai/langchainjs/issues/11222
+test.fails("stream() yields the final output when a tool has returnDirect", async () => {
+  const agent = new RunnableSingleActionAgent({
+    runnable: RunnableLambda.from(
+      async (): Promise<AgentAction> => ({
+        tool: "lookup",
+        toolInput: "answer",
+        log: "Invoking lookup",
+      })
+    ),
+    streamRunnable: false,
+  });
+  const tool = new DynamicTool({
+    name: "lookup",
+    description: "Look up the answer",
+    returnDirect: true,
+    func: async () => "the final answer is 42",
+  });
+  const executor = AgentExecutor.fromAgentAndTools({ agent, tools: [tool] });
+
+  const chunks: Record<string, unknown>[] = [];
+  for await (const chunk of await executor.stream({
+    input: "What is the answer?",
+  })) {
+    chunks.push(chunk);
+  }
+
+  expect(
+    chunks.some((chunk) => chunk.output === "the final answer is 42")
+  ).toBe(true);
+});

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -5,7 +5,7 @@ import { AgentExecutor } from "../executor.js";
 import { RunnableSingleActionAgent } from "../agent.js";
 
 // Regression test for https://github.com/langchain-ai/langchainjs/issues/11222
-test.fails("stream() yields the final output when a tool has returnDirect", async () => {
+test("stream() yields the final output when a tool has returnDirect", async () => {
   const agent = new RunnableSingleActionAgent({
     runnable: RunnableLambda.from(
       async (): Promise<AgentAction> => ({

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -1,4 +1,4 @@
-import { AgentAction } from "@langchain/core/agents";
+import { AgentAction, AgentFinish, AgentStep } from "@langchain/core/agents";
 import { RunnableLambda } from "@langchain/core/runnables";
 import { DynamicTool } from "@langchain/core/tools";
 import { AgentExecutor } from "../executor.js";
@@ -34,4 +34,49 @@ test("stream() yields the final output when a tool has returnDirect", async () =
   expect(
     chunks.some((chunk) => chunk.output === "the final answer is 42")
   ).toBe(true);
+});
+
+test("stream() still yields intermediate steps for tools without returnDirect", async () => {
+  const agent = new RunnableSingleActionAgent({
+    runnable: RunnableLambda.from(
+      async (input: {
+        steps: AgentStep[];
+      }): Promise<AgentAction | AgentFinish> => {
+        if (input.steps.length === 0) {
+          return {
+            tool: "lookup",
+            toolInput: "answer",
+            log: "Invoking lookup",
+          };
+        }
+        return {
+          returnValues: { output: "final answer from the agent" },
+          log: "Finishing",
+        };
+      }
+    ),
+    streamRunnable: false,
+  });
+  const tool = new DynamicTool({
+    name: "lookup",
+    description: "Look up the answer",
+    returnDirect: false,
+    func: async () => "an intermediate observation",
+  });
+  const executor = AgentExecutor.fromAgentAndTools({ agent, tools: [tool] });
+
+  const chunks: Record<string, unknown>[] = [];
+  for await (const chunk of await executor.stream({
+    input: "What is the answer?",
+  })) {
+    chunks.push(chunk);
+  }
+
+  expect(chunks).toHaveLength(2);
+  const [stepChunk, finalChunk] = chunks;
+  expect(stepChunk.intermediateSteps).toHaveLength(1);
+  expect(
+    (stepChunk.intermediateSteps as AgentStep[])[0].observation
+  ).toEqual("an intermediate observation");
+  expect(finalChunk.output).toEqual("final answer from the agent");
 });

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -36,6 +36,43 @@ test("stream() yields the final output when a tool has returnDirect", async () =
   ).toBe(true);
 });
 
+test("stream() final chunk matches invoke() output for returnDirect tools", async () => {
+  const makeExecutor = () => {
+    const agent = new RunnableSingleActionAgent({
+      runnable: RunnableLambda.from(
+        async (): Promise<AgentAction> => ({
+          tool: "lookup",
+          toolInput: "answer",
+          log: "Invoking lookup",
+        })
+      ),
+      streamRunnable: false,
+    });
+    const tool = new DynamicTool({
+      name: "lookup",
+      description: "Look up the answer",
+      returnDirect: true,
+      func: async () => "the final answer is 42",
+    });
+    return AgentExecutor.fromAgentAndTools({ agent, tools: [tool] });
+  };
+
+  const invokeResult = await makeExecutor().invoke({
+    input: "What is the answer?",
+  });
+
+  const chunks: Record<string, unknown>[] = [];
+  for await (const chunk of await makeExecutor().stream({
+    input: "What is the answer?",
+  })) {
+    chunks.push(chunk);
+  }
+  const finalChunk = chunks[chunks.length - 1];
+
+  expect(finalChunk.output).toEqual(invokeResult.output);
+  expect(finalChunk.output).toEqual("the final answer is 42");
+});
+
 test("stream() still yields intermediate steps for tools without returnDirect", async () => {
   const agent = new RunnableSingleActionAgent({
     runnable: RunnableLambda.from(

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -112,8 +112,8 @@ test("stream() still yields intermediate steps for tools without returnDirect", 
   expect(chunks).toHaveLength(2);
   const [stepChunk, finalChunk] = chunks;
   expect(stepChunk.intermediateSteps).toHaveLength(1);
-  expect(
-    (stepChunk.intermediateSteps as AgentStep[])[0].observation
-  ).toEqual("an intermediate observation");
+  expect((stepChunk.intermediateSteps as AgentStep[])[0].observation).toEqual(
+    "an intermediate observation"
+  );
   expect(finalChunk.output).toEqual("final answer from the agent");
 });


### PR DESCRIPTION
Fixes #11222

## Problem

When an `AgentExecutor` is consumed via `.stream()` and a tool has `returnDirect: true`, the final answer is never yielded. The async iteration ends with only intermediate-step chunks, while `.invoke()` returns the answer correctly.

## Root cause

In `AgentExecutorIterator._processNextStepOutput` (`libs/langchain-classic/src/agents/executor.ts`), the `returnDirect` branch computes the final output via `_return(...)` and stores it with `setFinalOutputs(output)`, but then falls through to the unconditional `output = { intermediateSteps: nextStepOutput }` assignment. The caller therefore receives the intermediate-steps chunk instead of the final answer. On the next `_callNext()`, the stored `finalOutputs` triggers the "Final outputs already reached" path in `streamIterator`, which `return`s (rather than yields) the value — and `for await...of` discards generator return values, so the answer is silently dropped.

## Fix

Return early in the `returnDirect` branch after storing the final output, mirroring the `AgentFinish` branch directly above it (and matching the Python implementation's behavior).

## Tests

New unit test file `libs/langchain-classic/src/agents/tests/executor.test.ts` (no API keys required, uses a fake `RunnableSingleActionAgent`):

- regression test reproducing #11222 — fails without the fix, passes with it (committed as `test.fails` first, then flipped in the fix commit so every commit stays green)
- parity test asserting the final `.stream()` chunk matches the `.invoke()` output for a `returnDirect` tool
- guard test asserting the normal (non-`returnDirect`) path still yields `{ intermediateSteps }` followed by the final output chunk

Also adds a `@langchain/classic` patch changeset and a JSDoc note on `_processNextStepOutput` documenting the short-circuit.