### PR TITLE
fix(google-common): send functionCallingConfig.mode as the uppercase Gemini enum

### DIFF
--- a/.changeset/tender-moons-repeat.md
+++ b/.changeset/tender-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+Send `toolConfig.functionCallingConfig.mode` using the uppercase Gemini enum values (`AUTO` / `ANY` / `NONE`). The lowercase values sent previously were ignored by the API, which made `tool_choice` (including forcing a specific function) a silent no-op.

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -2865,6 +2865,76 @@ describe("Mock ChatGoogle - Gemini", () => {
     ).toBeUndefined();
   });
 
+  test.each([
+    ["auto", "AUTO"],
+    ["any", "ANY"],
+    ["none", "NONE"],
+  ])(
+    "6. tool_choice %s is sent as the %s enum value",
+    async (toolChoice, expectedMode) => {
+      const record: Record<string, any> = {};
+      const projectId = mockId();
+      const authOptions: MockClientAuthInfo = {
+        record,
+        projectId,
+        resultFile: "chat-6-mock.json",
+      };
+
+      const myTool = tool(async ({ query }) => `Result for ${query}`, {
+        name: "my_tool",
+        description: "A custom tool",
+        schema: z.object({ query: z.string() }),
+      });
+
+      const model = new ChatGoogle({
+        authOptions,
+        modelName: "gemini-2.0-flash",
+        temperature: 0,
+        maxRetries: 0,
+      })
+        .bindTools([myTool])
+        .withConfig({ tool_choice: toolChoice });
+
+      await model.invoke("Anything");
+
+      expect(record.opts.data.toolConfig.functionCallingConfig.mode).toBe(
+        expectedMode
+      );
+    }
+  );
+
+  test("6. tool_choice with a function name forces the ANY enum value", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const myTool = tool(async ({ query }) => `Result for ${query}`, {
+      name: "my_tool",
+      description: "A custom tool",
+      schema: z.object({ query: z.string() }),
+    });
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    })
+      .bindTools([myTool])
+      .withConfig({ tool_choice: "my_tool" });
+
+    await model.invoke("Anything");
+
+    expect(record.opts.data.toolConfig.functionCallingConfig).toEqual({
+      mode: "ANY",
+      allowedFunctionNames: ["my_tool"],
+    });
+  });
+
   test("7. logprobs request true", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -757,7 +757,7 @@ export interface GeminiRequest {
   tools?: GeminiTool[];
   toolConfig?: {
     functionCallingConfig?: {
-      mode: "auto" | "any" | "none";
+      mode: "AUTO" | "ANY" | "NONE";
       allowedFunctionNames?: string[];
     };
     /**

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1990,10 +1990,18 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
     let config: GeminiRequest["toolConfig"] | undefined;
 
     if (parameters.tool_choice && typeof parameters.tool_choice === "string") {
-      if (["auto", "any", "none"].includes(parameters.tool_choice)) {
+      // The API defines the mode as an enum, which is matched case-sensitively.
+      const modeMap = {
+        auto: "AUTO",
+        any: "ANY",
+        none: "NONE",
+      } as const;
+      const mode = modeMap[parameters.tool_choice as keyof typeof modeMap];
+
+      if (mode) {
         config = {
           functionCallingConfig: {
-            mode: parameters.tool_choice as "auto" | "any" | "none",
+            mode,
             allowedFunctionNames: parameters.allowed_function_names,
           },
         };
@@ -2001,7 +2009,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         // force tool choice to be a single function name in case of structured output
         config = {
           functionCallingConfig: {
-            mode: "any",
+            mode: "ANY",
             allowedFunctionNames: [parameters.tool_choice],
           },
         };


### PR DESCRIPTION
Fixes #11265

## Problem

`formatToolConfig` in `@langchain/google-common` serializes `toolConfig.functionCallingConfig.mode` with the lowercase user-facing values (`"auto"` / `"any"` / `"none"`), while the Gemini/Vertex API defines `FunctionCallingConfig.mode` as an enum whose values are `AUTO` / `ANY` / `NONE`. The lowercase value is not honored, so requests fall back to default `AUTO` semantics:

- `tool_choice: "any"` (and `tool_choice: "<function name>"`, which routes through the same code path) does not force a tool call — the model may answer with plain text instead, and the call loses ANY-mode's schema anchoring.
- `tool_choice: "none"` does not suppress tool calls.
- `allowed_function_names` is not enforced, since it only applies together with a valid mode.

Nothing errors, which is what makes this hard to spot: the model usually calls the tool anyway when the prompt asks for it, so the behavior just degrades intermittently.

The newer `@langchain/google` package already sends the enum values correctly (`libs/providers/langchain-google/src/converters/tools.ts`, typed from `gemini-openapi.json`), as does `@langchain/google-genai` via `FunctionCallingMode`, so this was the odd one out among the Google wrappers.

## Change

Map the lowercase values to the wire enum in `formatToolConfig`, mirroring how `formatGenerationConfig` in the same file already maps `reasoningLevel` to the uppercase `thinkingLevel` values, and update the `GeminiRequest["toolConfig"]` type accordingly. The forced-function-name branch now sends `mode: "ANY"` instead of `"any"`.

The public API is unchanged: callers keep passing lowercase `tool_choice` values, which are normalized in `processToolChoice` as before — only the serialized request body changes.

## Tests

Added mock-transport tests in `chat_models.test.ts` asserting the request body:

- `tool_choice` `auto` / `any` / `none` produce `mode: "AUTO"` / `"ANY"` / `"NONE"`
- `tool_choice: "my_tool"` produces `{ mode: "ANY", allowedFunctionNames: ["my_tool"] }`

`vitest run src/tests/chat_models.test.ts` → 105 passed (101 existing + 4 new). No existing test asserted the lowercase spelling.
