### PR TITLE
fix(core): _formatForTracing converts all base64/URL content blocks, not just the first

### DIFF
--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -171,27 +171,29 @@ export type BaseChatModelCallOptions = BaseLanguageModelCallOptions & {
 function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   const messagesToTrace: BaseMessage[] = [];
   for (const message of messages) {
-    let messageToTrace = message;
     if (Array.isArray(message.content)) {
-      for (let idx = 0; idx < message.content.length; idx++) {
-        const block = message.content[idx];
+      let changed = false;
+      const convertedContent = message.content.map((block) => {
         if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
+          changed = true;
+          return convertToOpenAIImageBlock(block);
         }
+        return block;
+      });
+      if (changed) {
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        messagesToTrace.push(
+          new (message.constructor as any)({
+            ...message,
+            content: convertedContent,
+          })
+        );
+      } else {
+        messagesToTrace.push(message);
       }
+    } else {
+      messagesToTrace.push(message);
     }
-    messagesToTrace.push(messageToTrace);
   }
   return messagesToTrace;
 }

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -616,3 +616,58 @@ test("Test ChatModel applies v1 outputVersion after implicit streaming aggregati
     },
   ]);
 });
+
+test("_formatForTracing converts all base64 content blocks, not just the first", async () => {
+  // Regression test for https://github.com/langchain-ai/langchainjs/issues/11291
+  // The previous implementation used `if (messageToTrace === message)` as a
+  // once-only guard, so only the first base64 block per message was converted;
+  // every subsequent block was left as raw base64 data in the traced message.
+  let capturedMessages: HumanMessage[] | undefined;
+
+  class CaptureHandler extends BaseCallbackHandler {
+    name = "capture";
+
+    async handleChatModelStart(
+      _llm: unknown,
+      messages: HumanMessage[][]
+    ): Promise<void> {
+      capturedMessages = messages[0] as HumanMessage[];
+    }
+  }
+
+  const model = new FakeListChatModel({ responses: ["ok"] });
+
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "two PDFs" },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjQK",
+      },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjUK",
+      },
+    ],
+  });
+
+  await model.invoke([message], { callbacks: [new CaptureHandler()] });
+
+  expect(capturedMessages).toBeDefined();
+  const tracedContent = capturedMessages![0].content as Array<
+    Record<string, unknown>
+  >;
+
+  // The text block should be unchanged.
+  expect(tracedContent[0]).toEqual({ type: "text", text: "two PDFs" });
+
+  // Both base64 blocks must have been converted — not just the first one.
+  expect(tracedContent[1].source_type).toBeUndefined();
+  expect(tracedContent[2].source_type).toBeUndefined();
+  expect(tracedContent[1].type).toBe("image_url");
+  expect(tracedContent[2].type).toBe("image_url");
+});


### PR DESCRIPTION
Fixes #11291.

## Problem

`_formatForTracing` in `chat_models.ts` used a `if (messageToTrace === message)` one-shot guard inside its inner loop. Once the **first** base64 (or URL) content block was found and the message was shallow-copied into `messageToTrace`, the guard evaluated to `false` for every subsequent block in the same message. Those blocks were left as raw base64 data in the traced payload and never converted.

```ts
// before — only the first base64 block is converted
for (let idx = 0; idx < message.content.length; idx++) {
  const block = message.content[idx];
  if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
    if (messageToTrace === message) {   // ← false after the first hit
      messageToTrace = new (...) { ... }
    }
    // second, third, … blocks fall through unconverted
  }
}
```

## Fix

Replace the loop-with-guard with a single `.map()` pass that converts **every** base64/URL block in one sweep, and only allocates a new message instance when at least one block changed:

```ts
// after — all base64/URL blocks are converted
let changed = false;
const convertedContent = message.content.map((block) => {
  if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
    changed = true;
    return convertToOpenAIImageBlock(block);
  }
  return block;
});
if (changed) {
  messagesToTrace.push(new (message.constructor as any)({ ...message, content: convertedContent }));
} else {
  messagesToTrace.push(message);
}
```

## Test

Added a regression test in `libs/langchain-core/src/language_models/tests/chat_models.test.ts` that sends a `HumanMessage` with **two** base64 PDF blocks through `model.invoke()`, captures the message seen by `handleChatModelStart`, and asserts that **both** blocks have been converted (no `source_type` field, `type === "image_url"`).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>