### PR TITLE
fix(openai): drop input_json_delta blocks in chat completions converter

### DIFF
--- a/.changeset/openai-drop-input-json-delta.md
+++ b/.changeset/openai-drop-input-json-delta.md
@@ -1,0 +1,12 @@
+---
+"@langchain/openai": patch
+---
+
+Drop `input_json_delta` streaming-artifact content blocks when converting
+messages to Chat Completions params. Anthropic streaming can leave
+`input_json_delta` blocks in `AIMessage.content`, including after the message is
+checkpointed and restored; these were passed through raw and rejected by OpenAI
+with `400 Invalid value: 'input_json_delta'` — e.g. when a message authored by a
+Claude model is replayed to an OpenAI model. For finalized messages the
+consolidated tool call is already present in `message.tool_calls`, so dropping
+the residual delta does not lose tool-call information.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -811,17 +811,22 @@ export const convertMessagesToCompletionsMessageParams: Converter<
             //  - Tool-call blocks (`tool_use`, `tool_call`) are already
             //    carried in message.tool_calls, so resending them as content
             //    would be a duplicate/invalid part.
+            //  - Streaming tool-call artifacts (`input_json_delta`) are
+            //    residues left in Anthropic-authored content; the finalized
+            //    call is already carried in message.tool_calls.
             //  - Reasoning traces (`reasoning`, `reasoning_content`,
             //    `thinking`) are output-only.
             // Echoing any of these back in the request history is rejected by
             // strict openai-compatible providers, e.g. DeepSeek:
-            // "unknown variant `reasoning`, expected `text`".
+            // "unknown variant `reasoning`, expected `text`", or OpenAI:
+            // "400 Invalid value: 'input_json_delta'".
             if (
               typeof m === "object" &&
               m !== null &&
               "type" in m &&
               (m.type === "tool_use" ||
                 m.type === "tool_call" ||
+                m.type === "input_json_delta" ||
                 m.type === "reasoning" ||
                 m.type === "reasoning_content" ||
                 m.type === "thinking")

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -593,5 +593,53 @@ describe("convertCompletionsMessageToBaseMessage", () => {
         { type: "text", text: "The answer is 42." },
       ]);
     });
+
+    it("should drop input_json_delta blocks from content (cross-provider replay)", () => {
+      // Regression: an AIMessage authored by an Anthropic model can retain
+      // streaming tool-call artifacts (`input_json_delta`) in its content.
+      // When replayed to an OpenAI model these were passed through raw and
+      // rejected with "400 Invalid value: 'input_json_delta'". The finalized
+      // tool call is already carried in message.tool_calls, so dropping the
+      // residual delta blocks loses nothing.
+      const message = new AIMessage({
+        content: [
+          { type: "text", text: "reading files" },
+          {
+            type: "input_json_delta",
+            index: 0,
+            input: '{"file_path": "/README.md"}',
+          },
+        ] as any,
+        tool_calls: [
+          {
+            id: "call_1",
+            name: "read_file",
+            args: { file_path: "/README.md" },
+          },
+        ],
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toHaveLength(1);
+      // The streaming artifact is dropped; only the text block remains.
+      expect(result[0].content).toEqual([
+        { type: "text", text: "reading files" },
+      ]);
+      // The finalized tool call is preserved verbatim in tool_calls — proving
+      // we removed only the redundant residual delta, not tool-call data.
+      expect((result[0] as any).tool_calls).toEqual([
+        {
+          id: "call_1",
+          type: "function",
+          function: {
+            name: "read_file",
+            arguments: '{"file_path":"/README.md"}',
+          },
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
### What
`convertMessagesToCompletionsMessageParams` now drops `input_json_delta` content
blocks, alongside the `tool_use` / `tool_call` / `reasoning` /
`reasoning_content` / `thinking` blocks it already drops.

### Why
Anthropic streaming can leave `input_json_delta` blocks in `AIMessage.content`,
including after the message is checkpointed and restored. When such a message is
replayed to an OpenAI model, the raw blocks were passed through to the Chat
Completions request and rejected with:

`400 Invalid value: 'input_json_delta'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', 'audio', 'file'.`

For finalized messages where the consolidated call is already present in
`message.tool_calls`, dropping the residual delta does not lose tool-call
information.

This follows the provider-level fix in #9809 for `@langchain/anthropic`, which
removes the residual `input_json_delta` blocks and rebuilds each `tool_use` input
from `tool_calls` as the primary source (matched by `id`), falling back to
merging the delta chunks by `index` when `tool_calls` is unavailable. OpenAI
carries the finalized call in the separate `tool_calls` field rather than inside
content, so here the redundant delta blocks can simply be dropped. #9809 covered
the Anthropic→Anthropic path; this covers the Anthropic→OpenAI path.

### Repro (no network; converter only)
```ts
import { AIMessage } from "@langchain/core/messages";
import { convertMessagesToCompletionsMessageParams } from "@langchain/openai/converters/completions";

const msg = new AIMessage({
  content: [
    { type: "text", text: "reading" },
    { type: "input_json_delta", index: 0, input: '{"file_path":"/README.md"}' } as any,
  ],
  tool_calls: [{ id: "call_1", name: "read_file", args: { file_path: "/README.md" } }],
});

const [param] = convertMessagesToCompletionsMessageParams({ messages: [msg] });
console.log(JSON.stringify(param.content, null, 2));
// before: content still contains { "type": "input_json_delta", ... } → OpenAI 400
// after:  input_json_delta removed from content; tool_calls preserved
```

### Why the provider converter
The change lives in the OpenAI converter because that is already where blocks the
Chat Completions API cannot accept are stripped (`tool_use`, `tool_call`,
`reasoning`, `reasoning_content`, `thinking`), so adding `input_json_delta` is a
natural extension of the converter's existing responsibility. It also matches the
provider-level precedent set by #9809, and keeps the change narrow and low-risk.

### Test
Added a converter test asserting `input_json_delta` is removed from content while
`tool_calls` is preserved.

Related: #9798, #9809
