### PR TITLE
fix(openai): forward string tool_choice values on the Responses API

### DIFF
--- a/.changeset/tidy-pugs-smile.md
+++ b/.changeset/tidy-pugs-smile.md
@@ -1,0 +1,11 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): forward string `tool_choice` values on the Responses API
+
+`"none"`, `"auto"` and `"required"` were dropped when building a Responses
+request, so `tool_choice: "required"` did not force a tool call and
+`tool_choice: "none"` did not prevent one — both silently fell back to the
+provider default. These are valid `ToolChoiceOptions` values and are now sent
+unchanged; only the named-function shape still needs converting.

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -116,6 +116,12 @@ export class ChatOpenAIResponses<
         ? options?.tool_choice
         : (() => {
             const formatted = formatToOpenAIToolChoice(options?.tool_choice);
+            // "none" | "auto" | "required" are valid Responses `tool_choice`
+            // values (ToolChoiceOptions) and need no conversion — only the
+            // named-function shape differs between the two APIs.
+            if (typeof formatted === "string") {
+              return formatted;
+            }
             if (typeof formatted === "object" && "type" in formatted) {
               if (formatted.type === "function") {
                 return { type: "function", name: formatted.function.name };

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -248,3 +248,43 @@ describe("tool search support", () => {
     expect(tools[1]).toHaveProperty("name", "get_weather");
   });
 });
+
+describe("tool_choice", () => {
+  const model = new ChatOpenAIResponses({ model: "gpt-4o" });
+  const tools = [
+    {
+      type: "function" as const,
+      function: {
+        name: "lookup",
+        description: "testing",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+  ];
+
+  // "none" | "auto" | "required" are valid Responses tool_choice values and
+  // must reach the request unchanged. They were previously dropped, so a
+  // caller forcing a tool call silently got the provider default instead.
+  it.each(["none", "auto", "required"] as const)(
+    "forwards the %s option unchanged",
+    (tool_choice) => {
+      const params = model.invocationParams({ tools, tool_choice });
+      expect(params.tool_choice).toBe(tool_choice);
+    }
+  );
+
+  it("maps 'any' onto the API's 'required'", () => {
+    const params = model.invocationParams({ tools, tool_choice: "any" });
+    expect(params.tool_choice).toBe("required");
+  });
+
+  it("converts a named tool to the Responses function shape", () => {
+    const params = model.invocationParams({ tools, tool_choice: "lookup" });
+    expect(params.tool_choice).toEqual({ type: "function", name: "lookup" });
+  });
+
+  it("omits tool_choice when none is given", () => {
+    const params = model.invocationParams({ tools });
+    expect(params.tool_choice).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #11332.

On the Responses API path, `tool_choice` values of `"none"`, `"auto"` and `"required"` never reached the provider. `formatToOpenAIToolChoice` returns those as strings, but the Responses request builder only handled the object results, so the IIFE fell through to `return undefined` and the field was omitted from the request entirely.

The failure was silent in both directions: the value typechecks against the declared call options (`tool_choice?: OpenAIToolChoice | ResponsesToolChoice`, and `ResponsesToolChoice` includes that string union), nothing warns, and the request simply goes out without a `tool_choice` — leaving the provider default of `auto`. So `tool_choice: "required"` did not force a tool call, and `tool_choice: "none"` did not prevent one.

## The change

These are valid `ToolChoiceOptions` on the Responses API — the SDK's own type is `'none' | 'auto' | 'required'`, and it is the first member of the `tool_choice` union on `ResponseCreateParamsBase`. They need no conversion, so they are now returned unchanged. Only the named-function shape genuinely differs between the two APIs (`{type, name}` vs `{type, function: {name}}`) and still gets converted.

```ts
const formatted = formatToOpenAIToolChoice(options?.tool_choice);
if (typeof formatted === "string") {
  return formatted;
}
if (typeof formatted === "object" && "type" in formatted) { …unchanged… }
```

## Tests

Six cases in `chat_models/tests/responses.test.ts`, asserting on `invocationParams` — the three string options forwarded unchanged, `"any"` mapped onto `"required"`, the named-tool conversion (regression guard for the existing behaviour), and `tool_choice` omitted when none is passed.

Verified red/green: the four string assertions fail on `main` and pass with the change; the other two pass either way.

## Notes

Present since Responses support was introduced in `0.4.6`, and the logic is unchanged through `1.5.6`. Worth noting the Chat Completions builder in that same original file used the correct unconditional `tool_choice: formatToOpenAIToolChoice(options?.tool_choice)` — only the Responses path narrowed to objects.

`allowed_tools` is not a workable substitute for callers hitting this, which is part of why it is worth fixing rather than documenting: GPT-5-family models reject object `tool_choice` forms when hosted tools are present, while the bare strings keep working.

One adjacent defect is described in #11332 but deliberately **not** fixed here, to keep this reviewable: the Responses-native `{ type: "function", name }` shape throws `Cannot read properties of undefined (reading 'name')`, because the `formatted.type === "function"` branch reads `formatted.function.name` after `isBuiltInToolChoice` has already excluded `type: "function"` from the passthrough. Happy to follow up with a separate PR if you'd like it addressed.
