### PR TITLE
fix(aws): handle unstamped tool call content blocks

### DIFF
--- a/.changeset/quick-tools-replay.md
+++ b/.changeset/quick-tools-replay.md
@@ -2,4 +2,4 @@
 "@langchain/aws": patch
 ---
 
-fix(aws): replay unstamped standard tool call content blocks
+fix(aws): replay unstamped standard tool calls and skip invalid tool calls

--- a/.changeset/quick-tools-replay.md
+++ b/.changeset/quick-tools-replay.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): replay unstamped standard tool call content blocks

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1006,6 +1006,27 @@ describe("unstamped tool call content replay", () => {
       { role: "assistant", content: [{ text: "hello" }] },
     ]);
   });
+
+  it("skips invalid tool calls without output version metadata", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          { type: "text", text: "before" },
+          {
+            type: "invalid_tool_call",
+            id: "tool-call-1",
+            name: "write_file",
+            args: '{"file_path":',
+            error: "Failed to parse tool call arguments as JSON",
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      { role: "assistant", content: [{ text: "before" }] },
+    ]);
+  });
 });
 
 test("Streaming supports empty string chunks", async () => {

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -932,6 +932,82 @@ describe("reasoning content replay", () => {
   });
 });
 
+describe("unstamped tool call content replay", () => {
+  const createToolCallContent = () => [
+    { type: "text", text: "before" },
+    {
+      type: "tool_call",
+      id: "tool-call-1",
+      name: "write_file",
+      args: { file_path: "/tmp/example.txt" },
+    },
+    { type: "text", text: "\n  " },
+    { type: "text", text: "after" },
+  ];
+  const expectedContent = [
+    { text: "before" },
+    {
+      toolUse: {
+        toolUseId: "tool-call-1",
+        name: "write_file",
+        input: { file_path: "/tmp/example.txt" },
+      },
+    },
+    { text: "after" },
+  ];
+
+  it("converts standard tool calls without output version metadata", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({ content: createToolCallContent() }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      { role: "assistant", content: expectedContent },
+    ]);
+  });
+
+  it("deduplicates only matching tool calls", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: createToolCallContent(),
+        tool_calls: [
+          {
+            id: "tool-call-1",
+            name: "write_file",
+            args: { file_path: "/tmp/example.txt" },
+          },
+          {
+            id: "tool-call-1",
+            name: "read_file",
+            args: { file_path: "/tmp/example.txt" },
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      ...expectedContent,
+      {
+        toolUse: {
+          toolUseId: "tool-call-1",
+          name: "read_file",
+          input: { file_path: "/tmp/example.txt" },
+        },
+      },
+    ]);
+  });
+
+  it("keeps text-only assistant content unchanged", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({ content: [{ type: "text", text: "hello" }] }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      { role: "assistant", content: [{ text: "hello" }] },
+    ]);
+  });
+});
+
 test("Streaming supports empty string chunks", async () => {
   const contentBlocks = [
     {

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -941,7 +941,6 @@ describe("unstamped tool call content replay", () => {
       name: "write_file",
       args: { file_path: "/tmp/example.txt" },
     },
-    { type: "text", text: "\n  " },
     { type: "text", text: "after" },
   ];
   const expectedContent = [
@@ -963,6 +962,37 @@ describe("unstamped tool call content replay", () => {
 
     expect(result.converseMessages).toEqual([
       { role: "assistant", content: expectedContent },
+    ]);
+  });
+
+  it("does not merge whitespace-only text into a preceding tool call", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          {
+            type: "tool_call",
+            id: "tool-call-1",
+            name: "write_file",
+            args: { file_path: "/tmp/example.txt" },
+          },
+          { type: "text", text: "\n  " },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            toolUse: {
+              toolUseId: "tool-call-1",
+              name: "write_file",
+              input: { file_path: "/tmp/example.txt" },
+            },
+          },
+        ],
+      },
     ]);
   });
 
@@ -997,6 +1027,23 @@ describe("unstamped tool call content replay", () => {
     ]);
   });
 
+  it("prefers inline content when mirrored tool call arguments disagree", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: createToolCallContent(),
+        tool_calls: [
+          {
+            id: "tool-call-1",
+            name: "write_file",
+            args: { file_path: "/tmp/stale.txt" },
+          },
+        ],
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual(expectedContent);
+  });
+
   it("keeps text-only assistant content unchanged", () => {
     const result = convertToConverseMessages([
       new AIMessage({ content: [{ type: "text", text: "hello" }] }),
@@ -1026,6 +1073,43 @@ describe("unstamped tool call content replay", () => {
     expect(result.converseMessages).toEqual([
       { role: "assistant", content: [{ text: "before" }] },
     ]);
+  });
+
+  it("rejects tool calls without an id before creating a Bedrock request", () => {
+    expect(() =>
+      convertToConverseMessages([
+        new AIMessage({
+          content: [
+            {
+              type: "tool_call",
+              name: "write_file",
+              args: { file_path: "/tmp/example.txt" },
+            },
+          ],
+        }),
+      ])
+    ).toThrow(
+      "Tool call content blocks must include a non-empty string id for Bedrock Converse."
+    );
+  });
+
+  it("rejects tool calls with a whitespace-only id", () => {
+    expect(() =>
+      convertToConverseMessages([
+        new AIMessage({
+          content: [
+            {
+              type: "tool_call",
+              id: "   ",
+              name: "write_file",
+              args: { file_path: "/tmp/example.txt" },
+            },
+          ],
+        }),
+      ])
+    ).toThrow(
+      "Tool call content blocks must include a non-empty string id for Bedrock Converse."
+    );
   });
 });
 

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -598,11 +598,9 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         // Merge whitespace/newlines with previous text blocks to avoid validation errors.
         const cleanedText = block.text?.replace(/\n/g, "").trim();
         if (cleanedText === "") {
-          if (contentBlocks.length > 0) {
-            const mergedTextContent = `${
-              contentBlocks[contentBlocks.length - 1].text
-            }${block.text}`;
-            contentBlocks[contentBlocks.length - 1].text = mergedTextContent;
+          const previousBlock = contentBlocks[contentBlocks.length - 1];
+          if (previousBlock?.text !== undefined) {
+            previousBlock.text = `${previousBlock.text}${block.text}`;
           }
         } else {
           contentBlocks.push({
@@ -620,6 +618,15 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         }
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push(convertCachePointBlock(block));
+      } else if (block.type === "tool_call") {
+        // Handle v1 tool call blocks whose output version metadata was lost.
+        contentBlocks.push({
+          toolUse: {
+            toolUseId: block.id,
+            name: block.name,
+            input: block.args,
+          },
+        });
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")
@@ -642,13 +649,24 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
   if (msg.tool_calls && msg.tool_calls.length) {
     assistantMsg.content = [
       ...(assistantMsg.content ? assistantMsg.content : []),
-      ...msg.tool_calls.map((tc) => ({
-        toolUse: {
-          toolUseId: tc.id,
-          name: tc.name,
-          input: tc.args,
-        },
-      })),
+      ...msg.tool_calls
+        .filter(
+          (tc) =>
+            !Array.isArray(msg.content) ||
+            !msg.content.some(
+              (block) =>
+                block.type === "tool_call" &&
+                block.id === tc.id &&
+                block.name === tc.name
+            )
+        )
+        .map((tc) => ({
+          toolUse: {
+            toolUseId: tc.id,
+            name: tc.name,
+            input: tc.args,
+          },
+        })),
     ];
   }
 

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -627,6 +627,8 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
             input: block.args,
           },
         });
+      } else if (block.type === "invalid_tool_call") {
+        // Match v1 conversion: invalid tool calls cannot be replayed.
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -629,6 +629,7 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         });
       } else if (block.type === "invalid_tool_call") {
         // Match v1 conversion: invalid tool calls cannot be replayed.
+        return;
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -619,6 +619,11 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push(convertCachePointBlock(block));
       } else if (block.type === "tool_call") {
+        if (typeof block.id !== "string" || block.id.trim().length === 0) {
+          throw new Error(
+            "Tool call content blocks must include a non-empty string id for Bedrock Converse."
+          );
+        }
         // Handle v1 tool call blocks whose output version metadata was lost.
         contentBlocks.push({
           toolUse: {


### PR DESCRIPTION
Fixes #11260

## Summary

- Replay standard `tool_call` content blocks when `response_metadata.output_version` is missing.
- Skip diagnostic `invalid_tool_call` blocks in the same unstamped path, matching the existing v1 converter.
- Preserve inline content order, avoid duplicate `toolUse` blocks when `tool_calls` mirrors content, and keep inline standard content canonical when mirrored arguments disagree.
- Keep whitespace-only text from corrupting a preceding non-text block and reject missing or blank tool-call IDs before constructing an invalid Bedrock request.

## Context

#9766 routes stamped v1 messages through the standard converter. Persisted or middleware-reconstructed histories can retain v1 `tool_call` or `invalid_tool_call` content blocks after the output-version metadata is lost. Those messages take the legacy branch and currently throw `Unsupported content block type` before a Bedrock request is sent.

Observed downstream in [langchain-ai/openwiki](https://github.com/langchain-ai/openwiki/blob/264ee8465f3c9874b822bcbb7ca68de471143798/src/agent/index.ts#L728-L741) during long Bedrock agent runs: small repositories completed, while large-repository history replay surfaced unstamped v1 content blocks.

This adds a consumer-side fallback only; it does not assume which component removed the metadata. Valid tool calls are replayed as `toolUse`; invalid tool calls remain diagnostic data and are skipped, as they already are in the stamped v1 conversion path.

## Minimal reproduction

```ts
const message = new AIMessage({
  content: [
    { type: "tool_call", id: "t1", name: "write_file", args: { a: 1 } },
  ],
});

convertToConverseMessages([message]);
```

On current `main`, conversion throws `Unsupported content block type: tool_call`. An unstamped `invalid_tool_call` block reaches the same throw. The expected behavior is to convert valid calls and skip invalid calls while preserving surrounding text. No AWS request or credentials are required to reproduce it.

## Validation

Validated with Node.js 24.18.0 and pnpm 10.14.0:

- `pnpm --filter @langchain/aws test` — 8 files, 133 tests, no type errors
- `pnpm --filter @langchain/aws build` — compile, attw, and publint passed
- `pnpm lint`
- `pnpm exec oxfmt --check .changeset/quick-tools-replay.md libs/providers/langchain-aws/src/tests/chat_models.test.ts libs/providers/langchain-aws/src/utils/message_inputs.ts`

The full monorepo pre-push suite was also attempted. It stops on three existing `@langchain/google` message-converter tests in untouched code; the failures reproduce with the required runtime while both `libs/providers/langchain-google` and `libs/langchain-core` match `upstream/main` exactly.
