### PR TITLE
fix(core): convert all image content blocks when formatting for tracing

### DIFF
--- a/.changeset/tidy-trace-image-blocks.md
+++ b/.changeset/tidy-trace-image-blocks.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Fix tracing of multimodal messages so that every base64/URL image content block is converted, not just the first one in a message.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -173,22 +173,21 @@ function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   for (const message of messages) {
     let messageToTrace = message;
     if (Array.isArray(message.content)) {
-      for (let idx = 0; idx < message.content.length; idx++) {
-        const block = message.content[idx];
+      let converted = false;
+      const content = message.content.map((block) => {
         if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
+          converted = true;
+          return convertToOpenAIImageBlock(block);
         }
+        return block;
+      });
+      if (converted) {
+        // Only shallow-copy the message when at least one block changed.
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        messageToTrace = new (message.constructor as any)({
+          ...message,
+          content,
+        });
       }
     }
     messagesToTrace.push(messageToTrace);

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -4,6 +4,7 @@ import { z as z4 } from "zod/v4";
 import { zodToJsonSchema } from "../../utils/zod-to-json-schema/index.js";
 import { FakeChatModel, FakeListChatModel } from "../../utils/testing/index.js";
 import { HumanMessage } from "../../messages/human.js";
+import type { BaseMessage } from "../../messages/base.js";
 import { getBufferString } from "../../messages/utils.js";
 import { AIMessage } from "../../messages/ai.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
@@ -615,4 +616,58 @@ test("Test ChatModel applies v1 outputVersion after implicit streaming aggregati
       text: "Hello world!",
     },
   ]);
+});
+
+test("Traced messages convert every base64/URL content block, not just the first", async () => {
+  // Regression test for _formatForTracing only converting the first
+  // base64/URL content block per message.
+  const capturedInputs: BaseMessage[][] = [];
+  class CaptureInputHandler extends BaseCallbackHandler {
+    name = "CaptureInputHandler";
+
+    async handleChatModelStart(
+      _llm: Parameters<BaseCallbackHandler["handleChatModelStart"]>[0],
+      messages: BaseMessage[][]
+    ): Promise<void> {
+      capturedInputs.push(messages[0]);
+    }
+  }
+
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "Compare these images" },
+      {
+        type: "image",
+        source_type: "base64",
+        data: "AAAA",
+        mime_type: "image/png",
+      },
+      {
+        type: "image",
+        source_type: "base64",
+        data: "BBBB",
+        mime_type: "image/jpeg",
+      },
+    ],
+  });
+
+  const model = new FakeChatModel({});
+  await model.invoke([message], { callbacks: [new CaptureInputHandler()] });
+  await awaitAllCallbacks();
+
+  expect(capturedInputs.length).toBe(1);
+  const tracedContent = capturedInputs[0][0].content;
+  // Both image blocks should be converted to the OpenAI image_url shape...
+  expect(tracedContent).toEqual([
+    { type: "text", text: "Compare these images" },
+    { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+    { type: "image_url", image_url: { url: "data:image/jpeg;base64,BBBB" } },
+  ]);
+  // ...while the original message is left untouched (shallow copy).
+  expect(Array.isArray(message.content) && message.content[2]).toEqual({
+    type: "image",
+    source_type: "base64",
+    data: "BBBB",
+    mime_type: "image/jpeg",
+  });
 });


### PR DESCRIPTION
## Description

`_formatForTracing` (in `libs/langchain-core/src/language_models/chat_models.ts`) only converted the **first** base64/URL content block in a multimodal message. After the first matching block triggered a shallow copy of the message, the `messageToTrace === message` guard was `false` for every subsequent block, so any additional image blocks reached tracing (e.g. LangSmith) unconverted.

This rewrites the loop to map over the content once: every URL/base64 block is converted via `convertToOpenAIImageBlock`, and the message is shallow-copied a single time only when a block actually changed (preserving the original copy-once optimization).

## Changes

- Fix `_formatForTracing` to convert **all** image content blocks, not just the first.
- Add a regression test in `chat_models.test.ts` that traces a message containing two base64 image blocks (via a `handleChatModelStart` capture handler) and asserts both are converted, while the original message object is left untouched.

## Testing

- New test fails on `main` (second block remains a raw `source_type: "base64"` block) and passes with this change.
- Full `libs/langchain-core/.../chat_models.test.ts` suite passes (23/23), type-check clean, `oxlint` clean.

Fixes #11291
