### PR TITLE
fix(langchain): preserve model errors propagated through middleware

### DIFF
--- a/.changeset/soft-dogs-retry.md
+++ b/.changeset/soft-dogs-retry.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(langchain): preserve model errors propagated through middleware

--- a/libs/langchain/src/agents/middleware/modelRetry.ts
+++ b/libs/langchain/src/agents/middleware/modelRetry.ts
@@ -5,7 +5,6 @@ import { z } from "zod/v3";
 import { AIMessage } from "@langchain/core/messages";
 
 import { createMiddleware } from "../middleware.js";
-import { MiddlewareError } from "../errors.js";
 import { sleep, calculateRetryDelay } from "./utils.js";
 import { RetrySchema } from "./constants.js";
 import { InvalidRetryConfigError } from "./error.js";
@@ -141,29 +140,6 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
   } = data;
 
   /**
-   * Recover the error as it was originally thrown.
-   *
-   * `AgentNode` re-wraps every middleware throw in a `MiddlewareError`, which
-   * keeps only `message`/`name` and moves the original error to `cause`. So when
-   * any middleware sits inside the retry, `retryOn` would otherwise see the
-   * wrapper - losing `constructor`, `code`, custom properties, and the prototype -
-   * and never match, silently disabling retries. Walk the `cause` chain so both
-   * the class-array (`error.constructor === Ctor`) and predicate forms see the
-   * error as thrown, regardless of how many middleware wrapped it.
-   */
-  const unwrapMiddlewareError = (error: Error): Error => {
-    let current = error;
-    while (
-      MiddlewareError.isInstance(current) &&
-      // oxlint-disable-next-line no-instanceof/no-instanceof
-      current.cause instanceof Error
-    ) {
-      current = current.cause;
-    }
-    return current;
-  };
-
-  /**
    * Check if the exception should trigger a retry.
    */
   const shouldRetryException = (error: Error): boolean => {
@@ -220,14 +196,10 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
           const attemptsMade = attempt + 1; // attempt is 0-indexed
 
           // Ensure error is an Error instance
-          const rawError =
+          const err =
             error && typeof error === "object" && "message" in error
               ? (error as Error)
               : new Error(String(error));
-
-          // Unwrap any MiddlewareError layers added by AgentNode so retryOn and
-          // the failure handler see the error as it was originally thrown.
-          const err = unwrapMiddlewareError(rawError);
 
           // Check if we should retry this exception
           if (!shouldRetryException(err)) {

--- a/libs/langchain/src/agents/middleware/modelRetry.ts
+++ b/libs/langchain/src/agents/middleware/modelRetry.ts
@@ -5,6 +5,7 @@ import { z } from "zod/v3";
 import { AIMessage } from "@langchain/core/messages";
 
 import { createMiddleware } from "../middleware.js";
+import { MiddlewareError } from "../errors.js";
 import { sleep, calculateRetryDelay } from "./utils.js";
 import { RetrySchema } from "./constants.js";
 import { InvalidRetryConfigError } from "./error.js";
@@ -140,6 +141,29 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
   } = data;
 
   /**
+   * Recover the error as it was originally thrown.
+   *
+   * `AgentNode` re-wraps every middleware throw in a `MiddlewareError`, which
+   * keeps only `message`/`name` and moves the original error to `cause`. So when
+   * any middleware sits inside the retry, `retryOn` would otherwise see the
+   * wrapper - losing `constructor`, `code`, custom properties, and the prototype -
+   * and never match, silently disabling retries. Walk the `cause` chain so both
+   * the class-array (`error.constructor === Ctor`) and predicate forms see the
+   * error as thrown, regardless of how many middleware wrapped it.
+   */
+  const unwrapMiddlewareError = (error: Error): Error => {
+    let current = error;
+    while (
+      MiddlewareError.isInstance(current) &&
+      // oxlint-disable-next-line no-instanceof/no-instanceof
+      current.cause instanceof Error
+    ) {
+      current = current.cause;
+    }
+    return current;
+  };
+
+  /**
    * Check if the exception should trigger a retry.
    */
   const shouldRetryException = (error: Error): boolean => {
@@ -196,10 +220,14 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
           const attemptsMade = attempt + 1; // attempt is 0-indexed
 
           // Ensure error is an Error instance
-          const err =
+          const rawError =
             error && typeof error === "object" && "message" in error
               ? (error as Error)
               : new Error(String(error));
+
+          // Unwrap any MiddlewareError layers added by AgentNode so retryOn and
+          // the failure handler see the error as it was originally thrown.
+          const err = unwrapMiddlewareError(rawError);
 
           // Check if we should retry this exception
           if (!shouldRetryException(err)) {

--- a/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
@@ -605,16 +605,18 @@ describe("modelRetryMiddleware", () => {
     });
   });
 
-  describe("Unwrapping middleware-wrapped errors (issue #11324)", () => {
-    // AgentNode re-wraps every middleware throw in a MiddlewareError, which
-    // keeps only message/name and moves the original error to `cause`. With a
-    // middleware inside the retry, retryOn must still see the error as thrown.
+  describe("Errors propagated through a middleware reach retryOn (issue #11324)", () => {
+    // A middleware whose wrapModelCall only forwards to the handler used to make
+    // AgentNode re-wrap the model's error in a MiddlewareError, so retryOn saw
+    // the wrapper (constructor !== TimeoutError, custom fields gone) and stopped
+    // retrying. AgentNode now re-throws such pass-through errors unchanged, so
+    // both retryOn forms see the error as thrown regardless of the middleware.
     const passthrough = createMiddleware({
       name: "passthrough",
       wrapModelCall: async (request, handler) => handler(request),
     });
 
-    it("retries the class-array form when a middleware wraps the error", async () => {
+    it("retries the class-array form when a middleware sits inside the retry", async () => {
       const model = new AlwaysFailingModel(new TimeoutError("Timeout"));
 
       const retry = modelRetryMiddleware({
@@ -632,14 +634,22 @@ describe("modelRetryMiddleware", () => {
         checkpointer: new MemorySaver(),
       });
 
-      await agent.invoke(
+      const result = await agent.invoke(
         { messages: [new HumanMessage("Hello")] },
         { configurable: { thread_id: "test" } }
       );
 
-      // Initial attempt + 2 retries. Without unwrapping the retry would see a
-      // MiddlewareError (constructor !== TimeoutError) and fire only once.
+      // Initial attempt + 2 retries. If the pass-through error were wrapped the
+      // retry would see a MiddlewareError (constructor !== TimeoutError) and
+      // fire only once.
       expect(model._generate).toHaveBeenCalledTimes(3);
+
+      // The failure handler also receives the unwrapped error, so the formatted
+      // message names the original error type, not MiddlewareError.
+      const aiMessages = result.messages.filter(AIMessage.isInstance);
+      const lastContent = aiMessages[aiMessages.length - 1].content;
+      expect(lastContent).toContain("TimeoutError");
+      expect(lastContent).toContain("3 attempts");
     });
 
     it("gives the predicate form the original error, not the wrapper", async () => {
@@ -674,6 +684,39 @@ describe("modelRetryMiddleware", () => {
       // The predicate must receive the error as thrown, with statusCode intact.
       expect((shouldRetry.mock.calls[0][0] as any).statusCode).toBe(503);
       expect(model._generate).toHaveBeenCalledTimes(3);
+    });
+
+    it("re-raises the original error, not a wrapper, when onFailure is error", async () => {
+      const original = new TimeoutError("Timeout");
+      const model = new AlwaysFailingModel(original);
+
+      const retry = modelRetryMiddleware({
+        maxRetries: 1,
+        initialDelayMs: 10,
+        jitter: false,
+        retryOn: [TimeoutError],
+        onFailure: "error",
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [retry, passthrough] as const,
+        checkpointer: new MemorySaver(),
+      });
+
+      const error = await agent
+        .invoke(
+          { messages: [new HumanMessage("Hello")] },
+          { configurable: { thread_id: "test" } }
+        )
+        .catch((e) => e);
+
+      // retryOn matched the unwrapped TimeoutError (so it retried), and
+      // onFailure "error" re-raised the original error object rather than a
+      // MiddlewareError wrapper.
+      expect(error).toBe(original);
+      expect(model._generate).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
@@ -5,7 +5,7 @@ import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { StructuredTool } from "@langchain/core/tools";
 import { RunnableBinding } from "@langchain/core/runnables";
 
-import { createAgent } from "../../index.js";
+import { createAgent, createMiddleware } from "../../index.js";
 import { modelRetryMiddleware } from "../modelRetry.js";
 import { FakeToolCallingModel } from "../../tests/utils.js";
 import { InvalidRetryConfigError } from "../error.js";
@@ -601,6 +601,78 @@ describe("modelRetryMiddleware", () => {
       const avgDelay = delays.reduce((a, b) => a + b, 0) / delays.length;
       expect(avgDelay).toBeGreaterThanOrEqual(90);
       expect(avgDelay).toBeLessThan(150);
+      expect(model._generate).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("Unwrapping middleware-wrapped errors (issue #11324)", () => {
+    // AgentNode re-wraps every middleware throw in a MiddlewareError, which
+    // keeps only message/name and moves the original error to `cause`. With a
+    // middleware inside the retry, retryOn must still see the error as thrown.
+    const passthrough = createMiddleware({
+      name: "passthrough",
+      wrapModelCall: async (request, handler) => handler(request),
+    });
+
+    it("retries the class-array form when a middleware wraps the error", async () => {
+      const model = new AlwaysFailingModel(new TimeoutError("Timeout"));
+
+      const retry = modelRetryMiddleware({
+        maxRetries: 2,
+        initialDelayMs: 10,
+        jitter: false,
+        retryOn: [TimeoutError],
+        onFailure: "continue",
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [retry, passthrough] as const,
+        checkpointer: new MemorySaver(),
+      });
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Hello")] },
+        { configurable: { thread_id: "test" } }
+      );
+
+      // Initial attempt + 2 retries. Without unwrapping the retry would see a
+      // MiddlewareError (constructor !== TimeoutError) and fire only once.
+      expect(model._generate).toHaveBeenCalledTimes(3);
+    });
+
+    it("gives the predicate form the original error, not the wrapper", async () => {
+      const original = new Error("Service Unavailable");
+      (original as any).statusCode = 503;
+      const model = new AlwaysFailingModel(original);
+
+      const shouldRetry = vi.fn(
+        (error: Error): boolean => (error as any).statusCode === 503
+      );
+
+      const retry = modelRetryMiddleware({
+        maxRetries: 2,
+        initialDelayMs: 10,
+        jitter: false,
+        retryOn: shouldRetry,
+        onFailure: "continue",
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [retry, passthrough] as const,
+        checkpointer: new MemorySaver(),
+      });
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Hello")] },
+        { configurable: { thread_id: "test" } }
+      );
+
+      // The predicate must receive the error as thrown, with statusCode intact.
+      expect((shouldRetry.mock.calls[0][0] as any).statusCode).toBe(503);
       expect(model._generate).toHaveBeenCalledTimes(3);
     });
   });

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -542,6 +542,14 @@ export class AgentNode<
           };
 
           /**
+           * Track the exact values thrown by the inner handler so an error this
+           * middleware merely propagated is not re-attributed to it as a
+           * MiddlewareError. Mirrors `wrapToolCall` in utils.ts, so the
+           * model-call and tool-call paths treat pass-through errors the same.
+           */
+          const downstreamErrors = new Set<unknown>();
+
+          /**
            * Create handler that validates tools and calls the inner handler
            */
           const handlerWithValidation = async (
@@ -646,7 +654,18 @@ export class AgentNode<
               };
             }
 
-            const innerHandlerResult = await innerHandler(normalizedReq);
+            let innerHandlerResult: InternalModelResponse<StructuredResponseFormat>;
+            try {
+              innerHandlerResult = await innerHandler(normalizedReq);
+            } catch (error) {
+              /**
+               * The error was raised below this middleware and only propagated
+               * through it. Record it so the outer catch re-throws it unchanged
+               * instead of wrapping it as a failure of this middleware.
+               */
+              downstreamErrors.add(error);
+              throw error;
+            }
 
             /**
              * Normalize Commands so middleware always sees AIMessage from handler().
@@ -698,6 +717,15 @@ export class AgentNode<
 
             return middlewareResponse;
           } catch (error) {
+            /**
+             * An error the inner handler raised and this middleware only
+             * re-threw keeps its identity, so `retryOn` and other consumers see
+             * it as thrown. Errors originating in the middleware are wrapped so
+             * MiddlewareError can still attribute the failure to it.
+             */
+            if (downstreamErrors.has(error)) {
+              throw error;
+            }
             throw MiddlewareError.wrap(error, currentMiddleware.name);
           }
         };


### PR DESCRIPTION
## Description

A `wrapModelCall` middleware that only forwards to `handler(request)` currently turns downstream model errors into `MiddlewareError`. That changes the error identity, prototype, and custom fields before an outer middleware sees it, silently breaking both documented `modelRetryMiddleware.retryOn` forms:

- the class-array form compares `error.constructor` with the configured constructor;
- predicates commonly read custom fields such as `code` or `statusCode`.

The initial revision unwrapped errors inside `modelRetryMiddleware`. After review, I confirmed that the tool-call path already avoids wrapping errors merely propagated by middleware. This revision moves the fix to the model-call wrap site instead, so the two paths follow the same rule.

## Fix

`AgentNode` now tracks the exact values thrown by the inner model handler. If the current middleware propagates the same value, it is re-thrown unchanged. Errors originating in the middleware are still wrapped in `MiddlewareError`, preserving middleware attribution.

A patch changeset for `langchain` is included.

## Tests

Added three regression tests with a pass-through middleware inside the retry:

- the class-array form performs the initial call plus two retries;
- the predicate receives the original error with `statusCode` intact;
- exhausted retries format the original error type, and `onFailure: "error"` re-throws the original instance.

All three fail on `main` without the `AgentNode` change. Validation on this branch:

- `pnpm build --filter langchain`
- `pnpm run test:unit:ci --filter langchain` — 59 files, 851 tests, no type errors
- `pnpm run lint`
- `pnpm run format:check`

Fixes #11324