### PR TITLE
fix(core): coalesce duplicate LangChainTracer copies sharing a run store

### DIFF
--- a/libs/langchain-core/src/callbacks/manager.ts
+++ b/libs/langchain-core/src/callbacks/manager.ts
@@ -1381,26 +1381,126 @@ export class CallbackManager
       callbackManager &&
       (tracerInheritableMetadata || tracerInheritableTags)
     ) {
-      callbackManager.handlers = callbackManager.handlers.map((handler) =>
-        handler instanceof LangChainTracer
-          ? handler.copyWithTracingConfig({
-              metadata: tracerInheritableMetadata,
-              tags: tracerInheritableTags,
-            })
-          : handler
-      );
+      // Copy each tracer once and reuse that copy in both arrays. Copying the
+      // arrays separately would make two copies of the same tracer, which both
+      // handle the same run and make the second one throw.
+      const tracerCopies = new Map<LangChainTracer, LangChainTracer>();
+      const applyTracingConfig = (handler: BaseCallbackHandler) => {
+        if (!(handler instanceof LangChainTracer)) {
+          return handler;
+        }
+        let copy = tracerCopies.get(handler);
+        if (copy === undefined) {
+          copy = handler.copyWithTracingConfig({
+            metadata: tracerInheritableMetadata,
+            tags: tracerInheritableTags,
+          });
+          tracerCopies.set(handler, copy);
+        }
+        return copy;
+      };
+      callbackManager.handlers =
+        callbackManager.handlers.map(applyTracingConfig);
       callbackManager.inheritableHandlers =
-        callbackManager.inheritableHandlers.map((handler) =>
-          handler instanceof LangChainTracer
-            ? handler.copyWithTracingConfig({
-                metadata: tracerInheritableMetadata,
-                tags: tracerInheritableTags,
-              })
-            : handler
-        );
+        callbackManager.inheritableHandlers.map(applyTracingConfig);
+    }
+
+    if (callbackManager) {
+      coalesceTracers(callbackManager);
     }
 
     return callbackManager;
+  }
+}
+
+/**
+ * Dedupes tracers that share a run store down to one, so a run is not ended
+ * twice (which throws "No ... run to end").
+ *
+ * Nested config merges can leave several copies of the same tracer in one
+ * manager; this keeps a single merged survivor in `handlers` (and, if any copy
+ * was inheritable, in `inheritableHandlers`). Independent tracers and other
+ * handlers are left alone.
+ */
+function coalesceTracers(callbackManager: CallbackManager): void {
+  // `instanceof LangChainTracer` also matches look-alikes (via the class's
+  // `Symbol.hasInstance`). Only real tracers have `getRunStoreKey`, so key on
+  // that and skip the rest.
+  const isRunStoreTracer = (
+    handler: BaseCallbackHandler
+  ): handler is LangChainTracer =>
+    handler instanceof LangChainTracer &&
+    typeof (handler as LangChainTracer).getRunStoreKey === "function";
+
+  const inheritableSet = new Set<BaseCallbackHandler>(
+    callbackManager.inheritableHandlers
+  );
+
+  // One merged tracer per run store, plus which run stores were inheritable.
+  const canonicalByRunStore = new Map<object, LangChainTracer>();
+  const inheritableRunStores = new Set<object>();
+  let tracerCount = 0;
+
+  const consider = (handler: BaseCallbackHandler) => {
+    if (!isRunStoreTracer(handler)) {
+      return;
+    }
+    tracerCount += 1;
+    const key = handler.getRunStoreKey();
+    const existing = canonicalByRunStore.get(key);
+    // The merged tracer shares the same run store, so the key stays the same.
+    canonicalByRunStore.set(
+      key,
+      existing === undefined
+        ? handler
+        : existing.copyWithTracingConfig({
+            metadata: handler.tracingMetadata,
+            tags: handler.tracingTags,
+          })
+    );
+    if (inheritableSet.has(handler)) {
+      inheritableRunStores.add(key);
+    }
+  };
+  for (const handler of callbackManager.handlers) consider(handler);
+  for (const handler of callbackManager.inheritableHandlers) consider(handler);
+
+  // Nothing to do unless there was a duplicate.
+  if (tracerCount === canonicalByRunStore.size) {
+    return;
+  }
+
+  const replace = (handlers: BaseCallbackHandler[]) => {
+    const out: BaseCallbackHandler[] = [];
+    for (const handler of handlers) {
+      if (!isRunStoreTracer(handler)) {
+        out.push(handler);
+        continue;
+      }
+      const canonical = canonicalByRunStore.get(handler.getRunStoreKey())!;
+      if (!out.includes(canonical)) {
+        out.push(canonical);
+      }
+    }
+    return out;
+  };
+  callbackManager.handlers = replace(callbackManager.handlers);
+  callbackManager.inheritableHandlers = replace(
+    callbackManager.inheritableHandlers
+  );
+
+  // Keep each survivor in `handlers`, and inheritable ones in
+  // `inheritableHandlers` too.
+  for (const [key, canonical] of canonicalByRunStore) {
+    if (!callbackManager.handlers.includes(canonical)) {
+      callbackManager.handlers.push(canonical);
+    }
+    if (
+      inheritableRunStores.has(key) &&
+      !callbackManager.inheritableHandlers.includes(canonical)
+    ) {
+      callbackManager.inheritableHandlers.push(canonical);
+    }
   }
 }
 

--- a/libs/langchain-core/src/tracers/tracer_langchain.ts
+++ b/libs/langchain-core/src/tracers/tracer_langchain.ts
@@ -209,6 +209,17 @@ export class LangChainTracer
     return copied;
   }
 
+  /**
+   * Identity of this tracer's run store.
+   *
+   * Copies made by `copyWithTracingConfig()` share it, so two tracers with the
+   * same key are copies of each other. The callback manager uses this to dedupe
+   * them, since two copies handling the same run makes the second one throw.
+   */
+  getRunStoreKey(): object {
+    return this.runTreeMap;
+  }
+
   getRun(id: string): Run | undefined {
     return this.runTreeMap.get(id);
   }


### PR DESCRIPTION
## Summary

With LangSmith tracing on, nested runs flood the console with warnings and cause redundant LangSmith writes:

```
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleLLMEnd: Error: No LLM run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleToolEnd: Error: No tool run to end
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleLLMEnd: Error: No LLM run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
Error in handler LangChainTracer, handleChainEnd: Error: No chain run to end.
```

Two `LangChainTracer` instances end up sharing one run store. Both get the same end event which causes the first to delete the run meaning the second can't find it and throws.

## Root cause

1. `_configureSync()` mapped `handlers` and `inheritableHandlers` in two separate passes, each calling `copyWithTracingConfig()`. This produces two distinct copies of the same tracer and breaks the identity aliasing `copy()` relies on.
2. `mergeConfigs()` concatenates handler arrays without dedup so copies pile up across nested merges.

## Fix

- Copy each tracer once (`Map<source, copy>`) and reuse that copy in both arrays.
- Add `coalesceTracers()` to collapse tracers sharing a run store into one, keyed on `getRunStoreKey()`.

## Verification

Offline repro (nested `createAgent`, tracing to a dead endpoint): 12 warnings before, 0 after.
New unit tests
