### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/libs/providers/langchain-openai/README.md
+++ b/libs/providers/langchain-openai/README.md
@@ -58,7 +58,7 @@ const model = new ChatOpenAI({
 const response = await model.invoke(new HumanMessage("Hello world!"));
 ```
 
-OpenAI-compatible multi-model gateways work the same way via `configuration.baseURL` — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=langchainjs&utm_content=openai) at `https://api.daoxe.com/v1`:
+OpenAI-compatible multi-model gateways work the same way via `configuration.baseURL` — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`:
 
 ```typescript
 const model = new ChatOpenAI({

--- a/libs/providers/langchain-openai/README.md
+++ b/libs/providers/langchain-openai/README.md
@@ -58,6 +58,18 @@ const model = new ChatOpenAI({
 const response = await model.invoke(new HumanMessage("Hello world!"));
 ```
 
+OpenAI-compatible multi-model gateways work the same way via `configuration.baseURL` — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=langchainjs&utm_content=openai) at `https://api.daoxe.com/v1`:
+
+```typescript
+const model = new ChatOpenAI({
+  apiKey: process.env.DAOXE_API_KEY,
+  model: "gpt-4o-mini", // use an ID from the gateway's /v1/models
+  configuration: {
+    baseURL: "https://api.daoxe.com/v1",
+  },
+});
+```
+
 ### Streaming
 
 ```typescript


### PR DESCRIPTION
## Summary

Clarify that the OpenAI Python client `base_url` pattern works with OpenAI-compatible multi-model gateways when not using the default provider endpoint, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render
- [ ] Existing examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>