### PR TITLE
fix(google-common): send uppercase functionCallingConfig.mode for tool_choice

### DIFF
--- a/.changeset/gentle-plants-shine.md
+++ b/.changeset/gentle-plants-shine.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+fix(google-common): send uppercase functionCallingConfig.mode for tool_choice

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -2865,6 +2865,67 @@ describe("Mock ChatGoogle - Gemini", () => {
     ).toBeUndefined();
   });
 
+  test("6. tool_choice sends the Gemini API an uppercase functionCallingConfig mode", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const myTool = tool(async ({ query }) => `Result for ${query}`, {
+      name: "my_tool",
+      description: "A custom tool",
+      schema: z.object({ query: z.string() }),
+    });
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    })
+      .bindTools([myTool])
+      .withConfig({ tool_choice: "any" });
+
+    await model.invoke("Anything");
+
+    expect(record.opts.data.toolConfig.functionCallingConfig.mode).toBe("ANY");
+  });
+
+  test("6. forcing a specific tool_choice function name sends an uppercase mode", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const myTool = tool(async ({ query }) => `Result for ${query}`, {
+      name: "my_tool",
+      description: "A custom tool",
+      schema: z.object({ query: z.string() }),
+    });
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    })
+      .bindTools([myTool])
+      .withConfig({ tool_choice: "my_tool" });
+
+    await model.invoke("Anything");
+
+    expect(record.opts.data.toolConfig.functionCallingConfig.mode).toBe("ANY");
+    expect(
+      record.opts.data.toolConfig.functionCallingConfig.allowedFunctionNames
+    ).toEqual(["my_tool"]);
+  });
+
   test("7. logprobs request true", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -757,7 +757,7 @@ export interface GeminiRequest {
   tools?: GeminiTool[];
   toolConfig?: {
     functionCallingConfig?: {
-      mode: "auto" | "any" | "none";
+      mode: "AUTO" | "ANY" | "NONE";
       allowedFunctionNames?: string[];
     };
     /**

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1993,7 +1993,10 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       if (["auto", "any", "none"].includes(parameters.tool_choice)) {
         config = {
           functionCallingConfig: {
-            mode: parameters.tool_choice as "auto" | "any" | "none",
+            mode: parameters.tool_choice.toUpperCase() as
+              | "AUTO"
+              | "ANY"
+              | "NONE",
             allowedFunctionNames: parameters.allowed_function_names,
           },
         };
@@ -2001,7 +2004,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         // force tool choice to be a single function name in case of structured output
         config = {
           functionCallingConfig: {
-            mode: "any",
+            mode: "ANY",
             allowedFunctionNames: [parameters.tool_choice],
           },
         };


### PR DESCRIPTION
## Summary

`formatToolConfig` in `@langchain/google-common` builds the `toolConfig.functionCallingConfig.mode` field that goes to the Gemini/Vertex AI `generateContent` request whenever `tool_choice` is set. It was sending the mode in lowercase (`"auto"`, `"any"`, `"none"`), including the forced-function-name case which always used `"any"`.

The Gemini API and Vertex AI define `FunctionCallingConfig.mode` as an uppercase proto enum (`AUTO`, `ANY`, `NONE`). Their servers are lenient about the casing: they accept the lowercase value with a 200 response, but they don't recognize it, so they silently fall back to default `AUTO` behavior. That means setting `tool_choice` (directly, or indirectly through structured output forcing a specific function) currently has no effect for Gemini/Vertex users, and nothing in the response indicates anything went wrong.

This fixes `formatToolConfig` to upper-case the mode before it goes on the wire, and updates the `GeminiRequest` type to match the real wire format.

## Verification

Added a regression test in `libs/providers/langchain-google-common/src/tests/chat_models.test.ts` that binds a tool with `tool_choice: "any"` and one that forces a specific function name, then asserts the mocked outgoing request body has an uppercase mode.

Confirmed fail before / pass after with `git stash`:

Before the fix:
```
❯ src/tests/chat_models.test.ts:2894:68
AssertionError: expected 'any' to be 'ANY' // Object.is equality
Expected: "ANY"
Received: "any"

 Test Files  2 failed | 6 passed (8)
      Tests  4 failed | 294 passed (298)
```

After the fix:
```
 Test Files  8 passed (8)
      Tests  298 passed (298)
```

Also ran `oxlint .` and `oxfmt --check` on the touched files, both clean.

## Test plan

- [x] `turbo run test --filter=@langchain/google-common` passes (298/298)
- [x] `oxlint .` clean
- [x] `oxfmt --check` clean on changed files
- [x] Added a changeset

Fixes #11265
