### PR TITLE
fix(core): properly unwrap ZodDefault/ZodOptional wrappers in toJsonSchema

### DIFF
--- a/.changeset/curly-monkeys-live.md
+++ b/.changeset/curly-monkeys-live.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): properly unwrap ZodDefault/ZodOptional wrappers in toJsonSchema

--- a/libs/langchain-core/src/utils/json_schema.ts
+++ b/libs/langchain-core/src/utils/json_schema.ts
@@ -59,24 +59,51 @@ export function toJsonSchema(
     if (cached) return cached;
   }
 
+  let unwrappedSchema = schema as any;
+  let description: string | undefined = undefined;
+
+  if (isZodSchemaV3(unwrappedSchema) || isZodSchemaV4(unwrappedSchema)) {
+    while (unwrappedSchema != null) {
+      const def = unwrappedSchema._def || unwrappedSchema._zod?.def;
+      if (!def) break;
+      if (def.description && !description) {
+        description = def.description;
+      }
+      const typeName = def.typeName || def.type;
+      if (
+        typeName === "ZodDefault" || typeName === "default" ||
+        typeName === "ZodOptional" || typeName === "optional" ||
+        typeName === "ZodNullable" || typeName === "nullable"
+      ) {
+        unwrappedSchema = def.innerType;
+      } else {
+        break;
+      }
+    }
+  }
+
   let result: JSONSchema;
 
-  if (isStandardJsonSchema(schema) && !isZodSchemaV4(schema)) {
-    result = schema["~standard"].jsonSchema.input({
+  if (isStandardJsonSchema(unwrappedSchema) && !isZodSchemaV4(unwrappedSchema)) {
+    result = unwrappedSchema["~standard"].jsonSchema.input({
       target: "draft-07",
     }) as JSONSchema;
-  } else if (isZodSchemaV4(schema)) {
-    const inputSchema = interopZodTransformInputSchema(schema, true);
+  } else if (isZodSchemaV4(unwrappedSchema)) {
+    const inputSchema = interopZodTransformInputSchema(unwrappedSchema, true);
     if (isZodObjectV4(inputSchema)) {
       const strictSchema = interopZodObjectStrict(inputSchema, true);
       result = toJSONSchema(strictSchema as unknown as $ZodType, params);
     } else {
-      result = toJSONSchema(schema as unknown as $ZodType, params);
+      result = toJSONSchema(unwrappedSchema as unknown as $ZodType, params);
     }
-  } else if (isZodSchemaV3(schema)) {
-    result = zodToJsonSchema(schema as never);
+  } else if (isZodSchemaV3(unwrappedSchema)) {
+    result = zodToJsonSchema(unwrappedSchema as never);
   } else {
-    result = schema as JSONSchema;
+    result = unwrappedSchema as JSONSchema;
+  }
+
+  if (description && !result.description) {
+    result = { ...result, description };
   }
 
   if (canCache && result != null && typeof result === "object") {


### PR DESCRIPTION
Resolves #3292

Fixes IEEE 754 precision loss that was occurring when multiplying epoch milliseconds by 1,000,000 in float-land before casting to `BigInt`.

The fix properly casts the epoch milliseconds to `BigInt` before multiplying by `BigInt(1_000_000)`, completely preventing the ~256ns errors in timestamp values.

This affects:
- `getNowInNanoseconds()`
- `calculateDurationFromStart()`
- `recordRunDebugLog()`
- Retry event recording in `runEngineHandlers.server.ts`
