### PR TITLE
fix(langchain-classic): stream final answer for returnDirect tools

### DIFF
--- a/libs/langchain-classic/src/agents/executor.ts
+++ b/libs/langchain-classic/src/agents/executor.ts
@@ -239,6 +239,7 @@ export class AgentExecutorIterator
         );
         await this.runManager?.handleChainEnd(output);
         await this.setFinalOutputs(output);
+        return output;
       }
     }
     output = { intermediateSteps: nextStepOutput as AgentStep[] };

--- a/libs/langchain-classic/src/agents/tests/executor.test.ts
+++ b/libs/langchain-classic/src/agents/tests/executor.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "vitest";
+import { DynamicTool } from "@langchain/core/tools";
+import type {
+  AgentAction,
+  AgentFinish,
+  AgentStep,
+} from "@langchain/core/agents";
+import type { ChainValues } from "@langchain/core/utils/types";
+import { BaseSingleActionAgent } from "../agent.js";
+import { AgentExecutor } from "../executor.js";
+
+/**
+ * Minimal single-action agent that returns a single, predetermined action on
+ * its first plan and would return a finish afterwards. Used to drive the
+ * executor deterministically without requiring an LLM.
+ */
+class FakeSingleActionAgent extends BaseSingleActionAgent {
+  lc_namespace = ["langchain", "agents", "fake"];
+
+  action: AgentAction;
+
+  constructor(action: AgentAction) {
+    super({});
+    this.action = action;
+  }
+
+  get inputKeys(): string[] {
+    return ["input"];
+  }
+
+  async plan(
+    steps: AgentStep[],
+    _inputs: ChainValues
+  ): Promise<AgentAction | AgentFinish> {
+    // If the tool already ran, finish. With a returnDirect tool the executor
+    // should never reach this branch, but guard anyway to avoid loops.
+    if (steps.length > 0) {
+      return {
+        returnValues: { output: steps[steps.length - 1].observation },
+        log: "",
+      };
+    }
+    return this.action;
+  }
+}
+
+// https://github.com/langchain-ai/langchainjs/issues/11222
+test("AgentExecutor.stream yields the final answer for returnDirect tools", async () => {
+  const tool = new DynamicTool({
+    name: "search",
+    description: "returns a canned answer",
+    returnDirect: true,
+    func: async () => "the-direct-answer",
+  });
+
+  const agent = new FakeSingleActionAgent({
+    tool: "search",
+    toolInput: "anything",
+    log: "",
+  });
+
+  const executor = AgentExecutor.fromAgentAndTools({ agent, tools: [tool] });
+
+  const chunks: Record<string, unknown>[] = [];
+  for await (const chunk of await executor.stream({ input: "hi" })) {
+    chunks.push(chunk);
+  }
+
+  const finalChunk = chunks.find((chunk) => "output" in chunk);
+  expect(finalChunk).toBeDefined();
+  expect(finalChunk?.output).toBe("the-direct-answer");
+});


### PR DESCRIPTION
## Description

`AgentExecutor.stream()` silently drops the final answer when a tool is configured with `returnDirect: true`. Iterating the stream with `for await ... of` only ever yields `{ intermediateSteps: [...] }` — the tool's actual return value never reaches the caller.

### Root cause

In `AgentExecutorIterator._processNextStepOutput` ([libs/langchain-classic/src/agents/executor.ts](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-classic/src/agents/executor.ts)), when a `returnDirect` tool runs, the code correctly computes the final answer and stores it via `setFinalOutputs(output)` — but then **unconditionally overwrites** `output` with `{ intermediateSteps }` before returning:

```ts
if (toolReturn) {
  output = await this.agentExecutor._return(toolReturn, ...);
  await this.runManager?.handleChainEnd(output);
  await this.setFinalOutputs(output);
}
// this line runs even after a returnDirect answer was produced:
output = { intermediateSteps: nextStepOutput as AgentStep[] };
return output;
```

### Fix

Return the resolved output immediately once a `returnDirect` tool produces a final answer, mirroring the existing `AgentFinish` branch a few lines above. This matches the behavior of the non-streaming `_call` path, which already returns the final output for `returnDirect` tools.

### Tests

Adds `libs/langchain-classic/src/agents/tests/executor.test.ts` — a unit test (no API key required) that drives `.stream()` with a `returnDirect` `DynamicTool` via a minimal fake agent and asserts the final chunk carries the tool's return value. Verified the test fails on `main` and passes with this change.

Fixes #11222

🤖 Generated with [Claude Code](https://claude.com/claude-code)