### PR TITLE
fix(mcp-adapters): preserve nested anyOf instead of intersecting required

### DIFF
--- a/.changeset/mcp-preserve-nested-anyof.md
+++ b/.changeset/mcp-preserve-nested-anyof.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mcp-adapters": patch
+---
+
+Preserve nested anyOf schemas in simplifyJsonSchemaForLLM instead of intersecting required across branches.

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -1047,5 +1047,86 @@ describe("Simplified Tool Adapter Tests", () => {
 
       expect(result).toBe("User created");
     });
+
+    test("preserves nested anyOf required/const instead of intersecting", async () => {
+      // Regression for #11302: intersecting required across anyOf branches
+      // dropped `start` for kind=range and overwrote kind's const, so the LLM
+      // saw a schema the MCP server rejects.
+      const inputSchema = {
+        type: "object" as const,
+        properties: {
+          filter: {
+            anyOf: [
+              {
+                type: "object",
+                properties: { kind: { const: "none" } },
+                required: ["kind"],
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "range" },
+                  start: { type: "string" },
+                },
+                required: ["kind", "start"],
+              },
+            ],
+          },
+        },
+      };
+
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({
+          tools: [
+            {
+              name: "search",
+              description: "Search with a filter",
+              inputSchema,
+            },
+          ],
+        })
+      );
+
+      mockClient.callTool.mockImplementation(() => {
+        return Promise.resolve({
+          content: [{ type: "text", text: "ok" }],
+        });
+      });
+
+      const tools = await loadMcpTools(
+        "mockServer(nested anyOf preserve)",
+        mockClient as Client
+      );
+
+      expect(tools.length).toBe(1);
+      const schema = tools[0].schema as {
+        properties?: {
+          filter?: {
+            anyOf?: Array<{
+              required?: string[];
+              properties?: { kind?: { const?: string }; start?: unknown };
+            }>;
+          };
+        };
+      };
+
+      expect(schema.properties?.filter?.anyOf).toHaveLength(2);
+      expect(schema.properties?.filter?.anyOf?.[0]).toMatchObject({
+        required: ["kind"],
+        properties: { kind: { const: "none" } },
+      });
+      expect(schema.properties?.filter?.anyOf?.[1]).toMatchObject({
+        required: ["kind", "start"],
+        properties: {
+          kind: { const: "range" },
+          start: { type: "string" },
+        },
+      });
+
+      const result = await tools[0].invoke({
+        filter: { kind: "range", start: "2026-01-01" },
+      });
+      expect(result).toBe("ok");
+    });
   });
 });

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -360,72 +360,74 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
     );
   }
 
-  // Handle anyOf/oneOf by attempting to merge object schemas or picking first viable option
-  // Note: When merging anyOf/oneOf, we only merge properties but NOT required arrays,
-  // because the union semantics mean any ONE of the schemas should match, not all.
+  // Handle anyOf/oneOf.
+  // OpenAI rejects *top-level* unions, so when this schema already has an
+  // object shape (type/properties) we still flatten by merging properties.
+  // Pure nested unions (e.g. a property whose schema is only `anyOf`) must
+  // keep their branches — intersecting `required` / overwriting `const`
+  // otherwise produces a schema the MCP server will reject (#11302).
   const unionSchemas = anyOf || oneOf;
   if (Array.isArray(unionSchemas) && unionSchemas.length > 0) {
-    // Check if all schemas in the union are object-like (have type: object or have properties)
-    const allAreObjects = unionSchemas.every(
-      (s) =>
-        typeof s === "object" &&
-        s !== null &&
-        (s.type === "object" || s.properties)
-    );
+    const hasOwnObjectShape =
+      result.type === "object" ||
+      (result.properties != null &&
+        Object.keys(result.properties as object).length > 0);
 
-    // Collect all properties from all schemas, but only keep required fields
-    // that are common to ALL schemas (intersection)
-    const mergedProperties: Record<string, JsonSchemaObject> = {};
-    const requiredSets: Set<string>[] = [];
+    if (!hasOwnObjectShape) {
+      const key = anyOf ? "anyOf" : "oneOf";
+      result[key] = unionSchemas.map((subSchema) =>
+        simplifyJsonSchemaForLLM(subSchema)
+      );
+      debugLog(
+        `INFO: Preserved ${unionSchemas.length} schemas in nested ${key}`
+      );
+    } else {
+      // Check if all schemas in the union are object-like (have type: object or have properties)
+      const allAreObjects = unionSchemas.every(
+        (s) =>
+          typeof s === "object" &&
+          s !== null &&
+          (s.type === "object" || s.properties)
+      );
 
-    const schemasToMerge = allAreObjects
-      ? unionSchemas
-      : unionSchemas.filter(
-          (s) =>
-            typeof s === "object" &&
-            s !== null &&
-            (s.type === "object" || s.properties)
-        );
+      // Collect properties from all schemas. Do NOT merge `required` —
+      // union semantics mean any ONE branch may match, and intersecting
+      // required loses per-branch constraints.
+      const mergedProperties: Record<string, JsonSchemaObject> = {};
 
-    for (const subSchema of schemasToMerge) {
-      const simplified = simplifyJsonSchemaForLLM(subSchema);
-      // Merge properties
-      if (simplified.properties) {
-        Object.assign(mergedProperties, simplified.properties);
+      const schemasToMerge = allAreObjects
+        ? unionSchemas
+        : unionSchemas.filter(
+            (s) =>
+              typeof s === "object" &&
+              s !== null &&
+              (s.type === "object" || s.properties)
+          );
+
+      for (const subSchema of schemasToMerge) {
+        const simplified = simplifyJsonSchemaForLLM(subSchema);
+        // Merge properties
+        if (simplified.properties) {
+          Object.assign(mergedProperties, simplified.properties);
+        }
+        // Merge type if present
+        if (simplified.type && !result.type) {
+          result.type = simplified.type;
+        }
       }
-      // Collect required sets for intersection
-      if (simplified.required && Array.isArray(simplified.required)) {
-        requiredSets.push(new Set(simplified.required));
+
+      // Merge the collected properties
+      if (Object.keys(mergedProperties).length > 0) {
+        result.properties = {
+          ...(result.properties as Record<string, JsonSchemaObject>),
+          ...mergedProperties,
+        };
       }
-      // Merge type if present
-      if (simplified.type && !result.type) {
-        result.type = simplified.type;
-      }
+
+      debugLog(
+        `INFO: Merged ${schemasToMerge.length} object schemas from ${anyOf ? "anyOf" : "oneOf"}`
+      );
     }
-
-    // Merge the collected properties
-    if (Object.keys(mergedProperties).length > 0) {
-      result.properties = {
-        ...(result.properties as Record<string, JsonSchemaObject>),
-        ...mergedProperties,
-      };
-    }
-
-    // Only add required fields that are common to ALL schemas (intersection)
-    if (requiredSets.length > 0) {
-      const commonRequired = requiredSets.reduce((acc, set) => {
-        return new Set([...acc].filter((x) => set.has(x)));
-      });
-      if (commonRequired.size > 0) {
-        result.required = [
-          ...new Set([...(result.required || []), ...commonRequired]),
-        ];
-      }
-    }
-
-    debugLog(
-      `INFO: Merged ${schemasToMerge.length} object schemas from ${anyOf ? "anyOf" : "oneOf"}`
-    );
   }
 
   // Ensure we have type: "object" if there are properties


### PR DESCRIPTION
## Summary
- Nested `anyOf`/`oneOf` (e.g. a property whose schema is only a union) were flattened by merging properties and intersecting `required`.
- That dropped branch-specific requirements and overwrote `const` discriminators, so the LLM saw a schema the MCP server rejects.
- Preserve pure nested unions after simplifying children; still flatten top-level `type: object` + `anyOf` for OpenAI compatibility (#9805).

## Test plan
- [x] Regression test asserts nested `anyOf` keeps per-branch `required` / `const`
- [x] Proven to fail without the fix (`git stash` A/B)
- [x] Changeset for `@langchain/mcp-adapters`

Fixes #11302