### PR TITLE
fix(core): merge Anthropic input JSON deltas

### DIFF
--- a/.changeset/tidy-tools-stream.md
+++ b/.changeset/tidy-tools-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Merge Anthropic input JSON deltas into their indexed tool-use content blocks.

--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -573,12 +573,14 @@ function hasMismatchedMergeableType(left: unknown, right: unknown): boolean {
   if (typeof left !== "object" || left === null) return false;
   if (typeof right !== "object" || right === null) return false;
   if (!("type" in left) || !("type" in right)) return false;
+  if (typeof left.type !== "string" || typeof right.type !== "string") {
+    return false;
+  }
+  if (left.type === "tool_use" && right.type === "input_json_delta") {
+    return false;
+  }
 
-  return (
-    typeof left.type === "string" &&
-    typeof right.type === "string" &&
-    getMergeableTypeBase(left.type) !== getMergeableTypeBase(right.type)
-  );
+  return getMergeableTypeBase(left.type) !== getMergeableTypeBase(right.type);
 }
 
 /**

--- a/libs/langchain-core/src/messages/tests/base_message.test.ts
+++ b/libs/langchain-core/src/messages/tests/base_message.test.ts
@@ -248,6 +248,42 @@ test("_mergeLists keeps different content block types separate when indices coll
   ]);
 });
 
+test("_mergeLists merges Anthropic input JSON deltas into tool use blocks", () => {
+  const chunk1 = new AIMessageChunk({
+    content: [
+      {
+        type: "tool_use",
+        index: 0,
+        id: "toolu_abc123",
+        name: "get_weather",
+        input: {},
+      },
+    ],
+  });
+
+  const chunk2 = new AIMessageChunk({
+    content: [
+      {
+        type: "input_json_delta",
+        index: 0,
+        partial_json: '{"location":"San Francisco"}',
+      },
+    ],
+  });
+
+  const merged = chunk1.concat(chunk2);
+  expect(merged.content).toEqual([
+    {
+      type: "tool_use",
+      index: 0,
+      id: "toolu_abc123",
+      name: "get_weather",
+      input: {},
+      partial_json: '{"location":"San Francisco"}',
+    },
+  ]);
+});
+
 test("_mergeLists merges blocks by string index", () => {
   const chunk1 = new AIMessageChunk({
     content: [


### PR DESCRIPTION
## Summary

Fixes #11293

- allow Anthropic input_json_delta chunks to merge into their indexed tool_use content blocks
- preserve the semantic type guard for unrelated content block types
- add a focused core regression test and patch changeset

The same protocol compatibility was proposed in #10923. This follow-up isolates the core change and regression test against current main; #10923 currently also contains unrelated provider changes.

## Testing

- pnpm exec vitest run --typecheck.enabled=false (1367 passed, 1 skipped)
- pnpm --filter @langchain/core build
- pnpm exec oxfmt --check on changed TypeScript files
- pnpm exec oxlint on changed TypeScript files

## AI Disclosure

This contribution was prepared with AI-agent assistance.