### PR TITLE
fix(anthropic): include model in response_metadata when streaming

### DIFF
--- a/libs/providers/langchain-anthropic/src/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/message_outputs.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "vitest";
+import { _makeMessageChunkFromAnthropicEvent } from "../utils/message_outputs.js";
+
+test("_makeMessageChunkFromAnthropicEvent includes model in response_metadata on message_start", () => {
+  const event = {
+    type: "message_start",
+    message: {
+      id: "msg_123",
+      type: "message",
+      role: "assistant",
+      model: "claude-3-5-sonnet-20241022",
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 1,
+      },
+    },
+  } as const;
+
+  const result = _makeMessageChunkFromAnthropicEvent(event as any, {
+    streamUsage: true,
+    coerceContentToString: false,
+  });
+
+  expect(result).not.toBeNull();
+  expect(result?.chunk.response_metadata).toEqual({
+    model_provider: "anthropic",
+    model: "claude-3-5-sonnet-20241022",
+    usage: {},
+  });
+});

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -43,6 +43,7 @@ export function _makeMessageChunkFromAnthropicEvent(
         usage_metadata: fields.streamUsage ? usageMetadata : undefined,
         response_metadata: {
           ...response_metadata,
+          model: data.message.model,
           usage: {
             ...rest,
           },


### PR DESCRIPTION
﻿## Summary
- Populate `response_metadata.model` from the `message_start` event when streaming with `ChatAnthropic`.
- Add unit test verifying `response_metadata.model` is present in `_makeMessageChunkFromAnthropicEvent`.

## Root cause
In `libs/providers/langchain-anthropic/src/utils/message_outputs.ts`, `_makeMessageChunkFromAnthropicEvent` extracted `model_provider` and `usage` when constructing `response_metadata` for `message_start` events, but omitted `data.message.model`. Downstream token tracking and observability integrations (e.g. LangSmith, Braintrust) relying on `response_metadata.model` were unable to attribute cost to streaming runs.

Fixes #11230.

## Validation
- `pnpm --filter @langchain/anthropic build`
- `pnpm --filter @langchain/anthropic test src/tests/message_outputs.test.ts`
