### PR TITLE
fix(core): pass the mustache escape override per render call

### DIFF
--- a/.changeset/sweet-trams-shake.md
+++ b/.changeset/sweet-trams-shake.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): pass the mustache escape override per render call

--- a/libs/langchain-core/src/prompts/template.ts
+++ b/libs/langchain-core/src/prompts/template.ts
@@ -3,11 +3,12 @@ import { MessageContent } from "../messages/index.js";
 import type { InputValues } from "../utils/types/index.js";
 import { addLangChainErrorFields } from "../errors/index.js";
 
-function configureMustache() {
-  // Use unescaped HTML
-  // https://github.com/janl/mustache.js?tab=readme-ov-file#variables
-  mustache.escape = (text) => text;
-}
+// Use unescaped HTML, passed per render call so the shared mustache module
+// keeps escaping for unrelated callers in the same process.
+// https://github.com/janl/mustache.js?tab=readme-ov-file#variables
+const MUSTACHE_RENDER_OPTIONS: mustache.RenderOptions = {
+  escape: (text) => text,
+};
 
 /**
  * Type that specifies the format of a template.
@@ -116,7 +117,6 @@ const mustacheTemplateToNodes = (
 };
 
 export const parseMustache = (template: string) => {
-  configureMustache();
   const parsed = mustache.parse(template);
   return mustacheTemplateToNodes(parsed);
 };
@@ -139,8 +139,7 @@ export const interpolateFString = (template: string, values: InputValues) => {
 };
 
 export const interpolateMustache = (template: string, values: InputValues) => {
-  configureMustache();
-  return mustache.render(template, values);
+  return mustache.render(template, values, undefined, MUSTACHE_RENDER_OPTIONS);
 };
 
 /**

--- a/libs/langchain-core/src/prompts/tests/template.mustache.test.ts
+++ b/libs/langchain-core/src/prompts/tests/template.mustache.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "vitest";
+import mustache from "mustache";
+import { PromptTemplate } from "../prompt.js";
+import { interpolateMustache, parseMustache } from "../template.js";
+
+const VALUE_WITH_HTML_CHARS = "1 < 2 & 3 > 2";
+const HTML_ESCAPED_VALUE = "1 &lt; 2 &amp; 3 &gt; 2";
+
+test("formatting a mustache prompt template leaves mustache's defaults intact for other callers", async () => {
+  expect(
+    mustache.render("Hello {{name}}!", { name: VALUE_WITH_HTML_CHARS })
+  ).toBe(`Hello ${HTML_ESCAPED_VALUE}!`);
+
+  const prompt = PromptTemplate.fromTemplate("Answer: {{question}}", {
+    templateFormat: "mustache",
+  });
+  await prompt.format({ question: "test" });
+
+  expect(
+    mustache.render("Hello {{name}}!", { name: VALUE_WITH_HTML_CHARS })
+  ).toBe(`Hello ${HTML_ESCAPED_VALUE}!`);
+});
+
+test("mustache templates render prompt values without HTML escaping", async () => {
+  expect(
+    interpolateMustache("Hello {{name}}!", { name: VALUE_WITH_HTML_CHARS })
+  ).toBe(`Hello ${VALUE_WITH_HTML_CHARS}!`);
+
+  const prompt = PromptTemplate.fromTemplate("Hello {{name}}!", {
+    templateFormat: "mustache",
+  });
+  expect(await prompt.format({ name: VALUE_WITH_HTML_CHARS })).toBe(
+    `Hello ${VALUE_WITH_HTML_CHARS}!`
+  );
+});
+
+test("parsing a mustache template leaves mustache's defaults intact for other callers", () => {
+  parseMustache("Answer: {{question}}");
+
+  expect(
+    mustache.render("Hello {{name}}!", { name: VALUE_WITH_HTML_CHARS })
+  ).toBe(`Hello ${HTML_ESCAPED_VALUE}!`);
+});


### PR DESCRIPTION
## Description

`configureMustache()` assigned `mustache.escape` on the imported `mustache` module, a process-wide singleton, so parsing or rendering any prompt template replaced escaping for every other consumer of `mustache` in the process.

This PR passes the override as per-call render config in `interpolateMustache` and drops it from `parseMustache`, leaving module state untouched. Prompt template rendering behavior is unchanged.