### PR TITLE
fix(google-common): send tool results with the user role instead of the invalid function role

### DIFF
--- a/.changeset/witty-toes-argue.md
+++ b/.changeset/witty-toes-argue.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): send tool results with the `user` role instead of the invalid `function` role

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -2597,6 +2597,148 @@ describe("Mock ChatGoogle - Gemini", () => {
     expect(result).toBeDefined();
   });
 
+  const testTools: GeminiTool[] = [
+    {
+      functionDeclarations: [
+        {
+          name: "test",
+          description:
+            "Run a test with a specific name and get if it passed or failed",
+          parameters: {
+            type: "object",
+            properties: {
+              testName: {
+                type: "string",
+                description: "The name of the test that should be run.",
+              },
+            },
+            required: ["testName"],
+          },
+        },
+      ],
+    },
+  ];
+
+  test("5-1. Functions - function reply uses the user role", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-5-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+    }).bindTools(testTools);
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Run a test on the cobalt project."),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            id: "test_1",
+            name: "test",
+            args: { testName: "cobalt" },
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: "test_1",
+        name: "test",
+        content: JSON.stringify({ testPassed: true }),
+      }),
+    ];
+    await model.invoke(messages);
+
+    // Gemini only accepts the roles "user" and "model"
+    const contents = record?.opts?.data?.contents;
+    expect(contents.map((content: any) => content.role)).toEqual([
+      "user",
+      "model",
+      "user",
+    ]);
+    expect(contents[2].parts[0]).toHaveProperty("functionResponse");
+  });
+
+  test("5-2. Functions - parallel function replies stay in one turn", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-5-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+    }).bindTools(testTools);
+    const messages: BaseMessageLike[] = [
+      new HumanMessage("Run a test on the cobalt and nickel projects."),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            id: "test_1",
+            name: "test",
+            args: { testName: "cobalt" },
+            type: "tool_call",
+          },
+          {
+            id: "test_2",
+            name: "test",
+            args: { testName: "nickel" },
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: "test_1",
+        name: "test",
+        content: JSON.stringify({ testPassed: true }),
+      }),
+      new ToolMessage({
+        tool_call_id: "test_2",
+        name: "test",
+        content: JSON.stringify({ testPassed: false }),
+      }),
+    ];
+    await model.invoke(messages);
+
+    // Gemini requires one function response part per function call part, so
+    // splitting these into two turns is rejected
+    const contents = record?.opts?.data?.contents;
+    expect(contents).toHaveLength(3);
+    expect(contents[2].role).toEqual("user");
+    expect(contents[2].parts).toHaveLength(2);
+    expect(contents[2].parts[0]).toHaveProperty("functionResponse");
+    expect(contents[2].parts[1]).toHaveProperty("functionResponse");
+  });
+
+  test("5-3. Consecutive human messages are kept separate", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-1-mock.json",
+    };
+
+    const model = new ChatGoogle({
+      authOptions,
+    });
+    await model.invoke([
+      new HumanMessage("First question."),
+      new HumanMessage("Second question."),
+    ]);
+
+    // Only function responses are combined - giving tool results the "user"
+    // role must not start folding ordinary turns together
+    const contents = record?.opts?.data?.contents;
+    expect(contents).toHaveLength(2);
+  });
+
   test("4-5. Functions - conversation with signature", async () => {
     const messages: BaseMessageLike[] = [
       new HumanMessage("Run a test on the cobalt project."),

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -900,11 +900,13 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       (isAIMessage(prevMessage) && !!prevMessage.tool_calls?.length
         ? prevMessage.tool_calls[0].name
         : prevMessage.name) ?? message.tool_call_id;
+    // Gemini only accepts the roles "user" and "model" on a Content, so a tool
+    // result is sent as a "user" turn that carries a functionResponse part.
     try {
       const content = JSON.parse(contentStr);
       return [
         {
-          role: "function",
+          role: "user",
           parts: [
             {
               functionResponse: {
@@ -918,7 +920,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     } catch (_) {
       return [
         {
-          role: "function",
+          role: "user",
           parts: [
             {
               functionResponse: {
@@ -1728,6 +1730,13 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     return contents;
   }
 
+  function isFunctionResponseContent(content: GeminiContent): boolean {
+    return (
+      content.parts.length > 0 &&
+      content.parts.every((part) => "functionResponse" in part)
+    );
+  }
+
   async function formatBaseMessageContents(
     input: BaseMessage[],
     _parameters: GoogleAIModelParams
@@ -1743,16 +1752,16 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         return acc;
       }
 
-      // Combine adjacent function messages
+      // Combine adjacent function messages. Tool results no longer carry a
+      // distinguishing role, so they are identified by their parts.
+      const prev = acc[acc.length - 1];
       if (
-        cur[0]?.role === "function" &&
-        acc.length > 0 &&
-        acc[acc.length - 1].role === "function"
+        cur[0] !== undefined &&
+        isFunctionResponseContent(cur[0]) &&
+        prev !== undefined &&
+        isFunctionResponseContent(prev)
       ) {
-        acc[acc.length - 1].parts = [
-          ...acc[acc.length - 1].parts,
-          ...cur[0].parts,
-        ];
+        prev.parts = [...prev.parts, ...cur[0].parts];
       } else {
         acc.push(...cur);
       }


### PR DESCRIPTION
## Description

`Content.role` in the Gemini API accepts only `user` and `model`. Both discovery documents say so:

> `role`: _"Optional. The producer of the content. **Must be either 'user' or 'model'.** If not set, the service will default to 'user'."_
> — [Vertex v1](https://aiplatform.googleapis.com/$discovery/rest?version=v1), same wording in [Gemini API v1beta](https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta)

`toolMessageToContent` labels every tool result `role: "function"`. An unrecognised role is undefined behaviour rather than a defined error, so part of the Vertex fleet ignores it and part rejects the request with `400 INVALID_ARGUMENT — "Please use a valid role: user, model."`. Since the `global` endpoint spreads requests across a shared fleet, the same history intermittently 400s and an immediate retry usually works — which is why this reads as flakiness rather than a bug.

Measured against real Vertex (`gemini-3.1-flash-lite`, `location: global`) on one byte-identical payload, varying only the role:

| payload                                     | failures            |
| ------------------------------------------- | ------------------- |
| `role: "function"` (what this package sends) | **5/40** and **7/40** |
| `role: "user"`                              | **0/40**            |
| role omitted                                | **0/40**            |

Semantics are unaffected. With a tool result carrying values the model could not guess, all three variants produced the same correct answer — this is an invalid label, not a change in meaning.

`@langchain/google-common` is the only Google package still sending it. The three siblings already send `user`:

- `@langchain/google-genai` — [`src/utils/common.ts`](https://github.com/langchain-ai/langchainjs/blob/main/libs/providers/langchain-google-genai/src/utils/common.ts): `actualRole = "user"` with the comment _"GenerativeAI API will throw an error if the role is not 'user' or 'model.'"_
- `@langchain/google` — [`src/converters/messages.ts`](https://github.com/langchain-ai/langchainjs/blob/main/libs/providers/langchain-google/src/converters/messages.ts): _"Tool messages in Gemini were represented as function responses, but now are 'user'"_
- `langchain-google` (Python) — [#1059](https://github.com/langchain-ai/langchain-google/issues/1059), fixed by [PR #1238](https://github.com/langchain-ai/langchain-google/pull/1238)

## Changes

**`toolMessageToContent`** now emits `role: "user"`.

**`formatBaseMessageContents`** identifies adjacent function responses by their `functionResponse` parts instead of by the role, so parallel tool calls still collapse into a single turn — Gemini requires one function response part per function call part in the turn, and splitting them is rejected.

Note this differs from the fix suggested in the issue, which renamed the role _after_ the merge. Keying the merge on the parts is equivalent on the wire and never constructs the invalid role in the first place. What it deliberately does **not** do is switch the existing role comparison to `"user"`: that reduce runs over every converted content, so it would additionally fold two consecutive `HumanMessage`s into one turn. Test 5-3 below pins that down.

The `"function"` member of the exported `GeminiRole` union is left in place — nothing emits it now, but removing it would be a breaking type change.

## Tests

Three tests in `chat_models.test.ts`, asserting the serialized request via the existing mock-client `record`:

- **5-1** — tool result goes out as `user`, carrying a `functionResponse` part
- **5-2** — parallel tool results stay merged in one turn with two parts
- **5-3** — consecutive `HumanMessage`s are still kept separate

5-1 and 5-2 both fail if the role change is reverted; 5-3 passes either way, which is the point — it guards against this PR changing anything other than the role.

Verified locally on Node 24: `@langchain/google-common` 300/300, `google-gauth` 2/2, `google-vertexai` 12/12, `google-vertexai-web` 10/10, plus `oxlint` and `oxfmt --check` clean. (`@langchain/google` has 3 failures in `converters/tests/messages.test.ts` that reproduce on an unmodified `main` — unrelated to this change.)

Beyond the unit tests, the change was run against real Vertex through an application making 50 consecutive tool-calling turns: 50/50 succeeded, against ~6 expected failures at the observed baseline.

Fixes #11269
