### PR TITLE
fix(langchain): resolve LocalFileStore keys with path.relative

### DIFF
--- a/.changeset/two-cases-marry.md
+++ b/.changeset/two-cases-marry.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): resolve LocalFileStore keys with path.relative

--- a/libs/langchain/src/storage/file_system.ts
+++ b/libs/langchain/src/storage/file_system.ts
@@ -108,10 +108,15 @@ export class LocalFileStore extends BaseStore<string, Uint8Array> {
         throw new Error(`Invalid characters in key: ${key}`);
       }
 
-      const fullPath = path.resolve(this.rootPath, keyAsTxtFile);
-      const commonPath = path.resolve(this.rootPath);
+      const rootPath = path.resolve(this.rootPath);
+      const fullPath = path.resolve(rootPath, keyAsTxtFile);
+      const relativePath = path.relative(rootPath, fullPath);
 
-      if (!fullPath.startsWith(commonPath)) {
+      if (
+        relativePath === ".." ||
+        relativePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativePath)
+      ) {
         throw new Error(
           `Invalid key: ${key}. Key should be relative to the root path. ` +
             `Root path: ${this.rootPath}, Full path: ${fullPath}`

--- a/libs/langchain/src/storage/tests/file_system.test.ts
+++ b/libs/langchain/src/storage/tests/file_system.test.ts
@@ -215,4 +215,54 @@ describe("LocalFileStore", () => {
     await expect(store.mget(["\\foo"])).rejects.toThrowError();
     await fs.promises.rm(secondaryRootPath, { recursive: true, force: true });
   });
+
+  test("Should disallow writes into a sibling directory sharing the root path prefix", async () => {
+    const encoder = new TextEncoder();
+    const containerDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "file_system_store_sibling")
+    );
+    const rootPath = path.join(containerDir, "root");
+    const siblingPath = path.join(containerDir, "root2");
+    await fs.promises.mkdir(siblingPath, { recursive: true });
+    const store = await LocalFileStore.fromPath(rootPath);
+
+    await expect(
+      store.mset([["../root2/pwn", encoder.encode("pwned")]])
+    ).rejects.toThrowError();
+    expect(fs.existsSync(path.join(siblingPath, "pwn.txt"))).toBe(false);
+
+    await fs.promises.rm(containerDir, { recursive: true, force: true });
+  });
+
+  test("Should disallow deletes in a sibling directory sharing the root path prefix", async () => {
+    const containerDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "file_system_store_sibling")
+    );
+    const rootPath = path.join(containerDir, "root");
+    const siblingPath = path.join(containerDir, "root2");
+    await fs.promises.mkdir(siblingPath, { recursive: true });
+    const victimFile = path.join(siblingPath, "victim.txt");
+    fs.writeFileSync(victimFile, "do not delete");
+    const store = await LocalFileStore.fromPath(rootPath);
+
+    await expect(store.mdelete(["../root2/victim"])).rejects.toThrowError();
+    expect(fs.existsSync(victimFile)).toBe(true);
+
+    await fs.promises.rm(containerDir, { recursive: true, force: true });
+  });
+
+  test("Should allow keys nested in a subdirectory of the root path", async () => {
+    const encoder = new TextEncoder();
+    const nestedDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "file_system_store_nested")
+    );
+    const store = await LocalFileStore.fromPath(nestedDir);
+
+    await store.mset([["sub/dir/key", encoder.encode("nested")]]);
+    expect(
+      fs.readFileSync(path.join(nestedDir, "sub/dir/key.txt"), "utf8")
+    ).toBe("nested");
+
+    await fs.promises.rm(nestedDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
`LocalFileStore` checked key containment with `startsWith()` on resolved paths. That is a string prefix test, not a path test, so it accepted sibling directories extending the root's name: under root `/data/store`, key `../store2/notes` resolved to `/data/store2/notes.txt` and passed.

Now checked with `path.relative()`, rejecting resolved paths that are absolute or step above the root. Subdirectory keys still work.