### PR TITLE
fix(core): format every data content block for tracing

### DIFF
--- a/.changeset/bright-geese-trace.md
+++ b/.changeset/bright-geese-trace.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): format every data content block for tracing

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -172,24 +172,22 @@ function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   const messagesToTrace: BaseMessage[] = [];
   for (const message of messages) {
     let messageToTrace = message;
-    if (Array.isArray(message.content)) {
-      for (let idx = 0; idx < message.content.length; idx++) {
-        const block = message.content[idx];
-        if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
-        }
-      }
+    if (
+      Array.isArray(message.content) &&
+      message.content.some(
+        (block) => isURLContentBlock(block) || isBase64ContentBlock(block)
+      )
+    ) {
+      // Also shallow-copy content
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      messageToTrace = new (message.constructor as any)({
+        ...messageToTrace,
+        content: message.content.map((block) =>
+          isURLContentBlock(block) || isBase64ContentBlock(block)
+            ? convertToOpenAIImageBlock(block)
+            : block
+        ),
+      });
     }
     messagesToTrace.push(messageToTrace);
   }

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -4,6 +4,7 @@ import { z as z4 } from "zod/v4";
 import { zodToJsonSchema } from "../../utils/zod-to-json-schema/index.js";
 import { FakeChatModel, FakeListChatModel } from "../../utils/testing/index.js";
 import { HumanMessage } from "../../messages/human.js";
+import type { BaseMessage } from "../../messages/base.js";
 import { getBufferString } from "../../messages/utils.js";
 import { AIMessage } from "../../messages/ai.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
@@ -15,6 +16,7 @@ import type { ChatModelStream } from "../stream.js";
 import type { IterableReadableStream } from "../../utils/stream.js";
 import type { StreamEvent } from "../../tracers/event_stream.js";
 import type { LangSmithTracingClientInterface } from "langsmith";
+import type { Serialized } from "../../load/serializable.js";
 
 test("Test ChatModel accepts array shorthand for messages", async () => {
   const model = new FakeChatModel({});
@@ -139,6 +141,59 @@ test("Test ChatModel uses callbacks", async () => {
     ],
   });
   expect(response.content).toEqual(acc);
+});
+
+test("Test ChatModel formats every data content block for tracing", async () => {
+  class CaptureInputHandler extends BaseCallbackHandler {
+    name = "capture-input";
+
+    messages: BaseMessage[] | undefined;
+
+    handleChatModelStart(_llm: Serialized, messages: BaseMessage[][]) {
+      [this.messages] = messages;
+    }
+  }
+
+  const handler = new CaptureInputHandler();
+  const model = new FakeListChatModel({ responses: ["ok"] });
+  await model.invoke(
+    [
+      new HumanMessage({
+        content: [
+          { type: "text", text: "two PDFs" },
+          {
+            type: "file",
+            source_type: "base64",
+            mime_type: "application/pdf",
+            data: "JVBERi0xLjQK",
+          },
+          {
+            type: "file",
+            source_type: "base64",
+            mime_type: "application/pdf",
+            data: "JVBERi0xLjUK",
+          },
+        ],
+      }),
+    ],
+    { callbacks: [handler] }
+  );
+
+  expect(handler.messages?.[0].content).toEqual([
+    { type: "text", text: "two PDFs" },
+    {
+      type: "image_url",
+      image_url: {
+        url: "data:application/pdf;base64,JVBERi0xLjQK",
+      },
+    },
+    {
+      type: "image_url",
+      image_url: {
+        url: "data:application/pdf;base64,JVBERi0xLjUK",
+      },
+    },
+  ]);
 });
 
 test("Test ChatModel uses callbacks with a cache", async () => {


### PR DESCRIPTION
## Summary

Fixes #11291
- convert every URL or base64 data content block in the tracing copy
- preserve the original message while avoiding repeated message reconstruction
- add a callback-path regression test with multiple attachments

## Testing

- pnpm --filter @langchain/core test
- pnpm --filter @langchain/core build
- oxfmt --check on changed files
- oxlint on changed TypeScript files

## AI Disclosure

This bug was fixed with AI assistance. The regression test was written first and verified to fail on the previous implementation before the production change.