### PR TITLE
fix(google-genai): normalize union types for Gemini schemas

### DIFF
--- a/.changeset/eighty-clowns-obey.md
+++ b/.changeset/eighty-clowns-obey.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): normalize union types for Gemini schemas

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -18,7 +18,11 @@ import {
 } from "@langchain/core/messages";
 import { OutputParserException } from "@langchain/core/output_parsers";
 import { ChatGoogleGenerativeAI } from "../chat_models.js";
-import { removeAdditionalProperties } from "../utils/zod_to_genai_parameters.js";
+import {
+  jsonSchemaToGeminiParameters,
+  removeAdditionalProperties,
+  schemaToGenerativeAIParameters,
+} from "../utils/zod_to_genai_parameters.js";
 import {
   convertBaseMessagesToContent,
   convertMessageContentToParts,
@@ -248,6 +252,53 @@ test("removeAdditionalProperties can remove all instances of additionalPropertie
   expect(
     analysisSchemaObj.find((key) => key === "additionalProperties")
   ).toBeUndefined();
+});
+
+test("normalizes JSON Schema type arrays for Gemini", () => {
+  const schema = jsonSchemaToGeminiParameters({
+    type: "object",
+    properties: {
+      nullableString: { type: ["string", "null"] },
+      singleType: { type: ["string"] },
+      nullType: { type: ["null"] },
+      repeatedNull: { type: ["null", "null"] },
+      stringOrNumber: {
+        type: ["string", "number"],
+        description: "A string or number",
+      },
+    },
+  });
+
+  expect(schema).toEqual({
+    type: "object",
+    properties: {
+      nullableString: { type: "string", nullable: true },
+      singleType: { type: "string" },
+      nullType: { type: "null" },
+      repeatedNull: { nullable: true },
+      stringOrNumber: {
+        anyOf: [{ type: "string" }, { type: "number" }],
+        description: "A string or number",
+      },
+    },
+  });
+});
+
+test("normalizes Zod 3 nullable schemas for Gemini", () => {
+  const schema = schemaToGenerativeAIParameters(
+    z.object({
+      nickname: z.string().nullable(),
+      age: z.number(),
+    })
+  );
+
+  expect(schema).toMatchObject({
+    type: "object",
+    properties: {
+      nickname: { type: "string", nullable: true },
+      age: { type: "number" },
+    },
+  });
 });
 
 test("convertMessageContentToParts correctly handles message types", () => {

--- a/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
+++ b/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
@@ -16,8 +16,10 @@ import {
 } from "@langchain/core/utils/standard_schema";
 
 export interface GenerativeAIJsonSchema extends Record<string, unknown> {
+  anyOf?: GenerativeAIJsonSchema[];
+  nullable?: boolean;
   properties?: Record<string, GenerativeAIJsonSchema>;
-  type: FunctionDeclarationSchemaType;
+  type?: FunctionDeclarationSchemaType;
 }
 
 export interface GenerativeAIJsonSchemaDirty extends GenerativeAIJsonSchema {
@@ -40,6 +42,38 @@ export function removeAdditionalProperties(
     }
     if ("strict" in newObj) {
       delete newObj.strict;
+    }
+
+    if (Array.isArray(newObj.type)) {
+      const types = newObj.type;
+      if (
+        types.every((type: unknown): type is string => typeof type === "string")
+      ) {
+        const hasNull = types.includes("null");
+        const nonNullTypes = [
+          ...new Set(types.filter((type: string) => type !== "null")),
+        ];
+
+        if (nonNullTypes.length === 1) {
+          newObj.type = nonNullTypes[0];
+          if (hasNull) {
+            newObj.nullable = true;
+          }
+        } else if (nonNullTypes.length > 1) {
+          delete newObj.type;
+          newObj.anyOf = nonNullTypes.map((type) => ({ type }));
+          if (hasNull) {
+            newObj.nullable = true;
+          }
+        } else if (hasNull) {
+          if (types.length === 1) {
+            newObj.type = "null";
+          } else {
+            delete newObj.type;
+            newObj.nullable = true;
+          }
+        }
+      }
     }
 
     for (const key in newObj) {


### PR DESCRIPTION
## Summary

Gemini's `responseSchema.type` is a single enum, but the Zod 3 JSON Schema path can emit a JSON Schema type array for nullable and union fields. The array was forwarded unchanged and Gemini rejected the request before it reached the model.

This normalizes type arrays at the existing schema cleanup boundary:

- nullable single types become `type` plus `nullable`
- multiple non-null types become `anyOf` entries
- null-only arrays keep the proto-compatible semantics
- nested schema values continue to be normalized recursively

The regression coverage includes the reported Zod 3 nullable shape plus single-type, null-only, repeated-null, and multi-type arrays.

Fixes #11328

## Validation

- `vitest run src/tests/chat_models.test.ts --reporter=dot` (46 passed, no type errors)
- `oxfmt --check`
- `oxlint`
- `git diff --check`