### PR TITLE
feat(mcp-adapters): forward _meta from beforeToolCall to MCP callTool requests

### DIFF
--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -287,7 +287,7 @@ const client = new MultiServerMCPClient({
     },
   },
 
-  // Change args/headers before the tool call
+  // Change args/headers/_meta before the tool call
   beforeToolCall: ({ serverName, name, args }) => {
     // Add/override an argument
     const nextArgs = { ...(args as Record<string, unknown>), injected: true };
@@ -295,6 +295,7 @@ const client = new MultiServerMCPClient({
     return {
       args: nextArgs,
       headers: { "X-Request-ID": crypto.randomUUID() },
+      _meta: { "com.example/correlationId": crypto.randomUUID() },
     };
   },
 
@@ -321,8 +322,44 @@ const out = await t?.invoke({ a: 1, b: 2 });
 
 Notes:
 
-- **beforeToolCall** can return `{ args?, headers? }`. Headers are supported for HTTP/SSE. Stdio connections do not support custom headers.
+- **beforeToolCall** can return `{ args?, headers?, _meta? }`. Headers are supported for HTTP/SSE only (stdio connections do not support custom headers). `_meta` is forwarded as the MCP protocol-level `_meta` field on the `callTool` request and works for all transports, including stdio.
 - **afterToolCall** may return either a 2‑tuple `[content, artifact]`, a `ToolMessage`, a `Command` instance, or nothing (to keep the original result).
+
+### Passing `_meta` for tracing / correlation
+
+The `_meta` field is the MCP-native channel for attaching metadata (distributed-tracing IDs, correlation IDs, per-request context) that the server can read but that is **not** exposed to the model as tool arguments. Because `beforeToolCall` receives the per-call `RunnableConfig` (and LangGraph state), you can derive `_meta` per invocation — run-scoped values from `config.configurable`, and fresh per-call values inline:
+
+```ts
+const client = new MultiServerMCPClient({
+  mcpServers: {
+    /* ... */
+  },
+  beforeToolCall: (_req, _state, config) => ({
+    _meta: {
+      // run-scoped: supplied by the caller (see below), propagates to every tool call
+      "com.example/traceId": config.configurable?.traceId,
+      // per-call: a new span for each individual tool invocation
+      "com.example/spanId": crypto.randomUUID(),
+    },
+  }),
+});
+```
+
+> [!NOTE]
+> MCP recommends namespacing `_meta` keys with a reverse-DNS prefix (e.g. `com.example/`) to avoid collisions. Prefixes whose second label is `mcp` or `modelcontextprotocol` are reserved by the protocol. See the [MCP `_meta` specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#_meta).
+
+The caller supplies run-scoped context via `configurable`, which LangGraph/`createAgent` propagates to every tool call in the run:
+
+```ts
+import { createAgent } from "langchain";
+
+const agent = createAgent({ llm, tools: await client.getTools() });
+
+await agent.invoke(
+  { messages: [new HumanMessage("What's the weather in SF?")] },
+  { configurable: { traceId: "trace-abc-123" } }
+);
+```
 
 ## Tool Configuration Options
 

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -70,6 +70,7 @@ const toolCallModificationSchema = z
   .object({
     headers: z.record(z.string()),
     args: z.unknown(),
+    _meta: z.record(z.unknown()),
   })
   .partial();
 export type ToolCallModification = z.output<typeof toolCallModificationSchema>;
@@ -95,7 +96,11 @@ export const toolHooksSchema = z.object({
    *         ...toolCallRequest.args,
    *         custom: "Custom Value"
    *       },
-   *       header: { "X-Custom-Header": "Custom Value" }
+   *       headers: { "X-Custom-Header": "Custom Value" },
+   *       _meta: {
+   *         "com.example/traceId": runtime.configurable?.traceId,
+   *         "com.example/spanId": crypto.randomUUID()
+   *       }
    *     };
    *   },
    * };

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -24,6 +24,9 @@ test("check tool hooks types", () => {
         serverName: string;
         args?: unknown;
       }>();
+      return {
+        _meta: { traceId: runtime.configurable?.traceId },
+      };
     },
     afterToolCall: (toolCallResult, state, runtime) => {
       expectTypeOf(state).toEqualTypeOf<Record<string, unknown>>();

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -172,6 +172,27 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         await client.close();
       }
     });
+
+    test("_meta from beforeToolCall reaches the MCP server on all transports", async () => {
+      const correlationId = "corr-123";
+      const { client } = await setup({
+        beforeToolCall: () => ({ _meta: { correlationId } }),
+        afterToolCall: (res) => ({ result: res.result }),
+      });
+
+      try {
+        const tools = await client.getTools();
+        const t = tools.find((tool) => tool.name.includes("test_tool"))!;
+        const out = (await t.invoke({ input: "orig" })) as string;
+        const parsed = JSON.parse(out);
+        expect(parsed.meta).toEqual(
+          expect.objectContaining({ correlationId })
+        );
+      } finally {
+        await client.close();
+      }
+    });
+
     test("afterToolCall allows to modify tool result", async () => {
       const { client } = await setup();
 

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -1048,4 +1048,108 @@ describe("Simplified Tool Adapter Tests", () => {
       expect(result).toBe("User created");
     });
   });
+
+  describe("_meta forwarding via beforeToolCall", () => {
+    const pingTool = {
+      name: "ping",
+      description: "Ping tool",
+      inputSchema: {
+        type: "object" as const,
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+    };
+
+    test("forwards _meta returned by beforeToolCall as _meta on the callTool request", async () => {
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({ tools: [pingTool] })
+      );
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "pong" }],
+      });
+
+      const tools = await loadMcpTools("mockServer", mockClient as Client, {
+        beforeToolCall: () => ({
+          _meta: { trace_id: "t-1", span_id: "s-1" },
+        }),
+      });
+
+      await tools[0].invoke({ message: "hello" });
+
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ping",
+          arguments: { message: "hello" },
+          _meta: { trace_id: "t-1", span_id: "s-1" },
+        })
+      );
+    });
+
+    test("does not include _meta when no beforeToolCall hook is provided", async () => {
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({ tools: [pingTool] })
+      );
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "pong" }],
+      });
+
+      const tools = await loadMcpTools("mockServer", mockClient as Client);
+
+      await tools[0].invoke({ message: "hello" });
+
+      const callArgs = mockClient.callTool.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("_meta");
+    });
+
+    test("does not include _meta when beforeToolCall omits it", async () => {
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({ tools: [pingTool] })
+      );
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "pong" }],
+      });
+
+      const tools = await loadMcpTools("mockServer", mockClient as Client, {
+        beforeToolCall: ({ args }) => ({
+          args: { ...(args as Record<string, unknown>), extra: true },
+        }),
+      });
+
+      await tools[0].invoke({ message: "hello" });
+
+      const callArgs = mockClient.callTool.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("_meta");
+    });
+
+    test("derives _meta per call from the RunnableConfig passed to invoke", async () => {
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({ tools: [pingTool] })
+      );
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "pong" }],
+      });
+
+      const tools = await loadMcpTools("mockServer", mockClient as Client, {
+        beforeToolCall: (_req, _state, config) => ({
+          _meta: { trace_id: config.configurable?.traceId },
+        }),
+      });
+
+      await tools[0].invoke(
+        { message: "a" },
+        { configurable: { traceId: "trace-a" } }
+      );
+      await tools[0].invoke(
+        { message: "b" },
+        { configurable: { traceId: "trace-b" } }
+      );
+
+      expect(mockClient.callTool.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ _meta: { trace_id: "trace-a" } })
+      );
+      expect(mockClient.callTool.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ _meta: { trace_id: "trace-b" } })
+      );
+    });
+  });
 });

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -1068,10 +1068,13 @@ async function _callTool({
         ? await (client as Client).fork(headers)
         : client;
 
+    const meta = beforeToolCallInterception?._meta;
+
     const callToolArgs: Parameters<typeof finalClient.callTool> = [
       {
         name: toolName,
         arguments: finalArgs,
+        ...(meta ? { _meta: meta } : {}),
       },
     ];
 


### PR DESCRIPTION
## Description

Adds support for the MCP protocol-level [`_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#_meta) field on tool calls, via the existing `beforeToolCall` hook.

`beforeToolCall` can now return a `_meta` object alongside `args` and `headers`:

```ts
const client = new MultiServerMCPClient({
  mcpServers: {
    /* ... */
  },
  beforeToolCall: (_req, _state, config) => ({
    _meta: {
      "com.example/traceId": config.configurable?.traceId,
      "com.example/spanId": crypto.randomUUID(),
    },
  }),
});
```

When present, `_meta` is forwarded as the protocol-level `_meta` field on the underlying `callTool` request. Unlike custom headers (HTTP/SSE only), `_meta` works on **all transports, including stdio**, since it travels in the JSON-RPC params rather than the transport layer.

### Motivation

Requested on the forum: [Pass _meta through to MCP callTool](https://forum.langchain.com/t/feature-request-pass-meta-through-to-mcp-calltool-in-langchain-mcp-adapters/4225). This is the standard MCP channel for distributed-tracing IDs, correlation IDs, and per-request/session context that the server needs but that should **not** be surfaced to the model as tool arguments. It also brings the JS adapter closer to parity with the Python/Java adapters.

### Notes

- Does not clobber the SDK's progress token: when `onprogress` is set, the MCP SDK merges `progressToken` into `_meta`, so user-supplied keys and the progress token coexist.
- No `_meta` field is sent when `beforeToolCall` is absent or omits it.
- Examples follow [MCP's recommended](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#_meta) reverse-DNS key-prefix convention (`com.example/...`); the `mcp`/`modelcontextprotocol` prefixes are reserved by the spec.
