### PR TITLE
fix(google-common): serialize tool choice modes for Vertex AI

### DIFF
--- a/.changeset/calm-tools-call.md
+++ b/.changeset/calm-tools-call.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+fix Google tool choice modes sent to Vertex AI

--- a/libs/providers/langchain-google-common/src/tests/utils.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/utils.test.ts
@@ -848,6 +848,33 @@ describe("streaming", () => {
   });
 });
 
+describe("gemini tool config formatting", () => {
+  test.each([
+    ["auto", "AUTO"],
+    ["any", "ANY"],
+    ["none", "NONE"],
+  ] as const)("serializes %s mode as %s", async (toolChoice, expectedMode) => {
+    const api = getGeminiAPI();
+    const request = (await api.formatData([new HumanMessage("Use tools.")], {
+      tool_choice: toolChoice,
+    })) as GeminiRequest;
+
+    expect(request.toolConfig?.functionCallingConfig?.mode).toBe(expectedMode);
+  });
+
+  test("serializes a forced function name as ANY", async () => {
+    const api = getGeminiAPI();
+    const request = (await api.formatData([new HumanMessage("Use tools.")], {
+      tool_choice: "lookup_weather",
+    })) as GeminiRequest;
+
+    expect(request.toolConfig?.functionCallingConfig).toEqual({
+      mode: "ANY",
+      allowedFunctionNames: ["lookup_weather"],
+    });
+  });
+});
+
 describe("gemini image URL handling", () => {
   test("handles image_url with external URL and infers MIME type", async () => {
     const api = getGeminiAPI();

--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -757,7 +757,7 @@ export interface GeminiRequest {
   tools?: GeminiTool[];
   toolConfig?: {
     functionCallingConfig?: {
-      mode: "auto" | "any" | "none";
+      mode: "AUTO" | "ANY" | "NONE";
       allowedFunctionNames?: string[];
     };
     /**

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1988,10 +1988,23 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     let config: GeminiRequest["toolConfig"] | undefined;
 
     if (parameters.tool_choice && typeof parameters.tool_choice === "string") {
-      if (["auto", "any", "none"].includes(parameters.tool_choice)) {
+      const mode = (() => {
+        switch (parameters.tool_choice) {
+          case "auto":
+            return "AUTO";
+          case "any":
+            return "ANY";
+          case "none":
+            return "NONE";
+          default:
+            return undefined;
+        }
+      })();
+
+      if (mode) {
         config = {
           functionCallingConfig: {
-            mode: parameters.tool_choice as "auto" | "any" | "none",
+            mode,
             allowedFunctionNames: parameters.allowed_function_names,
           },
         };
@@ -1999,7 +2012,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         // force tool choice to be a single function name in case of structured output
         config = {
           functionCallingConfig: {
-            mode: "any",
+            mode: "ANY",
             allowedFunctionNames: [parameters.tool_choice],
           },
         };

--- a/libs/providers/langchain-google-vertexai/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-google-vertexai/src/tests/chat_models.int.test.ts
@@ -542,6 +542,7 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
 
   test("Can force a model to invoke a tool", async () => {
     const model = new ChatVertexAI({
+      callbacks,
       modelName,
     });
     const modelWithTools = model.bindTools([calculatorTool, weatherTool], {
@@ -557,6 +558,12 @@ describe.each(testGeminiModelNames)("GAuth Gemini Chat (%s)", (modelName) => {
     if (!result.tool_calls?.[0]) return;
     expect(result.tool_calls?.[0].name).toBe("calculator");
     expect(result.tool_calls?.[0].args).toHaveProperty("expression");
+    expect(
+      recorder.request.data.toolConfig.functionCallingConfig
+    ).toMatchObject({
+      mode: "ANY",
+      allowedFunctionNames: ["calculator"],
+    });
   });
 
   test(`stream tools`, async () => {


### PR DESCRIPTION
## Summary
Fixes #11265
- serialize user-facing `auto`, `any`, and `none` tool choices as the uppercase Vertex AI wire enums
- use `ANY` for forced function names while preserving `allowedFunctionNames`
- cover all modes with request-formatting tests and assert the live `ChatVertexAI` request payload in the existing integration test

## Test plan
- `pnpm --filter @langchain/google-common test` — 8 files, 298 tests passed; typecheck clean
- `pnpm --filter @langchain/google-common --filter @langchain/google-vertexai build` — passed
- `pnpm exec oxfmt --check <changed files>` — passed
- `pnpm exec oxlint <changed TypeScript files>` — passed
- live Vertex AI assertion added to the existing forced-tool integration test; not run locally because GCP credentials are unavailable

Reverse verification: the four focused request-formatting cases fail on current `main` with lowercase modes, then pass with this patch.

## AI Disclosure
AI assisted with issue triage, test drafting, and implementation. The diff, reverse verification, and local checks were reviewed before submission.