### PR TITLE
docs(langchain): fix stale constant name in TodoListMiddlewareOptions JSDoc

### DIFF
--- a/libs/langchain/src/agents/middleware/todoListMiddleware.ts
+++ b/libs/langchain/src/agents/middleware/todoListMiddleware.ts
@@ -254,7 +254,7 @@ export type TodoMiddlewareState = z.infer<typeof stateSchema>;
 export interface TodoListMiddlewareOptions {
   /**
    * Custom system prompt to guide the agent on using the todo tool.
-   * If not provided, uses the default {@link PLANNING_MIDDLEWARE_SYSTEM_PROMPT}.
+   * If not provided, uses the default {@link TODO_LIST_MIDDLEWARE_SYSTEM_PROMPT}.
    */
   systemPrompt?: string;
   /**


### PR DESCRIPTION
The `systemPrompt` JSDoc on `TodoListMiddlewareOptions` points at `{@link PLANNING_MIDDLEWARE_SYSTEM_PROMPT}`, which no longer exists. #9187 renamed that constant to `TODO_LIST_MIDDLEWARE_SYSTEM_PROMPT` and updated both the declaration and the fallback it documents, but left this link behind.

No runtime behavior changes.