### PR TITLE
fix(google): preserve tool call ids in native stream events

### DIFF
--- a/.changeset/calm-tools-stream.md
+++ b/.changeset/calm-tools-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Preserve tool call IDs in Google native stream events.

--- a/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -91,6 +91,7 @@ const toolChunks: Gemini.GenerateContentResponse[] = [
           parts: [
             {
               functionCall: {
+                id: "call-weather-1",
                 name: "web_search",
                 args: { query: "weather" },
               },
@@ -138,7 +139,11 @@ describe("ChatGoogle.streamEvents", () => {
     await expect(
       mockChatGoogle(toolChunks).streamEvents("Hello")
     ).toHaveStreamToolCalls([
-      { name: "web_search", args: { query: "weather" } },
+      {
+        id: "call-weather-1",
+        name: "web_search",
+        args: { query: "weather" },
+      },
     ]);
   });
 

--- a/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -140,11 +140,41 @@ describe("ChatGoogle.streamEvents", () => {
       mockChatGoogle(toolChunks).streamEvents("Hello")
     ).toHaveStreamToolCalls([
       {
-        id: "call-weather-1",
         name: "web_search",
         args: { query: "weather" },
       },
     ]);
+  });
+
+  test("preserves tool call ids in native events", async () => {
+    const events = [];
+    for await (const event of mockChatGoogle(toolChunks).streamEvents(
+      "Hello"
+    )) {
+      events.push(event);
+    }
+
+    expect(
+      events.find(
+        (event) =>
+          event.event === "content-block-start" &&
+          event.content.type === "tool_call_chunk"
+      )
+    ).toMatchObject({ content: { id: "call-weather-1" } });
+    expect(
+      events.find(
+        (event) =>
+          event.event === "content-block-delta" &&
+          event.delta.type === "block-delta"
+      )
+    ).toMatchObject({ delta: { fields: { id: "call-weather-1" } } });
+    expect(
+      events.find(
+        (event) =>
+          event.event === "content-block-finish" &&
+          event.content.type === "tool_call"
+      )
+    ).toMatchObject({ content: { id: "call-weather-1" } });
   });
 
   test("streams usage", async () => {

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -426,50 +426,6 @@ const readPages = tool(async ({ fileId }) => `page text for ${fileId}`, {
   schema: z.object({ fileId: z.string() }),
 });
 
-describe("Google stream event tool calls", () => {
-  test("include a stable id from the live API path", async () => {
-    const model = new ChatGoogle({
-      model: "gemini-2.0-flash",
-      apiKey: getEnvironmentVariable("TEST_API_KEY"),
-    }).bindTools([weatherTool], {
-      tool_choice: "get_weather",
-    });
-
-    const events = [];
-    for await (const event of model.streamEvents(
-      "What is the weather in New York?"
-    )) {
-      events.push(event);
-    }
-
-    const toolCallStart = events.find(
-      (event) =>
-        event.event === "content-block-start" &&
-        event.content.type === "tool_call_chunk"
-    );
-    const toolCallFinish = events.find(
-      (event) =>
-        event.event === "content-block-finish" &&
-        event.content.type === "tool_call"
-    );
-
-    expect(toolCallStart).toMatchObject({
-      content: {
-        type: "tool_call_chunk",
-        id: expect.any(String),
-        name: "get_weather",
-      },
-    });
-    expect(toolCallFinish).toMatchObject({
-      content: {
-        type: "tool_call",
-        id: toolCallStart?.content.id,
-        name: "get_weather",
-      },
-    });
-  });
-});
-
 const coreModelInfo: ModelInfo[] = filterTestableModels([
   (modelInfo: ModelInfo) => !modelInfo.testConfig?.isImage,
   (modelInfo: ModelInfo) => !modelInfo.testConfig?.isTts,
@@ -939,6 +895,35 @@ describe.each(coreModelInfo)(
       const result = functionResponsePart.functionResponse!.response!.result;
       expect(typeof result).not.toBe("string");
       expect(result).toEqual(toolResult);
+    });
+
+    test("streamEvents preserves stable tool call ids", async () => {
+      const llm = newChatGoogle();
+      const events = [];
+      for await (const event of llm.streamEvents(
+        "What is the weather in New York?",
+        { tools: [weatherTool], tool_choice: "get_weather" }
+      )) {
+        events.push(event);
+      }
+
+      const toolCallStart = events
+        .filter((event) => event.event === "content-block-start")
+        .map((event) => event.content)
+        .find((content) => content.type === "tool_call_chunk");
+      const toolCallFinish = events
+        .filter((event) => event.event === "content-block-finish")
+        .map((event) => event.content)
+        .find((content) => content.type === "tool_call");
+
+      expect(toolCallStart).toMatchObject({
+        id: expect.any(String),
+        name: "get_weather",
+      });
+      expect(toolCallFinish).toMatchObject({
+        id: toolCallStart?.id,
+        name: "get_weather",
+      });
     });
 
     test("function - force tool", async () => {

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -426,6 +426,50 @@ const readPages = tool(async ({ fileId }) => `page text for ${fileId}`, {
   schema: z.object({ fileId: z.string() }),
 });
 
+describe("Google stream event tool calls", () => {
+  test("include a stable id from the live API path", async () => {
+    const model = new ChatGoogle({
+      model: "gemini-2.0-flash",
+      apiKey: getEnvironmentVariable("TEST_API_KEY"),
+    }).bindTools([weatherTool], {
+      tool_choice: "get_weather",
+    });
+
+    const events = [];
+    for await (const event of model.streamEvents(
+      "What is the weather in New York?"
+    )) {
+      events.push(event);
+    }
+
+    const toolCallStart = events.find(
+      (event) =>
+        event.event === "content-block-start" &&
+        event.content.type === "tool_call_chunk"
+    );
+    const toolCallFinish = events.find(
+      (event) =>
+        event.event === "content-block-finish" &&
+        event.content.type === "tool_call"
+    );
+
+    expect(toolCallStart).toMatchObject({
+      content: {
+        type: "tool_call_chunk",
+        id: expect.any(String),
+        name: "get_weather",
+      },
+    });
+    expect(toolCallFinish).toMatchObject({
+      content: {
+        type: "tool_call",
+        id: toolCallStart?.content.id,
+        name: "get_weather",
+      },
+    });
+  });
+});
+
 const coreModelInfo: ModelInfo[] = filterTestableModels([
   (modelInfo: ModelInfo) => !modelInfo.testConfig?.isImage,
   (modelInfo: ModelInfo) => !modelInfo.testConfig?.isTts,

--- a/libs/providers/langchain-google/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google/src/utils/stream_events.ts
@@ -10,6 +10,7 @@ import type {
   FinishReason,
 } from "@langchain/core/language_models/event";
 import type { ContentBlock, UsageMetadata } from "@langchain/core/messages";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import type { Gemini } from "../chat_models/api-types.js";
 
 export type GeminiStreamResponse = Gemini.GenerateContentResponse;
@@ -123,8 +124,11 @@ export async function* convertGoogleGeminiStream(
       } else if (part.functionCall) {
         const key: BlockKey = `tool:${toolIdx}`;
         const args = JSON.stringify(part.functionCall.args ?? {});
+        const id =
+          part.functionCall.id ?? `lc-tool-call-${uuidv4().replace(/-/g, "")}`;
         const { index, isNew } = getOrCreateBlockIndex(key, {
           type: "tool_call_chunk",
+          id,
           name: part.functionCall.name,
           args: "",
           index: toolIdx,
@@ -135,6 +139,7 @@ export async function* convertGoogleGeminiStream(
             index,
             content: {
               type: "tool_call_chunk",
+              id,
               name: part.functionCall.name,
               args: "",
               index: toolIdx,
@@ -150,6 +155,7 @@ export async function* convertGoogleGeminiStream(
             type: "block-delta" as const,
             fields: {
               type: "tool_call_chunk",
+              id: acc.id,
               name: acc.name,
               args: acc.args,
             },

--- a/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
@@ -154,6 +154,34 @@ describe("convertGoogleGeminiStream", () => {
     });
   });
 
+  test("generates distinct ids for concurrent tool calls", async () => {
+    const events = await collectEvents([
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { name: "first_tool", args: {} } },
+                { functionCall: { name: "second_tool", args: {} } },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const ids = events
+      .filter((event) => event.event === "content-block-start")
+      .map((event) => event.content.id);
+
+    expect(ids).toHaveLength(2);
+    expect(ids).toEqual([
+      expect.stringMatching(/^lc-tool-call-/),
+      expect.stringMatching(/^lc-tool-call-/),
+    ]);
+    expect(new Set(ids).size).toBe(2);
+  });
+
   test("usage snapshots", async () => {
     const events = await collectEvents([
       {

--- a/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
@@ -101,6 +101,59 @@ describe("convertGoogleGeminiStream", () => {
     });
   });
 
+  test.each([
+    {
+      label: "preserves a model-provided tool call id",
+      functionCall: {
+        id: "server-assigned-id-123",
+        name: "web_search",
+        args: { query: "weather" },
+      },
+      expectedId: "server-assigned-id-123",
+    },
+    {
+      label: "generates a tool call id when the model omits it",
+      functionCall: {
+        name: "web_search",
+        args: { query: "weather" },
+      },
+      expectedId: expect.stringMatching(/^lc-tool-call-/),
+    },
+  ])("$label", async ({ functionCall, expectedId }) => {
+    const events = await collectEvents([
+      {
+        candidates: [{ content: { parts: [{ functionCall }] } }],
+      },
+    ]);
+
+    expect(
+      events.find((event) => event.event === "content-block-start")
+    ).toMatchObject({
+      content: {
+        type: "tool_call_chunk",
+        id: expectedId,
+      },
+    });
+    expect(
+      events.find((event) => event.event === "content-block-delta")
+    ).toMatchObject({
+      delta: {
+        fields: {
+          type: "tool_call_chunk",
+          id: expectedId,
+        },
+      },
+    });
+    expect(
+      events.find((event) => event.event === "content-block-finish")
+    ).toMatchObject({
+      content: {
+        type: "tool_call",
+        id: expectedId,
+      },
+    });
+  });
+
   test("usage snapshots", async () => {
     const events = await collectEvents([
       {


### PR DESCRIPTION
## Summary

Fixes #11261

- preserve a model-provided Gemini `functionCall.id` in native stream events
- generate the same `lc-tool-call-*` fallback used by the non-streaming converter when Gemini omits the ID
- propagate one stable ID through content-block start, delta, and finish events
- cover the converter, public `ChatGoogle.streamEvents` path, and a live API integration test

This is the `@langchain/google` sibling of #11258; that PR only changes `@langchain/google-genai`.

## Test plan

- `pnpm --filter @langchain/google exec vitest run src/utils/tests/stream_events.test.ts src/chat_models/tests/chat_models_stream_events.test.ts` — 10/10 passed, typecheck clean
- `pnpm --filter @langchain/google build` — passed, including publint and attw
- `pnpm exec oxfmt --check <changed files>` — passed
- `pnpm exec oxlint <changed TypeScript files>` — passed
- `pnpm --filter @langchain/google test` — 133 passed; 3 pre-existing failures remain in `converters/tests/messages.test.ts`, which this PR does not modify or import
- live API integration test added; not executed locally because `TEST_API_KEY` / `TEST_CREDENTIALS` are unavailable

Reverse verification: both focused ID tests fail on current `main` because `content-block-start` has no ID, then pass with this patch.

## AI Disclosure

AI assisted with code review, issue triage, test drafting, and implementation. The diff, reverse verification, and local checks were reviewed before submission.