### PR TITLE
fix(langchain): prevent summary output stream leaks

### DIFF
--- a/.changeset/quiet-summaries-stream.md
+++ b/.changeset/quiet-summaries-stream.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+prevent internal summarization model output from leaking into message streams

--- a/libs/langchain/src/agents/middleware/summarization.ts
+++ b/libs/langchain/src/agents/middleware/summarization.ts
@@ -454,7 +454,7 @@ export function summarizationMiddleware(
 
       const summaryMessage = new HumanMessage({
         content: `${summaryPrefix}\n\n${summary}`,
-        id: uuid(),
+        id: conversationMessages[0].id,
         additional_kwargs: { lc_source: "summarization" },
       });
 

--- a/libs/langchain/src/agents/middleware/summarization.ts
+++ b/libs/langchain/src/agents/middleware/summarization.ts
@@ -942,12 +942,14 @@ async function createSummary(
     );
     /**
      * Merge parent runnable config with summarization metadata so LangGraph's
-     * stream handlers (and other callback-based consumers) can properly track
-     * and tag the summarization model call.
+     * handlers can properly track and tag the summarization model call. Do not
+     * inherit callbacks because this is an internal housekeeping invocation
+     * whose output should not be emitted to the user-facing message stream.
      */
     const baseConfig: RunnableConfig = pickRunnableConfigKeys(runtime) ?? {};
     const config = mergeConfigs(baseConfig, {
       metadata: { lc_source: "summarization" },
+      callbacks: [],
     });
     const response = await model.invoke(formattedPrompt, config);
     const content = response.content;

--- a/libs/langchain/src/agents/middleware/tests/summarization.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/summarization.test.ts
@@ -1031,7 +1031,7 @@ describe("summarizationMiddleware", () => {
     });
   });
 
-  it("should not leak summarization model streaming chunks when using streamMode messages", async () => {
+  it("should not leak summarization messages when using streamMode messages", async () => {
     const MAIN_MODEL_CONTENT =
       "I understand your project. Let me analyze the architecture.";
 
@@ -1071,9 +1071,17 @@ describe("summarizationMiddleware", () => {
 
     // Collect all streamed AIMessage content (only assistant/AI responses)
     const streamedAIContents: string[] = [];
+    const streamedSummarizationMessages: string[] = [];
     for await (const [mode, chunk] of stream) {
       if (mode === "messages") {
         const [msg] = chunk as [any, any];
+        if (msg.additional_kwargs?.lc_source === "summarization") {
+          streamedSummarizationMessages.push(
+            typeof msg.content === "string"
+              ? msg.content
+              : JSON.stringify(msg.content)
+          );
+        }
         // Only collect AIMessage content (role === "assistant" or type === "ai")
         const isAIMessage =
           msg._getType?.() === "ai" ||
@@ -1096,6 +1104,7 @@ describe("summarizationMiddleware", () => {
 
     const allStreamedAIContent = streamedAIContents.join(" ");
     expect(allStreamedAIContent).not.toContain("Context Extraction Assistant");
+    expect(streamedSummarizationMessages).toEqual([]);
 
     // Verify the main model's content DOES appear in the stream
     expect(allStreamedAIContent).toContain(MAIN_MODEL_CONTENT);

--- a/libs/langchain/src/agents/middleware/tests/summarization.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/summarization.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from "vitest";
 import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import { FakeChatModel } from "@langchain/core/utils/testing";
 
 import { summarizationMiddleware } from "../summarization.js";
 import { createAgent } from "../../index.js";
@@ -1031,21 +1032,11 @@ describe("summarizationMiddleware", () => {
   });
 
   it("should not leak summarization model streaming chunks when using streamMode messages", async () => {
-    const SUMMARIZATION_RAW_OUTPUT =
-      "INTERNAL_SUMMARY_OUTPUT_SHOULD_NOT_BE_STREAMED_AS_AI_MESSAGE";
     const MAIN_MODEL_CONTENT =
       "I understand your project. Let me analyze the architecture.";
 
-    // Create a summarization model with distinctive content
-    const summarizationModel = {
-      invoke: vi.fn().mockImplementation(async () => {
-        return { content: SUMMARIZATION_RAW_OUTPUT };
-      }),
-      getName: () => "mock-summarizer",
-      _modelType: "mock",
-      lc_runnable: true,
-      profile: {},
-    };
+    const summarizationModel = new FakeChatModel({});
+    const summarizationInvoke = vi.spyOn(summarizationModel, "invoke");
 
     // Create a main model with a distinctive response
     const model = new FakeToolCallingChatModel({
@@ -1053,7 +1044,7 @@ describe("summarizationMiddleware", () => {
     });
 
     const middleware = summarizationMiddleware({
-      model: summarizationModel as any,
+      model: summarizationModel,
       trigger: { tokens: 50 },
       keep: { messages: 2 },
     });
@@ -1101,15 +1092,10 @@ describe("summarizationMiddleware", () => {
     }
 
     // Verify summarization was triggered
-    expect(summarizationModel.invoke).toHaveBeenCalled();
+    expect(summarizationInvoke).toHaveBeenCalled();
 
-    // Verify the raw summarization model output does NOT appear as an AIMessage
-    // This would happen if callbacks leaked from the internal model.invoke()
     const allStreamedAIContent = streamedAIContents.join(" ");
-    expect(allStreamedAIContent).not.toContain(
-      "INTERNAL_SUMMARY_OUTPUT_SHOULD_NOT_BE_STREAMED_AS_AI_MESSAGE"
-    );
-    expect(allStreamedAIContent).not.toContain(SUMMARIZATION_RAW_OUTPUT);
+    expect(allStreamedAIContent).not.toContain("Context Extraction Assistant");
 
     // Verify the main model's content DOES appear in the stream
     expect(allStreamedAIContent).toContain(MAIN_MODEL_CONTENT);


### PR DESCRIPTION
## Summary

Fixes #11238

- prevent the internal summarization model invocation from inheriting user-facing callbacks
- keep parent tags and metadata while isolating the housekeeping model call from message streams
- reuse the summarized state message ID so the synthetic summary remains in agent state without being emitted as a new message

## Test plan

- `pnpm --filter langchain test` — 59 files, 845 tests passed; typecheck clean
- `pnpm --filter langchain build` — passed, including publint and attw
- `pnpm exec oxfmt --check <changed files>` — passed
- `pnpm exec oxlint <changed TypeScript files>` — passed

Reverse verification covers both leak paths: removing callback isolation emits the internal summarizer model output, while assigning a fresh ID to the synthetic summary emits the `lc_source: "summarization"` `HumanMessage`.

## AI Disclosure

AI assisted with issue triage, test repair, implementation, and validation. The diff and reverse verification were reviewed before submission.