### PR TITLE
fix(mcp-adapters): preserve original error as ToolException cause

### DIFF
--- a/.changeset/mcp-toolexception-cause.md
+++ b/.changeset/mcp-toolexception-cause.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mcp-adapters": patch
+---
+
+Preserve the original error as `cause` when wrapping tool call failures in `ToolException`, so structured details like `McpError.code` survive for programmatic handling.

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -4,6 +4,7 @@ import {
   StructuredTool,
   ToolInputParsingException,
 } from "@langchain/core/tools";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type {
   EmbeddedResource,
   ImageContent,
@@ -194,6 +195,42 @@ describe("Simplified Tool Adapter Tests", () => {
       expect(mockClient.callTool).toHaveBeenCalledWith({
         arguments: {},
         name: "weather",
+      });
+    });
+
+    test("should preserve the original error as ToolException cause when a tool call fails", async () => {
+      // Set up mock response
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({
+          tools: [
+            {
+              name: "failing",
+              description: "Always fails",
+              inputSchema: { type: "object", properties: {}, required: [] },
+            },
+          ],
+        })
+      );
+
+      const originalError = new McpError(
+        ErrorCode.ConnectionClosed,
+        "Connection closed"
+      );
+      mockClient.callTool.mockImplementation(() =>
+        Promise.reject(originalError)
+      );
+
+      // Load tools
+      const tools = await loadMcpTools(
+        "mockServer(should preserve ToolException cause)",
+        mockClient as Client
+      );
+
+      // The structured McpError (e.g. its code) must survive for programmatic
+      // handling instead of being flattened into the message string
+      await expect(tools[0].invoke({})).rejects.toMatchObject({
+        name: "ToolException",
+        cause: originalError,
       });
     });
 

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -1171,7 +1171,10 @@ async function _callTool({
     if (isToolException(error)) {
       throw error;
     }
-    throw new ToolException(`Error calling tool ${toolName}: ${String(error)}`);
+    throw new ToolException(
+      `Error calling tool ${toolName}: ${String(error)}`,
+      error instanceof Error ? error : undefined
+    );
   }
 }
 


### PR DESCRIPTION
When an MCP tool call fails, `_callTool` wraps the error in a `ToolException` without forwarding the original error, so structured details like `McpError.code` are destroyed and callers have to regex the message string to tell retryable transport failures (`-32000`) from contract bugs (`-32602`). The `ToolException` constructor already accepts `cause` and stores it (the Zod path a few lines above passes it), so this just forwards the caught error the same way. Includes a regression test that fails on the current code (`cause` is `undefined`) and a changeset. Full `@langchain/mcp-adapters` vitest suite passes (167 tests), tsdown build and lint are clean.

Fixes #11300
