### PR TITLE
fix(core): redact MCP tracing credentials

### DIFF
--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -1164,16 +1164,9 @@ export abstract class BaseChatModel<
 
   protected _getCallOptionsForTracing(
     options: this["ParsedCallOptions"],
-    invocationParams: ReturnType<this["invocationParams"]>
+    _invocationParams: ReturnType<this["invocationParams"]>
   ): this["ParsedCallOptions"] {
-    const traceOptions = { ...options };
-    for (const key of Object.keys(traceOptions)) {
-      if (key in invocationParams) {
-        traceOptions[key as keyof this["ParsedCallOptions"]] =
-          invocationParams[key];
-      }
-    }
-    return traceOptions;
+    return options;
   }
 
   /**

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -523,7 +523,7 @@ export abstract class BaseChatModel<
         ...runnableConfig.metadata,
         ...this.getLsParamsWithDefaults(callOptions),
       };
-      const invocationParams = this.invocationParams(callOptions);
+      const invocationParams = this._getInvocationParamsForTracing(callOptions);
       const callbackManager_ = await CallbackManager.configure(
         runnableConfig.callbacks,
         this.callbacks,
@@ -538,7 +538,7 @@ export abstract class BaseChatModel<
         }
       );
       const extra = {
-        options: callOptions,
+        options: this._getCallOptionsForTracing(callOptions, invocationParams),
         invocation_params: invocationParams,
         batch_size: 1,
       };
@@ -664,7 +664,8 @@ export abstract class BaseChatModel<
         ...handledOptions.metadata,
         ...this.getLsParamsWithDefaults(parsedOptions),
       };
-      const invocationParams = this.invocationParams(parsedOptions);
+      const invocationParams =
+        this._getInvocationParamsForTracing(parsedOptions);
       // create callback manager and start run
       const callbackManager_ = await CallbackManager.configure(
         handledOptions.callbacks,
@@ -680,7 +681,10 @@ export abstract class BaseChatModel<
         }
       );
       const extra = {
-        options: parsedOptions,
+        options: this._getCallOptionsForTracing(
+          parsedOptions,
+          invocationParams
+        ),
         invocation_params: invocationParams,
         batch_size: 1,
       };
@@ -944,7 +948,7 @@ export abstract class BaseChatModel<
       ...handledOptions.metadata,
       ...this.getLsParamsWithDefaults(parsedOptions),
     };
-    const invocationParams = this.invocationParams(parsedOptions);
+    const invocationParams = this._getInvocationParamsForTracing(parsedOptions);
     // create callback manager and start run
     const callbackManager_ = await CallbackManager.configure(
       handledOptions.callbacks,
@@ -960,7 +964,7 @@ export abstract class BaseChatModel<
       }
     );
     const extra = {
-      options: parsedOptions,
+      options: this._getCallOptionsForTracing(parsedOptions, invocationParams),
       invocation_params: invocationParams,
       batch_size: 1,
     };
@@ -1150,6 +1154,26 @@ export abstract class BaseChatModel<
     }
 
     return { generations, llmOutput } as LLMResult;
+  }
+
+  protected _getInvocationParamsForTracing(
+    options?: this["ParsedCallOptions"]
+  ): ReturnType<this["invocationParams"]> {
+    return this.invocationParams(options);
+  }
+
+  protected _getCallOptionsForTracing(
+    options: this["ParsedCallOptions"],
+    invocationParams: ReturnType<this["invocationParams"]>
+  ): this["ParsedCallOptions"] {
+    const traceOptions = { ...options };
+    for (const key of Object.keys(traceOptions)) {
+      if (key in invocationParams) {
+        traceOptions[key as keyof this["ParsedCallOptions"]] =
+          invocationParams[key];
+      }
+    }
+    return traceOptions;
   }
 
   /**

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1323,6 +1323,27 @@ export class ChatAnthropicMessages<
     };
   }
 
+  protected override _getCallOptionsForTracing(
+    options: this["ParsedCallOptions"],
+    _invocationParams: ReturnType<this["invocationParams"]>
+  ): this["ParsedCallOptions"] {
+    if (!Array.isArray(options.mcp_servers)) {
+      return options;
+    }
+    return {
+      ...options,
+      mcp_servers: options.mcp_servers.map((server) => {
+        if (!("authorization_token" in server)) {
+          return server;
+        }
+        return {
+          ...server,
+          authorization_token: "**REDACTED**",
+        };
+      }),
+    };
+  }
+
   /** @ignore */
   _identifyingParams() {
     return {

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1302,6 +1302,27 @@ export class ChatAnthropicMessages<
     return output;
   }
 
+  protected override _getInvocationParamsForTracing(
+    options?: this["ParsedCallOptions"]
+  ): ReturnType<this["invocationParams"]> {
+    const params = this.invocationParams(options);
+    if (!Array.isArray(params.mcp_servers)) {
+      return params;
+    }
+    return {
+      ...params,
+      mcp_servers: params.mcp_servers.map((server) => {
+        if (!("authorization_token" in server)) {
+          return server;
+        }
+        return {
+          ...server,
+          authorization_token: "**REDACTED**",
+        };
+      }),
+    };
+  }
+
   /** @ignore */
   _identifyingParams() {
     return {

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -72,6 +72,8 @@ import {
   createFunctionCallingParser,
 } from "@langchain/core/language_models/structured_output";
 
+const MCP_CREDENTIALS_REDACTED = "**REDACTED**";
+
 // Default max output tokens per model family (prefix-matched).
 // These are sensible defaults for the `max_tokens` API parameter when
 // the user does not explicitly set `maxTokens`. Values are based on the
@@ -1317,7 +1319,7 @@ export class ChatAnthropicMessages<
         }
         return {
           ...server,
-          authorization_token: "**REDACTED**",
+          authorization_token: MCP_CREDENTIALS_REDACTED,
         };
       }),
     };
@@ -1338,7 +1340,7 @@ export class ChatAnthropicMessages<
         }
         return {
           ...server,
-          authorization_token: "**REDACTED**",
+          authorization_token: MCP_CREDENTIALS_REDACTED,
         };
       }),
     };

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -34,8 +34,15 @@ test("MCP authorization tokens are redacted from traces", () => {
     modelName: "claude-haiku-4-5-20251001",
     anthropicApiKey: "testing",
   });
+  const publicServer = {
+    type: "url" as const,
+    url: "https://example.com/public-mcp",
+    name: "public-server",
+  };
   const options = {
+    stop: ["done"],
     mcp_servers: [
+      publicServer,
       {
         type: "url" as const,
         url: "https://example.com/mcp",
@@ -49,13 +56,15 @@ test("MCP authorization tokens are redacted from traces", () => {
   const traceParams = model.traceParams(options);
   const traceOptions = model.traceOptions(options);
 
-  expect(requestParams.mcp_servers?.[0].authorization_token).toBe(
+  expect(requestParams.mcp_servers?.[1].authorization_token).toBe(
     "authorization-secret"
   );
-  expect(traceParams.mcp_servers?.[0].authorization_token).toBe("**REDACTED**");
-  expect(traceOptions.mcp_servers?.[0].authorization_token).toBe(
+  expect(traceParams.mcp_servers?.[1].authorization_token).toBe("**REDACTED**");
+  expect(traceOptions.mcp_servers?.[1].authorization_token).toBe(
     "**REDACTED**"
   );
+  expect(traceOptions.stop).toBe(options.stop);
+  expect(traceOptions.mcp_servers?.[0]).toBe(publicServer);
   expect(JSON.stringify({ traceParams, traceOptions })).not.toContain(
     "authorization-secret"
   );

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -14,6 +14,53 @@ import { ChatAnthropic, ChatAnthropicMessages } from "../chat_models.js";
 import { _convertMessagesToAnthropicPayload } from "../utils/message_inputs.js";
 import { AnthropicToolExtrasSchema } from "../utils/tools.js";
 
+class TraceableChatAnthropic extends ChatAnthropicMessages {
+  traceParams(
+    options: Parameters<ChatAnthropicMessages["invocationParams"]>[0]
+  ) {
+    return this._getInvocationParamsForTracing(options);
+  }
+
+  traceOptions(
+    options: Parameters<ChatAnthropicMessages["invocationParams"]>[0]
+  ) {
+    const params = this._getInvocationParamsForTracing(options);
+    return this._getCallOptionsForTracing(options ?? {}, params);
+  }
+}
+
+test("MCP authorization tokens are redacted from traces", () => {
+  const model = new TraceableChatAnthropic({
+    modelName: "claude-haiku-4-5-20251001",
+    anthropicApiKey: "testing",
+  });
+  const options = {
+    mcp_servers: [
+      {
+        type: "url" as const,
+        url: "https://example.com/mcp",
+        name: "private-server",
+        authorization_token: "authorization-secret",
+      },
+    ],
+  };
+
+  const requestParams = model.invocationParams(options);
+  const traceParams = model.traceParams(options);
+  const traceOptions = model.traceOptions(options);
+
+  expect(requestParams.mcp_servers?.[0].authorization_token).toBe(
+    "authorization-secret"
+  );
+  expect(traceParams.mcp_servers?.[0].authorization_token).toBe("**REDACTED**");
+  expect(traceOptions.mcp_servers?.[0].authorization_token).toBe(
+    "**REDACTED**"
+  );
+  expect(JSON.stringify({ traceParams, traceOptions })).not.toContain(
+    "authorization-secret"
+  );
+});
+
 test("constructor supports model shorthand for ChatAnthropicMessages", () => {
   const model = new ChatAnthropicMessages("claude-haiku-4-5-20251001", {
     anthropicApiKey: "testing",

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -70,6 +70,8 @@ import {
   createFunctionCallingParser,
 } from "@langchain/core/language_models/structured_output";
 
+const MCP_CREDENTIALS_REDACTED = "**REDACTED**";
+
 interface OpenAILLMOutput {
   tokenUsage: {
     completionTokens?: number;
@@ -453,10 +455,10 @@ export abstract class BaseChatOpenAI<
         }
         const redactedTool: Record<string, unknown> = { ...tool };
         if ("headers" in redactedTool) {
-          redactedTool.headers = "**REDACTED**";
+          redactedTool.headers = MCP_CREDENTIALS_REDACTED;
         }
         if ("authorization" in redactedTool) {
-          redactedTool.authorization = "**REDACTED**";
+          redactedTool.authorization = MCP_CREDENTIALS_REDACTED;
         }
         return redactedTool;
       }),
@@ -483,10 +485,10 @@ export abstract class BaseChatOpenAI<
         }
         const redactedTool = { ...tool };
         if ("headers" in redactedTool) {
-          redactedTool.headers = "**REDACTED**";
+          redactedTool.headers = MCP_CREDENTIALS_REDACTED;
         }
         if ("authorization" in redactedTool) {
-          redactedTool.authorization = "**REDACTED**";
+          redactedTool.authorization = MCP_CREDENTIALS_REDACTED;
         }
         return redactedTool;
       }),

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -438,6 +438,31 @@ export abstract class BaseChatOpenAI<
     };
   }
 
+  protected override _getInvocationParamsForTracing(
+    options?: this["ParsedCallOptions"]
+  ): ReturnType<this["invocationParams"]> {
+    const params = this.invocationParams(options);
+    if (!Array.isArray(params.tools)) {
+      return params;
+    }
+    return {
+      ...params,
+      tools: params.tools.map((tool) => {
+        if (tool?.type !== "mcp") {
+          return tool;
+        }
+        const redactedTool: Record<string, unknown> = { ...tool };
+        if ("headers" in redactedTool) {
+          redactedTool.headers = "**REDACTED**";
+        }
+        if ("authorization" in redactedTool) {
+          redactedTool.authorization = "**REDACTED**";
+        }
+        return redactedTool;
+      }),
+    };
+  }
+
   /** @ignore */
   _identifyingParams(): Omit<
     OpenAIClient.Chat.ChatCompletionCreateParams,

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -463,6 +463,36 @@ export abstract class BaseChatOpenAI<
     };
   }
 
+  protected override _getCallOptionsForTracing(
+    options: this["ParsedCallOptions"],
+    _invocationParams: ReturnType<this["invocationParams"]>
+  ): this["ParsedCallOptions"] {
+    if (!Array.isArray(options.tools)) {
+      return options;
+    }
+    return {
+      ...options,
+      tools: options.tools.map((tool) => {
+        if (
+          typeof tool !== "object" ||
+          tool === null ||
+          !("type" in tool) ||
+          tool.type !== "mcp"
+        ) {
+          return tool;
+        }
+        const redactedTool = { ...tool };
+        if ("headers" in redactedTool) {
+          redactedTool.headers = "**REDACTED**";
+        }
+        if ("authorization" in redactedTool) {
+          redactedTool.authorization = "**REDACTED**";
+        }
+        return redactedTool;
+      }),
+    };
+  }
+
   /** @ignore */
   _identifyingParams(): Omit<
     OpenAIClient.Chat.ChatCompletionCreateParams,

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -3,6 +3,56 @@ import { HumanMessage } from "@langchain/core/messages";
 import { describe, it, expect, vi } from "vitest";
 import { ChatOpenAIResponses } from "../responses.js";
 
+class TraceableChatOpenAIResponses extends ChatOpenAIResponses {
+  traceParams(options: Parameters<ChatOpenAIResponses["invocationParams"]>[0]) {
+    return this._getInvocationParamsForTracing(options);
+  }
+
+  traceOptions(
+    options: Parameters<ChatOpenAIResponses["invocationParams"]>[0]
+  ) {
+    const params = this._getInvocationParamsForTracing(options);
+    return this._getCallOptionsForTracing(options ?? {}, params);
+  }
+}
+
+describe("MCP credential tracing", () => {
+  it("redacts MCP credentials without changing request params", () => {
+    const model = new TraceableChatOpenAIResponses({ model: "gpt-4o" });
+    const options = {
+      tools: [
+        {
+          type: "mcp" as const,
+          server_label: "private-server",
+          server_url: "https://example.com/mcp",
+          headers: { Authorization: "Bearer header-secret" },
+          authorization: "Bearer authorization-secret",
+        },
+      ],
+    };
+
+    const requestParams = model.invocationParams(options);
+    const traceParams = model.traceParams(options);
+    const traceOptions = model.traceOptions(options);
+
+    expect(requestParams.tools?.[0]).toMatchObject({
+      headers: { Authorization: "Bearer header-secret" },
+      authorization: "Bearer authorization-secret",
+    });
+    expect(traceParams.tools?.[0]).toMatchObject({
+      headers: "**REDACTED**",
+      authorization: "**REDACTED**",
+    });
+    expect(traceOptions.tools?.[0]).toMatchObject({
+      headers: "**REDACTED**",
+      authorization: "**REDACTED**",
+    });
+    expect(JSON.stringify({ traceParams, traceOptions })).not.toContain(
+      "secret"
+    );
+  });
+});
+
 describe("constructor shorthand", () => {
   it("supports string model shorthand", () => {
     const model = new ChatOpenAIResponses("gpt-4o-mini", { temperature: 0.3 });

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -19,8 +19,17 @@ class TraceableChatOpenAIResponses extends ChatOpenAIResponses {
 describe("MCP credential tracing", () => {
   it("redacts MCP credentials without changing request params", () => {
     const model = new TraceableChatOpenAIResponses({ model: "gpt-4o" });
+    const functionTool = {
+      type: "function" as const,
+      function: {
+        name: "lookup",
+        parameters: { type: "object", properties: {} },
+      },
+    };
     const options = {
+      temperature: 0.3,
       tools: [
+        functionTool,
         {
           type: "mcp" as const,
           server_label: "private-server",
@@ -35,18 +44,20 @@ describe("MCP credential tracing", () => {
     const traceParams = model.traceParams(options);
     const traceOptions = model.traceOptions(options);
 
-    expect(requestParams.tools?.[0]).toMatchObject({
+    expect(requestParams.tools?.[1]).toMatchObject({
       headers: { Authorization: "Bearer header-secret" },
       authorization: "Bearer authorization-secret",
     });
-    expect(traceParams.tools?.[0]).toMatchObject({
+    expect(traceParams.tools?.[1]).toMatchObject({
       headers: "**REDACTED**",
       authorization: "**REDACTED**",
     });
-    expect(traceOptions.tools?.[0]).toMatchObject({
+    expect(traceOptions.tools?.[1]).toMatchObject({
       headers: "**REDACTED**",
       authorization: "**REDACTED**",
     });
+    expect(traceOptions.temperature).toBe(options.temperature);
+    expect(traceOptions.tools?.[0]).toBe(functionTool);
     expect(JSON.stringify({ traceParams, traceOptions })).not.toContain(
       "secret"
     );


### PR DESCRIPTION
Remote MCP credentials were included in chat-model callback metadata and could be persisted in LangSmith traces. OpenAI MCP tools exposed `headers` and `authorization`; Anthropic MCP server definitions exposed `authorization_token`.

This adds a tracing-only invocation-parameter hook in `BaseChatModel`, uses it for streaming, uncached, and cached callback starts, and sanitizes corresponding callback options. OpenAI and Anthropic override the hook to redact their MCP credential fields without mutating caller input or provider request parameters.

Provider unit tests verify trace payloads are redacted while request parameters retain the original credentials.

## Release note

OpenAI and Anthropic chat-model traces now redact credentials from remote MCP tool and server definitions.

This contribution was prepared with AI-agent assistance.