### PR TITLE
fix(vectorstores): correct MemoryVectorStore similarity sort comparator

### DIFF
--- a/libs/langchain-classic/src/vectorstores/memory.ts
+++ b/libs/langchain-classic/src/vectorstores/memory.ts
@@ -220,7 +220,7 @@ export class MemoryVectorStore extends VectorStore {
         embedding: vector.embedding,
         id: vector.id,
       }))
-      .sort((a, b) => (a.similarity > b.similarity ? -1 : 0))
+      .sort((a, b) => b.similarity - a.similarity)
       .slice(0, k);
   }
 


### PR DESCRIPTION
## Problem
`MemoryVectorStore.similaritySearchVectorWithScore` uses a broken sort comparator:

```ts
.sort((a, b) => (a.similarity > b.similarity ? -1 : 0))
```

When `a.similarity < b.similarity`, it returns `0` instead of a positive number. This violates the total order contract required by `Array.prototype.sort` (ECMAScript 2019+). V8's TimSort leaves such pairs in an implementation-defined order, producing incorrect top-k results on document sets with >= 8 entries (TimSort's threshold for non-trivial sorting).

## Fix
```ts
.sort((a, b) => b.similarity - a.similarity)
```

Subtraction gives a correct total order and is the conventional pattern for descending numeric sort.