### PR TITLE
fix(langchain-ibm): allow passing custom auth url when authenticating via IAM

### DIFF
--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -72,7 +72,7 @@ export const authenticateAndSetInstance = ({
       serviceUrl,
       authenticator: new IamAuthenticator({
         apikey: watsonxAIApikey,
-        url: watsonxAIUrl
+        url: watsonxAIUrl,
       }),
     });
   } else if (watsonxAIAuthType === "bearertoken" && watsonxAIBearerToken) {

--- a/libs/providers/langchain-ibm/src/utils/ibm.ts
+++ b/libs/providers/langchain-ibm/src/utils/ibm.ts
@@ -72,6 +72,7 @@ export const authenticateAndSetInstance = ({
       serviceUrl,
       authenticator: new IamAuthenticator({
         apikey: watsonxAIApikey,
+        url: watsonxAIUrl
       }),
     });
   } else if (watsonxAIAuthType === "bearertoken" && watsonxAIBearerToken) {

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -37,9 +37,9 @@ describe("Utils tests", () => {
         ...fakeAuthProp,
         watsonxAIUrl: privateIamUrl,
       });
-      expect(instance).toBeDefined()
-      const auth = instance?.['authenticator'] as IamAuthenticator;
-      const tokenManagerUrl = auth['tokenManager']['url'];
+      expect(instance).toBeDefined();
+      const auth = instance?.["authenticator"] as IamAuthenticator;
+      const tokenManagerUrl = auth["tokenManager"]["url"];
       expect(tokenManagerUrl).toBe(privateIamUrl);
     });
 
@@ -49,8 +49,8 @@ describe("Utils tests", () => {
         serviceUrl,
         ...fakeAuthProp,
       })!;
-      const auth = instance?.['authenticator'] as IamAuthenticator;
-      const tokenManagerUrl = auth['tokenManager']['url'];
+      const auth = instance?.["authenticator"] as IamAuthenticator;
+      const tokenManagerUrl = auth["tokenManager"]["url"];
       expect(tokenManagerUrl).toBe("https://iam.cloud.ibm.com");
     });
 

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -1,5 +1,6 @@
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
+import { Authenticator, IamAuthenticator } from "ibm-cloud-sdk-core";
 import { describe, test, expect } from "vitest";
 import {
   authenticateAndSetInstance,
@@ -26,6 +27,34 @@ describe("Utils tests", () => {
         ...fakeAuthProp,
       });
       expect(instance).toBeInstanceOf(WatsonXAI);
+    });
+
+    test("authenticateAndSetInstance IAM forwards watsonxAIUrl to IamAuthenticator", () => {
+      const privateIamUrl = "https://private.iam.cloud.ibm.com";
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        ...fakeAuthProp,
+        watsonxAIUrl: privateIamUrl,
+      });
+      expect(instance).toBeDefined()
+      const auth = instance?.['authenticator'] as IamAuthenticator;
+      const tokenManagerUrl = auth['tokenManager']['url'];
+      expect(tokenManagerUrl).toBe(privateIamUrl);
+    });
+
+    test("authenticateAndSetInstance IAM uses default IAM URL when watsonxAIUrl is absent", () => {
+      const instance = authenticateAndSetInstance({
+        version: "2024-05-31",
+        serviceUrl,
+        ...fakeAuthProp,
+      })!;
+      const auth = (instance as unknown as { authenticator: IamAuthenticator })
+        .authenticator;
+      const tokenManagerUrl = (
+        auth as unknown as { tokenManager: { url: string } }
+      ).tokenManager.url;
+      expect(tokenManagerUrl).toBe("https://iam.cloud.ibm.com");
     });
 
     test("authenticateAndSetGatewayInstance creates Gateway with IAM", () => {

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -49,11 +49,8 @@ describe("Utils tests", () => {
         serviceUrl,
         ...fakeAuthProp,
       })!;
-      const auth = (instance as unknown as { authenticator: IamAuthenticator })
-        .authenticator;
-      const tokenManagerUrl = (
-        auth as unknown as { tokenManager: { url: string } }
-      ).tokenManager.url;
+      const auth = instance?.['authenticator'] as IamAuthenticator;
+      const tokenManagerUrl = auth['tokenManager']['url'];
       expect(tokenManagerUrl).toBe("https://iam.cloud.ibm.com");
     });
 

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -1,6 +1,6 @@
 import { WatsonXAI } from "@ibm-cloud/watsonx-ai";
 import { Gateway } from "@ibm-cloud/watsonx-ai/gateway";
-import { Authenticator, IamAuthenticator } from "ibm-cloud-sdk-core";
+import { IamAuthenticator } from "ibm-cloud-sdk-core";
 import { describe, test, expect } from "vitest";
 import {
   authenticateAndSetInstance,

--- a/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
+++ b/libs/providers/langchain-ibm/src/utils/tests/ibm.test.ts
@@ -49,6 +49,7 @@ describe("Utils tests", () => {
         serviceUrl,
         ...fakeAuthProp,
       })!;
+      expect(instance).toBeDefined();
       const auth = instance?.["authenticator"] as IamAuthenticator;
       const tokenManagerUrl = auth["tokenManager"]["url"];
       expect(tokenManagerUrl).toBe("https://iam.cloud.ibm.com");


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

1. Fix: IAM authenticator now respects a custom IAM URL
```typescript
 authenticator: new IamAuthenticator({
   apikey: watsonxAIApikey,
   url: watsonxAIUrl
 }),
```
watsonxAIUrl is forwarded as the url option to IamAuthenticator. Previously this field was silently ignored, meaning the SDK always hit the public IAM endpoint (https://iam.cloud.ibm.com) even when a private/on-prem one was configured. Now the token service URL is fully user-controlled.