### PR TITLE
fix(anthropic): preserve model metadata in streaming chunks

### DIFF
--- a/.changeset/fresh-anthropic-model.md
+++ b/.changeset/fresh-anthropic-model.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): preserve model response metadata in streaming chunks

--- a/libs/providers/langchain-anthropic/src/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models_stream_events.test.ts
@@ -299,6 +299,29 @@ describe("ChatAnthropic._streamChatModelEvents (native)", () => {
       ).toBe(25);
     });
 
+    test("streaming invoke preserves message_start model in response metadata", async () => {
+      const model = new MockStreamChatAnthropic(textOnlyEvents());
+      model.streaming = true;
+
+      const message = await model.invoke([new HumanMessage("hello")]);
+
+      expect(message.response_metadata).toMatchObject({
+        model_provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        usage: {},
+      });
+      expect(message.additional_kwargs).toMatchObject({
+        model: "claude-sonnet-4-20250514",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+      });
+      expect(message.usage_metadata).toMatchObject({
+        input_tokens: 25,
+        output_tokens: 2,
+        total_tokens: 27,
+      });
+    });
+
     test("text deltas accumulate correctly", async () => {
       const model = new MockStreamChatAnthropic(textOnlyEvents());
       const events: ChatModelStreamEvent[] = [];

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -36,6 +36,10 @@ export function _makeMessageChunkFromAnthropicEvent(
     const { input_tokens, output_tokens, ...rest }: Record<string, any> =
       usage ?? {};
     const usageMetadata = buildUsageMetadata(usage);
+    const model =
+      "model" in filteredAdditionalKwargs
+        ? { model: filteredAdditionalKwargs.model }
+        : {};
     return {
       chunk: new AIMessageChunk({
         content: fields.coerceContentToString ? "" : [],
@@ -43,6 +47,7 @@ export function _makeMessageChunkFromAnthropicEvent(
         usage_metadata: fields.streamUsage ? usageMetadata : undefined,
         response_metadata: {
           ...response_metadata,
+          ...model,
           usage: {
             ...rest,
           },

--- a/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/message_outputs.test.ts
@@ -35,6 +35,111 @@ describe("_makeMessageChunkFromAnthropicEvent", () => {
     expect(usage.input_token_details?.cache_read).toBe(1000);
   });
 
+  test("message_start model is preserved in response metadata after concat", () => {
+    const event = {
+      type: "message_start" as const,
+      message: {
+        id: "msg_01",
+        type: "message" as const,
+        role: "assistant" as const,
+        content: [],
+        model: "test-model-name",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+        },
+      },
+    };
+    const textDeltaEvent = {
+      type: "content_block_delta" as const,
+      index: 0,
+      delta: { type: "text_delta" as const, text: "Hello" },
+    };
+    const messageDeltaEvent = {
+      type: "message_delta" as const,
+      delta: { stop_reason: "end_turn" as const, stop_sequence: null },
+      usage: { output_tokens: 2 },
+    };
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const start = _makeMessageChunkFromAnthropicEvent(event as any, fields);
+    const textDelta = _makeMessageChunkFromAnthropicEvent(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      textDeltaEvent as any,
+      fields
+    );
+    const messageDelta = _makeMessageChunkFromAnthropicEvent(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      messageDeltaEvent as any,
+      fields
+    );
+
+    expect(start).not.toBeNull();
+    expect(textDelta).not.toBeNull();
+    expect(messageDelta).not.toBeNull();
+
+    expect(start!.chunk.response_metadata).toMatchObject({
+      model_provider: "anthropic",
+      model: "test-model-name",
+      usage: {},
+    });
+    expect(start!.chunk.additional_kwargs.model).toBe("test-model-name");
+
+    const finalMessage = start!.chunk
+      .concat(textDelta!.chunk)
+      .concat(messageDelta!.chunk);
+
+    expect(finalMessage.response_metadata).toMatchObject({
+      model_provider: "anthropic",
+      model: "test-model-name",
+      usage: {},
+    });
+    expect(finalMessage.additional_kwargs).toMatchObject({
+      id: "msg_01",
+      type: "message",
+      role: "assistant",
+      model: "test-model-name",
+      stop_reason: "end_turn",
+      stop_sequence: null,
+    });
+    expect(finalMessage.usage_metadata).toMatchObject({
+      input_tokens: 7,
+      output_tokens: 2,
+      total_tokens: 9,
+    });
+  });
+
+  test("message_start without model does not throw", () => {
+    const event = {
+      type: "message_start" as const,
+      message: {
+        id: "msg_01",
+        type: "message" as const,
+        role: "assistant" as const,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+        },
+      },
+    };
+    let result:
+      | ReturnType<typeof _makeMessageChunkFromAnthropicEvent>
+      | undefined;
+
+    expect(() => {
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      result = _makeMessageChunkFromAnthropicEvent(event as any, fields);
+    }).not.toThrow();
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+    expect(result!.chunk.response_metadata.model).toBeUndefined();
+  });
+
   test("message_delta chunk has input_tokens=0 and no cache token details", () => {
     const event = {
       type: "message_delta" as const,


### PR DESCRIPTION
Fixes #11230

This PR fixes Anthropic streaming responses losing the model name after streamed `AIMessageChunk`s are aggregated.

Anthropic sends the model name on the `message_start` streaming event. Previously, LangChain.js preserved that value in `additional_kwargs`, but did not copy it into `response_metadata`, so the final concatenated streamed message lacked `response_metadata.model`. Non-streaming Anthropic responses already include the model in `response_metadata`.

This change copies `message_start.message.model` into the first streamed chunk's `response_metadata.model` when Anthropic provides it, while preserving the existing `additional_kwargs` behavior.

Tests added:
- Verifies `message_start` creates an `AIMessageChunk` with `response_metadata.model`.
- Verifies concatenating multiple chunks preserves `response_metadata.model`.
- Verifies usage metadata and stop metadata are preserved.
- Verifies missing `model` in `message_start` does not throw.
- Verifies `ChatAnthropic` with `streaming = true` preserves model metadata through `invoke()`.

Checks run:
- Targeted regression tests for Anthropic streaming metadata passed.
- Anthropic package unit tests passed.
- Build completed successfully.