### PR TITLE
fix(anthropic): filter unsupported root tool schemas

### DIFF
--- a/.changeset/tidy-otters-filter.md
+++ b/.changeset/tidy-otters-filter.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): filter tools with unsupported root schema composition

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -31,6 +31,7 @@ import { AnthropicToolsOutputParser } from "./output_parsers.js";
 import {
   ANTHROPIC_TOOL_BETAS,
   AnthropicToolExtrasSchema,
+  getTopLevelSchemaCompositionKeys,
   handleToolChoice,
 } from "./utils/tools.js";
 import { _convertMessagesToAnthropicPayload } from "./utils/message_inputs.js";
@@ -1137,7 +1138,7 @@ export class ChatAnthropicMessages<
     if (!tools) {
       return undefined;
     }
-    return tools.map((tool) => {
+    const formattedTools = tools.map((tool) => {
       if (isLangChainTool(tool) && tool.extras?.providerToolDefinition) {
         return tool.extras
           .providerToolDefinition as Anthropic.Messages.ToolUnion;
@@ -1193,6 +1194,17 @@ export class ChatAnthropicMessages<
           2
         )}`
       );
+    });
+
+    return formattedTools.filter((tool) => {
+      if (!isAnthropicTool(tool)) {
+        return true;
+      }
+      const compositionKeys = getTopLevelSchemaCompositionKeys(tool);
+      if (compositionKeys.length === 0) {
+        return true;
+      }
+      return false;
     });
   }
 

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1267,14 +1267,29 @@ export class ChatAnthropicMessages<
       : [];
     const taskBudgetBetas = getTaskBudgetBetas(this.model, mergedOutputConfig);
 
+    const tools = this.formatStructuredToolToAnthropic(options?.tools, {
+      strict: options?.strict,
+    });
+    if (
+      tool_choice?.type === "tool" &&
+      !tools?.some((tool) => "name" in tool && tool.name === tool_choice.name)
+    ) {
+      throw new Error(
+        `Anthropic tool_choice references "${tool_choice.name}", but that tool is not available.`
+      );
+    }
+    if (tool_choice?.type === "any" && (!tools || tools.length === 0)) {
+      throw new Error(
+        "Anthropic tool_choice requires at least one available tool."
+      );
+    }
+
     const output: AnthropicInvocationParams = {
       model: this.model,
       stop_sequences: options?.stop ?? this.stopSequences,
       stream: this.streaming,
       max_tokens: this.maxTokens,
-      tools: this.formatStructuredToolToAnthropic(options?.tools, {
-        strict: options?.strict,
-      }),
+      tools,
       tool_choice,
       thinking: this.thinkingExplicitlySet ? this.thinking : undefined,
       context_management: this.contextManagement,

--- a/libs/providers/langchain-anthropic/src/tests/chat_models-tools.int.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models-tools.int.test.ts
@@ -231,6 +231,32 @@ test("Can bind & invoke AnthropicTools", async () => {
   expect(input.location).toBeTruthy();
 });
 
+test("drops tools with root schema composition before invoking Anthropic", async () => {
+  const invalidTool = {
+    name: "invalid_composition_tool",
+    description: "This tool has an unsupported root schema composition.",
+    input_schema: {
+      type: "object" as const,
+      anyOf: [
+        {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      ],
+    },
+  };
+  const modelWithTools = model.bindTools([anthropicTool, invalidTool], {
+    tool_choice: { type: "tool", name: "get_weather" },
+  });
+
+  const result = await modelWithTools.invoke(
+    "What is the weather in London today?"
+  );
+
+  expect(result.tool_calls?.[0].name).toBe("get_weather");
+});
+
 test("Can bind & stream AnthropicTools", async () => {
   const modelWithTools = model.bindTools([anthropicTool]).withConfig({
     tool_choice: {

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -1150,6 +1150,62 @@ describe("formatStructuredToolToAnthropic", () => {
   });
 });
 
+describe("tool choice with filtered tools", () => {
+  const rootCompositionTool = {
+    name: "invalid_composition_tool",
+    description: "Uses unsupported root composition.",
+    input_schema: {
+      type: "object" as const,
+      anyOf: [],
+    },
+  };
+
+  test("throws when a named choice references a filtered tool", () => {
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+
+    expect(() =>
+      model.invocationParams({
+        tools: [rootCompositionTool],
+        tool_choice: { type: "tool", name: rootCompositionTool.name },
+      })
+    ).toThrow(
+      'Anthropic tool_choice references "invalid_composition_tool", but that tool is not available.'
+    );
+  });
+
+  test("throws when required tool use has no remaining tools", () => {
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+
+    expect(() =>
+      model.invocationParams({
+        tools: [rootCompositionTool],
+        tool_choice: "required",
+      })
+    ).toThrow("Anthropic tool_choice requires at least one available tool.");
+  });
+
+  test("allows automatic tool choice when all tools are filtered", () => {
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+
+    const params = model.invocationParams({
+      tools: [rootCompositionTool],
+      tool_choice: "auto",
+    });
+
+    expect(params.tools).toEqual([]);
+    expect(params.tool_choice).toEqual({ type: "auto" });
+  });
+});
+
 describe("Tool search beta auto-append", () => {
   test("tool_search_tool_regex adds advanced-tool-use beta", () => {
     const getWeather = tool(

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -1105,6 +1105,49 @@ describe("formatStructuredToolToAnthropic", () => {
 
     expect(result).toEqual([]);
   });
+
+  test("drops tools with top-level schema composition keys", () => {
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+    const result = model.formatStructuredToolToAnthropic([
+      {
+        name: "invalid_tool",
+        description: "Uses unsupported root composition.",
+        input_schema: {
+          type: "object",
+          oneOf: [],
+          anyOf: [],
+          allOf: [],
+        },
+      },
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  test("retains tools with nested schema composition keys", () => {
+    const model = new ChatAnthropic({
+      modelName: "claude-haiku-4-5-20251001",
+      anthropicApiKey: "testing",
+    });
+    const tool = {
+      name: "valid_tool",
+      description: "Uses nested composition.",
+      input_schema: {
+        type: "object" as const,
+        properties: {
+          choice: {
+            anyOf: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      },
+    };
+    const result = model.formatStructuredToolToAnthropic([tool]);
+
+    expect(result).toEqual([tool]);
+  });
 });
 
 describe("Tool search beta auto-append", () => {

--- a/libs/providers/langchain-anthropic/src/utils/tools.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tools.ts
@@ -2,6 +2,23 @@ import type { Anthropic } from "@anthropic-ai/sdk";
 import * as z from "zod/v4";
 import { AnthropicToolChoice } from "../types.js";
 
+const TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ["oneOf", "anyOf", "allOf"] as const;
+
+/**
+ * Returns root-level JSON Schema composition keys that Anthropic rejects for
+ * custom tool input schemas. Nested composition keys remain supported.
+ */
+export function getTopLevelSchemaCompositionKeys(
+  tool: Anthropic.Messages.Tool
+): string[] {
+  if (typeof tool.input_schema !== "object" || tool.input_schema === null) {
+    return [];
+  }
+  return TOP_LEVEL_SCHEMA_COMPOSITION_KEYS.filter((key) =>
+    Object.prototype.hasOwnProperty.call(tool.input_schema, key)
+  );
+}
+
 export function handleToolChoice(
   toolChoice?: AnthropicToolChoice
 ):


### PR DESCRIPTION
## Summary

filters custom Anthropic tools whose root `input_schema` contains `oneOf`, `anyOf`, or `allOf`, which Anthropic rejects at request validation.

Some MCP v2 tools use these composition keys in their input schemas, which upstream providers do not support. This adds a fail fast mechanism to prevent hard 400 errors.
