### PR TITLE
fix(neo4j): bind every parameter when combining nested metadata filters

### DIFF
--- a/.changeset/neo4j-param-rename-collision.md
+++ b/.changeset/neo4j-param-rename-collision.md
@@ -1,0 +1,7 @@
+---
+"@langchain/neo4j": patch
+---
+
+fix(neo4j): bind every parameter when combining nested metadata filters
+
+`combineQueries` renamed parameters with a first-occurrence string replace that also matched prefixes of longer parameter names, so nested `$and`/`$or` filters could produce an unbound parameter and two fields sharing one value. Renaming now matches the whole parameter token everywhere it appears.

--- a/libs/providers/langchain-neo4j/src/vectorstores/neo4j_vector.ts
+++ b/libs/providers/langchain-neo4j/src/vectorstores/neo4j_vector.ts
@@ -947,7 +947,17 @@ function combineQueries(
       }
       const newParamName = `${param}_${paramCounter[param]}`;
 
-      newQuery = newQuery.replace(`$${param}`, `$${newParamName}`);
+      // Match the whole parameter token, everywhere it appears. A plain string replace
+      // rewrites only the FIRST occurrence and happily matches a prefix of a longer
+      // parameter name, so `$param_1_1` would corrupt `$param_1_1_1_1`. `\b` will not match
+      // between a digit and an underscore, which is what keeps the names apart.
+      newQuery = newQuery.replace(
+        new RegExp(
+          `\\$${param.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+          "g"
+        ),
+        () => `$${newParamName}`
+      );
       combinedParams[newParamName] = value;
     }
 

--- a/libs/providers/langchain-neo4j/src/vectorstores/tests/neo4j_vector.test.ts
+++ b/libs/providers/langchain-neo4j/src/vectorstores/tests/neo4j_vector.test.ts
@@ -265,4 +265,20 @@ describe("constructMetadataFilter", () => {
       constructMetadataFilter({ name: { $eq: "A", $ne: "B" } })
     ).toThrow("Expected a value which is a dictionary");
   });
+
+  test("should bind every parameter it references when filters are nested", () => {
+    // Renaming used a plain string replace, which rewrites only the first occurrence and
+    // matches a prefix of a longer name. Nesting makes parameter names accumulate suffixes,
+    // so `$param_1_1` would rewrite the start of `$param_1_1_1_1`.
+    const [query, params] = constructMetadataFilter({
+      $and: [{ $and: [{ $and: [{ a: 1 }] }, { b: 2 }] }, { c: 3 }],
+    });
+
+    const referenced = [...query.matchAll(/\$([A-Za-z_][A-Za-z0-9_]*)/g)].map(
+      (m) => m[1]
+    );
+    expect(referenced.sort()).toEqual(Object.keys(params).sort());
+    // and each condition keeps its own parameter
+    expect(new Set(referenced).size).toBe(3);
+  });
 });


### PR DESCRIPTION
`combineQueries` renames each sub-query's parameters so they cannot collide, using a plain string replace:

```js
newQuery = newQuery.replace(`$${param}`, `$${newParamName}`);
```

That rewrites only the first occurrence, and it matches a prefix of a longer parameter name. Nesting is what makes it bite: every level appends `_N`, so names accumulate suffixes until one is a prefix of another in the same sub-query.

```js
constructMetadataFilter({ $and: [{ $and: [{ $and: [{ a: 1 }] }, { b: 2 }] }, { c: 3 }] })

// query : (((n.a = $param_1_1_1_1_1)) AND (n.b = $param_1_1)) AND (n.c = $param_1_1)
// params: { param_1_1_1_1: 1, param_1_1_1: 2, param_1_1: 3 }
```

Two things go wrong. `$param_1_1_1_1_1` is never bound, so the query fails. And `n.b` and `n.c` now point at the same parameter, because renaming `param_1_1` landed inside the already renamed `$param_1_1_1_1` and orphaned b's own value. That second one would be a wrong result if the first did not throw first.

The fix replaces globally and anchors on a word boundary, which cannot match between a digit and `_`, so `$param_1_1` stays out of `$param_1_1_1_1`.

Verified with `pnpm vitest run` in `libs/providers/langchain-neo4j`: 44 passed before and 45 after, with the new test failing on the unpatched file. `oxlint` and `oxfmt --check` are clean on both changed files.

Also confirmed against a local `neo4j:5` container: the unpatched code fails at runtime with `Neo.ClientError.Statement.ParameterMissing` ("Expected parameter(s): param_1_1_1_1_1"), and the patched code runs the same filter with all three parameters bound. I built and tested only `@langchain/neo4j`.

Low severity, since it takes three levels of nesting to reach. Not a security issue.
