### PR TITLE
feat(core): route tiktoken encoding through hypertok, with js-tiktoken fallback

### DIFF
--- a/.changeset/swift-tokens.md
+++ b/.changeset/swift-tokens.md
@@ -1,0 +1,7 @@
+---
+"@langchain/core": minor
+---
+
+feat(core): route tiktoken encoding through hypertok by default, with js-tiktoken fallback
+
+Fixes #9248

--- a/environment_tests/test-exports-cf/src/index.ts
+++ b/environment_tests/test-exports-cf/src/index.ts
@@ -20,6 +20,7 @@ import {
 import { OpenAI } from "@langchain/openai";
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { StringOutputParser } from "@langchain/core/output_parsers";
+import { calculateMaxTokens } from "@langchain/core/language_models/base";
 
 export interface Env {
   OPENAI_API_KEY?: string;
@@ -35,6 +36,14 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
+    if (new URL(request.url).pathname === "/token-count") {
+      const maxTokens = await calculateMaxTokens({
+        prompt: "hello",
+        modelName: "gpt-3.5-turbo",
+      });
+      return Response.json({ maxTokens });
+    }
+
     const constructorParameters = env.AZURE_OPENAI_API_KEY
       ? {
           azureOpenAIApiKey: env.AZURE_OPENAI_API_KEY,

--- a/environment_tests/test-exports-cf/src/index.unit.test.ts
+++ b/environment_tests/test-exports-cf/src/index.unit.test.ts
@@ -7,6 +7,7 @@ describe("Worker", () => {
 
   beforeAll(async () => {
     worker = await unstable_dev("src/index.ts", {
+      compatibilityFlags: ["nodejs_compat"],
       experimental: { disableExperimentalWarning: true },
     });
   }, 30000);
@@ -15,7 +16,10 @@ describe("Worker", () => {
     await worker.stop();
   });
 
-  it("should start", async () => {
-    expect(true).toBe(true);
-  });
+  it("should count tokens", async () => {
+    const response = await worker.fetch("http://example.com/token-count");
+
+    expect(response.ok).toBe(true);
+    await expect(response.json()).resolves.toEqual({ maxTokens: 4095 });
+  }, 30000);
 });

--- a/environment_tests/test-exports-vercel/src/pages/api/hello-edge.ts
+++ b/environment_tests/test-exports-vercel/src/pages/api/hello-edge.ts
@@ -13,6 +13,7 @@ import {
 import { OpenAI } from "@langchain/openai";
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { CallbackManager } from "@langchain/core/callbacks/manager";
+import { calculateMaxTokens } from "@langchain/core/language_models/base";
 
 import { NextRequest, NextResponse } from "next/server";
 
@@ -21,6 +22,14 @@ export const config = {
 };
 
 export default async function handler(req: NextRequest) {
+  if (req.nextUrl.searchParams.has("token-count")) {
+    const maxTokens = await calculateMaxTokens({
+      prompt: "hello",
+      modelName: "gpt-3.5-turbo",
+    });
+    return NextResponse.json({ maxTokens });
+  }
+
   // Intantiate a few things to test the exports
   new OpenAI({ openAIApiKey: process.env.OPENAI_API_KEY });
   const emb = new OpenAIEmbeddings({

--- a/libs/langchain-core/package.json
+++ b/libs/langchain-core/package.json
@@ -26,13 +26,21 @@
   "dependencies": {
     "@cfworker/json-schema": "^4.0.2",
     "@standard-schema/spec": "^1.1.0",
+    "hypertok": ">=0.3.3 <1.0.0",
     "js-tiktoken": "^1.0.12",
     "langsmith": ">=0.5.0 <1.0.0",
     "mustache": "^4.2.0",
     "p-queue": "^6.6.2",
     "zod": "^3.25.76 || ^4"
   },
+  "optionalDependencies": {
+    "@hypertok/vocab-cl100k": "^1.0.0",
+    "@hypertok/vocab-gpt2": "^1.0.0",
+    "@hypertok/vocab-o200k": "^1.0.0",
+    "@hypertok/vocab-p50k": "^1.0.0"
+  },
   "devDependencies": {
+    "@dqbd/tiktoken": "1.0.21",
     "@langchain/tsconfig": "workspace:*",
     "@types/mustache": "^4",
     "@types/node": "^26.1.2",

--- a/libs/langchain-core/scripts/benchmark_tiktoken.mjs
+++ b/libs/langchain-core/scripts/benchmark_tiktoken.mjs
@@ -1,0 +1,410 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createRequire, registerHooks } from "node:module";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const coreRoot = resolve(dirname(scriptPath), "..");
+const repositoryRoot = resolve(coreRoot, "../..");
+const requireFromCore = createRequire(resolve(coreRoot, "package.json"));
+const encodings = ["cl100k_base", "o200k_base"];
+const documentTypes = ["prose", "typescript", "cjk"];
+const coldScenarios = ["hypertok", "js-fetch", "js-cached"];
+const steadyScenarios = ["hypertok", "js-cached"];
+const samples = 9;
+const coldCheckpoints = [1, 10, 100];
+const warmups = 2;
+const coldDocumentBytes = 4 * 1024;
+const steadyCorpusBytes = 512 * 1024;
+const steadyDocumentCharacters = 16_000;
+
+const proseSources = ["README.md", "CONTRIBUTING.md"];
+const typescriptSources = [
+  "libs/langchain-core/src/language_models/base.ts",
+  "libs/langchain-core/src/language_models/chat_models.ts",
+  "libs/langchain-core/src/messages/base.ts",
+  "libs/langchain-core/src/prompts/chat.ts",
+  "libs/langchain-core/src/runnables/base.ts",
+  "libs/langchain-core/src/output_parsers/base.ts",
+];
+const cjkSeed = `机器学习系统需要准确计算多语言文本的标记数量。检索、工具调用和结构化输出共享同一个上下文预算。
+東京とソウルの利用者も同じ経路を使います。正確なトークン数は、検索と生成の両方で重要です。
+한국어 문서에서도 토큰 수를 정확하게 계산해야 합니다. 검색, 도구 호출, 구조화된 출력을 함께 처리합니다.
+`;
+
+function readSources(paths) {
+  return paths
+    .map((path) => readFileSync(resolve(repositoryRoot, path), "utf8"))
+    .join("\n");
+}
+
+function getSeed(type) {
+  if (type === "prose") {
+    return readSources(proseSources);
+  }
+  if (type === "typescript") {
+    return readSources(typescriptSources);
+  }
+  return cjkSeed;
+}
+
+function truncateUtf8(text, byteLimit) {
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const midpoint = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, midpoint), "utf8") <= byteLimit) {
+      low = midpoint;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+  return text.slice(0, low);
+}
+
+function repeatToBytes(seed, byteTarget) {
+  return seed.repeat(
+    Math.ceil(byteTarget / Buffer.byteLength(seed, "utf8")) + 1
+  );
+}
+
+function createCorpus(type) {
+  const seed = getSeed(type);
+  const expanded = repeatToBytes(seed, steadyCorpusBytes);
+  const coldDocument = truncateUtf8(expanded, coldDocumentBytes);
+  const documents = [];
+  let offset = 0;
+  let bytes = 0;
+  while (bytes < steadyCorpusBytes) {
+    const candidate = expanded.slice(offset, offset + steadyDocumentCharacters);
+    const document = truncateUtf8(candidate, steadyCorpusBytes - bytes);
+    if (document.length === 0) {
+      break;
+    }
+    documents.push(document);
+    bytes += Buffer.byteLength(document, "utf8");
+    offset += candidate.length;
+  }
+  return {
+    coldDocument,
+    coldBytes: Buffer.byteLength(coldDocument, "utf8"),
+    documents,
+    bytes,
+  };
+}
+
+function median(values) {
+  const ordered = [...values].sort((left, right) => left - right);
+  return ordered[Math.floor(ordered.length / 2)];
+}
+
+function configureBackend(scenario, encoding) {
+  if (scenario !== "hypertok") {
+    registerHooks({
+      resolve(specifier, context, nextResolve) {
+        if (specifier === "hypertok" || specifier.startsWith("hypertok/")) {
+          throw new Error("hypertok disabled for comparison");
+        }
+        return nextResolve(specifier, context);
+      },
+    });
+  }
+
+  let fetchCount = 0;
+  let fetchedUrl;
+  const expectedUrl = `https://tiktoken.pages.dev/js/${encoding}.json`;
+  if (scenario === "js-fetch") {
+    const nativeFetch = globalThis.fetch;
+    globalThis.fetch = async (...args) => {
+      fetchCount += 1;
+      fetchedUrl = String(args[0]);
+      return nativeFetch(...args);
+    };
+  } else if (scenario === "js-cached") {
+    const ranks = requireFromCore(`js-tiktoken/ranks/${encoding}`);
+    globalThis.fetch = async (url) => {
+      fetchCount += 1;
+      fetchedUrl = String(url);
+      return { ok: true, json: async () => ranks };
+    };
+  } else {
+    globalThis.fetch = async (url) => {
+      throw new Error(`unexpected network request: ${url}`);
+    };
+  }
+
+  return () => {
+    if (scenario === "hypertok") {
+      assert.equal(fetchCount, 0);
+    } else {
+      assert.equal(fetchCount, 1);
+      assert.equal(fetchedUrl, expectedUrl);
+    }
+  };
+}
+
+async function importGetEncoding() {
+  const module = await import(
+    pathToFileURL(resolve(coreRoot, "dist/utils/tiktoken.js")).href
+  );
+  return module.getEncoding;
+}
+
+async function runColdWorker(scenario, encoding, type) {
+  const assertBackend = configureBackend(scenario, encoding);
+  const getEncoding = await importGetEncoding();
+  const { coldDocument, coldBytes } = createCorpus(type);
+  globalThis.gc?.();
+  const started = performance.now();
+  const encoder = await getEncoding(encoding);
+  const cumulativeMs = {};
+  let tokenCount;
+  for (let call = 1; call <= coldCheckpoints.at(-1); call += 1) {
+    const count = encoder.encode(coldDocument).length;
+    tokenCount ??= count;
+    assert.equal(count, tokenCount);
+    if (coldCheckpoints.includes(call)) {
+      cumulativeMs[call] = performance.now() - started;
+    }
+  }
+  assertBackend();
+  return { coldBytes, tokenCount, cumulativeMs };
+}
+
+function measureSteady(encoder, documents) {
+  globalThis.gc?.();
+  let tokenCount = 0;
+  const started = performance.now();
+  for (const document of documents) {
+    tokenCount += encoder.encode(document).length;
+  }
+  return { tokenCount, milliseconds: performance.now() - started };
+}
+
+async function runSteadyWorker(scenario, encoding, type) {
+  const assertBackend = configureBackend(scenario, encoding);
+  const getEncoding = await importGetEncoding();
+  const { documents, bytes } = createCorpus(type);
+  const encoder = await getEncoding(encoding);
+  assertBackend();
+  for (let warmup = 0; warmup < warmups; warmup += 1) {
+    measureSteady(encoder, documents);
+  }
+  const timings = [];
+  let tokenCount;
+  for (let sample = 0; sample < samples; sample += 1) {
+    const measurement = measureSteady(encoder, documents);
+    tokenCount ??= measurement.tokenCount;
+    assert.equal(measurement.tokenCount, tokenCount);
+    timings.push(measurement.milliseconds);
+  }
+  return { bytes, documents: documents.length, tokenCount, timings };
+}
+
+function runWorker(args) {
+  const child = spawnSync(
+    process.execPath,
+    ["--expose-gc", scriptPath, "--worker", ...args],
+    { encoding: "utf8" }
+  );
+  if (child.status !== 0) {
+    throw new Error(
+      `${args.join("/")} failed (${child.status})\n${child.stdout}\n${child.stderr}`
+    );
+  }
+  return JSON.parse(child.stdout.trim().split(/\r?\n/).at(-1));
+}
+
+function collectColdResults() {
+  const raw = {};
+  for (const encoding of encodings) {
+    raw[encoding] = {};
+    for (const type of documentTypes) {
+      raw[encoding][type] = Object.fromEntries(
+        coldScenarios.map((scenario) => [scenario, []])
+      );
+      for (let sample = 0; sample < samples; sample += 1) {
+        const order = coldScenarios.map(
+          (_, index) => coldScenarios[(index + sample) % coldScenarios.length]
+        );
+        for (const scenario of order) {
+          raw[encoding][type][scenario].push(
+            runWorker(["cold", scenario, encoding, type])
+          );
+        }
+      }
+      const counts = new Set(
+        coldScenarios.flatMap((scenario) =>
+          raw[encoding][type][scenario].map((result) => result.tokenCount)
+        )
+      );
+      assert.equal(counts.size, 1);
+    }
+  }
+  return raw;
+}
+
+function collectSteadyResults() {
+  const raw = {};
+  for (const encoding of encodings) {
+    raw[encoding] = {};
+    for (const type of documentTypes) {
+      raw[encoding][type] = {};
+      const order =
+        (encodings.indexOf(encoding) + documentTypes.indexOf(type)) % 2 === 0
+          ? steadyScenarios
+          : [...steadyScenarios].reverse();
+      for (const scenario of order) {
+        raw[encoding][type][scenario] = runWorker([
+          "steady",
+          scenario,
+          encoding,
+          type,
+        ]);
+      }
+      assert.equal(
+        raw[encoding][type].hypertok.tokenCount,
+        raw[encoding][type]["js-cached"].tokenCount
+      );
+    }
+  }
+  return raw;
+}
+
+function renderResults(cold, steady) {
+  const lines = [
+    "# LangChainJS token-count benchmark",
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    `Node: ${process.version}. Medians of ${samples}. Equal token counts are asserted for every comparison.`,
+    "",
+    "## Cold start",
+    "",
+    "Each sample runs in a fresh process. Timing begins immediately before `getEncoding` and includes encoder initialization plus 1, 10, or 100 counts of one document. Process startup, corpus preparation, and module import are excluded. Values are median milliseconds per call, including initialization amortized across the named call count.",
+    "",
+    "| Encoding | Document type | Path | Document bytes | Tokens | 1 call | 10 calls | 100 calls |",
+    "|---|---|---|---:|---:|---:|---:|---:|",
+  ];
+  for (const encoding of encodings) {
+    for (const type of documentTypes) {
+      for (const scenario of coldScenarios) {
+        const results = cold[encoding][type][scenario];
+        const cumulative = Object.fromEntries(
+          coldCheckpoints.map((checkpoint) => [
+            checkpoint,
+            median(results.map((result) => result.cumulativeMs[checkpoint])),
+          ])
+        );
+        const label = {
+          hypertok: "hypertok local",
+          "js-fetch": "js-tiktoken live fetch",
+          "js-cached": "js-tiktoken pre-cached JSON",
+        }[scenario];
+        lines.push(
+          `| ${encoding} | ${type} | ${label} | ${results[0].coldBytes} | ${results[0].tokenCount} | ${cumulative[1].toFixed(4)} | ${(cumulative[10] / 10).toFixed(4)} | ${(cumulative[100] / 100).toFixed(4)} |`
+        );
+      }
+    }
+  }
+  lines.push(
+    "",
+    "### Cold-start raw timings",
+    "",
+    "Each entry contains cumulative milliseconds at 1, 10, and 100 calls for all nine samples.",
+    ""
+  );
+  for (const encoding of encodings) {
+    for (const type of documentTypes) {
+      for (const scenario of coldScenarios) {
+        const raw = cold[encoding][type][scenario].map((result) =>
+          coldCheckpoints.map((checkpoint) => result.cumulativeMs[checkpoint])
+        );
+        lines.push(
+          `- ${encoding} / ${type} / ${scenario}: \`${JSON.stringify(raw)}\``
+        );
+      }
+    }
+  }
+
+  lines.push(
+    "",
+    "## Steady state",
+    "",
+    `Each path is constructed once through \`getEncoding\`. Two warmups are discarded, followed by ${samples} timed corpus passes. The js-tiktoken path receives pre-cached rank JSON so the table isolates encode throughput.`,
+    "",
+    "| Encoding | Document type | Path | Corpus bytes | Documents | Tokens | Median ms | MB/s | Relative speed |",
+    "|---|---|---|---:|---:|---:|---:|---:|---:|"
+  );
+  for (const encoding of encodings) {
+    for (const type of documentTypes) {
+      const hypertokMedian = median(steady[encoding][type].hypertok.timings);
+      for (const scenario of steadyScenarios) {
+        const result = steady[encoding][type][scenario];
+        const milliseconds = median(result.timings);
+        const mbps = result.bytes / 1_000_000 / (milliseconds / 1000);
+        const relative =
+          scenario === "hypertok" ? 1 : milliseconds / hypertokMedian;
+        const label = scenario === "hypertok" ? "hypertok" : "js-tiktoken";
+        lines.push(
+          `| ${encoding} | ${type} | ${label} | ${result.bytes} | ${result.documents} | ${result.tokenCount} | ${milliseconds.toFixed(4)} | ${mbps.toFixed(2)} | ${relative.toFixed(2)}x |`
+        );
+      }
+    }
+  }
+  lines.push("", "### Steady-state raw timings", "");
+  for (const encoding of encodings) {
+    for (const type of documentTypes) {
+      for (const scenario of steadyScenarios) {
+        lines.push(
+          `- ${encoding} / ${type} / ${scenario}: \`${JSON.stringify(steady[encoding][type][scenario].timings)}\``
+        );
+      }
+    }
+  }
+
+  lines.push(
+    "",
+    "## Method",
+    "",
+    "- `hypertok local` uses the default `getEncoding` path and rejects any unexpected network request.",
+    "- `js-tiktoken live fetch` rejects hypertok imports and verifies exactly one request to `tiktoken.pages.dev`.",
+    "- `js-tiktoken pre-cached JSON` rejects hypertok imports and supplies the rank object from memory through the same fetch boundary.",
+    "- Prose comes from the repository README and contributing guide. TypeScript comes from six `@langchain/core` source files. CJK uses Chinese, Japanese, and Korean text. No result blends document types.",
+    "- Garbage collection runs immediately before timed sections when Node exposes it. Operating-system file caches are not flushed. Live-fetch results include network conditions on the generation date.",
+    "",
+    "Run from the repository root:",
+    "",
+    "```sh",
+    "node libs/langchain-core/scripts/benchmark_tiktoken.mjs",
+    "```",
+    ""
+  );
+  return lines.join("\n");
+}
+
+async function main() {
+  const [mode, regime, scenario, encoding, type] = process.argv.slice(2);
+  if (mode === "--worker") {
+    assert.ok(["cold", "steady"].includes(regime));
+    assert.ok(encodings.includes(encoding));
+    assert.ok(documentTypes.includes(type));
+    assert.ok(
+      (regime === "cold" ? coldScenarios : steadyScenarios).includes(scenario)
+    );
+    const result =
+      regime === "cold"
+        ? await runColdWorker(scenario, encoding, type)
+        : await runSteadyWorker(scenario, encoding, type);
+    console.log(JSON.stringify(result));
+    return;
+  }
+  const cold = collectColdResults();
+  const steady = collectSteadyResults();
+  console.log(renderResults(cold, steady));
+}
+
+await main();

--- a/libs/langchain-core/src/utils/tests/fixtures/tiktoken-canonical-fixtures.json
+++ b/libs/langchain-core/src/utils/tests/fixtures/tiktoken-canonical-fixtures.json
@@ -1,0 +1,358 @@
+{
+  "representative": [
+    {
+      "encoding": "cl100k_base",
+      "category": "empty-and-small",
+      "input": "",
+      "canonicalLength": 0
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "prose",
+      "input": "It was the best of times, it was the worst of times.",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "code",
+      "input": "const answer = (value) => value * 42;",
+      "canonicalLength": 12
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "cjk",
+      "input": "中文分词测试。",
+      "canonicalLength": 7
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "emoji",
+      "input": "😀 😃 😄 😁 😆 😅 😂 🤣",
+      "canonicalLength": 17
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "ascii-whitespace",
+      "input": " ",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "unicode-whitespace",
+      "input": "a b",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "zero-width-and-feff",
+      "input": "​",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "combining-and-normalization",
+      "input": "café",
+      "canonicalLength": 2
+    },
+    {
+      "encoding": "cl100k_base",
+      "category": "punctuation-and-symbols",
+      "input": "!@#$%^&*()_+-=[]{}|;':,./<>?",
+      "canonicalLength": 18
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "empty-and-small",
+      "input": "",
+      "canonicalLength": 0
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "prose",
+      "input": "It was the best of times, it was the worst of times.",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "code",
+      "input": "const answer = (value) => value * 42;",
+      "canonicalLength": 12
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "cjk",
+      "input": "中文分词测试。",
+      "canonicalLength": 5
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "emoji",
+      "input": "😀 😃 😄 😁 😆 😅 😂 🤣",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "ascii-whitespace",
+      "input": " ",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "unicode-whitespace",
+      "input": "a b",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "zero-width-and-feff",
+      "input": "​",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "combining-and-normalization",
+      "input": "café",
+      "canonicalLength": 2
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "punctuation-and-symbols",
+      "input": "!@#$%^&*()_+-=[]{}|;':,./<>?",
+      "canonicalLength": 18
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "empty-and-small",
+      "input": "",
+      "canonicalLength": 0
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "prose",
+      "input": "It was the best of times, it was the worst of times.",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "code",
+      "input": "const answer = (value) => value * 42;",
+      "canonicalLength": 11
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "cjk",
+      "input": "中文分词测试。",
+      "canonicalLength": 12
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "emoji",
+      "input": "😀 😃 😄 😁 😆 😅 😂 🤣",
+      "canonicalLength": 17
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "ascii-whitespace",
+      "input": " ",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "unicode-whitespace",
+      "input": "a b",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "zero-width-and-feff",
+      "input": "​",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "combining-and-normalization",
+      "input": "café",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "punctuation-and-symbols",
+      "input": "!@#$%^&*()_+-=[]{}|;':,./<>?",
+      "canonicalLength": 23
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "empty-and-small",
+      "input": "",
+      "canonicalLength": 0
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "prose",
+      "input": "It was the best of times, it was the worst of times.",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "code",
+      "input": "const answer = (value) => value * 42;",
+      "canonicalLength": 11
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "cjk",
+      "input": "中文分词测试。",
+      "canonicalLength": 12
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "emoji",
+      "input": "😀 😃 😄 😁 😆 😅 😂 🤣",
+      "canonicalLength": 17
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "ascii-whitespace",
+      "input": " ",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "unicode-whitespace",
+      "input": "a b",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "zero-width-and-feff",
+      "input": "​",
+      "canonicalLength": 1
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "combining-and-normalization",
+      "input": "café",
+      "canonicalLength": 3
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "punctuation-and-symbols",
+      "input": "!@#$%^&*()_+-=[]{}|;':,./<>?",
+      "canonicalLength": 23
+    }
+  ],
+  "knownEdgeCases": [
+    {
+      "encoding": "o200k_base",
+      "category": "zero-width-and-feff",
+      "input": ".\n\n﻿﻿Also on HuffPost:\n\n",
+      "canonicalLength": 7
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 27
+    },
+    {
+      "encoding": "o200k_base",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 82
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "emoji",
+      "input": "emoji\n\n﻿following BOM",
+      "canonicalLength": 11
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "unicode-whitespace",
+      "input": "\n\nnext",
+      "canonicalLength": 4
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "zero-width-and-feff",
+      "input": "\n\n﻿",
+      "canonicalLength": 5
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "zero-width-and-feff",
+      "input": ".\n\n﻿﻿Also on HuffPost:\n\n",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 47
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 140
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "emoji",
+      "input": "emoji\n\n﻿following BOM",
+      "canonicalLength": 11
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "unicode-whitespace",
+      "input": "\n\nnext",
+      "canonicalLength": 4
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "zero-width-and-feff",
+      "input": "\n\n﻿",
+      "canonicalLength": 5
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "zero-width-and-feff",
+      "input": ".\n\n﻿﻿Also on HuffPost:\n\n",
+      "canonicalLength": 14
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 47
+    },
+    {
+      "encoding": "p50k_base",
+      "category": "zero-width-and-feff",
+      "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.\n\n﻿﻿Also on HuffPost:\n\nyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "canonicalLength": 140
+    }
+  ],
+  "specialPolicy": [
+    {
+      "encoding": "cl100k_base",
+      "input": "<|endoftext|>",
+      "allowedAllLength": 1
+    },
+    {
+      "encoding": "o200k_base",
+      "input": "<|endoftext|>",
+      "allowedAllLength": 1
+    },
+    {
+      "encoding": "r50k_base/gpt2",
+      "input": "<|endoftext|>",
+      "allowedAllLength": 1
+    },
+    {
+      "encoding": "p50k_base",
+      "input": "<|endoftext|>",
+      "allowedAllLength": 1
+    }
+  ]
+}

--- a/libs/langchain-core/src/utils/tests/tiktoken.test.ts
+++ b/libs/langchain-core/src/utils/tests/tiktoken.test.ts
@@ -1,0 +1,266 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { get_encoding } from "@dqbd/tiktoken";
+import { Tiktoken as JsTiktoken } from "js-tiktoken/lite";
+import type { TiktokenEncoding } from "js-tiktoken/lite";
+import cl100kRanks from "js-tiktoken/ranks/cl100k_base";
+
+type FixtureRow = {
+  encoding: string;
+  category: string;
+  input: string;
+  canonicalLength: number;
+};
+
+type SpecialPolicy = {
+  encoding: string;
+  input: string;
+  allowedAllLength: number;
+};
+
+type FixtureData = {
+  representative: FixtureRow[];
+  knownEdgeCases: FixtureRow[];
+  specialPolicy: SpecialPolicy[];
+};
+
+const fixtures = JSON.parse(
+  readFileSync(
+    new URL("./fixtures/tiktoken-canonical-fixtures.json", import.meta.url),
+    "utf8"
+  )
+) as FixtureData;
+const originalFetch = globalThis.fetch;
+const moduleSpecifiers = [
+  "hypertok",
+  "hypertok/tiktoken",
+  "hypertok/vocab-resolve",
+];
+
+const encodingNames: Record<string, TiktokenEncoding> = {
+  cl100k_base: "cl100k_base",
+  o200k_base: "o200k_base",
+  "r50k_base/gpt2": "r50k_base",
+  p50k_base: "p50k_base",
+};
+
+function jsonFetch(response = cl100kRanks) {
+  const fetchMock = vi.fn<typeof fetch>(async () =>
+    Promise.resolve(
+      new Response(JSON.stringify(response), {
+        headers: { "content-type": "application/json" },
+      })
+    )
+  );
+  globalThis.fetch = fetchMock;
+  return fetchMock;
+}
+
+function unavailableFetch() {
+  const error = new Error("tokenizer endpoint unavailable");
+  error.name = "AbortError";
+  const fetchMock = vi.fn<typeof fetch>(async () => Promise.reject(error));
+  globalThis.fetch = fetchMock;
+  return fetchMock;
+}
+
+function mockFailingHypertok(message = "hypertok unavailable") {
+  const loadVocab = vi.fn(async () => {
+    throw new Error(message);
+  });
+  vi.doMock("hypertok", () => ({ fromBytes: vi.fn() }));
+  vi.doMock("hypertok/tiktoken", () => ({
+    createTiktokenShim: vi.fn(),
+  }));
+  vi.doMock("hypertok/vocab-resolve", () => ({ loadVocab }));
+  return loadVocab;
+}
+
+function mockSuccessfulHypertok({ throwOnEncode = false } = {}) {
+  const loadVocab = vi.fn(async () => new Uint8Array([1]));
+  const fromBytes = vi.fn(async () => ({ runtime: true }));
+  const encode = vi.fn((text: string) => {
+    if (throwOnEncode) throw new Error("encode failed");
+    return Uint32Array.of(text.length);
+  });
+  const decode = vi.fn(() => new TextEncoder().encode("decoded"));
+  const createTiktokenShim = vi.fn(() => ({ encode, decode }));
+  vi.doMock("hypertok", () => ({ fromBytes }));
+  vi.doMock("hypertok/tiktoken", () => ({ createTiktokenShim }));
+  vi.doMock("hypertok/vocab-resolve", () => ({ loadVocab }));
+  return { loadVocab, fromBytes, createTiktokenShim, encode };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  for (const specifier of moduleSpecifiers) {
+    vi.doUnmock(specifier);
+  }
+  vi.resetModules();
+});
+
+describe.sequential("tiktoken integration", () => {
+  test("matches canonical counts for representative and known edge cases", async () => {
+    const { getEncoding } = await import("../tiktoken.js");
+    const fixturesByEncoding = [
+      ...fixtures.representative,
+      ...fixtures.knownEdgeCases,
+    ];
+
+    for (const [fixtureName, encodingName] of Object.entries(encodingNames)) {
+      const rows = fixturesByEncoding.filter(
+        (row) => row.encoding === fixtureName
+      );
+      const canonical = get_encoding(encodingName);
+      const encoder = await getEncoding(encodingName);
+      try {
+        for (const row of rows) {
+          expect(canonical.encode(row.input).length).toBe(row.canonicalLength);
+          expect(encoder.encode(row.input).length).toBe(row.canonicalLength);
+        }
+      } finally {
+        canonical.free();
+      }
+    }
+  });
+
+  test("preserves canonical special-token throw semantics", async () => {
+    const { getEncoding } = await import("../tiktoken.js");
+
+    for (const policy of fixtures.specialPolicy) {
+      const encodingName = encodingNames[policy.encoding];
+      const canonical = get_encoding(encodingName);
+      const encoder = await getEncoding(encodingName);
+      try {
+        expect(() => canonical.encode(policy.input)).toThrow();
+        expect(() => encoder.encode(policy.input)).toThrow();
+        expect(canonical.encode(policy.input, "all").length).toBe(
+          policy.allowedAllLength
+        );
+        expect(encoder.encode(policy.input, "all").length).toBe(
+          policy.allowedAllLength
+        );
+      } finally {
+        canonical.free();
+      }
+    }
+  });
+
+  test("warns and falls back to js-tiktoken when hypertok fails", async () => {
+    mockFailingHypertok("local tokenizer unavailable");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = jsonFetch();
+    const { getEncoding } = await import("../tiktoken.js");
+
+    const encoder = await getEncoding("cl100k_base");
+    const expected = new JsTiktoken(cl100kRanks).encode("fallback");
+    expect(encoder.encode("fallback")).toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://tiktoken.pages.dev/js/cl100k_base.json"
+    );
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(
+      "Failed to initialize hypertok, falling back to js-tiktoken",
+      expect.objectContaining({ message: "local tokenizer unavailable" })
+    );
+  });
+
+  test("falls back after a vocabulary request times out", async () => {
+    vi.useFakeTimers();
+    const { createVocabLoader } = await vi.importActual<
+      typeof import("hypertok/vocab-resolve")
+    >("hypertok/vocab-resolve");
+    const abortObserved = vi.fn();
+    const hangingFetch = vi.fn(
+      (_input: string, { signal }: { signal: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              abortObserved();
+              reject(new Error("aborted"));
+            },
+            { once: true }
+          );
+        })
+    );
+    const loader = createVocabLoader({
+      readLocal: async () => {
+        throw new Error("local vocab unavailable");
+      },
+      fetch: hangingFetch,
+    });
+    vi.doMock("hypertok", () => ({ fromBytes: vi.fn() }));
+    vi.doMock("hypertok/tiktoken", () => ({
+      createTiktokenShim: vi.fn(),
+    }));
+    vi.doMock("hypertok/vocab-resolve", () => ({
+      loadVocab: (name: string, options?: { file?: string }) =>
+        loader(name, { ...options, timeoutMs: 50 }),
+    }));
+    const fetchMock = jsonFetch();
+    const { getEncoding } = await import("../tiktoken.js");
+
+    const pending = getEncoding("cl100k_base");
+    await vi.waitFor(() => expect(hangingFetch).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(51);
+    const encoder = await pending;
+
+    expect(abortObserved).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(encoder.encode("fallback").length).toBeGreaterThan(0);
+  });
+
+  test("shares encoder initialization across concurrent callers", async () => {
+    const { loadVocab, fromBytes, createTiktokenShim } =
+      mockSuccessfulHypertok();
+    const { getEncoding } = await import("../tiktoken.js");
+
+    const [first, concurrent] = await Promise.all([
+      getEncoding("cl100k_base"),
+      getEncoding("cl100k_base"),
+    ]);
+    const sequential = await getEncoding("cl100k_base");
+
+    expect(first).toBe(concurrent);
+    expect(first).toBe(sequential);
+    expect(loadVocab).toHaveBeenCalledOnce();
+    expect(fromBytes).toHaveBeenCalledOnce();
+    expect(createTiktokenShim).toHaveBeenCalledOnce();
+  });
+
+  test("preserves caller fallback behavior", async () => {
+    mockFailingHypertok();
+    unavailableFetch();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const [{ calculateMaxTokens }, { FakeLLM }] = await Promise.all([
+      import("../../language_models/base.js"),
+      import("../testing/index.js"),
+    ]);
+    const model = new FakeLLM({});
+
+    await expect(
+      calculateMaxTokens({ prompt: "12345", modelName: "gpt-3.5-turbo" })
+    ).resolves.toBe(4094);
+    await expect(model.getNumTokens("12345")).resolves.toBe(2);
+  });
+
+  test("preserves per-call encode failure behavior", async () => {
+    mockSuccessfulHypertok({ throwOnEncode: true });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const [{ getEncoding }, { calculateMaxTokens }] = await Promise.all([
+      import("../tiktoken.js"),
+      import("../../language_models/base.js"),
+    ]);
+
+    const encoder = await getEncoding("cl100k_base");
+    expect(() => encoder.encode("12345")).toThrow("encode failed");
+    await expect(
+      calculateMaxTokens({ prompt: "12345", modelName: "gpt-3.5-turbo" })
+    ).resolves.toBe(4094);
+  });
+});

--- a/libs/langchain-core/src/utils/tiktoken.ts
+++ b/libs/langchain-core/src/utils/tiktoken.ts
@@ -6,16 +6,71 @@ import {
 } from "js-tiktoken/lite";
 import { AsyncCaller } from "./async_caller.js";
 
-const cache: Record<string, Promise<Tiktoken>> = {};
+type TiktokenCompatible = Pick<Tiktoken, "encode" | "decode">;
+
+type VocabSpec = {
+  name: string;
+  file?: string;
+};
+
+const ENCODING_VOCAB: Partial<Record<TiktokenEncoding, VocabSpec>> = {
+  cl100k_base: { name: "cl100k" },
+  o200k_base: { name: "o200k" },
+  r50k_base: { name: "gpt2" },
+  gpt2: { name: "gpt2" },
+  p50k_base: { name: "p50k" },
+  p50k_edit: { name: "p50k", file: "p50k-edit.htk" },
+};
+
+const cache: Record<string, Promise<Tiktoken | TiktokenCompatible>> = {};
 
 const caller = /* #__PURE__ */ new AsyncCaller({});
 
-export async function getEncoding(encoding: TiktokenEncoding) {
+async function tryHypertok(
+  encoding: TiktokenEncoding
+): Promise<TiktokenCompatible> {
+  const vocab = ENCODING_VOCAB[encoding];
+  if (!vocab) {
+    throw new Error(`No hypertok vocabulary mapped for ${encoding}`);
+  }
+
+  const [{ fromBytes }, { createTiktokenShim }, { loadVocab }] =
+    await Promise.all([
+      import("hypertok"),
+      import("hypertok/tiktoken"),
+      import("hypertok/vocab-resolve"),
+    ]);
+  const bytes = await loadVocab(
+    vocab.name,
+    vocab.file === undefined ? undefined : { file: vocab.file }
+  );
+  const tokenizer = await fromBytes(bytes);
+  const shim = createTiktokenShim(tokenizer, { name: encoding });
+  const decoder = new TextDecoder();
+
+  return {
+    encode: (text, allowedSpecial, disallowedSpecial) =>
+      Array.from(shim.encode(text, allowedSpecial, disallowedSpecial)),
+    decode: (tokens) => decoder.decode(shim.decode(tokens)),
+  };
+}
+
+export async function getEncoding(
+  encoding: TiktokenEncoding
+): Promise<Tiktoken> {
   if (!(encoding in cache)) {
-    cache[encoding] = caller
-      .fetch(`https://tiktoken.pages.dev/js/${encoding}.json`)
-      .then((res) => res.json())
-      .then((data) => new Tiktoken(data))
+    // Fallback order: hypertok local, hypertok CDN, js-tiktoken CDN, then caller char/4 approximation.
+    cache[encoding] = tryHypertok(encoding)
+      .catch((error) => {
+        console.warn(
+          "Failed to initialize hypertok, falling back to js-tiktoken",
+          error
+        );
+        return caller
+          .fetch(`https://tiktoken.pages.dev/js/${encoding}.json`)
+          .then((res) => res.json())
+          .then((data) => new Tiktoken(data));
+      })
       .catch((e) => {
         delete cache[encoding];
         throw e;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
+      hypertok:
+        specifier: '>=0.3.3 <1.0.0'
+        version: 0.3.3
       js-tiktoken:
         specifier: ^1.0.12
         version: 1.0.21
@@ -1032,6 +1035,9 @@ importers:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
     devDependencies:
+      '@dqbd/tiktoken':
+        specifier: 1.0.21
+        version: 1.0.21
       '@langchain/tsconfig':
         specifier: workspace:*
         version: link:../../internal/tsconfig
@@ -1062,6 +1068,19 @@ importers:
       web-streams-polyfill:
         specifier: ^4.3.0
         version: 4.3.0
+    optionalDependencies:
+      '@hypertok/vocab-cl100k':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@hypertok/vocab-gpt2':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@hypertok/vocab-o200k':
+        specifier: ^1.0.0
+        version: 1.0.0
+      '@hypertok/vocab-p50k':
+        specifier: ^1.0.0
+        version: 1.0.0
 
   libs/langchain-mcp-adapters:
     dependencies:
@@ -3235,6 +3254,9 @@ packages:
   '@datastructures-js/deque@1.0.8':
     resolution: {integrity: sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==}
 
+  '@dqbd/tiktoken@1.0.21':
+    resolution: {integrity: sha512-grBxRSY9+/iBM205EWjbMm5ySeXQrhJyXWMP38VJd+pO2DRGraDAbi4n8J8T9M4XY1M/FHgonMcmu3J+KjcX0Q==}
+
   '@dsnp/parquetjs@1.8.7':
     resolution: {integrity: sha512-3DkkN3FKJ++BQy8PE3LONoVSVBONG7hld9D+VqBp1Dcfw2PGSnWyg20NET5cJkiygWK2y2H1ra8GWk3yixzuuA==}
     engines: {node: '>=18.18.2'}
@@ -3660,6 +3682,18 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@hypertok/vocab-cl100k@1.0.0':
+    resolution: {integrity: sha512-MBvD5Rz5oiO9Qfp9iY5kHNXeMOs03TvNm11dF+pR8HHfDUsbhaZebMJLTbkZTXQrxdx2peACP7FiVhfyDjNKQw==}
+
+  '@hypertok/vocab-gpt2@1.0.0':
+    resolution: {integrity: sha512-vagcVHOKkO/jx7QQNfvvqPJEE+65C1q4Hd30Ye5fZ4UyKFgbb+p61B9G5Q2ScSVP+yXZGrCgL3mhHevt8DWL5Q==}
+
+  '@hypertok/vocab-o200k@1.0.0':
+    resolution: {integrity: sha512-TTEyRSlGLpyyBjR872aibUGi3m6/WrcnPlZDWK9OIZw+s/I2ba0YbuOzLlx+HI33k7vYzrpSdiEiGGNJG5DFuA==}
+
+  '@hypertok/vocab-p50k@1.0.0':
+    resolution: {integrity: sha512-etM2hEGnilMI1tPiGGW8MEfMA3Jy3GbVlP5+5XYJY1dvQRS/JOqzAb7Mrt0hB78i3eP7b9p++NT4t2RrIYoXdw==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -8708,6 +8742,10 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  hypertok@0.3.3:
+    resolution: {integrity: sha512-HWDxgp7UAgSDhCUDKFAH8VwW02xqpnErZNwhcW2bWLyhfZndLg2ootmDZJELTfsU1mUgEjA+oNtMqxPnQm6ZFA==}
+    engines: {node: '>=20'}
 
   ibm-cloud-sdk-core@5.6.0:
     resolution: {integrity: sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==}
@@ -14085,6 +14123,8 @@ snapshots:
 
   '@datastructures-js/deque@1.0.8': {}
 
+  '@dqbd/tiktoken@1.0.21': {}
+
   '@dsnp/parquetjs@1.8.7(bufferutil@4.1.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1041.0
@@ -14550,6 +14590,18 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@hypertok/vocab-cl100k@1.0.0':
+    optional: true
+
+  '@hypertok/vocab-gpt2@1.0.0':
+    optional: true
+
+  '@hypertok/vocab-o200k@1.0.0':
+    optional: true
+
+  '@hypertok/vocab-p50k@1.0.0':
+    optional: true
 
   '@iarna/toml@2.2.5': {}
 
@@ -19915,6 +19967,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  hypertok@0.3.3: {}
 
   ibm-cloud-sdk-core@5.6.0:
     dependencies:


### PR DESCRIPTION
<!-- PR title: feat(core): route tiktoken encoding through hypertok, with js-tiktoken fallback -->

Fixes #9248

## Summary

Routes `@langchain/core`'s OpenAI-encoding token counting through hypertok, an exact WebAssembly BPE tokenizer, with js-tiktoken and the character-count approximation kept as fallbacks. The public `getEncoding` surface and all caller behavior stay the same. hypertok's engine keeps vocabularies out of the wasm binary and the measured worker remains below Cloudflare's 3 MB free-tier limit, detailed in Footprint.

## Mechanism

`getEncoding` currently fetches each encoding's rank JSON from a CDN at runtime, and on timeout or a 404 it silently degrades to an approximate character-count. This PR tries hypertok first. hypertok reads vocabulary data from an installed `@hypertok/vocab-*` package on Node, so the common path has nothing to fetch and nothing to time out; where no local read is available (browser, edge), it falls back to fetching the same vocabulary from hypertok's own jsDelivr CDN, bounded by a 5-second timeout. hypertok loads its own wasm engine internally across every runtime it supports, Node, browsers, Cloudflare Workers, and Vercel Edge, with no wiring required from this integration. Only if hypertok fails entirely does the existing js-tiktoken CDN path run, unchanged. If that also fails, the existing character-count approximation runs, unchanged. The existing encoder cache memoizes the in-flight construction promise, so concurrent first calls for the same encoding still resolve to one construction, not one per caller.

## Evidence

### Correctness

hypertok returns the same token counts as canonical `@dqbd/tiktoken`, a build of OpenAI's own tokenizer. A 408-probe audit across cl100k, o200k, gpt2, and p50k confirmed hypertok matched canonical on every row. js-tiktoken matched canonical on cl100k and diverged on 15 o200k, gpt2, and p50k rows, all involving zero-width or FEFF characters, Unicode whitespace, or FEFF-adjacent emoji. On those 15 inputs, the count, when processed through hypertok, returns the canonical value, so the output is correct against the reference, but not identical to js-tiktoken. If you'd prefer the counts remain identical to js-tiktoken instead, let me know and I can patch that here. The fixture in this diff carries a curated 55-row subset of that audit, all 15 known-divergent cases plus a representative sample across every category, at `libs/langchain-core/src/utils/tests/fixtures/tiktoken-canonical-fixtures.json`.

### Fix for #9248

A frozen, clean-install run confirms all five vocab files (cl100k, o200k, gpt2, p50k, p50k-edit) resolve from the installed package with no network access, so the default Node path issues zero fetches and has nothing to time out. A dedicated test exercises the failure case #9248 describes directly: hypertok's local read fails, its jsDelivr fallback hangs past the bound, the request aborts, and js-tiktoken's fetch takes over, so counting still succeeds instead of silently degrading to an approximate count.

## Speed

Token counting with hypertok is significantly faster than js-tiktoken on both first use and in steady state.

Benchmarking was executed on a 13th Gen Intel Core i7-13700HX laptop with 16 cores and 16 GB of RAM, running Windows 11 Pro (build 10.0.26200) and Node v24.6.0.

### Method

Each path was constructed once through `getEncoding`. Cold-start samples ran in a fresh process and amortized initialization over 1, 10, and 100 calls. Steady-state samples discarded two warmups, then timed nine passes. Every value below is a median of nine samples, and equal token counts were asserted for every comparison.

Cold start (time to first count, initialization included, amortized over 1 / 10 / 100 calls):

| Encoding | Document | hypertok | vs js-tiktoken live fetch | vs js-tiktoken pre-cached JSON |
|---|---|---:|---:|---:|
| cl100k_base | prose | 142.77 ms | 2.62x / 2.72x / 3.60x | 1.26x / 1.40x / 2.31x |
| cl100k_base | TypeScript | 141.22 ms | 2.53x / 2.68x / 3.74x | 1.26x / 1.44x / 2.61x |
| cl100k_base | CJK | 140.68 ms | 2.79x / 3.49x / 9.36x | 1.38x / 2.09x / 8.01x |
| o200k_base | prose | 229.48 ms | 2.86x / 2.97x / 3.42x | 1.70x / 1.77x / 2.29x |
| o200k_base | TypeScript | 231.98 ms | 2.64x / 2.74x / 3.25x | 1.65x / 1.70x / 2.29x |
| o200k_base | CJK | 235.80 ms | 2.80x / 3.26x / 7.33x | 1.68x / 2.25x / 6.36x |

Steady state (construct-once throughput, warmups discarded):

| Encoding | Document | hypertok | js-tiktoken | Relative speed |
|---|---|---:|---:|---:|
| cl100k_base | prose | 80.41 MB/s | 2.73 MB/s | 29.42x |
| cl100k_base | TypeScript | 71.27 MB/s | 1.65 MB/s | 43.14x |
| cl100k_base | CJK | 70.09 MB/s | 0.21 MB/s | 331.06x |
| o200k_base | prose | 85.46 MB/s | 2.95 MB/s | 29.01x |
| o200k_base | TypeScript | 71.77 MB/s | 3.55 MB/s | 20.20x |
| o200k_base | CJK | 87.88 MB/s | 0.20 MB/s | 447.17x |

The benchmark script is included in the diff at `libs/langchain-core/scripts/benchmark_tiktoken.mjs`. Note that the absolute timings are hardware dependent; the script only reproduces the comparison.

## Footprint

This PR revisits #1239, which in 2023 moved token counting to pure JS and added the runtime CDN fetch to keep the bundle small for edge functions. **hypertok respects that calculus rather than reversing it: it keeps vocabularies out of the engine, so it fits the same edge budgets #1239 protected, and the fetch #9248 reports as fragile is no longer the default Node path.**

The single-tier engine is 427.69 KiB gzip; vocabularies live in separate optional packages rather than inside the engine. In this repository's Cloudflare Workers export test the full worker uploads at 1022.05 KiB gzip, well under Cloudflare's 3 MB free-tier limit, with hypertok itself serving the token route. The same patch compiles in the Vercel Edge and Vite fixtures, both also served by hypertok directly. Vercel's 1 MB Hobby tier is the tightest edge budget, with Pro at 2 MB and Enterprise at 4 MB; Vercel now recommends its Node runtime (250 MB) for new workloads. Deno Deploy's documented limit is about 1 GB. hypertok is imported lazily inside the encoder cache, so it adds no startup work for callers that never count tokens.

## Scope and risk

I am the author of hypertok, the MIT-licensed tokenizer added here. The contribution was prepared with the assumption that my package could break something, and stands only on the merit of the tests passing proving it does not, the counts verified against `@dqbd/tiktoken`, and the benchmark script included in the diff. Every number is reproducible.

`hypertok` is pinned `">=0.3.3 <1.0.0"` in `dependencies`; `@hypertok/vocab-cl100k`, `@hypertok/vocab-o200k`, `@hypertok/vocab-gpt2`, and `@hypertok/vocab-p50k` are pinned `"^1.0.0"` in `optionalDependencies`.

On browser and edge runtimes, hypertok's second tier fetches the vocabulary from jsDelivr, pinned to an exact package name, version, and filename. Integrity there rests on npm and jsDelivr's per-version immutability plus that pin; there is no SRI hash. That fallback URL is never caller-controlled, so it does not take the path described in #10948. This PR does not modify #10948 or its open fix, #11038.

## Changes

- Adds `hypertok` and optional cl100k, o200k, gpt2, and p50k vocabulary packages.
- Wraps hypertok, js-tiktoken, and the character-count approximation behind `getEncoding`'s existing cache.
- Warns when hypertok initialization fails before continuing to the js-tiktoken fallback.
- Adds a `calculateMaxTokens` call to the Cloudflare and Vercel edge fixtures so the token path runs in those builds.

## Validation

- `@langchain/core` package build: attw and publint clean.
- Direct dependency checks: publint is clean for hypertok and all four vocab packages. attw flags CommonJS resolution (needs dynamic import) and the `.wasm`/`.htk` asset subpaths as untyped, both expected, since this PR already uses dynamic import and reads those subpaths as raw assets, not modules.
- `pnpm lint` and `pnpm format:check` over 2,443 files: pass.
- `pnpm --filter @langchain/core test`: 100 files, 1,475 tests pass, 1 skipped, no type errors.
- `pnpm --filter langchain test`: 59 downstream package files and 848 tests pass, no type errors.
- Cloudflare export container: 1022.05 KiB gzip; an identity-bearing workerd request reports hypertok, not js-tiktoken, with no wasm wiring in this diff. The fixture's `nodejs_compat` test-runner override supports its existing broad export sweep and is not a deployment requirement introduced by this change.
- Vercel export container: both Next 16.3.0 production builds compile the edge route; an identity-bearing request reports hypertok, not js-tiktoken.
- Local vocabulary resolution for cl100k, o200k, gpt2, p50k, and p50k-edit works with no network access.
- Isolated install with optional dependencies omitted: hypertok remains installed, all four vocab packages are absent, and a failed vocab CDN request falls through to js-tiktoken successfully.
- Installed-package CommonJS and ESM smoke tests both load hypertok from the local vocab package with zero network requests.
- Identity checks against every `environment_tests` fixture that executes the tokenizer at runtime (CJS, esbuild, ESM, TSC, Vite, zod-compat, Bun) all report hypertok serving the request. `node-classic` fails to resolve unrelated `@langchain/core` subpaths under TypeScript's classic `moduleResolution`; see below.
- Changeset added: minor bump, `@langchain/core` (`.changeset/swift-tokens.md`).

As for the node classic failures, I was able to reproduce the identical errors on the unpatched baseline, meaning this PR's changes are not responsible for them. I'd be happy to look into them separately and put together a fix, if you'd like.

If it's not too much of a bother, I'd love a shoutout. My X handle is @davidkogan_.

cc @jacoblee93 @hntrl
