### PR TITLE
fix(langchain-mongodb): route Atlas-provisioned Voyage keys to MongoDB AI endpoint

### DIFF
--- a/.changeset/fix-voyage-mongodb-atlas-base-url.md
+++ b/.changeset/fix-voyage-mongodb-atlas-base-url.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mongodb": patch
+---
+
+fix(voyage): route Atlas-provisioned Voyage API keys to the MongoDB AI endpoint instead of api.voyageai.com

--- a/libs/providers/langchain-mongodb/src/voyage.ts
+++ b/libs/providers/langchain-mongodb/src/voyage.ts
@@ -135,7 +135,7 @@ export class VoyageEmbeddings
   private apiKey: string;
 
   /** Do not modify directly. Pass in the basePath option to the constructor. */
-  basePath?: string = "https://api.voyageai.com/v1";
+  basePath?: string;
 
   apiUrl: string;
 
@@ -179,7 +179,11 @@ export class VoyageEmbeddings
     this.modelName = fieldsWithDefaults?.modelName ?? this.modelName;
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.apiKey = apiKey;
-    this.basePath = fieldsWithDefaults?.basePath ?? this.basePath;
+    this.basePath =
+      fieldsWithDefaults?.basePath ??
+      (apiKey.startsWith("al-")
+        ? "https://ai.mongodb.com/v1"
+        : "https://api.voyageai.com/v1");
     this.apiUrl = `${this.basePath}/embeddings`;
     this.inputType = fieldsWithDefaults?.inputType;
     this.truncation = fieldsWithDefaults?.truncation;


### PR DESCRIPTION
MongoDB Atlas–provisioned Voyage AI API keys start with `al-` and must be
routed to `https://ai.mongodb.com/v1` instead of the default
`https://api.voyageai.com/v1`. The Python `VoyageEmbeddings` class already
implements this routing via `get_default_base_url(api_key)`, but the JS
class always uses the Voyage AI endpoint regardless of key prefix.

**Fix:** detect the `al-` prefix in the constructor and set the base URL
accordingly, unless the caller explicitly passed a `basePath` override.

The class-field default `basePath = "https://api.voyageai.com/v1"` is
removed since the constructor now always assigns deterministically.