### PR TITLE
fix(openai): convert standard image blocks to input_image on the Responses API

### DIFF
--- a/.changeset/openai-responses-image-input-image.md
+++ b/.changeset/openai-responses-image-input-image.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Convert standard `image` data content blocks to the Responses API native `input_image` shape. When `useResponsesApi` is active (the default for reasoning models such as the `gpt-5.x` / `o`-series), a user message carrying a LangChain standard image block (`{ type: 'image', source_type: 'base64' | 'url' | 'id', ... }`) was routed through the Chat Completions converter, producing an `image_url` part that the Responses API rejects with `400 Invalid value: 'image_url'. Supported values are ... 'input_image' ...`. This mirrors the existing `file` → `input_file` special-case (the image counterpart of #9895).

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1706,6 +1706,42 @@ export const convertMessagesToResponsesInput: Converter<
                 };
               }
             }
+            // The Responses API expects images as native `input_image` parts.
+            // The Chat Completions converter would emit an `image_url` part,
+            // which the Responses API rejects
+            // (`400 Invalid value: 'image_url' ... 'input_image'`). Convert
+            // standard image blocks natively, mirroring the `file` handling
+            // above. (The adjacent `image_url` branch below already produces
+            // `input_image`; this covers the standard data-block shape.)
+            if (item.type === "image") {
+              // Honor a caller-provided detail hint, matching the standard
+              // content-block path; default to "auto".
+              const detail =
+                (item.metadata as { detail?: "low" | "high" | "auto" })
+                  ?.detail ?? "auto";
+              if (item.source_type === "url") {
+                return {
+                  type: "input_image",
+                  image_url: item.url,
+                  detail,
+                };
+              }
+              if (item.source_type === "id") {
+                return {
+                  type: "input_image",
+                  file_id: item.id,
+                  detail,
+                };
+              }
+              if (item.source_type === "base64") {
+                const mimeType = item.mime_type ?? "image/png";
+                return {
+                  type: "input_image",
+                  image_url: `data:${mimeType};base64,${item.data}`,
+                  detail,
+                };
+              }
+            }
             return convertToProviderContentBlock(
               item,
               completionsApiContentBlockConverter

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1305,6 +1305,114 @@ describe("convertMessagesToResponsesInput", () => {
         },
       ]);
     });
+
+    it("routes standard base64 image blocks to native input_image instead of the completions converter", () => {
+      const messages = [
+        new HumanMessage({
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image",
+              source_type: "base64",
+              mime_type: "image/png",
+              data: "iVBORw0KGgoAAAANSUhEUgAAAAE",
+            },
+          ],
+        }),
+      ];
+
+      const result = convertMessagesToResponsesInput({
+        messages,
+        model: "gpt-5-mini",
+        zdrEnabled: false,
+      });
+
+      expect(result).toMatchObject([
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "What is in this image?" },
+            {
+              type: "input_image",
+              image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE",
+              detail: "auto",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("routes standard url image blocks to native input_image instead of the completions converter", () => {
+      const messages = [
+        new HumanMessage({
+          content: [
+            {
+              type: "image",
+              source_type: "url",
+              url: "https://example.com/image.png",
+              mime_type: "image/png",
+            },
+          ],
+        }),
+      ];
+
+      const result = convertMessagesToResponsesInput({
+        messages,
+        model: "gpt-5-mini",
+        zdrEnabled: false,
+      });
+
+      expect(result).toMatchObject([
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_image",
+              image_url: "https://example.com/image.png",
+              detail: "auto",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("honors a caller-provided detail hint on standard image blocks", () => {
+      const messages = [
+        new HumanMessage({
+          content: [
+            {
+              type: "image",
+              source_type: "base64",
+              mime_type: "image/png",
+              data: "iVBORw0KGgoAAAANSUhEUgAAAAE",
+              metadata: { detail: "high" },
+            },
+          ],
+        }),
+      ];
+
+      const result = convertMessagesToResponsesInput({
+        messages,
+        model: "gpt-5-mini",
+        zdrEnabled: false,
+      });
+
+      expect(result).toMatchObject([
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_image",
+              image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE",
+              detail: "high",
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe("ToolMessage conversion", () => {


### PR DESCRIPTION
## Summary

When the Responses API is active (the default for reasoning models such as the `gpt-5.x` / `o`-series), a user message carrying a LangChain **standard `image` data content block** — `{ type: 'image', source_type: 'base64' | 'url' | 'id', ... }` — was routed through the Chat Completions content converter, producing an `image_url` part that the Responses API rejects:

```
400 Invalid value: 'image_url'. Supported values are: 'input_text', 'input_image',
'output_text', 'refusal', 'input_file', 'computer_screenshot', 'summary_text', and 'encrypted_content'.
```

In `convertMessagesToResponsesInput` (`src/converters/responses.ts`), the `user` / `system` / `developer` path special-cases the `file` data block (→ `input_file`) but let the `image` data block fall through to `convertToProviderContentBlock(item, completionsApiContentBlockConverter)`, which emits the Completions-only `image_url` shape. The adjacent `item.type === "image_url"` branch already maps to `input_image` correctly, so this was a one-branch omission for the standard `image` data block.

This is the **image counterpart of #9895** (which fixed the identical mis-routing for `file` URL blocks).

## What changed

- Added an `image` → `input_image` special-case next to the existing `file` → `input_file` handling, covering `source_type` `base64` (→ data-URL `image_url`), `url` (→ `image_url`), and `id` (→ `file_id`).
- Honors a caller-provided `metadata.detail` hint (matching the standard-content-block path, which already does), defaulting to `"auto"`.

Fixes #11248

## Test plan

- Added unit tests in `src/converters/tests/responses.test.ts`: standard base64 image → `input_image`, url image → `input_image`, and `metadata.detail` passthrough.
- `pnpm --filter @langchain/openai build` — clean, no type errors.
- The `converters/responses.test.ts` suite passes (92 tests).
- `oxlint` and `oxfmt --check` — clean.
- Live-verified against the real OpenAI Responses API (`new ChatOpenAI({ model: "gpt-4o", useResponsesApi: true })` with a base64 image data block): the request is accepted and the model returns a description — no `400`.

<sub>Note: the package's full `pnpm test` currently reports 85 unrelated `TypeCheckError`s that are also present on `main` (in `chat_models/*` and `standard-tests`); this change introduces no new type errors and only adds passing tests.</sub>
