### PR TITLE
ci: harden the npm release workflows and add a Plumber score

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -9,6 +9,10 @@ on:
         required: false
         default: "dev"
         type: string
+    secrets:
+      NPM_TOKEN:
+        description: "npm token used to authenticate the publish"
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
-          cache: "pnpm"
 
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,33 @@
+# Plumber scans the GitHub Actions workflows for CI/CD security issues
+# (unpinned actions, over-broad token permissions, risky triggers, ...)
+# and publishes a score badge for the README.
+name: Plumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    name: Plumber Score
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF report to code scanning
+      id-token: write # publish the score badge (score-push)
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 🔍 Plumber Score
+        uses: getplumber/plumber@ce2d9603cc9faf10df2b76b276366104a61c68d0 # v0.4.31
+        with:
+          score-push: true
+          min-points: 85
+          # code scanning upload is not available to fork PRs
+          upload-sarif: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ name: 🦋 Changesets Release
 # Called by publish.yml (the npm Trusted Publisher entry point)
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        description: "npm token used to authenticate the publish"
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".nvmrc"
-          cache: "pnpm"
 
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Dev release - triggered by workflow_dispatch
   dev-release:
@@ -51,4 +52,5 @@ jobs:
       pull-requests: write
     with:
       npm_tag: ${{ inputs.npm_tag }}
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,12 @@
+# Plumber overlay: everything inherits the built-in defaults
+# (plumber config view), only the deltas below are written.
+extends: plumber:default
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # keep the default trusted owners/actions and add the repo's own
+      includePlumberDefaults: true
+      trustedGithubActions:
+        # PR title linting (pr_lint.yml), pinned by commit SHA
+        - amannn/action-semantic-pull-request

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <h3>The agent engineering platform.</h3>
 </div>
 
-![npm](https://img.shields.io/npm/dm/langchain) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchain_js.svg?style=social&label=Follow%20%40LangChain)](https://x.com/langchain_js)
+![npm](https://img.shields.io/npm/dm/langchain) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Plumber Score](https://score.getplumber.io/github.com/langchain-ai/langchainjs.svg)](https://score.getplumber.io/github.com/langchain-ai/langchainjs) [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/langchain_js.svg?style=social&label=Follow%20%40LangChain)](https://x.com/langchain_js)
 
 LangChain is a framework for building LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development — all while future-proofing decisions as the underlying technology evolves.
 


### PR DESCRIPTION
Two hardening changes on the npm release path. A third commit adds the check that found them. It's independent and can be dropped.

**1. No dependency cache on the publish jobs** (`publish.yml`, `dev-release.yml`)

Six test and compatibility workflows run on pushes to `main` with the same pnpm store cache key family, and `pnpm install` executes lifecycle scripts from the dependency tree during those runs. The release jobs restore that main-scoped cache before installing and publishing to npm, so anything those runs write into the cache can end up in published packages, and the `restore-keys` prefix fallback keeps a stale store eligible even after the lockfile changes. Dropping `cache: "pnpm"` on the two publish jobs keeps the release install derived from the lockfile and registry alone. Test workflows keep their cache, so the cost is a longer install on release runs only.

**2. Only forward `NPM_TOKEN` to the called release workflows** (`release.yml`)

`secrets: inherit` hands every repository secret to the called workflows, while `publish.yml` and `dev-release.yml` only read `NPM_TOKEN` (`GITHUB_TOKEN` is provided by the runner either way). The callees now declare the one secret they need and the entry point passes it explicitly, so future secrets added to the repo stay out of the release jobs' reach by default.

**3. Plumber workflow and badge**

The two issues above were found with the Plumber CLI, verified on `main`. The last commit adds it as a workflow so the same checks run on future changes:

- It scans the workflows for CI/CD security issues (unpinned actions, over-broad token permissions, caches on release paths) and uploads results as SARIF to code scanning.
- It runs on built-in defaults, no config needed. The small `.plumber.yaml` here only adds `amannn/action-semantic-pull-request` (already pinned by SHA) to the trusted actions list.
- The badge works like OpenSSF Scorecard's published results: it shows the default branch score, a failed publish never fails CI, and it reads UNKNOWN until the first run on `main`. The gate is 85/100 so a single small finding does not block PRs.

I work on Plumber. If you do not want the tool, no hard feelings, say so and I remove that commit, the hardening stands on its own.
