### PR TITLE
fix(aws): respect reasoning output version

### DIFF
--- a/.changeset/quiet-bears-reason.md
+++ b/.changeset/quiet-bears-reason.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): respect the configured output version for Bedrock reasoning blocks

--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -1093,7 +1093,8 @@ export class ChatBedrockConverse
 
       const message = convertConverseMessageToLangChainMessage(
         output.message,
-        responseMetadata
+        responseMetadata,
+        options.outputVersion ?? this.outputVersion ?? "v0"
       );
       return {
         generations: [
@@ -1245,7 +1246,8 @@ export class ChatBedrockConverse
               );
             } else if (chunk.contentBlockDelta) {
               const textChatGeneration = handleConverseStreamContentBlockDelta(
-                chunk.contentBlockDelta
+                chunk.contentBlockDelta,
+                options.outputVersion ?? this.outputVersion ?? "v0"
               );
               yield textChatGeneration;
               await runManager?.handleLLMNewToken(

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -971,6 +971,86 @@ test("Streaming supports empty string chunks", async () => {
   expect(finalChunk.content).toBe("Hello world!");
 });
 
+test.each([
+  {
+    name: "v0",
+    outputVersion: undefined,
+    expected: [
+      {
+        type: "reasoning_content",
+        reasoningText: { text: "Reasoning summary" },
+      },
+      {
+        type: "reasoning_content",
+        reasoningText: { signature: "opaque-signature" },
+      },
+    ],
+  },
+  {
+    name: "v1",
+    outputVersion: "v1" as const,
+    expected: [
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        index: 0,
+      },
+      {
+        type: "reasoning",
+        reasoning: "",
+        signature: "opaque-signature",
+        index: 0,
+      },
+    ],
+  },
+])(
+  "Streaming respects $name reasoning output shape",
+  async ({ outputVersion, expected }) => {
+    const mockClient = {
+      send: vi.fn().mockResolvedValue({
+        stream: (async function* () {
+          yield {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: {
+                reasoningContent: { text: "Reasoning summary" },
+              },
+            },
+          };
+          yield {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: {
+                reasoningContent: { signature: "opaque-signature" },
+              },
+            },
+          };
+        })(),
+      }),
+    } as unknown as BedrockRuntimeClient;
+
+    const model = new ChatBedrockConverse({
+      region: "us-east-1",
+      credentials: {
+        secretAccessKey: "test-secret-key",
+        accessKeyId: "test-access-key",
+      },
+      model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+      client: mockClient,
+      ...(outputVersion ? { outputVersion } : {}),
+    });
+
+    const content = [];
+    for await (const chunk of await model.stream("Think step by step")) {
+      if (Array.isArray(chunk.content)) {
+        content.push(...chunk.content);
+      }
+    }
+
+    expect(content).toEqual(expected);
+  }
+);
+
 test("Streaming throws when Bedrock stream stalls between chunks", async () => {
   vi.useFakeTimers();
   try {

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -1,14 +1,22 @@
-import type { ContentBlock, UsageMetadata } from "@langchain/core/messages";
+import type {
+  ContentBlock,
+  MessageOutputVersion,
+  UsageMetadata,
+} from "@langchain/core/messages";
 import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
 import type { ToolCall } from "@langchain/core/messages/tool";
 import type * as Bedrock from "@aws-sdk/client-bedrock-runtime";
 import type { DocumentType as __DocumentType } from "@smithy/types";
 import { ChatGenerationChunk } from "@langchain/core/outputs";
-import { MessageContentReasoningBlockRedacted } from "../types.js";
+import {
+  MessageContentReasoningBlock,
+  MessageContentReasoningBlockRedacted,
+} from "../types.js";
 
 export function convertConverseMessageToLangChainMessage(
   message: Bedrock.Message,
-  responseMetadata: Omit<Bedrock.ConverseResponse, "output">
+  responseMetadata: Omit<Bedrock.ConverseResponse, "output">,
+  outputVersion: MessageOutputVersion = "v0"
 ): AIMessage {
   if (!message.content) {
     throw new Error("No message content found in response.");
@@ -90,7 +98,10 @@ export function convertConverseMessageToLangChainMessage(
         content.push({ type: "image", image: c.image });
       } else if ("reasoningContent" in c && c.reasoningContent) {
         content.push(
-          bedrockReasoningBlockToLangchainReasoningBlock(c.reasoningContent)
+          bedrockReasoningBlockToLangchainReasoningBlock(
+            c.reasoningContent,
+            outputVersion
+          )
         );
       } else if ("text" in c && typeof c.text === "string") {
         content.push({ type: "text", text: c.text });
@@ -127,7 +138,8 @@ export function convertConverseMessageToLangChainMessage(
 }
 
 export function handleConverseStreamContentBlockDelta(
-  contentBlockDelta: Bedrock.ContentBlockDeltaEvent
+  contentBlockDelta: Bedrock.ContentBlockDeltaEvent,
+  outputVersion: MessageOutputVersion = "v0"
 ): ChatGenerationChunk {
   if (!contentBlockDelta.delta) {
     throw new Error("No delta found in content block.");
@@ -161,7 +173,8 @@ export function handleConverseStreamContentBlockDelta(
         content: [
           bedrockReasoningDeltaToLangchainPartialReasoningBlock(
             contentBlockDelta.delta.reasoningContent,
-            contentBlockDelta.contentBlockIndex
+            contentBlockDelta.contentBlockIndex,
+            outputVersion
           ),
         ],
       }),
@@ -245,10 +258,20 @@ export function handleConverseStreamMetadata(
 
 export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
   reasoningContent: Bedrock.ReasoningContentBlockDelta,
-  index?: number
-): ContentBlock.Reasoning | MessageContentReasoningBlockRedacted {
+  index?: number,
+  outputVersion: MessageOutputVersion = "v0"
+):
+  | ContentBlock.Reasoning
+  | MessageContentReasoningBlock
+  | MessageContentReasoningBlockRedacted {
   const { text, redactedContent, signature } = reasoningContent;
   if (typeof text === "string") {
+    if (outputVersion === "v0") {
+      return {
+        type: "reasoning_content",
+        reasoningText: { text },
+      };
+    }
     return {
       type: "reasoning",
       reasoning: text,
@@ -256,6 +279,12 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
     };
   }
   if (typeof signature === "string") {
+    if (outputVersion === "v0") {
+      return {
+        type: "reasoning_content",
+        reasoningText: { signature },
+      };
+    }
     return {
       type: "reasoning",
       reasoning: "",
@@ -273,10 +302,25 @@ export function bedrockReasoningDeltaToLangchainPartialReasoningBlock(
 }
 
 export function bedrockReasoningBlockToLangchainReasoningBlock(
-  reasoningContent: Bedrock.ReasoningContentBlock
-): ContentBlock.Reasoning | MessageContentReasoningBlockRedacted {
+  reasoningContent: Bedrock.ReasoningContentBlock,
+  outputVersion: MessageOutputVersion = "v0"
+):
+  | ContentBlock.Reasoning
+  | MessageContentReasoningBlock
+  | MessageContentReasoningBlockRedacted {
   const { reasoningText, redactedContent } = reasoningContent;
   if (reasoningText && typeof reasoningText.text === "string") {
+    if (outputVersion === "v0") {
+      return {
+        type: "reasoning_content",
+        reasoningText: {
+          text: reasoningText.text,
+          ...(typeof reasoningText.signature === "string"
+            ? { signature: reasoningText.signature }
+            : {}),
+        },
+      };
+    }
     return {
       type: "reasoning",
       reasoning: reasoningText.text,

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../message_outputs.js";
 
 describe("reasoning output conversion", () => {
-  test("uses standard reasoning content by default", () => {
+  test("uses provider-native reasoning content by default", () => {
     const result = convertConverseMessageToLangChainMessage(
       {
         role: "assistant",
@@ -36,15 +36,53 @@ describe("reasoning output conversion", () => {
 
     expect(result.content).toEqual([
       {
-        type: "reasoning",
-        reasoning: "Reasoning summary",
-        signature: "opaque-signature",
+        type: "reasoning_content",
+        reasoningText: {
+          text: "Reasoning summary",
+          signature: "opaque-signature",
+        },
       },
     ]);
     expect(result.response_metadata).not.toHaveProperty("output_version");
   });
 
-  test("merges streaming reasoning and signature into a standard block", () => {
+  test("uses standard reasoning content for v1 output", () => {
+    const result = convertConverseMessageToLangChainMessage(
+      {
+        role: "assistant",
+        content: [
+          {
+            reasoningContent: {
+              reasoningText: {
+                text: "Reasoning summary",
+                signature: "opaque-signature",
+              },
+            },
+          },
+        ],
+      },
+      {
+        stopReason: "end_turn",
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        metrics: { latencyMs: 0 },
+      },
+      "v1"
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        signature: "opaque-signature",
+      },
+    ]);
+  });
+
+  test("uses provider-native reasoning chunks by default", () => {
     const reasoning = handleConverseStreamContentBlockDelta({
       contentBlockIndex: 0,
       delta: { reasoningContent: { text: "Reasoning summary" } },
@@ -53,6 +91,36 @@ describe("reasoning output conversion", () => {
       contentBlockIndex: 0,
       delta: { reasoningContent: { signature: "opaque-signature" } },
     });
+
+    expect(reasoning.message.content).toEqual([
+      {
+        type: "reasoning_content",
+        reasoningText: { text: "Reasoning summary" },
+      },
+    ]);
+    expect(signature.message.content).toEqual([
+      {
+        type: "reasoning_content",
+        reasoningText: { signature: "opaque-signature" },
+      },
+    ]);
+  });
+
+  test("merges streaming reasoning and signature for v1 output", () => {
+    const reasoning = handleConverseStreamContentBlockDelta(
+      {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { text: "Reasoning summary" } },
+      },
+      "v1"
+    );
+    const signature = handleConverseStreamContentBlockDelta(
+      {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { signature: "opaque-signature" } },
+      },
+      "v1"
+    );
 
     const result = concat(reasoning.message, signature.message);
 


### PR DESCRIPTION
## Summary

`@langchain/aws` 1.4.3 normalized Bedrock reasoning output to v1 blocks even when callers used the default v0 message shape. This restores the provider-native `reasoning_content` shape for v0 while keeping standard `reasoning` blocks available when `outputVersion: "v1"` is selected.

- propagate the resolved output version through non-streaming and streaming Bedrock response conversion
- preserve provider-native reasoning blocks for the default v0 path
- retain standard reasoning blocks for explicit v1 output
- cover helper conversion and the public streaming API

Fixes #11246

## Test plan

- `pnpm --filter @langchain/aws test` — 8 files, 129 tests passed; no type errors
- `pnpm --filter @langchain/aws build` — passed, including publint and attw
- `pnpm exec oxfmt --check` on all changed files — passed
- `pnpm exec oxlint` on all changed TypeScript files — passed

## AI Disclosure

AI assisted with issue triage and drafting the implementation and tests. The diff and verification results were reviewed locally before submission.