### PR TITLE
fix(langchain): don't crash the process on an unconsumed tool-call rejection

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Prevent a failed tool call or subagent from crashing the process when its `output` promise is never consumed

--- a/libs/langchain/src/agents/transformers/subagent.ts
+++ b/libs/langchain/src/agents/transformers/subagent.ts
@@ -176,6 +176,9 @@ export function createSubagentTransformer(
         resolveOutput = resolve as (value: unknown) => void;
         rejectOutput = reject;
       });
+      // Same rationale as the tool-call transformer: a subagent that fails
+      // must not crash the process just because nobody awaited its `output`.
+      output.catch(() => {});
 
       handles.set(key, {
         key,

--- a/libs/langchain/src/agents/transformers/tests/tool-call.test.ts
+++ b/libs/langchain/src/agents/transformers/tests/tool-call.test.ts
@@ -722,4 +722,95 @@ describe("streamEvents", () => {
     expect(await pendingCall.value.output).toBe("serialized result");
     expect(await iterator.next()).toEqual({ done: true, value: undefined });
   });
+
+  it("does not emit an unhandled rejection when a failing tool call's output is never consumed", async () => {
+    const transformer = createToolCallTransformer([])();
+    // Deliberately do not iterate `projection.toolCalls`, mirroring a caller
+    // that only reads `run.messages` — nothing ever awaits `output`.
+    transformer.init();
+    const toolEvent = (data: Record<string, unknown>): ProtocolEvent =>
+      ({
+        method: "tools",
+        params: {
+          namespace: ["tools"],
+          data,
+        },
+      }) as ProtocolEvent;
+
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      transformer.process(
+        toolEvent({
+          event: "tool-started",
+          tool_call_id: "call_1",
+          tool_name: "search",
+          input: {},
+        })
+      );
+
+      transformer.process(
+        toolEvent({
+          event: "tool-error",
+          tool_call_id: "call_1",
+          message: "ENOTFOUND api.example.com",
+        })
+      );
+
+      transformer.finalize?.();
+
+      // `unhandledRejection` fires once the microtask queue has drained, so
+      // yield a macrotask before asserting.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("still rejects output for callers that do consume a failing tool call", async () => {
+    const transformer = createToolCallTransformer([])();
+    const projection = transformer.init();
+    const toolEvent = (data: Record<string, unknown>): ProtocolEvent =>
+      ({
+        method: "tools",
+        params: {
+          namespace: ["tools"],
+          data,
+        },
+      }) as ProtocolEvent;
+
+    transformer.process(
+      toolEvent({
+        event: "tool-started",
+        tool_call_id: "call_1",
+        tool_name: "search",
+        input: {},
+      })
+    );
+
+    const iterator = projection.toolCalls[Symbol.asyncIterator]();
+    const pendingCall = await iterator.next();
+
+    transformer.process(
+      toolEvent({
+        event: "tool-error",
+        tool_call_id: "call_1",
+        message: "ENOTFOUND api.example.com",
+      })
+    );
+
+    transformer.finalize?.();
+
+    expect(await pendingCall.value.status).toBe("error");
+    expect(await pendingCall.value.error).toBe("ENOTFOUND api.example.com");
+    await expect(pendingCall.value.output).rejects.toThrow(
+      "ENOTFOUND api.example.com"
+    );
+  });
 });

--- a/libs/langchain/src/agents/transformers/tool-call.ts
+++ b/libs/langchain/src/agents/transformers/tool-call.ts
@@ -142,6 +142,15 @@ export function createToolCallTransformer(
         resolveOutput = res;
         rejectOutput = rej;
       });
+      // `output` is created eagerly for every tool call, but consuming it is
+      // optional — a caller may never iterate `run.toolCalls`, or may read
+      // only `status`/`error`. Without a handler attached here, a failing tool
+      // rejects a promise nobody awaits, and Node's default
+      // `--unhandled-rejections=throw` terminates the whole process. The no-op
+      // catch marks the rejection as handled; callers that do await `output`
+      // still observe it, since `catch` returns a new promise and leaves
+      // `output` itself rejected.
+      output.catch(() => {});
       const status = new Promise<ToolCallStatus>((res) => {
         resolveStatus = res;
       });


### PR DESCRIPTION
*Found while using [OpenWiki](https://github.com/langchain-ai/openwiki) (v0.2.5, on `langchain` 1.5.4) against OpenAI — long documentation runs kept dying partway through with a rate-limit stack trace, losing the whole session.*

## Problem

When a provider returns a 429 rate-limit error during a tool call or subagent execution, it surfaces as a `tool-error` event. The handler calls `pending.rejectOutput(new Error(message))` — and if nothing is awaiting that promise, the rejection is unhandled, so Node's default `--unhandled-rejections=throw` **terminates the process**. The entire agent session dies and all conversation context is lost.

This is especially painful for users on lower provider tiers (Free / Tier 1), where TPM limits are easy to hit — particularly when subagents fire in parallel. A transient, entirely expected 429 shouldn't be fatal, but right now it takes down the whole run:

```
node_modules/langchain/dist/agents/transformers/tool-call.cjs:153
              pending.rejectOutput(new Error(message));
                                   ^
Error: Rate limit reached for gpt-5-mini on tokens per min (TPM): Limit 200000
    at Object.process (.../tool-call.cjs:153:29)
```

### Root cause is more general

The rate limit is what makes this fire constantly on low tiers, but it isn't specific to 429s. `createToolCallTransformer` creates an `output` promise eagerly for **every** tool call, while consuming it is optional — a caller may never iterate `run.toolCalls`, or may read only `status` / `error`. So *any* `tool-error` on an unconsumed call is fatal. Substituting `ENOTFOUND api.example.com` for the rate-limit message above crashes identically.

`createSubagentTransformer` has the same shape via `finishHandle` → `handle.rejectOutput(...)`.

The codebase already recognises this hazard for interrupts (`tool-call.ts`, above the `isToolInterrupt` check):

> "…and never reject `output`, which would otherwise become an unhandled rejection and crash the run."

That reasoning applies to genuine tool failures too, and there the promise is still rejected.

### Reproduction

Drive the transformer without consuming `toolCalls` — which is exactly what OpenWiki does, since it renders `run.messages` and never iterates `run.toolCalls`:

```js
const t = createToolCallTransformer([])();
t.init(); // note: projection.toolCalls is never iterated

const ev = (data) => ({ method: "tools", params: { namespace: ["tools"], data } });
t.process(ev({ event: "tool-started", tool_call_id: "call_1", tool_name: "search", input: {} }));
t.process(ev({
  event: "tool-error",
  tool_call_id: "call_1",
  message: "Rate limit reached for gpt-5-mini on tokens per min (TPM): Limit 200000",
}));

setTimeout(() => console.log("survived"), 250);
```

On Node 22 and 24 this never prints `survived`; the process exits 1 with the trace above.

## Fix

Attach a no-op `catch` to `output` at creation, in both transformers:

```ts
output.catch(() => {});
```

This marks the rejection as handled, so an unobserved failure can't take down the process. Callers that *do* await `output` still observe the rejection — `catch` returns a *new* promise and leaves `output` itself rejected.

Deliberately **not** done here: no error is reclassified, and rate limits are not special-cased. A failing tool still reports `status: "error"` with a populated `error`, and `output` still rejects. Pattern-matching 429s to resolve them as successful results was considered and rejected — it would report a failure to the agent as a completed tool call, and only paper over one instance of a crash that any tool error can cause.

## Why not retry here?

Model-level `maxRetries` already handles HTTP 429 retries. Errors that reach the transformer have exhausted those retries. At this layer the correct behavior is to surface the failure to whoever asked for it, rather than terminate the process on behalf of a caller that never asked.

## Tests

- New: asserts no `unhandledRejection` fires when a failing tool call's `output` is never consumed. Fails on `main` with `expected [ Error: ENOTFOUND api.example.com ] to deeply equal []`, passes with the fix.
- New: asserts `output` still rejects, and `status` / `error` are unchanged, for callers that *do* consume it.
- `libs/langchain` agent suite: 774 passed, no type errors. `oxlint` and `oxfmt --check` clean.
