### PR TITLE
fix(core): treat empty tool-call args as {} in finalizeContentBlock

### DIFF
--- a/.changeset/zero-arg-tool-call-finalize.md
+++ b/.changeset/zero-arg-tool-call-finalize.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Treat missing streamed tool-call args as an empty object in finalizeContentBlock so zero-arg tools are not marked invalid_tool_call.

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -508,7 +508,9 @@ export function finalizeContentBlock(block: ContentBlock): ContentBlock {
     const chunk = block as ContentBlock.Tools.ToolCallChunk;
     let parsedArgs: unknown;
     try {
-      parsedArgs = JSON.parse(chunk.args ?? "{}");
+      // Empty string is the seeded default when a provider never sends arg
+      // deltas (zero-arg tools). `??` would leave "" and JSON.parse("") throws.
+      parsedArgs = JSON.parse(chunk.args || "{}");
     } catch {
       return {
         type: "invalid_tool_call" as const,

--- a/libs/langchain-core/src/language_models/tests/finalize_content_block.test.ts
+++ b/libs/langchain-core/src/language_models/tests/finalize_content_block.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { finalizeContentBlock } from "../compat.js";
+
+describe("finalizeContentBlock", () => {
+  test("empty args string becomes valid zero-arg tool_call", () => {
+    // Providers (e.g. Bedrock Converse) seed tool_call_chunk with args: ""
+    // and never send an input delta for parameterless tools. Using `??`
+    // left "" through to JSON.parse(""), which became invalid_tool_call.
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "tooluse_1",
+      name: "list_things",
+      args: "",
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "tooluse_1",
+      name: "list_things",
+      args: {},
+    });
+  });
+
+  test("undefined args also become valid zero-arg tool_call", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "tooluse_2",
+      name: "ping",
+      index: 0,
+    } as Parameters<typeof finalizeContentBlock>[0]);
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "tooluse_2",
+      name: "ping",
+      args: {},
+    });
+  });
+
+  test("malformed args still become invalid_tool_call", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "tooluse_3",
+      name: "broken",
+      args: "{not-json",
+      index: 0,
+    });
+
+    expect(result).toMatchObject({
+      type: "invalid_tool_call",
+      id: "tooluse_3",
+      name: "broken",
+      args: "{not-json",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Zero-arg streamed tool calls leave accumulated `args` as `""` (seeded default, no input deltas).
- `finalizeContentBlock` used `chunk.args ?? "{}"`, so `JSON.parse("")` threw and the call became `invalid_tool_call`.
- Use `|| "{}"` (same as `@langchain/anthropic`) so empty args parse to `{}`.

## Test plan
- [x] Unit test for empty / undefined / malformed args
- [x] Proven to fail without the fix (`git stash` → expect `invalid_tool_call` → pop)
- [x] Changeset for `@langchain/core`

Fixes #11311