### PR TITLE
fix(langchain): script-aware approximate token counting for middleware budgets

### DIFF
--- a/.changeset/script-aware-token-count.md
+++ b/.changeset/script-aware-token-count.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): script-aware approximate token counting for middleware budgets

--- a/libs/langchain/src/agents/middleware/tests/utils.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/utils.test.ts
@@ -6,6 +6,52 @@ import { tool } from "@langchain/core/tools";
 import { countTokensApproximately } from "../utils.js";
 
 describe("countTokensApproximately", () => {
+  describe("script density (issue #11304)", () => {
+    it("should not underrate CJK / Hangul relative to Latin prose of similar meaning", () => {
+      // Parallel sentences of roughly the same content length intent;
+      // under a fixed 4-chars/token budget the non-Latin samples are
+      // severely under-counted.
+      const english =
+        "LangChain is a framework for developing applications powered by language models.";
+      const korean =
+        "랭체인은 언어 모델을 기반으로 애플리케이션을 개발하기 위한 프레임워크입니다.";
+      const japanese =
+        "ラングチェーンは、言語モデルを利用したアプリケーションを開発するためのフレームワークです。";
+      const chinese =
+        "朗琴是一个用于开发由语言模型驱动的应用程序的框架。它使应用程序能够感知上下文。";
+
+      const en = countTokensApproximately([new HumanMessage(english)]);
+      const ko = countTokensApproximately([new HumanMessage(korean)]);
+      const ja = countTokensApproximately([new HumanMessage(japanese)]);
+      const zh = countTokensApproximately([new HumanMessage(chinese)]);
+
+      // Dense-script estimates must not be drastically smaller than the
+      // Latin baseline (old fixed-4 ratio reported ~60% undercounts).
+      expect(ko).toBeGreaterThan(en * 0.7);
+      expect(ja).toBeGreaterThan(en * 0.7);
+      expect(zh).toBeGreaterThan(en * 0.7);
+    });
+
+    it("should still scale roughly with pure Latin length at ~4 chars/token", () => {
+      const short = countTokensApproximately([new HumanMessage("abcd")]);
+      const long = countTokensApproximately([
+        new HumanMessage("abcd".repeat(25)),
+      ]);
+      // 4 chars → 1 token; 100 chars → 25 tokens
+      expect(short).toBe(1);
+      expect(long).toBe(25);
+    });
+
+    it("should count CJK ideographs denser than Latin letters of the same length", () => {
+      const latin = countTokensApproximately([new HumanMessage("aaaa")]);
+      const cjk = countTokensApproximately([new HumanMessage("你好世界")]);
+      expect(latin).toBe(1);
+      // 4 CJK chars at 1.5 chars/token ≈ 2.67 → ceil 3
+      expect(cjk).toBeGreaterThan(latin);
+      expect(cjk).toBe(3);
+    });
+  });
+
   describe("with tools parameter", () => {
     it("should increase token count when a LangChain tool is provided", () => {
       const messages = [new HumanMessage("Hello")];

--- a/libs/langchain/src/agents/middleware/utils.ts
+++ b/libs/langchain/src/agents/middleware/utils.ts
@@ -14,9 +14,68 @@ import {
 import { JumpToTarget } from "../constants.js";
 
 /**
+ * Characters that typically map to far more than 1 token / 4 chars under
+ * modern BPE tokenizers (e.g. o200k_base). Using a Latin-only density here
+ * under-counts Korean/Japanese/Chinese/Thai/Emoji text by ~40–66%, which
+ * delays summarization and context-editing budget triggers (see #11304).
+ */
+function isHighTokenDensityCodePoint(code: number): boolean {
+  return (
+    // CJK Unified Ideographs + Extension A
+    (code >= 0x3400 && code <= 0x4dbf) ||
+    (code >= 0x4e00 && code <= 0x9fff) ||
+    // Hiragana / Katakana
+    (code >= 0x3040 && code <= 0x30ff) ||
+    // Hangul Jamo + Hangul Syllables
+    (code >= 0x1100 && code <= 0x11ff) ||
+    (code >= 0xac00 && code <= 0xd7af) ||
+    // Thai
+    (code >= 0x0e00 && code <= 0x0e7f) ||
+    // Hebrew / Arabic (right-to-left scripts with dense tokenization)
+    (code >= 0x0590 && code <= 0x05ff) ||
+    (code >= 0x0600 && code <= 0x06ff) ||
+    // Common emoji blocks
+    (code >= 0x1f300 && code <= 0x1faff) ||
+    (code >= 0x1f600 && code <= 0x1f64f)
+  );
+}
+
+/**
+ * Approximate token weight for a string, accounting for script density.
+ *
+ * Latin / code-like text ≈ 4 chars per token; CJK / Hangul / Kana / Thai /
+ * emoji ≈ 1.5 chars per token (≈ measured o200k_base density for those scripts).
+ */
+function approximateTokenWeight(text: string): number {
+  const DENSE_CHARS_PER_TOKEN = 1.5;
+  const SPARSE_CHARS_PER_TOKEN = 4;
+  let denseChars = 0;
+  let sparseChars = 0;
+
+  for (const char of text) {
+    const code = char.codePointAt(0);
+    if (code === undefined) continue;
+    // Skip the trail surrogate pair half when iterating by code unit via for-of
+    // — `for…of` yields full code points for astral-plane chars.
+    if (isHighTokenDensityCodePoint(code)) {
+      denseChars += 1;
+    } else {
+      sparseChars += 1;
+    }
+  }
+
+  return (
+    denseChars / DENSE_CHARS_PER_TOKEN + sparseChars / SPARSE_CHARS_PER_TOKEN
+  );
+}
+
+/**
  * Default token counter that approximates based on character count.
  *
- * If tools are provided, the token count also includes stringified tool schemas.
+ * Script-aware: non-Latin scripts (CJK, Hangul, Kana, Thai, emoji, etc.)
+ * are counted at a higher density so summarization / context-editing budgets
+ * still fire on multilingual histories. Tools, when provided, contribute
+ * their stringified schemas under the same estimator.
  *
  * @param messages Messages to count tokens for
  * @param tools Optional list of tools to include in the token count. Each tool
@@ -29,17 +88,14 @@ export function countTokensApproximately(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   tools?: Array<Record<string, any>> | null
 ): number {
-  const charsPerToken = 4;
-  let totalChars = 0;
+  let totalWeight = 0;
 
   // Count tokens for tools if provided
   if (tools && tools.length > 0) {
-    let toolsChars = 0;
     for (const tool of tools) {
       const toolDict = isLangChainTool(tool) ? convertToOpenAITool(tool) : tool;
-      toolsChars += JSON.stringify(toolDict).length;
+      totalWeight += approximateTokenWeight(JSON.stringify(toolDict));
     }
-    totalChars += toolsChars;
   }
 
   for (const msg of messages) {
@@ -70,10 +126,10 @@ export function countTokensApproximately(
       textContent += msg.tool_call_id ?? "";
     }
 
-    totalChars += textContent.length;
+    totalWeight += approximateTokenWeight(textContent);
   }
-  // Approximate 1 token = 4 characters
-  return Math.ceil(totalChars / charsPerToken);
+
+  return Math.ceil(totalWeight);
 }
 
 export function getHookConstraint(


### PR DESCRIPTION
## Summary

Fixes #11304.

`countTokensApproximately` used a fixed **4 characters/token** estimate. That matches English prose reasonably, but o200k_base density for CJK / Hangul / Kana / Thai (and similar) is roughly **1.4–2.4 chars/token**, so approximate counts under-reported by ~40–66%.

Because `summarizationMiddleware` and `contextEditingMiddleware` (`tokenCountMethod: "approx"`) trust this default to **decide when to intervene**, multilingual histories could blow past real context windows without ever triggering summarization or context editing.

### Change

- Estimate token weight with a two-tier density model:
  - **Dense scripts** (CJK, Hangul, Kana, Thai, Hebrew/Arabic, common emoji): ~1.5 chars/token
  - **Everything else** (Latin prose, code, JSON tool schemas): ~4 chars/token
- Preserve the existing API and `Math.ceil` outer rounding
- Keep tool-schema inclusion behavior, just through the same weight function

This remains an *approximation* — precise budgets should still use a real tokenizer — but the default is no longer systematically blind to non-Latin scripts.

## Test plan

- [x] `pnpm test src/agents/middleware/tests/utils.test.ts` (8 passing, including new #11304 denser-script cases)
- [ ] Confirm summarizationMiddleware threshold unit tests that hardcode “50 tokens = 200 Latin chars” still pass (they encode Latin assumptions and remain valid under the sparse tier)

## Example

| Script | Old (`len/4`) vs dense-aware roughly |
|--------|--------------------------------------|
| Latin `"abcd"` (4 chars) | still **1** token |
| CJK `"你好世界"` (4 chars) | was **1**, now **3** |


Made with [Cursor](https://cursor.com)