### PR TITLE
ci: cover missing Dependabot dependency roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,24 @@ updates:
         update-types:
           - "major"
 
+  # Docker — maintained local GitHub Action used by .github/workflows/people.yml.
+  - package-ecosystem: docker
+    directory: "/.github/actions/people"
+    schedule:
+      interval: monthly
+    groups:
+      docker-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      docker-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
   # npm — single workspace-aware entry.
   # This is a pnpm workspace (see pnpm-workspace.yaml) with one root
   # pnpm-lock.yaml. Dependabot must run from "/" so it discovers every


### PR DESCRIPTION
## Summary

- Add Dependabot Docker coverage for the maintained local GitHub Action under `.github/actions/people`.
- Keep existing GitHub Actions and root pnpm workspace coverage unchanged.

## Test Plan

- [x] Parse `.github/dependabot.yml` with Ruby YAML.
- [x] Run `git diff --check`.
- [x] Inspect the diff to confirm it only changes `.github/dependabot.yml`.