### PR TITLE
feat(openai): support explicit prompt caching

### DIFF
--- a/.changeset/bright-caches-write.md
+++ b/.changeset/bright-caches-write.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": minor
+---
+
+feat(openai): support explicit prompt cache options, content breakpoints, and cache-write usage metadata

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -34,6 +34,7 @@ import {
   OpenAIVerbosityParam,
   type OpenAIApiKey,
   OpenAICacheRetentionParam,
+  OpenAIPromptCacheOptions,
 } from "../types.js";
 import {
   type OpenAIEndpointConfig,
@@ -214,6 +215,11 @@ export interface BaseChatOpenAICallOptions
   promptCacheRetention?: OpenAICacheRetentionParam;
 
   /**
+   * Options controlling OpenAI prompt cache behavior.
+   */
+  promptCacheOptions?: OpenAIPromptCacheOptions;
+
+  /**
    * The verbosity of the model's response.
    */
   verbosity?: OpenAIVerbosityParam;
@@ -337,6 +343,11 @@ export abstract class BaseChatOpenAI<
   promptCacheRetention?: OpenAICacheRetentionParam;
 
   /**
+   * Options controlling OpenAI prompt cache behavior.
+   */
+  promptCacheOptions?: OpenAIPromptCacheOptions;
+
+  /**
    * The verbosity of the model's response.
    */
   verbosity?: OpenAIVerbosityParam;
@@ -422,6 +433,7 @@ export abstract class BaseChatOpenAI<
       "reasoning",
       "promptCacheKey",
       "promptCacheRetention",
+      "promptCacheOptions",
       "verbosity",
     ];
   }
@@ -498,6 +510,8 @@ export abstract class BaseChatOpenAI<
     this.promptCacheKey = fields?.promptCacheKey ?? this.promptCacheKey;
     this.promptCacheRetention =
       fields?.promptCacheRetention ?? this.promptCacheRetention;
+    this.promptCacheOptions =
+      fields?.promptCacheOptions ?? this.promptCacheOptions;
     this.verbosity = fields?.verbosity ?? this.verbosity;
 
     this.disableStreaming = fields?.disableStreaming === true;

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -133,6 +133,8 @@ export class ChatOpenAICompletions<
       prompt_cache_key: options?.promptCacheKey ?? this.promptCacheKey,
       prompt_cache_retention:
         options?.promptCacheRetention ?? this.promptCacheRetention,
+      prompt_cache_options:
+        options?.promptCacheOptions ?? this.promptCacheOptions,
       verbosity: options?.verbosity ?? this.verbosity,
     };
     if (options?.prediction !== undefined) {

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -159,6 +159,8 @@ export class ChatOpenAIResponses<
       prompt_cache_key: options?.promptCacheKey ?? this.promptCacheKey,
       prompt_cache_retention:
         options?.promptCacheRetention ?? this.promptCacheRetention,
+      prompt_cache_options:
+        options?.promptCacheOptions ?? this.promptCacheOptions,
       ...(this.zdrEnabled ? { store: false } : {}),
       ...this.modelKwargs,
     };

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -14,6 +14,23 @@ import { NewTokenIndices } from "@langchain/core/callbacks/base";
 
 describe("ChatOpenAI", () => {
   describe("should initialize with correct values", () => {
+    it("forwards and overrides prompt cache options", () => {
+      const chat = new ChatOpenAI({
+        model: "gpt-5.6",
+        promptCacheOptions: { mode: "explicit", ttl: "30m" },
+      });
+
+      expect(chat.invocationParams().prompt_cache_options).toEqual({
+        mode: "explicit",
+        ttl: "30m",
+      });
+      expect(
+        chat.invocationParams({
+          promptCacheOptions: { mode: "implicit" },
+        }).prompt_cache_options
+      ).toEqual({ mode: "implicit" });
+    });
+
     it("supports string model shorthand", () => {
       const chat = new ChatOpenAI("gpt-4o-mini", { temperature: 0.2 });
       expect(chat.model).toBe("gpt-4o-mini");

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -40,6 +40,30 @@ import {
   messageToOpenAIRole,
 } from "../utils/misc.js";
 
+export function applyPromptCacheBreakpoint<T extends object>(
+  source: Record<string, unknown>,
+  target: T
+): T {
+  const extras = source.extras;
+  if ("prompt_cache_breakpoint" in source) {
+    return {
+      ...target,
+      prompt_cache_breakpoint: source.prompt_cache_breakpoint,
+    };
+  }
+  if (
+    typeof extras === "object" &&
+    extras !== null &&
+    "prompt_cache_breakpoint" in extras
+  ) {
+    return {
+      ...target,
+      prompt_cache_breakpoint: extras.prompt_cache_breakpoint,
+    };
+  }
+  return target;
+}
+
 /**
  * @deprecated This converter is an internal detail of the OpenAI provider. Do not use it directly. This will be revisited in a future release.
  */
@@ -802,10 +826,19 @@ export const convertMessagesToCompletionsMessageParams: Converter<
         ? message.content
         : message.content.flatMap((m) => {
             if (isDataContentBlock(m)) {
-              return convertToProviderContentBlock(
+              return applyPromptCacheBreakpoint(
                 m,
-                completionsApiContentBlockConverter
+                convertToProviderContentBlock(
+                  m,
+                  completionsApiContentBlockConverter
+                )
               );
+            }
+            if (m.type === "text") {
+              return applyPromptCacheBreakpoint(m, {
+                type: "text",
+                text: m.text,
+              });
             }
             // Drop content blocks the Chat Completions API rejects as input:
             //  - Tool-call blocks (`tool_use`, `tool_call`) are already

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -38,7 +38,10 @@ import {
   messageToOpenAIRole,
 } from "../utils/misc.js";
 import { Converter } from "@langchain/core/utils/format";
-import { completionsApiContentBlockConverter } from "./completions.js";
+import {
+  applyPromptCacheBreakpoint,
+  completionsApiContentBlockConverter,
+} from "./completions.js";
 
 const _FUNCTION_CALL_IDS_MAP_KEY = "__openai_function_call_ids__";
 const _CUSTOM_TOOL_CALL_IDS_MAP_KEY = "__openai_custom_tool_call_ids__";
@@ -263,7 +266,10 @@ export const convertResponsesUsageToUsageMetadata: Converter<
 > = (usage) => {
   const inputTokenDetails = {
     ...(usage?.input_tokens_details?.cached_tokens != null && {
-      cache_read: usage?.input_tokens_details?.cached_tokens,
+      cache_read: usage.input_tokens_details.cached_tokens,
+    }),
+    ...(usage?.input_tokens_details?.cache_write_tokens != null && {
+      cache_creation: usage.input_tokens_details.cache_write_tokens,
     }),
   };
   const outputTokenDetails = {
@@ -1684,38 +1690,41 @@ export const convertMessagesToResponsesInput: Converter<
             if (item.type === "file") {
               const filename = getFilenameFromMetadata(item);
               if (item.source_type === "url") {
-                return {
+                return applyPromptCacheBreakpoint(item, {
                   type: "input_file",
                   file_url: item.url,
                   ...(filename ? { filename } : {}),
-                };
+                });
               }
               if (item.source_type === "id") {
-                return {
+                return applyPromptCacheBreakpoint(item, {
                   type: "input_file",
                   file_id: item.id,
                   ...(filename ? { filename } : {}),
-                };
+                });
               }
               if (item.source_type === "base64") {
                 const mimeType = item.mime_type ?? "";
-                return {
+                return applyPromptCacheBreakpoint(item, {
                   type: "input_file",
                   file_data: `data:${mimeType};base64,${item.data}`,
                   filename: getRequiredFilenameFromMetadata(item),
-                };
+                });
               }
             }
-            return convertToProviderContentBlock(
+            return applyPromptCacheBreakpoint(
               item,
-              completionsApiContentBlockConverter
+              convertToProviderContentBlock(
+                item,
+                completionsApiContentBlockConverter
+              )
             );
           }
           if (item.type === "text") {
-            return {
+            return applyPromptCacheBreakpoint(item, {
               type: "input_text",
               text: item.text,
-            };
+            });
           }
           if (item.type === "image_url") {
             const imageUrl = iife(() => {
@@ -1742,11 +1751,11 @@ export const convertMessagesToResponsesInput: Converter<
               }
               return undefined;
             });
-            return {
+            return applyPromptCacheBreakpoint(item, {
               type: "input_image",
               image_url: imageUrl,
               detail,
-            };
+            });
           }
           if (
             item.type === "input_text" ||

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from "vitest";
 import { ChatCompletionMessage } from "openai/resources";
-import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from "@langchain/core/messages";
 import {
   completionsApiContentBlockConverter,
   convertCompletionsDeltaToBaseMessageChunk,
@@ -252,6 +256,44 @@ describe("convertCompletionsMessageToBaseMessage", () => {
   });
 
   describe("convertMessagesToCompletionsMessageParams", () => {
+    it("preserves prompt cache breakpoints and drops other extras", () => {
+      const message = new HumanMessage({
+        content: [
+          {
+            type: "text",
+            text: "Stable prefix",
+            extras: {
+              prompt_cache_breakpoint: { mode: "explicit" },
+              unsupported: true,
+            },
+          },
+          {
+            type: "image",
+            source_type: "url",
+            url: "https://example.com/image.png",
+            extras: { prompt_cache_breakpoint: null },
+          },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result[0].content).toEqual([
+        {
+          type: "text",
+          text: "Stable prefix",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+        {
+          type: "image_url",
+          image_url: { url: "https://example.com/image.png" },
+          prompt_cache_breakpoint: null,
+        },
+      ]);
+    });
+
     it("should preserve AIMessage content when tool_calls are present", () => {
       const message = new AIMessage({
         content:

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -27,6 +27,7 @@ describe("convertResponsesUsageToUsageMetadata", () => {
       total_tokens: 150,
       input_tokens_details: {
         cached_tokens: 75,
+        cache_write_tokens: 25,
         text_tokens: 25,
       },
       output_tokens_details: {
@@ -43,6 +44,7 @@ describe("convertResponsesUsageToUsageMetadata", () => {
       total_tokens: 150,
       input_token_details: {
         cache_read: 75,
+        cache_creation: 25,
       },
       output_token_details: {
         reasoning: 10,
@@ -1204,6 +1206,54 @@ describe("convertStandardContentMessageToResponsesInput (role-aware text parts)"
 });
 
 describe("convertMessagesToResponsesInput", () => {
+  it("preserves prompt cache breakpoints on converted content blocks", () => {
+    const message = new HumanMessage({
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          extras: { prompt_cache_breakpoint: { mode: "explicit" } },
+        },
+        {
+          type: "image_url",
+          image_url: { url: "https://example.com/image.png" },
+          prompt_cache_breakpoint: null,
+        },
+        {
+          type: "file",
+          source_type: "id",
+          id: "file_123",
+          extras: { prompt_cache_breakpoint: { mode: "explicit" } },
+        },
+      ],
+    });
+
+    const result = convertMessagesToResponsesInput({
+      messages: [message],
+      model: "gpt-5.6",
+      zdrEnabled: false,
+    });
+
+    expect((result[0] as any).content).toEqual([
+      {
+        type: "input_text",
+        text: "Stable prefix",
+        prompt_cache_breakpoint: { mode: "explicit" },
+      },
+      {
+        type: "input_image",
+        image_url: "https://example.com/image.png",
+        detail: undefined,
+        prompt_cache_breakpoint: null,
+      },
+      {
+        type: "input_file",
+        file_id: "file_123",
+        prompt_cache_breakpoint: { mode: "explicit" },
+      },
+    ]);
+  });
+
   describe("Regression Tests", () => {
     it("allows file_url without filename metadata and excludes filename from payload", () => {
       const messages = [

--- a/libs/providers/langchain-openai/src/types.ts
+++ b/libs/providers/langchain-openai/src/types.ts
@@ -24,6 +24,8 @@ export type OpenAIChatModelId =
 
 export type OpenAIVerbosityParam = "low" | "medium" | "high" | null;
 export type OpenAICacheRetentionParam = "in-memory" | "24h" | null;
+export type OpenAIPromptCacheOptions =
+  OpenAIClient.Responses.ResponseCreateParams["prompt_cache_options"];
 
 export type OpenAIApiKey = ClientOptions["apiKey"];
 
@@ -221,6 +223,11 @@ export interface OpenAIChatInput extends OpenAIBaseInput {
    * Used by OpenAI to set cache retention time
    */
   promptCacheRetention?: OpenAICacheRetentionParam;
+
+  /**
+   * Options controlling OpenAI prompt cache behavior.
+   */
+  promptCacheOptions?: OpenAIPromptCacheOptions;
 }
 
 export interface AzureOpenAIInput {


### PR DESCRIPTION
## Description
Ports langchain-ai/langchain#38762 to `@langchain/openai`, forwarding explicit prompt cache options through both OpenAI APIs, preserving content-block breakpoints, and exposing cache-write token usage.

## Test Plan
- [x] Verify model- and invocation-level cache option precedence
- [x] Verify text, image, and file breakpoint conversion, including null values
- [x] Verify cache-write usage maps to `cache_creation`

Made by [Open SWE](https://openswe.vercel.app/agents/6c6f35ee-9326-5f82-bc9e-44fa6572e80d)