### PR TITLE
feat(core): mark errors as retryable or not, and stop retrying the ones that aren't

### DIFF
--- a/.changeset/brave-moons-invent.md
+++ b/.changeset/brave-moons-invent.md
@@ -1,18 +1,9 @@
 ---
 "@langchain/google": minor
-"@langchain/openai": patch
-"@langchain/anthropic": patch
-"@langchain/fireworks": minor
 ---
 
-feat(providers): mark provider errors as retryable or not
+feat(google): mark Google provider errors as retryable or not
 
-Builds on `stampRetryable` in `@langchain/core`, so the retry middleware can tell a transient provider failure from a deterministic one. Each dispatcher marks the errors it already recognizes; the SDK's own error object is marked in place, so `instanceof` against the provider's error classes is unaffected. Statuses a dispatcher does not recognize stay unmarked and keep retrying as before.
+Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Timeouts, rate limits, and server errors are marked retryable; bad credentials, blocked prompts, invalid tools, and invalid input non-retryable. Errors that may succeed on a regeneration stay unmarked and retry as before.
 
-**`@langchain/google`**: `RequestError` publishes the verdict from its existing `isRetryable()`, and `AuthError` is marked from its status code, so a bad credential is non-retryable while a transient failure of the auth endpoint itself is not. `ConfigurationError`, `PromptBlockedError`, `InvalidToolError`, `ToolCallNotFoundError`, and `InvalidInputError` are marked non-retryable. `NoCandidatesError` and `MalformedOutputError` are deliberately left unmarked, since both can resolve on a regeneration.
-
-**`@langchain/openai`** and **`@langchain/anthropic`**: connection timeouts and rate limits retryable; user aborts, context overflow, invalid tool results, authentication failures, and unknown models non-retryable.
-
-**`@langchain/fireworks`**: fixes `FireworksEmbeddings` throwing a plain `Error` with the HTTP status only inside the message string. With no `status` field, neither the retry middleware nor `AsyncCaller` could act on it, so a bad API key was retried to exhaustion on every embed call. The status is now a field and the error is marked; the message text is unchanged.
-
-`@langchain/google` and `@langchain/fireworks` move their `@langchain/core` peer range from `^1.0.0` to `workspace:^`, matching `@langchain/openai` and `@langchain/anthropic`. It publishes as the core version shipped in the same release, which is the one that introduces `stampRetryable`. Left at `^1.0.0`, npm would resolve these packages against a core lacking the export, and the failure would only surface on the error path.
+The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, since this release depends on `stampRetryable`.

--- a/.changeset/brave-moons-invent.md
+++ b/.changeset/brave-moons-invent.md
@@ -1,0 +1,18 @@
+---
+"@langchain/google": minor
+"@langchain/openai": patch
+"@langchain/anthropic": patch
+"@langchain/fireworks": minor
+---
+
+feat(providers): mark provider errors as retryable or not
+
+Builds on `stampRetryable` in `@langchain/core`, so the retry middleware can tell a transient provider failure from a deterministic one. Each dispatcher marks the errors it already recognizes; the SDK's own error object is marked in place, so `instanceof` against the provider's error classes is unaffected. Statuses a dispatcher does not recognize stay unmarked and keep retrying as before.
+
+**`@langchain/google`**: `RequestError` publishes the verdict from its existing `isRetryable()`, and `AuthError` is marked from its status code, so a bad credential is non-retryable while a transient failure of the auth endpoint itself is not. `ConfigurationError`, `PromptBlockedError`, `InvalidToolError`, `ToolCallNotFoundError`, and `InvalidInputError` are marked non-retryable. `NoCandidatesError` and `MalformedOutputError` are deliberately left unmarked, since both can resolve on a regeneration.
+
+**`@langchain/openai`** and **`@langchain/anthropic`**: connection timeouts and rate limits retryable; user aborts, context overflow, invalid tool results, authentication failures, and unknown models non-retryable.
+
+**`@langchain/fireworks`**: fixes `FireworksEmbeddings` throwing a plain `Error` with the HTTP status only inside the message string. With no `status` field, neither the retry middleware nor `AsyncCaller` could act on it, so a bad API key was retried to exhaustion on every embed call. The status is now a field and the error is marked; the message text is unchanged.
+
+`@langchain/google` and `@langchain/fireworks` move their `@langchain/core` peer range from `^1.0.0` to `workspace:^`, matching `@langchain/openai` and `@langchain/anthropic`. It publishes as the core version shipped in the same release, which is the one that introduces `stampRetryable`. Left at `^1.0.0`, npm would resolve these packages against a core lacking the export, and the failure would only surface on the error path.

--- a/.changeset/brave-moons-invent.md
+++ b/.changeset/brave-moons-invent.md
@@ -6,4 +6,6 @@ feat(google): mark Google provider errors as retryable or not
 
 Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Timeouts, rate limits, and server errors are marked retryable; bad credentials, blocked prompts, invalid tools, and invalid input non-retryable. Errors that may succeed on a regeneration stay unmarked and retry as before.
 
+Also forwards a per-call `maxRetries` to the retry loop, so a surrounding retry loop such as `modelRetryMiddleware` can take over instead of the two multiplying against each other.
+
 The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, since this release depends on `stampRetryable`.

--- a/.changeset/brave-moons-invent.md
+++ b/.changeset/brave-moons-invent.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/google": minor
+"@langchain/google": patch
 ---
 
 feat(google): mark Google provider errors as retryable or not

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,15 +1,11 @@
 ---
 "@langchain/core": minor
 "langchain": minor
-"@langchain/google": minor
-"@langchain/openai": patch
-"@langchain/anthropic": patch
-"@langchain/fireworks": minor
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
 
-Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model.
+Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model. Worse, the two retry layers multiply: `AsyncCaller` defaults to 7 attempts and `modelRetryMiddleware` to 3, so a single unclassified failure could cost 21 API calls.
 
 `@langchain/core/errors` adds two functions:
 
@@ -22,10 +18,8 @@ if (e.status === 401) throw stampRetryable(e, false);
 getRetryable(error); // true | false | undefined
 ```
 
-The mark is a non-enumerable symbol set on the error itself, so a provider SDK error can be marked in place without changing its class — `instanceof` is unaffected. `getRetryable` returns `undefined` for unclassified errors and follows the `.cause` chain. It is exported, so tool authors can classify their own failures too.
+The mark is a non-enumerable symbol set on the error itself, so a provider SDK error can be marked in place without changing its class — `instanceof` is unaffected. `getRetryable` returns `undefined` for unclassified errors. It is exported, so tool authors can classify their own failures too.
 
-`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `AsyncCaller` also stops retrying once it sees an error already marked non-retryable, so a verdict reached inside the call — a provider's own dispatcher, or a tool — takes effect on the first failure instead of after the retry budget is spent. `ModelAbortError` and `ContextOverflowError` are marked at construction, and `AsyncCaller` marks what it already classifies. Google, OpenAI, Anthropic, and Fireworks mark the errors their dispatchers already recognize; `FireworksEmbeddings` also exposes the HTTP status as a field instead of only inside the message string, which had hidden it from every retry layer.
-
-`@langchain/google` and `@langchain/fireworks` move their `@langchain/core` peer range to `workspace:^`.
+`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `AsyncCaller` also stops retrying once it sees an error already marked non-retryable, so a verdict reached inside the call — a provider's dispatcher, or a tool — takes effect on the first failure rather than after both retry budgets are spent. `413 Payload Too Large` joins its non-retryable status list, since resending identical bytes cannot succeed. `ModelAbortError` and `ContextOverflowError` are marked at construction.
 
 **Behavior change:** errors marked non-retryable now fail on the first attempt. Unclassified errors — including any from third-party integrations or custom tools — retry exactly as before. Pass `retryOn: () => true` to restore the old default. A custom `onFailedAttempt` replaces `AsyncCaller`'s handler and opts out of its marking.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -24,7 +24,7 @@ getRetryable(error); // true | false | undefined
 
 The mark is a non-enumerable symbol set on the error itself, so a provider SDK error can be marked in place without changing its class — `instanceof` is unaffected. `getRetryable` returns `undefined` for unclassified errors and follows the `.cause` chain. It is exported, so tool authors can classify their own failures too.
 
-`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `ModelAbortError` and `ContextOverflowError` are marked at construction, and `AsyncCaller` marks what it already classifies. Google, OpenAI, Anthropic, and Fireworks mark the errors their dispatchers already recognize; `FireworksEmbeddings` also exposes the HTTP status as a field instead of only inside the message string, which had hidden it from every retry layer.
+`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `AsyncCaller` also stops retrying once it sees an error already marked non-retryable, so a verdict reached inside the call — a provider's own dispatcher, or a tool — takes effect on the first failure instead of after the retry budget is spent. `ModelAbortError` and `ContextOverflowError` are marked at construction, and `AsyncCaller` marks what it already classifies. Google, OpenAI, Anthropic, and Fireworks mark the errors their dispatchers already recognize; `FireworksEmbeddings` also exposes the HTTP status as a field instead of only inside the message string, which had hidden it from every retry layer.
 
 `@langchain/google` and `@langchain/fireworks` move their `@langchain/core` peer range to `workspace:^`.
 

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,6 +1,7 @@
 ---
 "@langchain/core": minor
 "langchain": minor
+"@langchain/google": minor
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
@@ -25,5 +26,11 @@ getRetryable(error); // true | false | undefined
 `ModelAbortError` and `ContextOverflowError` are now marked non-retryable at construction. `AsyncCaller` marks what it already classifies: the `STATUS_NO_RETRY` codes (400, 401, 402, 403, 404, 405, 406, 407, 409), aborted calls, and exhausted quota as non-retryable; rate limits as retryable. It previously acted on these internally and then threw, leaving an outer retry loop to repeat the whole call with no idea the verdict had already been reached.
 
 **`langchain`**: the default `retryOn` for `modelRetryMiddleware` and `toolRetryMiddleware` changes from "retry everything" to `getRetryable(error) ?? true`.
+
+**`@langchain/google`**: provider errors are now marked. `RequestError` already had an `isRetryable()` method covering 408/429/500/502/503/504 — that verdict is now published on the error itself rather than only being available to callers who knew to ask. `AuthError` is marked from its status code the same way, so a bad credential is non-retryable while a transient failure of the auth endpoint itself is not. `ConfigurationError`, `PromptBlockedError`, `InvalidToolError`, `ToolCallNotFoundError`, and `InvalidInputError` are marked non-retryable.
+
+`NoCandidatesError` and `MalformedOutputError` are deliberately left unmarked: both can plausibly resolve on a regeneration, so they keep the existing retry behavior rather than being guessed at in either direction.
+
+The `@langchain/core` peer range moves from a hardcoded `^1.0.0` to `workspace:^`, matching `@langchain/openai` and `@langchain/anthropic`. It publishes as the core version shipped in the same release, so the range tracks the version that actually introduces `stampRetryable`. Left at `^1.0.0`, npm would happily resolve this package against a core that lacks the export, and the failure would only surface on the error path.
 
 **Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -10,5 +10,6 @@ Retry middleware retried every failure up to `maxRetries`, including determinist
 `@langchain/core/errors` adds `stampRetryable(error, retryable)` and `getRetryable(error)`. Marking an error leaves its class and shape untouched, so a provider SDK error can be classified without breaking `instanceof`. `getRetryable` returns `undefined` for errors nobody classified, and both are exported so tool authors can mark their own failures.
 
 `modelRetryMiddleware` and `toolRetryMiddleware` now respect the mark by default, and retries stop as soon as one is found rather than each layer spending its own budget. Aborted calls, context overflow, and oversized payloads are marked non-retryable out of the box.
+Models accept a per-call `maxRetries` so a surrounding retry loop can take over.
 
 **Behavior change:** errors marked non-retryable now fail on the first attempt. Unclassified errors — including any from third-party integrations or custom tools — retry exactly as before. Pass `retryOn: () => true` to restore the old default. A custom `onFailedAttempt` replaces the built-in handler and opts out of marking.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -2,6 +2,7 @@
 "@langchain/core": minor
 "langchain": minor
 "@langchain/google": minor
+"@langchain/openai": patch
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
@@ -32,5 +33,11 @@ getRetryable(error); // true | false | undefined
 `NoCandidatesError` and `MalformedOutputError` are deliberately left unmarked: both can plausibly resolve on a regeneration, so they keep the existing retry behavior rather than being guessed at in either direction.
 
 The `@langchain/core` peer range moves from a hardcoded `^1.0.0` to `workspace:^`, matching `@langchain/openai` and `@langchain/anthropic`. It publishes as the core version shipped in the same release, so the range tracks the version that actually introduces `stampRetryable`. Left at `^1.0.0`, npm would happily resolve this package against a core that lacks the export, and the failure would only surface on the error path.
+
+**`@langchain/openai`**: `wrapOpenAIClientError` marks each branch it already dispatches on — connection timeouts retryable; user aborts, context overflow, invalid tool results, authentication failures, and unknown models non-retryable; rate limits retryable. Statuses it doesn't branch on, including 5xx, stay unmarked and keep retrying.
+
+The branches that call `addLangChainErrorFields` mark the SDK's own error object in place, so `error instanceof OpenAI.APIError` is unaffected. The timeout and abort branches construct a fresh `Error` and discard the original status, which is why they have to be marked here — `AsyncCaller` has nothing left to classify them by.
+
+Rate limits are marked retryable, but `wrapOpenAIClientError` runs inside `AsyncCaller`, which re-marks them non-retryable when it recognizes quota exhaustion rather than transient pressure. The more specific verdict wins.
 
 **Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -9,9 +9,9 @@
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
 
-Retry middleware had no way to tell a transient failure (rate limit, timeout, 5xx) from a deterministic one (bad API key, unknown model, oversized input). Everything was retried up to `maxRetries`, so a typo'd API key cost three identical round trips before surfacing.
+Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model.
 
-**`@langchain/core`** gains two functions from `@langchain/core/errors`:
+`@langchain/core/errors` adds two functions:
 
 ```ts
 import { stampRetryable, getRetryable } from "@langchain/core/errors";
@@ -22,36 +22,10 @@ if (e.status === 401) throw stampRetryable(e, false);
 getRetryable(error); // true | false | undefined
 ```
 
-`stampRetryable` sets a non-enumerable `Symbol.for("langchain.errors.retryable")` property directly on the error. The error's class, prototype, fields, and JSON serialization are untouched, so a provider SDK's own error can be marked in place and `error instanceof SomeSdkError` keeps working exactly as before. The symbol comes from the global registry, so duplicate copies of `@langchain/core` in one dependency tree agree on it.
+The mark is a non-enumerable symbol set on the error itself, so a provider SDK error can be marked in place without changing its class — `instanceof` is unaffected. `getRetryable` returns `undefined` for unclassified errors and follows the `.cause` chain. It is exported, so tool authors can classify their own failures too.
 
-`getRetryable` follows the `.cause` chain, so a marked error that was later rewrapped is still recognized. It returns `undefined` for errors that were never classified — callers must supply their own default (`getRetryable(error) ?? true`) rather than relying on truthiness, which would silently treat every unclassified error as non-retryable.
+`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `ModelAbortError` and `ContextOverflowError` are marked at construction, and `AsyncCaller` marks what it already classifies. Google, OpenAI, Anthropic, and Fireworks mark the errors their dispatchers already recognize; `FireworksEmbeddings` also exposes the HTTP status as a field instead of only inside the message string, which had hidden it from every retry layer.
 
-`ModelAbortError` and `ContextOverflowError` are now marked non-retryable at construction. `AsyncCaller` marks what it already classifies: the `STATUS_NO_RETRY` codes (400, 401, 402, 403, 404, 405, 406, 407, 409), aborted calls, and exhausted quota as non-retryable; rate limits as retryable. It previously acted on these internally and then threw, leaving an outer retry loop to repeat the whole call with no idea the verdict had already been reached.
+`@langchain/google` and `@langchain/fireworks` move their `@langchain/core` peer range to `workspace:^`.
 
-**`langchain`**: the default `retryOn` for `modelRetryMiddleware` and `toolRetryMiddleware` changes from "retry everything" to `getRetryable(error) ?? true`.
-
-**`@langchain/google`**: provider errors are now marked. `RequestError` already had an `isRetryable()` method covering 408/429/500/502/503/504 — that verdict is now published on the error itself rather than only being available to callers who knew to ask. `AuthError` is marked from its status code the same way, so a bad credential is non-retryable while a transient failure of the auth endpoint itself is not. `ConfigurationError`, `PromptBlockedError`, `InvalidToolError`, `ToolCallNotFoundError`, and `InvalidInputError` are marked non-retryable.
-
-`NoCandidatesError` and `MalformedOutputError` are deliberately left unmarked: both can plausibly resolve on a regeneration, so they keep the existing retry behavior rather than being guessed at in either direction.
-
-The `@langchain/core` peer range moves from a hardcoded `^1.0.0` to `workspace:^`, matching `@langchain/openai` and `@langchain/anthropic`. It publishes as the core version shipped in the same release, so the range tracks the version that actually introduces `stampRetryable`. Left at `^1.0.0`, npm would happily resolve this package against a core that lacks the export, and the failure would only surface on the error path.
-
-**`@langchain/openai`**: `wrapOpenAIClientError` marks each branch it already dispatches on — connection timeouts retryable; user aborts, context overflow, invalid tool results, authentication failures, and unknown models non-retryable; rate limits retryable. Statuses it doesn't branch on, including 5xx, stay unmarked and keep retrying.
-
-The branches that call `addLangChainErrorFields` mark the SDK's own error object in place, so `error instanceof OpenAI.APIError` is unaffected. The timeout and abort branches construct a fresh `Error` and discard the original status, which is why they have to be marked here — `AsyncCaller` has nothing left to classify them by.
-
-Rate limits are marked retryable, but `wrapOpenAIClientError` runs inside `AsyncCaller`, which re-marks them non-retryable when it recognizes quota exhaustion rather than transient pressure. The more specific verdict wins.
-
-**`@langchain/anthropic`**: `wrapAnthropicClientError` gets the same treatment — invalid tool results, authentication failures, and unknown models non-retryable; rate limits retryable; context overflow already non-retryable by construction. As with `@langchain/openai`, the SDK's own error object is marked in place, and rate limits can still be re-marked by `AsyncCaller` when it recognizes quota exhaustion.
-
-Two differences from `@langchain/openai` worth noting. This dispatcher has no connection-timeout or user-abort branches, so those keep falling through unmarked and retrying, which is already the right behavior for a timeout. And it applies a legacy `CONTEXT_OVERFLOW` error code that the OpenAI dispatcher does not — that divergence is preserved rather than normalized away, and is now pinned by a test.
-
-**`@langchain/fireworks`**: two separate problems.
-
-`ChatFireworks` and `Fireworks` are `openai` SDK clients pointed at a different base URL, so they inherit that package's classification for free. Fireworks also returns 402, 408, and 413, which the OpenAI SDK has no named error class for and therefore leaves unmarked. `wrapFireworksModelError` fills that gap — 402 (billing) and 413 (oversized payload) non-retryable, 408 retryable — and passes through anything already marked, so an earlier, more specific verdict wins.
-
-`FireworksEmbeddings` was the real bug. It doesn't use the SDK at all, just raw `fetch`, and threw a plain `Error` with the status embedded only in the message _string_ — no `status` field anywhere. Nothing downstream could act on it: not the retry middleware, and not `AsyncCaller`'s own status-based suppression. A bad API key was retried to exhaustion on every embed call. The status is now a field as well, and the error is marked. The message text is unchanged.
-
-The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, for the same reason as `@langchain/google`.
-
-**Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.
+**Behavior change:** errors marked non-retryable now fail on the first attempt. Unclassified errors — including any from third-party integrations or custom tools — retry exactly as before. Pass `retryOn: () => true` to restore the old default. A custom `onFailedAttempt` replaces `AsyncCaller`'s handler and opts out of its marking.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -4,6 +4,7 @@
 "@langchain/google": minor
 "@langchain/openai": patch
 "@langchain/anthropic": patch
+"@langchain/fireworks": minor
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
@@ -44,5 +45,13 @@ Rate limits are marked retryable, but `wrapOpenAIClientError` runs inside `Async
 **`@langchain/anthropic`**: `wrapAnthropicClientError` gets the same treatment — invalid tool results, authentication failures, and unknown models non-retryable; rate limits retryable; context overflow already non-retryable by construction. As with `@langchain/openai`, the SDK's own error object is marked in place, and rate limits can still be re-marked by `AsyncCaller` when it recognizes quota exhaustion.
 
 Two differences from `@langchain/openai` worth noting. This dispatcher has no connection-timeout or user-abort branches, so those keep falling through unmarked and retrying, which is already the right behavior for a timeout. And it applies a legacy `CONTEXT_OVERFLOW` error code that the OpenAI dispatcher does not — that divergence is preserved rather than normalized away, and is now pinned by a test.
+
+**`@langchain/fireworks`**: two separate problems.
+
+`ChatFireworks` and `Fireworks` are `openai` SDK clients pointed at a different base URL, so they inherit that package's classification for free. Fireworks also returns 402, 408, and 413, which the OpenAI SDK has no named error class for and therefore leaves unmarked. `wrapFireworksModelError` fills that gap — 402 (billing) and 413 (oversized payload) non-retryable, 408 retryable — and passes through anything already marked, so an earlier, more specific verdict wins.
+
+`FireworksEmbeddings` was the real bug. It doesn't use the SDK at all, just raw `fetch`, and threw a plain `Error` with the status embedded only in the message _string_ — no `status` field anywhere. Nothing downstream could act on it: not the retry middleware, and not `AsyncCaller`'s own status-based suppression. A bad API key was retried to exhaustion on every embed call. The status is now a field as well, and the error is marked. The message text is unchanged.
+
+The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, for the same reason as `@langchain/google`.
 
 **Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -3,6 +3,7 @@
 "langchain": minor
 "@langchain/google": minor
 "@langchain/openai": patch
+"@langchain/anthropic": patch
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
@@ -39,5 +40,9 @@ The `@langchain/core` peer range moves from a hardcoded `^1.0.0` to `workspace:^
 The branches that call `addLangChainErrorFields` mark the SDK's own error object in place, so `error instanceof OpenAI.APIError` is unaffected. The timeout and abort branches construct a fresh `Error` and discard the original status, which is why they have to be marked here — `AsyncCaller` has nothing left to classify them by.
 
 Rate limits are marked retryable, but `wrapOpenAIClientError` runs inside `AsyncCaller`, which re-marks them non-retryable when it recognizes quota exhaustion rather than transient pressure. The more specific verdict wins.
+
+**`@langchain/anthropic`**: `wrapAnthropicClientError` gets the same treatment — invalid tool results, authentication failures, and unknown models non-retryable; rate limits retryable; context overflow already non-retryable by construction. As with `@langchain/openai`, the SDK's own error object is marked in place, and rate limits can still be re-marked by `AsyncCaller` when it recognizes quota exhaustion.
+
+Two differences from `@langchain/openai` worth noting. This dispatcher has no connection-timeout or user-abort branches, so those keep falling through unmarked and retrying, which is already the right behavior for a timeout. And it applies a legacy `CONTEXT_OVERFLOW` error code that the OpenAI dispatcher does not — that divergence is preserved rather than normalized away, and is now pinned by a test.
 
 **Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -5,21 +5,10 @@
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
 
-Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model. Worse, the two retry layers multiply: `AsyncCaller` defaults to 7 attempts and `modelRetryMiddleware` to 3, so a single unclassified failure could cost 21 API calls.
+Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model. Retries also nest, so a single such failure could cost dozens of API calls.
 
-`@langchain/core/errors` adds two functions:
+`@langchain/core/errors` adds `stampRetryable(error, retryable)` and `getRetryable(error)`. Marking an error leaves its class and shape untouched, so a provider SDK error can be classified without breaking `instanceof`. `getRetryable` returns `undefined` for errors nobody classified, and both are exported so tool authors can mark their own failures.
 
-```ts
-import { stampRetryable, getRetryable } from "@langchain/core/errors";
+`modelRetryMiddleware` and `toolRetryMiddleware` now respect the mark by default, and retries stop as soon as one is found rather than each layer spending its own budget. Aborted calls, context overflow, and oversized payloads are marked non-retryable out of the box.
 
-if (e.status === 429) throw stampRetryable(e, true);
-if (e.status === 401) throw stampRetryable(e, false);
-
-getRetryable(error); // true | false | undefined
-```
-
-The mark is a non-enumerable symbol set on the error itself, so a provider SDK error can be marked in place without changing its class — `instanceof` is unaffected. `getRetryable` returns `undefined` for unclassified errors. It is exported, so tool authors can classify their own failures too.
-
-`modelRetryMiddleware` and `toolRetryMiddleware` now default to `retryOn: (error) => getRetryable(error) ?? true`. `AsyncCaller` also stops retrying once it sees an error already marked non-retryable, so a verdict reached inside the call — a provider's dispatcher, or a tool — takes effect on the first failure rather than after both retry budgets are spent. `413 Payload Too Large` joins its non-retryable status list, since resending identical bytes cannot succeed. `ModelAbortError` and `ContextOverflowError` are marked at construction.
-
-**Behavior change:** errors marked non-retryable now fail on the first attempt. Unclassified errors — including any from third-party integrations or custom tools — retry exactly as before. Pass `retryOn: () => true` to restore the old default. A custom `onFailedAttempt` replaces `AsyncCaller`'s handler and opts out of its marking.
+**Behavior change:** errors marked non-retryable now fail on the first attempt. Unclassified errors — including any from third-party integrations or custom tools — retry exactly as before. Pass `retryOn: () => true` to restore the old default. A custom `onFailedAttempt` replaces the built-in handler and opts out of marking.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,0 +1,29 @@
+---
+"@langchain/core": minor
+"langchain": minor
+---
+
+feat(core): mark errors as retryable or not, and stop retrying the ones that aren't
+
+Retry middleware had no way to tell a transient failure (rate limit, timeout, 5xx) from a deterministic one (bad API key, unknown model, oversized input). Everything was retried up to `maxRetries`, so a typo'd API key cost three identical round trips before surfacing.
+
+**`@langchain/core`** gains two functions from `@langchain/core/errors`:
+
+```ts
+import { stampRetryable, getRetryable } from "@langchain/core/errors";
+
+if (e.status === 429) throw stampRetryable(e, true);
+if (e.status === 401) throw stampRetryable(e, false);
+
+getRetryable(error); // true | false | undefined
+```
+
+`stampRetryable` sets a non-enumerable `Symbol.for("langchain.errors.retryable")` property directly on the error. The error's class, prototype, fields, and JSON serialization are untouched, so a provider SDK's own error can be marked in place and `error instanceof SomeSdkError` keeps working exactly as before. The symbol comes from the global registry, so duplicate copies of `@langchain/core` in one dependency tree agree on it.
+
+`getRetryable` follows the `.cause` chain, so a marked error that was later rewrapped is still recognized. It returns `undefined` for errors that were never classified — callers must supply their own default (`getRetryable(error) ?? true`) rather than relying on truthiness, which would silently treat every unclassified error as non-retryable.
+
+`ModelAbortError` and `ContextOverflowError` are now marked non-retryable at construction. `AsyncCaller` marks what it already classifies: the `STATUS_NO_RETRY` codes (400, 401, 402, 403, 404, 405, 406, 407, 409), aborted calls, and exhausted quota as non-retryable; rate limits as retryable. It previously acted on these internally and then threw, leaving an outer retry loop to repeat the whole call with no idea the verdict had already been reached.
+
+**`langchain`**: the default `retryOn` for `modelRetryMiddleware` and `toolRetryMiddleware` changes from "retry everything" to `getRetryable(error) ?? true`.
+
+**Behavior change:** errors explicitly marked non-retryable now fail on the first attempt instead of being retried. Unclassified errors — including any from third-party integrations or custom tools — still retry exactly as before. An explicit `retryOn` is unaffected. To restore the old behavior, pass `retryOn: () => true`.

--- a/.changeset/olive-hounds-repeat.md
+++ b/.changeset/olive-hounds-repeat.md
@@ -1,6 +1,6 @@
 ---
-"@langchain/core": minor
-"langchain": minor
+"@langchain/core": patch
+"langchain": patch
 ---
 
 feat(core): mark errors as retryable or not, and stop retrying the ones that aren't

--- a/.changeset/quick-rocks-listen.md
+++ b/.changeset/quick-rocks-listen.md
@@ -1,0 +1,9 @@
+---
+"@langchain/openai": patch
+---
+
+feat(openai): mark OpenAI provider errors as retryable or not
+
+Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Timeouts and rate limits are marked retryable; aborts, context overflow, invalid tool results, bad credentials, and unknown models non-retryable. Anything else stays unmarked and retries as before.
+
+Errors keep their original class, so `instanceof` against the `openai` SDK error types is unaffected.

--- a/.changeset/quick-rocks-listen.md
+++ b/.changeset/quick-rocks-listen.md
@@ -6,4 +6,6 @@ feat(openai): mark OpenAI provider errors as retryable or not
 
 Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Timeouts and rate limits are marked retryable; aborts, context overflow, invalid tool results, bad credentials, and unknown models non-retryable. Anything else stays unmarked and retries as before.
 
+Also forwards a per-call `maxRetries` to the retry loop, so a surrounding retry loop such as `modelRetryMiddleware` can take over instead of the two multiplying against each other.
+
 Errors keep their original class, so `instanceof` against the `openai` SDK error types is unaffected.

--- a/.changeset/soft-pandas-agree.md
+++ b/.changeset/soft-pandas-agree.md
@@ -6,4 +6,6 @@ feat(anthropic): mark Anthropic provider errors as retryable or not
 
 Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Rate limits are marked retryable; context overflow, invalid tool results, bad credentials, and unknown models non-retryable. Anything else stays unmarked and retries as before.
 
+Also forwards a per-call `maxRetries` to the retry loop, so a surrounding retry loop such as `modelRetryMiddleware` can take over instead of the two multiplying against each other.
+
 Errors keep their original class, so `instanceof` against the `@anthropic-ai/sdk` error types is unaffected.

--- a/.changeset/soft-pandas-agree.md
+++ b/.changeset/soft-pandas-agree.md
@@ -1,0 +1,9 @@
+---
+"@langchain/anthropic": patch
+---
+
+feat(anthropic): mark Anthropic provider errors as retryable or not
+
+Builds on `stampRetryable` in `@langchain/core` so the retry middleware can tell a transient failure from a deterministic one. Rate limits are marked retryable; context overflow, invalid tool results, bad credentials, and unknown models non-retryable. Anything else stays unmarked and retries as before.
+
+Errors keep their original class, so `instanceof` against the `@anthropic-ai/sdk` error types is unaffected.

--- a/.changeset/warm-berries-shake.md
+++ b/.changeset/warm-berries-shake.md
@@ -6,6 +6,8 @@ fix(fireworks): stop retrying deterministic embeddings failures
 
 `FireworksEmbeddings` threw errors with the HTTP status buried in the message text, so nothing downstream could act on it and a bad API key was retried to exhaustion on every embed call. The status is now available on the error, and failures are marked retryable or not using `stampRetryable` from `@langchain/core`. Error messages are unchanged.
 
-`ChatFireworks` and `Fireworks` are unchanged; they already inherit marking from `@langchain/openai`.
+`ChatFireworks` and `Fireworks` already inherit marking from `@langchain/openai`.
+
+Also forwards a per-call `maxRetries` to the retry loop, so a surrounding retry loop such as `modelRetryMiddleware` can take over instead of the two multiplying against each other.
 
 The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, since this release depends on `stampRetryable`.

--- a/.changeset/warm-berries-shake.md
+++ b/.changeset/warm-berries-shake.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/fireworks": minor
+"@langchain/fireworks": patch
 ---
 
 fix(fireworks): stop retrying deterministic embeddings failures

--- a/.changeset/warm-berries-shake.md
+++ b/.changeset/warm-berries-shake.md
@@ -1,0 +1,11 @@
+---
+"@langchain/fireworks": minor
+---
+
+fix(fireworks): stop retrying deterministic embeddings failures
+
+`FireworksEmbeddings` threw errors with the HTTP status buried in the message text, so nothing downstream could act on it and a bad API key was retried to exhaustion on every embed call. The status is now available on the error, and failures are marked retryable or not using `stampRetryable` from `@langchain/core`. Error messages are unchanged.
+
+`ChatFireworks` and `Fireworks` are unchanged; they already inherit marking from `@langchain/openai`.
+
+The `@langchain/core` peer range moves from `^1.0.0` to `workspace:^`, since this release depends on `stampRetryable`.

--- a/libs/langchain-core/src/errors/index.ts
+++ b/libs/langchain-core/src/errors/index.ts
@@ -36,22 +36,12 @@ const MAX_CAUSE_DEPTH = 10;
 /**
  * Mark an error as safe or unsafe to retry.
  *
- * The mark is a non-enumerable symbol property set directly on the error, so
- * it carries retryability without changing the error's class, prototype,
- * fields, or JSON serialization. That makes it safe to apply to a provider
- * SDK's own error instance: callers doing `err instanceof SomeSdkError`
- * keep working exactly as before.
+ * Sets a non-enumerable symbol on the error itself, leaving its class and
+ * shape untouched, so it is safe to apply to a provider SDK's own error.
  *
  * @param error - The error to mark. Non-objects are returned untouched.
- * @param retryable - `true` if retrying may succeed, `false` if an identical
- *   retry will fail identically.
+ * @param retryable - `true` if retrying may succeed.
  * @returns The same error instance, for chaining.
- *
- * @example
- * ```typescript
- * if (e.status === 429) throw stampRetryable(e, true);
- * if (e.status === 401) throw stampRetryable(e, false);
- * ```
  */
 export function stampRetryable<T>(error: T, retryable: boolean): T {
   if (typeof error !== "object" || error === null) {
@@ -69,16 +59,10 @@ export function stampRetryable<T>(error: T, retryable: boolean): T {
 }
 
 /**
- * Read an error's retryability mark, following the `.cause` chain so a
- * classified error that later got rewrapped is still recognized.
+ * Read an error's retryability mark, following the `.cause` chain.
  *
- * @param error - The error to inspect.
- * @returns `true` or `false` when the error was marked by
- *   {@link stampRetryable}, or `undefined` when it was never classified.
- *   Callers must supply their own default for the `undefined` case — e.g.
- *   `getRetryable(error) ?? true`. Do not rely on truthiness: a bare
- *   `if (getRetryable(error))` silently treats every unclassified error as
- *   non-retryable, which is rarely what you want.
+ * @returns `true`/`false` when marked, `undefined` when unclassified —
+ *   supply your own default, e.g. `getRetryable(error) ?? true`.
  */
 export function getRetryable(error: unknown): boolean | undefined {
   let current: unknown = error;

--- a/libs/langchain-core/src/errors/index.ts
+++ b/libs/langchain-core/src/errors/index.ts
@@ -30,9 +30,6 @@ export const ns = baseNs.sub("error");
 /** Registered globally so duplicate copies of core in one dependency tree agree. */
 const retryableSymbol = Symbol.for("langchain.errors.retryable");
 
-/** Bounds the `.cause` walk so a cyclic chain can't spin forever. */
-const MAX_CAUSE_DEPTH = 10;
-
 /**
  * Mark an error as safe or unsafe to retry.
  *
@@ -59,32 +56,18 @@ export function stampRetryable<T>(error: T, retryable: boolean): T {
 }
 
 /**
- * Read an error's retryability mark, following the `.cause` chain.
+ * Read an error's retryability mark.
  *
  * @returns `true`/`false` when marked, `undefined` when unclassified —
  *   supply your own default, e.g. `getRetryable(error) ?? true`.
  */
 export function getRetryable(error: unknown): boolean | undefined {
-  let current: unknown = error;
-  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
-    if (typeof current !== "object" || current === null) {
-      return undefined;
-    }
-    try {
-      const descriptor = Object.getOwnPropertyDescriptor(
-        current,
-        retryableSymbol
-      );
-      if (descriptor) {
-        return descriptor.value as boolean;
-      }
-      current = (current as { cause?: unknown }).cause;
-    } catch {
-      // A throwing `cause` getter shouldn't take down the error path.
-      return undefined;
-    }
+  if (typeof error !== "object" || error === null) {
+    return undefined;
   }
-  return undefined;
+  return Object.getOwnPropertyDescriptor(error, retryableSymbol)?.value as
+    | boolean
+    | undefined;
 }
 
 /**

--- a/libs/langchain-core/src/errors/index.ts
+++ b/libs/langchain-core/src/errors/index.ts
@@ -27,6 +27,82 @@ export function addLangChainErrorFields(
 /** The error namespace for all LangChain errors */
 export const ns = baseNs.sub("error");
 
+/** Registered globally so duplicate copies of core in one dependency tree agree. */
+const retryableSymbol = Symbol.for("langchain.errors.retryable");
+
+/** Bounds the `.cause` walk so a cyclic chain can't spin forever. */
+const MAX_CAUSE_DEPTH = 10;
+
+/**
+ * Mark an error as safe or unsafe to retry.
+ *
+ * The mark is a non-enumerable symbol property set directly on the error, so
+ * it carries retryability without changing the error's class, prototype,
+ * fields, or JSON serialization. That makes it safe to apply to a provider
+ * SDK's own error instance: callers doing `err instanceof SomeSdkError`
+ * keep working exactly as before.
+ *
+ * @param error - The error to mark. Non-objects are returned untouched.
+ * @param retryable - `true` if retrying may succeed, `false` if an identical
+ *   retry will fail identically.
+ * @returns The same error instance, for chaining.
+ *
+ * @example
+ * ```typescript
+ * if (e.status === 429) throw stampRetryable(e, true);
+ * if (e.status === 401) throw stampRetryable(e, false);
+ * ```
+ */
+export function stampRetryable<T>(error: T, retryable: boolean): T {
+  if (typeof error !== "object" || error === null) {
+    return error;
+  }
+  try {
+    Object.defineProperty(error, retryableSymbol, {
+      value: retryable,
+      configurable: true,
+    });
+  } catch {
+    // Frozen or sealed error object; leave it unmarked rather than throwing.
+  }
+  return error;
+}
+
+/**
+ * Read an error's retryability mark, following the `.cause` chain so a
+ * classified error that later got rewrapped is still recognized.
+ *
+ * @param error - The error to inspect.
+ * @returns `true` or `false` when the error was marked by
+ *   {@link stampRetryable}, or `undefined` when it was never classified.
+ *   Callers must supply their own default for the `undefined` case — e.g.
+ *   `getRetryable(error) ?? true`. Do not rely on truthiness: a bare
+ *   `if (getRetryable(error))` silently treats every unclassified error as
+ *   non-retryable, which is rarely what you want.
+ */
+export function getRetryable(error: unknown): boolean | undefined {
+  let current: unknown = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) {
+      return undefined;
+    }
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        current,
+        retryableSymbol
+      );
+      if (descriptor) {
+        return descriptor.value as boolean;
+      }
+      current = (current as { cause?: unknown }).cause;
+    } catch {
+      // A throwing `cause` getter shouldn't take down the error path.
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Base error class for all LangChain errors.
  *
@@ -103,6 +179,8 @@ export class ModelAbortError extends ns.brand(LangChainError, "model-abort") {
   constructor(message: string, partialOutput?: AIMessageChunk) {
     super(message);
     this.partialOutput = partialOutput;
+    // Retrying would mean ignoring the caller's explicit abort signal.
+    stampRetryable(this, false);
   }
 }
 
@@ -154,6 +232,8 @@ export class ContextOverflowError extends ns.brand(
 
   constructor(message?: string) {
     super(message ?? "Input exceeded the model's context window.");
+    // The same oversized input fails identically; it needs trimming, not another attempt.
+    stampRetryable(this, false);
   }
 
   /**

--- a/libs/langchain-core/src/errors/tests/retryable.test.ts
+++ b/libs/langchain-core/src/errors/tests/retryable.test.ts
@@ -76,52 +76,6 @@ describe("getRetryable", () => {
     expect(getRetryable("boom")).toBeUndefined();
     expect(getRetryable(429)).toBeUndefined();
   });
-
-  test("finds a mark through the cause chain", () => {
-    const root = stampRetryable(new Error("root"), true);
-    const wrapped = new Error("outer", { cause: new Error("mid") });
-    (wrapped.cause as Error).cause = root;
-
-    expect(getRetryable(wrapped)).toBe(true);
-  });
-
-  test("nearest mark in the chain wins", () => {
-    const root = stampRetryable(new Error("root"), true);
-    const wrapped = stampRetryable(new Error("outer", { cause: root }), false);
-
-    expect(getRetryable(wrapped)).toBe(false);
-  });
-
-  test("terminates on a cyclic cause chain", () => {
-    const a = new Error("a");
-    const b = new Error("b");
-    a.cause = b;
-    b.cause = a;
-
-    expect(getRetryable(a)).toBeUndefined();
-  });
-
-  test("gives up past the depth cap", () => {
-    const root = stampRetryable(new Error("root"), true);
-    let current: Error = root;
-    for (let i = 0; i < 12; i += 1) {
-      current = new Error(`wrap-${i}`, { cause: current });
-    }
-
-    expect(getRetryable(current)).toBeUndefined();
-  });
-
-  test("does not throw when cause has a throwing getter", () => {
-    const error = new Error("boom");
-    Object.defineProperty(error, "cause", {
-      get() {
-        throw new Error("nope");
-      },
-    });
-
-    expect(() => getRetryable(error)).not.toThrow();
-    expect(getRetryable(error)).toBeUndefined();
-  });
 });
 
 describe("core error classification", () => {

--- a/libs/langchain-core/src/errors/tests/retryable.test.ts
+++ b/libs/langchain-core/src/errors/tests/retryable.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect } from "vitest";
+import {
+  ContextOverflowError,
+  ModelAbortError,
+  getRetryable,
+  stampRetryable,
+} from "../index.js";
+
+describe("stampRetryable", () => {
+  test("marks an error retryable", () => {
+    expect(getRetryable(stampRetryable(new Error("boom"), true))).toBe(true);
+  });
+
+  test("marks an error non-retryable", () => {
+    expect(getRetryable(stampRetryable(new Error("boom"), false))).toBe(false);
+  });
+
+  test("returns the same instance and preserves the prototype", () => {
+    class SdkError extends Error {}
+    const original = new SdkError("boom");
+    const stamped = stampRetryable(original, false);
+
+    expect(stamped).toBe(original);
+    expect(stamped).toBeInstanceOf(SdkError);
+    expect(stamped.name).toBe("Error");
+    expect(stamped.message).toBe("boom");
+  });
+
+  test("mark is invisible to enumeration and serialization", () => {
+    const error = stampRetryable(
+      Object.assign(new Error("boom"), { status: 429 }),
+      true
+    );
+
+    expect(Object.keys(error)).toEqual(["status"]);
+    expect(JSON.stringify(error)).toBe('{"status":429}');
+    expect({ ...error }).toEqual({ status: 429 });
+  });
+
+  test("can be re-stamped with a different verdict", () => {
+    const error = stampRetryable(new Error("boom"), true);
+
+    expect(getRetryable(stampRetryable(error, false))).toBe(false);
+  });
+
+  test("does not throw on non-objects", () => {
+    expect(() => stampRetryable(null, true)).not.toThrow();
+    expect(() => stampRetryable(undefined, true)).not.toThrow();
+    expect(() => stampRetryable("boom", true)).not.toThrow();
+    expect(stampRetryable("boom", true)).toBe("boom");
+  });
+
+  test("does not throw on a frozen error", () => {
+    const frozen = Object.freeze(new Error("boom"));
+
+    expect(() => stampRetryable(frozen, false)).not.toThrow();
+    expect(getRetryable(frozen)).toBeUndefined();
+  });
+
+  test("uses the global symbol registry", () => {
+    const error = stampRetryable(new Error("boom"), true);
+    const symbol = Symbol.for("langchain.errors.retryable");
+
+    expect((error as unknown as Record<symbol, unknown>)[symbol]).toBe(true);
+  });
+});
+
+describe("getRetryable", () => {
+  test("returns undefined for an unclassified error", () => {
+    expect(getRetryable(new Error("boom"))).toBeUndefined();
+  });
+
+  test("returns undefined for non-objects", () => {
+    expect(getRetryable(null)).toBeUndefined();
+    expect(getRetryable(undefined)).toBeUndefined();
+    expect(getRetryable("boom")).toBeUndefined();
+    expect(getRetryable(429)).toBeUndefined();
+  });
+
+  test("finds a mark through the cause chain", () => {
+    const root = stampRetryable(new Error("root"), true);
+    const wrapped = new Error("outer", { cause: new Error("mid") });
+    (wrapped.cause as Error).cause = root;
+
+    expect(getRetryable(wrapped)).toBe(true);
+  });
+
+  test("nearest mark in the chain wins", () => {
+    const root = stampRetryable(new Error("root"), true);
+    const wrapped = stampRetryable(new Error("outer", { cause: root }), false);
+
+    expect(getRetryable(wrapped)).toBe(false);
+  });
+
+  test("terminates on a cyclic cause chain", () => {
+    const a = new Error("a");
+    const b = new Error("b");
+    a.cause = b;
+    b.cause = a;
+
+    expect(getRetryable(a)).toBeUndefined();
+  });
+
+  test("gives up past the depth cap", () => {
+    const root = stampRetryable(new Error("root"), true);
+    let current: Error = root;
+    for (let i = 0; i < 12; i += 1) {
+      current = new Error(`wrap-${i}`, { cause: current });
+    }
+
+    expect(getRetryable(current)).toBeUndefined();
+  });
+
+  test("does not throw when cause has a throwing getter", () => {
+    const error = new Error("boom");
+    Object.defineProperty(error, "cause", {
+      get() {
+        throw new Error("nope");
+      },
+    });
+
+    expect(() => getRetryable(error)).not.toThrow();
+    expect(getRetryable(error)).toBeUndefined();
+  });
+});
+
+describe("core error classification", () => {
+  test("ModelAbortError is non-retryable", () => {
+    expect(getRetryable(new ModelAbortError("aborted"))).toBe(false);
+  });
+
+  test("ContextOverflowError is non-retryable", () => {
+    expect(getRetryable(new ContextOverflowError())).toBe(false);
+  });
+
+  test("ContextOverflowError.fromError is non-retryable", () => {
+    expect(
+      getRetryable(ContextOverflowError.fromError(new Error("too long")))
+    ).toBe(false);
+  });
+});

--- a/libs/langchain-core/src/language_models/base.ts
+++ b/libs/langchain-core/src/language_models/base.ts
@@ -323,6 +323,10 @@ export interface BaseLanguageModelCallOptions
    * If not provided, the default stop tokens for the model will be used.
    */
   stop?: string[];
+  /**
+   * Overrides the model's configured `maxRetries` for this call only.
+   */
+  maxRetries?: number;
 }
 
 export interface FunctionDefinition {

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -1,5 +1,6 @@
 import PQueueMod from "p-queue";
 
+import { stampRetryable } from "../errors/index.js";
 import { getAbortSignalError } from "./signal.js";
 import pRetry from "./p-retry/index.js";
 
@@ -267,7 +268,8 @@ const defaultFailedAttemptHandler = (error: unknown) => {
       typeof error.name === "string" &&
       error.name === "AbortError")
   ) {
-    throw error;
+    // Deliberate cancellation, not a failure worth another attempt.
+    throw stampRetryable(error, false);
   }
   if (
     "code" in error &&
@@ -278,7 +280,8 @@ const defaultFailedAttemptHandler = (error: unknown) => {
   }
   const status = getResponseStatus(error) ?? getDirectStatus(error);
   if (status && STATUS_NO_RETRY.includes(+status)) {
-    throw error;
+    // Deterministic client error; retrying it unchanged fails identically.
+    throw stampRetryable(error, false);
   }
 
   const code = getErrorCode(error);
@@ -292,13 +295,15 @@ const defaultFailedAttemptHandler = (error: unknown) => {
       action: "stop",
       reason: "insufficient_quota",
     });
-    throw err;
+    // Exhausted quota needs an account action, not another attempt.
+    throw stampRetryable(err, false);
   }
 
   const rateLimitClassification = classifyRateLimitError(error);
   if (rateLimitClassification) {
     if (rateLimitClassification.action === "wait") {
       setRateLimitMetadata(error, rateLimitClassification);
+      stampRetryable(error, true);
       return;
     }
 
@@ -313,7 +318,9 @@ const defaultFailedAttemptHandler = (error: unknown) => {
           : "RateLimitCapacityError";
     }
     setRateLimitMetadata(err, rateLimitClassification);
-    throw err;
+    // "stop" is exhausted quota; "capacity" is a transient 429 this caller
+    // just declines to wait out, which an outer retry may still handle.
+    throw stampRetryable(err, rateLimitClassification.action !== "stop");
   }
 };
 

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -347,9 +347,6 @@ export interface AsyncCallerParams {
    * Custom handler to handle failed attempts. Takes the originally thrown
    * error object as input, and should itself throw an error if the input
    * error is not retryable.
-   *
-   * Replaces the built-in handler entirely, so supplying one opts out of its
-   * retryability marking (see `stampRetryable` in `@langchain/core/errors`).
    */
   onFailedAttempt?: FailedAttemptHandler;
 }

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -14,6 +14,7 @@ const STATUS_NO_RETRY = [
   406, // Not Acceptable
   407, // Proxy Authentication Required
   409, // Conflict
+  413, // Payload Too Large
 ];
 
 const RETRY_AFTER_AUTO_RETRY_THRESHOLD_MS = 60_000;

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -353,6 +353,7 @@ export interface AsyncCallerParams {
 
 export interface AsyncCallerCallOptions {
   signal?: AbortSignal;
+  maxRetries?: number;
 }
 
 /**
@@ -394,6 +395,19 @@ export class AsyncCaller {
     callable: T,
     ...args: Parameters<T>
   ): Promise<Awaited<ReturnType<T>>> {
+    return this.callWithRetries(this.maxRetries, callable, args);
+  }
+
+  private callWithRetries<
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    A extends any[],
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    T extends (...args: A) => Promise<any>,
+  >(
+    retries: AsyncCallerParams["maxRetries"],
+    callable: T,
+    args: Parameters<T>
+  ): Promise<Awaited<ReturnType<T>>> {
     return this.queue.add(
       () =>
         pRetry(
@@ -408,7 +422,7 @@ export class AsyncCaller {
             }),
           {
             onFailedAttempt: ({ error }) => this.onFailedAttempt?.(error),
-            retries: this.maxRetries,
+            retries,
             randomize: true,
             // If needed we can change some of the defaults here,
             // but they're quite sensible.
@@ -424,12 +438,13 @@ export class AsyncCaller {
     callable: T,
     ...args: Parameters<T>
   ): Promise<Awaited<ReturnType<T>>> {
+    const retries = options.maxRetries ?? this.maxRetries;
     // Note this doesn't cancel the underlying request,
     // when available prefer to use the signal option of the underlying call
     if (options.signal) {
       let listener: (() => void) | undefined;
       return Promise.race([
-        this.call<A, T>(callable, ...args),
+        this.callWithRetries<A, T>(retries, callable, args),
         new Promise<never>((_, reject) => {
           listener = () => {
             reject(getAbortSignalError(options.signal));
@@ -442,7 +457,7 @@ export class AsyncCaller {
         }
       });
     }
-    return this.call<A, T>(callable, ...args);
+    return this.callWithRetries<A, T>(retries, callable, args);
   }
 
   fetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -1,6 +1,6 @@
 import PQueueMod from "p-queue";
 
-import { stampRetryable } from "../errors/index.js";
+import { getRetryable, stampRetryable } from "../errors/index.js";
 import { getAbortSignalError } from "./signal.js";
 import pRetry from "./p-retry/index.js";
 
@@ -257,6 +257,11 @@ export function classifyRateLimitError(
 const defaultFailedAttemptHandler = (error: unknown) => {
   if (typeof error !== "object" || error === null) {
     return;
+  }
+
+  // Honor a verdict already reached inside the callable, e.g. by a provider.
+  if (getRetryable(error) === false) {
+    throw error;
   }
 
   if (

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -318,8 +318,7 @@ const defaultFailedAttemptHandler = (error: unknown) => {
           : "RateLimitCapacityError";
     }
     setRateLimitMetadata(err, rateLimitClassification);
-    // "stop" is exhausted quota; "capacity" is a transient 429 this caller
-    // just declines to wait out, which an outer retry may still handle.
+    // Only "stop" is exhausted quota; "capacity" can still succeed later.
     throw stampRetryable(err, rateLimitClassification.action !== "stop");
   }
 };
@@ -342,6 +341,9 @@ export interface AsyncCallerParams {
    * Custom handler to handle failed attempts. Takes the originally thrown
    * error object as input, and should itself throw an error if the input
    * error is not retryable.
+   *
+   * Replaces the built-in handler entirely, so supplying one opts out of its
+   * retryability marking (see `stampRetryable` in `@langchain/core/errors`).
    */
   onFailedAttempt?: FailedAttemptHandler;
 }

--- a/libs/langchain-core/src/utils/tests/async_caller.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller.test.ts
@@ -509,3 +509,66 @@ describe("AsyncCaller honors marks applied inside the callable", () => {
     expect(callable).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("AsyncCaller per-call maxRetries override", () => {
+  test("honors a per-call override of 0", async () => {
+    const caller = new AsyncCaller({ maxRetries: 5 });
+    const callable = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(() =>
+      caller.callWithOptions({ maxRetries: 0 }, callable)
+    ).rejects.toThrow("boom");
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("honors a per-call override above zero", async () => {
+    const caller = new AsyncCaller({ maxRetries: 5 });
+    const callable = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(() =>
+      caller.callWithOptions({ maxRetries: 2 }, callable)
+    ).rejects.toThrow("boom");
+    expect(callable).toHaveBeenCalledTimes(3);
+  });
+
+  test("falls back to the configured value when not overridden", async () => {
+    const caller = new AsyncCaller({ maxRetries: 2 });
+    const callable = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(() => caller.callWithOptions({}, callable)).rejects.toThrow(
+      "boom"
+    );
+    expect(callable).toHaveBeenCalledTimes(3);
+  });
+
+  test("call() is unaffected by the option", async () => {
+    const caller = new AsyncCaller({ maxRetries: 1 });
+    const callable = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(() => caller.call(callable)).rejects.toThrow("boom");
+    expect(callable).toHaveBeenCalledTimes(2);
+  });
+
+  test("an override of 0 skips the Retry-After wait entirely", async () => {
+    const caller = new AsyncCaller({ maxRetries: 3 });
+    const callable = vi.fn(async () => {
+      throw Object.assign(new Error("rate limited"), {
+        status: 429,
+        headers: { "retry-after": "30" },
+      });
+    });
+
+    await expect(() =>
+      caller.callWithOptions({ maxRetries: 0 }, callable)
+    ).rejects.toThrow("rate limited");
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/langchain-core/src/utils/tests/async_caller.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi } from "vitest";
+import { getRetryable } from "../../errors/index.js";
 import {
   AsyncCaller,
   parseRetryAfterMs,
@@ -364,5 +365,72 @@ describe("classifyRateLimitError", () => {
       action: "capacity",
       reason: "headerless_429",
     });
+  });
+});
+
+describe("AsyncCaller retryability marking", () => {
+  const handle = (error: unknown) => {
+    const caller = new AsyncCaller({ maxRetries: 0 });
+    try {
+      (
+        caller as unknown as { onFailedAttempt: (error: unknown) => void }
+      ).onFailedAttempt(error);
+    } catch (thrown) {
+      return thrown;
+    }
+    return error;
+  };
+
+  test.each([400, 401, 402, 403, 404, 405, 406, 407, 409])(
+    "marks status %i non-retryable",
+    (status) => {
+      expect(
+        getRetryable(handle(Object.assign(new Error("nope"), { status })))
+      ).toBe(false);
+    }
+  );
+
+  test("marks an aborted call non-retryable", () => {
+    expect(
+      getRetryable(
+        handle(Object.assign(new Error("boom"), { name: "AbortError" }))
+      )
+    ).toBe(false);
+  });
+
+  test("marks insufficient quota non-retryable", () => {
+    const error = new Error("Insufficient quota");
+    (error as unknown as { error: { code: string } }).error = {
+      code: "insufficient_quota",
+    };
+
+    expect(getRetryable(handle(error))).toBe(false);
+  });
+
+  test("marks a rate limit with a retry hint retryable", () => {
+    const error = Object.assign(new Error("Rate limit exceeded"), {
+      status: 429,
+      headers: { "retry-after": "4" },
+    });
+
+    expect(getRetryable(handle(error))).toBe(true);
+  });
+
+  test("marks headerless capacity pressure retryable", () => {
+    const error = Object.assign(new Error("Rate limit exceeded"), {
+      statusCode: 429,
+    });
+
+    expect(getRetryable(handle(error))).toBe(true);
+  });
+
+  test("leaves an unrecognized error unmarked", () => {
+    expect(getRetryable(handle(new Error("who knows")))).toBeUndefined();
+  });
+
+  test("leaves a 500 unmarked so outer retries still apply", () => {
+    expect(
+      getRetryable(handle(Object.assign(new Error("server"), { status: 500 })))
+    ).toBeUndefined();
   });
 });

--- a/libs/langchain-core/src/utils/tests/async_caller.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller.test.ts
@@ -437,6 +437,28 @@ describe("AsyncCaller retryability marking", () => {
       getRetryable(handle(Object.assign(new Error("server"), { status: 500 })))
     ).toBeUndefined();
   });
+
+  test("marks an unmarked 413 non-retryable", () => {
+    expect(
+      getRetryable(
+        handle(Object.assign(new Error("too large"), { status: 413 }))
+      )
+    ).toBe(false);
+  });
+});
+
+describe("AsyncCaller 413 handling", () => {
+  test("does not retry an unmarked payload-too-large error", async () => {
+    const caller = new AsyncCaller({ maxRetries: 3 });
+    const callable = vi.fn(async () => {
+      throw Object.assign(new Error("payload too large"), { status: 413 });
+    });
+
+    await expect(() => caller.call(callable)).rejects.toThrow(
+      "payload too large"
+    );
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("AsyncCaller honors marks applied inside the callable", () => {

--- a/libs/langchain-core/src/utils/tests/async_caller.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, vi } from "vitest";
-import { getRetryable } from "../../errors/index.js";
+import {
+  ContextOverflowError,
+  getRetryable,
+  stampRetryable,
+} from "../../errors/index.js";
 import {
   AsyncCaller,
   parseRetryAfterMs,
@@ -432,5 +436,54 @@ describe("AsyncCaller retryability marking", () => {
     expect(
       getRetryable(handle(Object.assign(new Error("server"), { status: 500 })))
     ).toBeUndefined();
+  });
+});
+
+describe("AsyncCaller honors marks applied inside the callable", () => {
+  test("stops retrying an error marked non-retryable by the callable", async () => {
+    const caller = new AsyncCaller({ maxRetries: 3 });
+    const callable = vi.fn(async () => {
+      throw stampRetryable(
+        Object.assign(new Error("payload too large"), { status: 413 }),
+        false
+      );
+    });
+
+    await expect(() => caller.call(callable)).rejects.toThrow(
+      "payload too large"
+    );
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops retrying a marked error with no status at all", async () => {
+    const caller = new AsyncCaller({ maxRetries: 3 });
+    const callable = vi.fn(async () => {
+      throw stampRetryable(new ContextOverflowError(), false);
+    });
+
+    await expect(() => caller.call(callable)).rejects.toThrow();
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("still retries an error marked retryable", async () => {
+    const caller = new AsyncCaller({ maxRetries: 2 });
+    const callable = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(stampRetryable(new Error("upstream busy"), true))
+      .mockResolvedValueOnce();
+
+    await expect(caller.call(callable)).resolves.toBeUndefined();
+    expect(callable).toHaveBeenCalledTimes(2);
+  });
+
+  test("still retries an unmarked error", async () => {
+    const caller = new AsyncCaller({ maxRetries: 2 });
+    const callable = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce();
+
+    await expect(caller.call(callable)).resolves.toBeUndefined();
+    expect(callable).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/langchain/src/agents/middleware/constants.ts
+++ b/libs/langchain/src/agents/middleware/constants.ts
@@ -11,9 +11,7 @@ export const RetrySchema = z.object({
   /**
    * Either an array of error constructors to retry on, or a function
    * that takes an error and returns `true` if it should be retried.
-   * Default is to retry unless the error was explicitly marked
-   * non-retryable (e.g. bad credentials, unknown model), which would
-   * fail identically on every attempt. Unclassified errors still retry.
+   * Default is to retry unless the error is marked non-retryable.
    */
   retryOn: z
     .union([

--- a/libs/langchain/src/agents/middleware/constants.ts
+++ b/libs/langchain/src/agents/middleware/constants.ts
@@ -1,3 +1,4 @@
+import { getRetryable } from "@langchain/core/errors";
 import { z } from "zod/v3";
 
 export const RetrySchema = z.object({
@@ -10,7 +11,9 @@ export const RetrySchema = z.object({
   /**
    * Either an array of error constructors to retry on, or a function
    * that takes an error and returns `true` if it should be retried.
-   * Default is to retry on all errors.
+   * Default is to retry unless the error was explicitly marked
+   * non-retryable (e.g. bad credentials, unknown model), which would
+   * fail identically on every attempt. Unclassified errors still retry.
    */
   retryOn: z
     .union([
@@ -18,7 +21,7 @@ export const RetrySchema = z.object({
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       z.array(z.custom<new (...args: any[]) => Error>()),
     ])
-    .default(() => () => true),
+    .default(() => (error: Error) => getRetryable(error) ?? true),
 
   /**
    * Multiplier for exponential backoff. Each retry waits

--- a/libs/langchain/src/agents/middleware/modelRetry.ts
+++ b/libs/langchain/src/agents/middleware/modelRetry.ts
@@ -5,7 +5,7 @@ import { z } from "zod/v3";
 import { AIMessage } from "@langchain/core/messages";
 
 import { createMiddleware } from "../middleware.js";
-import { sleep, calculateRetryDelay } from "./utils.js";
+import { sleep, calculateRetryDelay, getRetryAfterMs } from "./utils.js";
 import { RetrySchema } from "./constants.js";
 import { InvalidRetryConfigError } from "./error.js";
 
@@ -188,10 +188,15 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
     name: "modelRetryMiddleware",
     contextSchema: ModelRetryMiddlewareOptionsSchema,
     wrapModelCall: async (request, handler) => {
+      const delegated = {
+        ...request,
+        modelSettings: { maxRetries: 0, ...request.modelSettings },
+      };
+
       // Initial attempt + retries
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-          return await handler(request);
+          return await handler(delegated);
         } catch (error) {
           const attemptsMade = attempt + 1; // attempt is 0-indexed
 
@@ -210,7 +215,11 @@ export function modelRetryMiddleware(config: ModelRetryMiddlewareConfig = {}) {
           // Check if we have more retries left
           if (attempt < maxRetries) {
             // Calculate and apply backoff delay
-            const delay = calculateRetryDelay(delayConfig, attempt);
+            const delay = calculateRetryDelay(
+              delayConfig,
+              attempt,
+              getRetryAfterMs(err)
+            );
             if (delay > 0) {
               await sleep(delay);
             }

--- a/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
@@ -669,3 +669,62 @@ describe("modelRetryMiddleware", () => {
     });
   });
 });
+
+describe("Retry-After handling", () => {
+  it("waits at least as long as the error asks", async () => {
+    const error = Object.assign(new Error("rate limited"), {
+      retryAfterMs: 300,
+    });
+    const model = new AlwaysFailingModel(error);
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [
+        modelRetryMiddleware({
+          maxRetries: 1,
+          initialDelayMs: 1,
+          jitter: false,
+          onFailure: "continue",
+        }),
+      ] as const,
+      checkpointer: new MemorySaver(),
+    });
+
+    const start = Date.now();
+    await agent.invoke(
+      { messages: [new HumanMessage("Hello")] },
+      { configurable: { thread_id: "retry-after" } }
+    );
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(280);
+    expect(model._generate).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses its own backoff when no hint is present", async () => {
+    const model = new AlwaysFailingModel(new Error("boom"));
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [
+        modelRetryMiddleware({
+          maxRetries: 1,
+          initialDelayMs: 1,
+          jitter: false,
+          onFailure: "continue",
+        }),
+      ] as const,
+      checkpointer: new MemorySaver(),
+    });
+
+    const start = Date.now();
+    await agent.invoke(
+      { messages: [new HumanMessage("Hello")] },
+      { configurable: { thread_id: "no-hint" } }
+    );
+
+    expect(Date.now() - start).toBeLessThan(200);
+    expect(model._generate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from "vitest";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import { ContextOverflowError, stampRetryable } from "@langchain/core/errors";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { StructuredTool } from "@langchain/core/tools";
 import { RunnableBinding } from "@langchain/core/runnables";
@@ -468,6 +469,69 @@ describe("modelRetryMiddleware", () => {
       expect(aiMessages.length).toBeGreaterThan(0);
       expect(shouldRetry).toHaveBeenCalledTimes(1);
       expect(model._generate).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Default retryability classification", () => {
+    const runWithDefaultRetryOn = async (error: Error, threadId: string) => {
+      const model = new AlwaysFailingModel(error);
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [
+          modelRetryMiddleware({
+            maxRetries: 2,
+            initialDelayMs: 10,
+            jitter: false,
+            onFailure: "continue",
+          }),
+        ] as const,
+        checkpointer: new MemorySaver(),
+      });
+
+      await agent.invoke(
+        { messages: [new HumanMessage("Hello")] },
+        { configurable: { thread_id: threadId } }
+      );
+
+      return model._generate;
+    };
+
+    it("should not retry an error marked non-retryable", async () => {
+      const generate = await runWithDefaultRetryOn(
+        stampRetryable(new Error("Invalid API key"), false),
+        "non-retryable"
+      );
+
+      expect(generate).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry an error marked retryable", async () => {
+      const generate = await runWithDefaultRetryOn(
+        stampRetryable(new Error("Rate limited"), true),
+        "retryable"
+      );
+
+      expect(generate).toHaveBeenCalledTimes(3);
+    });
+
+    it("should retry an unclassified error", async () => {
+      const generate = await runWithDefaultRetryOn(
+        new Error("Who knows"),
+        "unclassified"
+      );
+
+      expect(generate).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not retry a core error that is non-retryable by construction", async () => {
+      const generate = await runWithDefaultRetryOn(
+        new ContextOverflowError(),
+        "context-overflow"
+      );
+
+      expect(generate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libs/langchain/src/agents/middleware/tests/toolRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/toolRetry.test.ts
@@ -975,3 +975,30 @@ describe("toolRetryMiddleware", () => {
     });
   });
 });
+
+describe("calculateRetryDelay retryAfterMs floor", () => {
+  const config = {
+    backoffFactor: 2.0,
+    initialDelayMs: 100,
+    maxDelayMs: 60000,
+    jitter: false,
+  };
+
+  it("raises the delay to the hint when the hint is larger", () => {
+    expect(calculateRetryDelay(config, 0, 5000)).toBe(5000);
+  });
+
+  it("keeps the backoff when it already exceeds the hint", () => {
+    expect(calculateRetryDelay(config, 0, 50)).toBe(100);
+  });
+
+  it("ignores maxDelayMs for the hint", () => {
+    expect(calculateRetryDelay({ ...config, maxDelayMs: 200 }, 0, 9000)).toBe(
+      9000
+    );
+  });
+
+  it("is unchanged when no hint is given", () => {
+    expect(calculateRetryDelay(config, 0)).toBe(100);
+  });
+});

--- a/libs/langchain/src/agents/middleware/toolRetry.ts
+++ b/libs/langchain/src/agents/middleware/toolRetry.ts
@@ -6,7 +6,7 @@ import { ToolMessage } from "@langchain/core/messages";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import { createMiddleware } from "../middleware.js";
-import { sleep, calculateRetryDelay } from "./utils.js";
+import { sleep, calculateRetryDelay, getRetryAfterMs } from "./utils.js";
 import { RetrySchema } from "./constants.js";
 import { InvalidRetryConfigError } from "./error.js";
 
@@ -306,7 +306,11 @@ export function toolRetryMiddleware(config: ToolRetryMiddlewareConfig = {}) {
           // Check if we have more retries left
           if (attempt < maxRetries) {
             // Calculate and apply backoff delay
-            const delay = calculateRetryDelay(delayConfig, attempt);
+            const delay = calculateRetryDelay(
+              delayConfig,
+              attempt,
+              getRetryAfterMs(error)
+            );
             if (delay > 0) {
               await sleep(delay);
             }

--- a/libs/langchain/src/agents/middleware/utils.ts
+++ b/libs/langchain/src/agents/middleware/utils.ts
@@ -111,6 +111,8 @@ export function sleep(ms: number): Promise<void> {
  *
  * @param retryNumber - The retry attempt number (0-indexed)
  * @param config - Configuration for backoff calculation
+ * @param retryAfterMs - A provider-supplied wait hint, e.g. from a `Retry-After`
+ *   header. Used as a floor so we never retry sooner than the server asked.
  * @returns Delay in milliseconds before next retry
  *
  * @internal Exported for testing purposes
@@ -122,7 +124,8 @@ export function calculateRetryDelay(
     maxDelayMs: number;
     jitter: boolean;
   },
-  retryNumber: number
+  retryNumber: number,
+  retryAfterMs?: number
 ): number {
   const { backoffFactor, initialDelayMs, maxDelayMs, jitter } = config;
 
@@ -143,5 +146,15 @@ export function calculateRetryDelay(
     delay = Math.max(0, delay);
   }
 
-  return delay;
+  return Math.max(delay, retryAfterMs ?? 0);
+}
+
+export function getRetryAfterMs(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const { retryAfterMs } = error as { retryAfterMs?: unknown };
+  return typeof retryAfterMs === "number" && retryAfterMs >= 0
+    ? retryAfterMs
+    : undefined;
 }

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1421,14 +1421,11 @@ export class ChatAnthropicMessages<
       !_thinkingInParams(payload) &&
       !_compactionInParams(payload);
 
-    const stream = await this.createStreamWithRetry(
-      payload,
-      {
-        headers: options.headers,
-        signal: options.signal,
-      },
-      options.maxRetries
-    );
+    const stream = await this.createStreamWithRetry(payload, {
+      headers: options.headers,
+      signal: options.signal,
+      maxRetries: options.maxRetries,
+    });
 
     for await (const data of stream) {
       if (options.signal?.aborted) {
@@ -1497,14 +1494,11 @@ export class ChatAnthropicMessages<
       stream: true,
     } as const;
 
-    const stream = await this.createStreamWithRetry(
-      payload,
-      {
-        headers: options.headers,
-        signal: options.signal,
-      },
-      options.maxRetries
-    );
+    const stream = await this.createStreamWithRetry(payload, {
+      headers: options.headers,
+      signal: options.signal,
+      maxRetries: options.maxRetries,
+    });
 
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
 
@@ -1537,8 +1531,7 @@ export class ChatAnthropicMessages<
       "messages"
     > &
       Kwargs,
-    requestOptions: AnthropicRequestOptions,
-    callerMaxRetries?: number
+    requestOptions: AnthropicRequestOptions
   ) {
     const formattedMessages = _convertMessagesToAnthropicPayload(messages);
 
@@ -1548,8 +1541,7 @@ export class ChatAnthropicMessages<
         stream: false,
         ...formattedMessages,
       },
-      requestOptions,
-      callerMaxRetries
+      requestOptions
     );
 
     const { content, ...additionalKwargs } = response;
@@ -1598,12 +1590,11 @@ export class ChatAnthropicMessages<
         ],
       };
     } else {
-      return this._generateNonStreaming(
-        messages,
-        params,
-        { signal: options.signal, headers: options.headers },
-        options.maxRetries
-      );
+      return this._generateNonStreaming(messages, params, {
+        signal: options.signal,
+        headers: options.headers,
+        maxRetries: options.maxRetries,
+      });
     }
   }
 
@@ -1615,8 +1606,7 @@ export class ChatAnthropicMessages<
    */
   protected async createStreamWithRetry(
     request: AnthropicStreamingMessageCreateParams & Kwargs,
-    options?: AnthropicRequestOptions,
-    callerMaxRetries?: number
+    options?: AnthropicRequestOptions
   ): Promise<Stream<AnthropicMessageStreamEvent>> {
     if (!this.streamingClient) {
       const options_ = this.apiUrl ? { baseURL: this.apiUrl } : undefined;
@@ -1659,7 +1649,7 @@ export class ChatAnthropicMessages<
       }
     };
     return this.caller.callWithOptions(
-      { maxRetries: callerMaxRetries },
+      { maxRetries: options?.maxRetries },
       makeCompletionRequest
     );
   }
@@ -1667,8 +1657,7 @@ export class ChatAnthropicMessages<
   /** @ignore */
   protected async completionWithRetry(
     request: AnthropicMessageCreateParams & Kwargs,
-    options: AnthropicRequestOptions,
-    callerMaxRetries?: number
+    options: AnthropicRequestOptions
   ): Promise<Anthropic.Message> {
     if (!this.batchClient) {
       const options = this.apiUrl ? { baseURL: this.apiUrl } : undefined;
@@ -1708,7 +1697,7 @@ export class ChatAnthropicMessages<
       }
     };
     return this.caller.callWithOptions(
-      { signal: options.signal ?? undefined, maxRetries: callerMaxRetries },
+      { signal: options.signal ?? undefined, maxRetries: options.maxRetries },
       makeCompletionRequest
     );
   }

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -1421,10 +1421,14 @@ export class ChatAnthropicMessages<
       !_thinkingInParams(payload) &&
       !_compactionInParams(payload);
 
-    const stream = await this.createStreamWithRetry(payload, {
-      headers: options.headers,
-      signal: options.signal,
-    });
+    const stream = await this.createStreamWithRetry(
+      payload,
+      {
+        headers: options.headers,
+        signal: options.signal,
+      },
+      options.maxRetries
+    );
 
     for await (const data of stream) {
       if (options.signal?.aborted) {
@@ -1493,10 +1497,14 @@ export class ChatAnthropicMessages<
       stream: true,
     } as const;
 
-    const stream = await this.createStreamWithRetry(payload, {
-      headers: options.headers,
-      signal: options.signal,
-    });
+    const stream = await this.createStreamWithRetry(
+      payload,
+      {
+        headers: options.headers,
+        signal: options.signal,
+      },
+      options.maxRetries
+    );
 
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
 
@@ -1529,7 +1537,8 @@ export class ChatAnthropicMessages<
       "messages"
     > &
       Kwargs,
-    requestOptions: AnthropicRequestOptions
+    requestOptions: AnthropicRequestOptions,
+    callerMaxRetries?: number
   ) {
     const formattedMessages = _convertMessagesToAnthropicPayload(messages);
 
@@ -1539,7 +1548,8 @@ export class ChatAnthropicMessages<
         stream: false,
         ...formattedMessages,
       },
-      requestOptions
+      requestOptions,
+      callerMaxRetries
     );
 
     const { content, ...additionalKwargs } = response;
@@ -1588,10 +1598,12 @@ export class ChatAnthropicMessages<
         ],
       };
     } else {
-      return this._generateNonStreaming(messages, params, {
-        signal: options.signal,
-        headers: options.headers,
-      });
+      return this._generateNonStreaming(
+        messages,
+        params,
+        { signal: options.signal, headers: options.headers },
+        options.maxRetries
+      );
     }
   }
 
@@ -1603,7 +1615,8 @@ export class ChatAnthropicMessages<
    */
   protected async createStreamWithRetry(
     request: AnthropicStreamingMessageCreateParams & Kwargs,
-    options?: AnthropicRequestOptions
+    options?: AnthropicRequestOptions,
+    callerMaxRetries?: number
   ): Promise<Stream<AnthropicMessageStreamEvent>> {
     if (!this.streamingClient) {
       const options_ = this.apiUrl ? { baseURL: this.apiUrl } : undefined;
@@ -1645,13 +1658,17 @@ export class ChatAnthropicMessages<
         throw error;
       }
     };
-    return this.caller.call(makeCompletionRequest);
+    return this.caller.callWithOptions(
+      { maxRetries: callerMaxRetries },
+      makeCompletionRequest
+    );
   }
 
   /** @ignore */
   protected async completionWithRetry(
     request: AnthropicMessageCreateParams & Kwargs,
-    options: AnthropicRequestOptions
+    options: AnthropicRequestOptions,
+    callerMaxRetries?: number
   ): Promise<Anthropic.Message> {
     if (!this.batchClient) {
       const options = this.apiUrl ? { baseURL: this.apiUrl } : undefined;
@@ -1691,7 +1708,7 @@ export class ChatAnthropicMessages<
       }
     };
     return this.caller.callWithOptions(
-      { signal: options.signal ?? undefined },
+      { signal: options.signal ?? undefined, maxRetries: callerMaxRetries },
       makeCompletionRequest
     );
   }

--- a/libs/providers/langchain-anthropic/src/utils/errors.ts
+++ b/libs/providers/langchain-anthropic/src/utils/errors.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 /* oxlint-disable no-param-reassign */
 
-import { ContextOverflowError } from "@langchain/core/errors";
+import { ContextOverflowError, stampRetryable } from "@langchain/core/errors";
 
 // Duplicate of core
 // TODO: Remove once we stop supporting 0.2.x core versions
@@ -32,18 +32,32 @@ export function wrapAnthropicClientError(e: any) {
     typeof e.message === "string" &&
     e.message.includes("prompt is too long")
   ) {
+    // ContextOverflowError marks itself non-retryable at construction.
     error = addLangChainErrorFields(
       ContextOverflowError.fromError(e),
       "CONTEXT_OVERFLOW"
     );
   } else if (e.status === 400 && e.message.includes("tool")) {
-    error = addLangChainErrorFields(e, "INVALID_TOOL_RESULTS");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "INVALID_TOOL_RESULTS"),
+      false
+    );
   } else if (e.status === 401) {
-    error = addLangChainErrorFields(e, "MODEL_AUTHENTICATION");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_AUTHENTICATION"),
+      false
+    );
   } else if (e.status === 404) {
-    error = addLangChainErrorFields(e, "MODEL_NOT_FOUND");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_NOT_FOUND"),
+      false
+    );
   } else if (e.status === 429) {
-    error = addLangChainErrorFields(e, "MODEL_RATE_LIMIT");
+    // AsyncCaller runs after this and re-marks false if it's quota exhaustion.
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_RATE_LIMIT"),
+      true
+    );
   } else {
     error = e;
   }

--- a/libs/providers/langchain-anthropic/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/errors.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "vitest";
+import { test, expect, describe, vi } from "vitest";
 import { ContextOverflowError, getRetryable } from "@langchain/core/errors";
 import { wrapAnthropicClientError } from "../errors.js";
 
@@ -166,5 +166,41 @@ describe("wrapAnthropicClientError retryability", () => {
 
     expect(wrapped.lc_error_code).toBe("CONTEXT_OVERFLOW");
     expect(getRetryable(wrapped)).toBe(false);
+  });
+});
+
+describe("per-call maxRetries", () => {
+  test("a call option of 0 stops the caller retrying", async () => {
+    const { ChatAnthropic } = await import("../../chat_models.js");
+    const model = new ChatAnthropic({ apiKey: "test", maxRetries: 3 });
+
+    const create = vi.fn(async () => {
+      throw Object.assign(new Error("server"), { status: 500 });
+    });
+    (model as unknown as { batchClient: unknown }).batchClient = {
+      messages: { create },
+      beta: { messages: { create } },
+    };
+
+    await expect(model.invoke("hi", { maxRetries: 0 })).rejects.toThrow(
+      "server"
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("without the option the configured retries still apply", async () => {
+    const { ChatAnthropic } = await import("../../chat_models.js");
+    const model = new ChatAnthropic({ apiKey: "test", maxRetries: 2 });
+
+    const create = vi.fn(async () => {
+      throw Object.assign(new Error("server"), { status: 500 });
+    });
+    (model as unknown as { batchClient: unknown }).batchClient = {
+      messages: { create },
+      beta: { messages: { create } },
+    };
+
+    await expect(model.invoke("hi")).rejects.toThrow("server");
+    expect(create).toHaveBeenCalledTimes(3);
   });
 });

--- a/libs/providers/langchain-anthropic/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "vitest";
-import { ContextOverflowError } from "@langchain/core/errors";
+import { ContextOverflowError, getRetryable } from "@langchain/core/errors";
 import { wrapAnthropicClientError } from "../errors.js";
 
 describe("wrapAnthropicClientError", () => {
@@ -77,5 +77,94 @@ describe("wrapAnthropicClientError", () => {
     const wrapped = wrapAnthropicClientError(originalError);
 
     expect(wrapped).toBe(originalError);
+  });
+});
+
+describe("wrapAnthropicClientError retryability", () => {
+  test("marks context overflow non-retryable", () => {
+    const wrapped = wrapAnthropicClientError({
+      status: 400,
+      message: "prompt is too long: 209752 tokens > 200000 maximum",
+    });
+
+    expect(wrapped).toBeInstanceOf(ContextOverflowError);
+    expect(getRetryable(wrapped)).toBe(false);
+  });
+
+  test("marks invalid tool results non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapAnthropicClientError({
+          status: 400,
+          message: "invalid tool result block",
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("marks authentication failures non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapAnthropicClientError({ status: 401, message: "invalid x-api-key" })
+      )
+    ).toBe(false);
+  });
+
+  test("marks a missing model non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapAnthropicClientError({ status: 404, message: "model not found" })
+      )
+    ).toBe(false);
+  });
+
+  test("marks rate limits retryable", () => {
+    expect(
+      getRetryable(
+        wrapAnthropicClientError({
+          status: 429,
+          message: "rate limit exceeded",
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("leaves server errors unclassified so they still retry", () => {
+    expect(
+      getRetryable(
+        wrapAnthropicClientError({ status: 500, message: "internal error" })
+      )
+    ).toBeUndefined();
+  });
+
+  test("marks the original error in place without replacing it", () => {
+    class APIError extends Error {
+      status = 401;
+    }
+    const original = new APIError("invalid x-api-key");
+    const wrapped = wrapAnthropicClientError(original);
+
+    expect(wrapped).toBe(original);
+    expect(wrapped).toBeInstanceOf(APIError);
+    expect(getRetryable(wrapped)).toBe(false);
+  });
+
+  test("marking adds no enumerable property", () => {
+    const raw = { status: 429, message: "rate limit exceeded" };
+    const before = Object.keys(raw);
+    const wrapped = wrapAnthropicClientError(raw);
+
+    expect(getRetryable(wrapped)).toBe(true);
+    expect(Object.keys(wrapped)).toEqual([...before, "lc_error_code"]);
+  });
+
+  test("preserves the legacy CONTEXT_OVERFLOW code alongside the mark", () => {
+    const wrapped = wrapAnthropicClientError({
+      status: 400,
+      message: "prompt is too long: 209752 tokens > 200000 maximum",
+    });
+
+    expect(wrapped.lc_error_code).toBe("CONTEXT_OVERFLOW");
+    expect(getRetryable(wrapped)).toBe(false);
   });
 });

--- a/libs/providers/langchain-fireworks/package.json
+++ b/libs/providers/langchain-fireworks/package.json
@@ -28,7 +28,7 @@
     "@langchain/openai": "workspace:*"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0"
+    "@langchain/core": "workspace:^"
   },
   "devDependencies": {
     "@langchain/core": "workspace:^",

--- a/libs/providers/langchain-fireworks/src/chat_models.ts
+++ b/libs/providers/langchain-fireworks/src/chat_models.ts
@@ -11,7 +11,6 @@ import {
   type OpenAIClient,
   type OpenAICoreRequestOptions,
 } from "@langchain/openai";
-import { wrapFireworksModelError } from "./utils/errors.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_FIREWORKS_CHAT_MODEL =
@@ -185,11 +184,7 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
     delete request.logit_bias;
     delete request.functions;
 
-    try {
-      return await super.completionWithRetry(request, options);
-    } catch (e) {
-      throw wrapFireworksModelError(e);
-    }
+    return super.completionWithRetry(request, options);
   }
 
   protected override get streamEventProvider(): string {

--- a/libs/providers/langchain-fireworks/src/chat_models.ts
+++ b/libs/providers/langchain-fireworks/src/chat_models.ts
@@ -11,6 +11,7 @@ import {
   type OpenAIClient,
   type OpenAICoreRequestOptions,
 } from "@langchain/openai";
+import { wrapFireworksModelError } from "./utils/errors.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_FIREWORKS_CHAT_MODEL =
@@ -184,7 +185,11 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
     delete request.logit_bias;
     delete request.functions;
 
-    return super.completionWithRetry(request, options);
+    try {
+      return await super.completionWithRetry(request, options);
+    } catch (e) {
+      throw wrapFireworksModelError(e);
+    }
   }
 
   protected override get streamEventProvider(): string {

--- a/libs/providers/langchain-fireworks/src/chat_models.ts
+++ b/libs/providers/langchain-fireworks/src/chat_models.ts
@@ -162,19 +162,22 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<OpenAIClient.Chat.Completions.ChatCompletion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
       | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<
     | AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
     | OpenAIClient.Chat.Completions.ChatCompletion
@@ -184,7 +187,7 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
     delete request.logit_bias;
     delete request.functions;
 
-    return super.completionWithRetry(request, options);
+    return super.completionWithRetry(request, options, callerMaxRetries);
   }
 
   protected override get streamEventProvider(): string {

--- a/libs/providers/langchain-fireworks/src/chat_models.ts
+++ b/libs/providers/langchain-fireworks/src/chat_models.ts
@@ -162,22 +162,19 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<OpenAIClient.Chat.Completions.ChatCompletion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
       | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<
     | AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
     | OpenAIClient.Chat.Completions.ChatCompletion
@@ -187,7 +184,7 @@ export class ChatFireworks extends ChatOpenAICompletions<ChatFireworksCallOption
     delete request.logit_bias;
     delete request.functions;
 
-    return super.completionWithRetry(request, options, callerMaxRetries);
+    return super.completionWithRetry(request, options);
   }
 
   protected override get streamEventProvider(): string {

--- a/libs/providers/langchain-fireworks/src/embeddings.ts
+++ b/libs/providers/langchain-fireworks/src/embeddings.ts
@@ -1,6 +1,7 @@
 import { type EmbeddingsParams, Embeddings } from "@langchain/core/embeddings";
 import { chunkArray } from "@langchain/core/utils/chunk_array";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { createFireworksResponseError } from "./utils/errors.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_FIREWORKS_EMBEDDING_MODEL = "nomic-ai/nomic-embed-text-v1.5";
@@ -161,8 +162,9 @@ export class FireworksEmbeddings
 
       if (!response.ok) {
         const body = (await response.json()) as { error?: string };
-        throw new Error(
-          `Error ${response.status}: ${body.error ?? "Unspecified error"}`
+        throw createFireworksResponseError(
+          response.status,
+          body.error ?? "Unspecified error"
         );
       }
 

--- a/libs/providers/langchain-fireworks/src/llms.ts
+++ b/libs/providers/langchain-fireworks/src/llms.ts
@@ -140,22 +140,19 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIClient.Completion>>;
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<OpenAIClient.Completions.Completion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.CompletionCreateParamsStreaming
       | OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<
     AsyncIterable<OpenAIClient.Completion> | OpenAIClient.Completions.Completion
   > {
@@ -177,6 +174,6 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
     delete request.best_of;
     delete request.logit_bias;
 
-    return super.completionWithRetry(request, options, callerMaxRetries);
+    return super.completionWithRetry(request, options);
   }
 }

--- a/libs/providers/langchain-fireworks/src/llms.ts
+++ b/libs/providers/langchain-fireworks/src/llms.ts
@@ -7,6 +7,7 @@ import {
   type OpenAICoreRequestOptions,
   type OpenAIInput,
 } from "@langchain/openai";
+import { wrapFireworksModelError } from "./utils/errors.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_FIREWORKS_LLM_MODEL = "accounts/fireworks/models/llama-v2-13b";
@@ -174,6 +175,10 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
     delete request.best_of;
     delete request.logit_bias;
 
-    return super.completionWithRetry(request, options);
+    try {
+      return await super.completionWithRetry(request, options);
+    } catch (e) {
+      throw wrapFireworksModelError(e);
+    }
   }
 }

--- a/libs/providers/langchain-fireworks/src/llms.ts
+++ b/libs/providers/langchain-fireworks/src/llms.ts
@@ -140,19 +140,22 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<AsyncIterable<OpenAIClient.Completion>>;
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<OpenAIClient.Completions.Completion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.CompletionCreateParamsStreaming
       | OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<
     AsyncIterable<OpenAIClient.Completion> | OpenAIClient.Completions.Completion
   > {
@@ -174,6 +177,6 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
     delete request.best_of;
     delete request.logit_bias;
 
-    return super.completionWithRetry(request, options);
+    return super.completionWithRetry(request, options, callerMaxRetries);
   }
 }

--- a/libs/providers/langchain-fireworks/src/llms.ts
+++ b/libs/providers/langchain-fireworks/src/llms.ts
@@ -7,7 +7,6 @@ import {
   type OpenAICoreRequestOptions,
   type OpenAIInput,
 } from "@langchain/openai";
-import { wrapFireworksModelError } from "./utils/errors.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const DEFAULT_FIREWORKS_LLM_MODEL = "accounts/fireworks/models/llama-v2-13b";
@@ -175,10 +174,6 @@ export class Fireworks extends OpenAI<FireworksCallOptions> {
     delete request.best_of;
     delete request.logit_bias;
 
-    try {
-      return await super.completionWithRetry(request, options);
-    } catch (e) {
-      throw wrapFireworksModelError(e);
-    }
+    return super.completionWithRetry(request, options);
   }
 }

--- a/libs/providers/langchain-fireworks/src/tests/embeddings.test.ts
+++ b/libs/providers/langchain-fireworks/src/tests/embeddings.test.ts
@@ -89,3 +89,63 @@ describe("FireworksEmbeddings", () => {
     );
   });
 });
+
+describe("FireworksEmbeddings retryability", () => {
+  test("does not retry a deterministic 413", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({ error: "payload too large" }),
+    } as Response);
+
+    const embeddings = new FireworksEmbeddings({
+      apiKey: "test-api-key",
+      maxRetries: 5,
+    });
+
+    await expect(embeddings.embedQuery("hello world")).rejects.toThrow(
+      "Error 413: payload too large"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry a bad API key", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    } as Response);
+
+    const embeddings = new FireworksEmbeddings({
+      apiKey: "bad-key",
+      maxRetries: 5,
+    });
+
+    await expect(embeddings.embedQuery("hello world")).rejects.toThrow(
+      "Error 401: unauthorized"
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("still retries a transient 503", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: "unavailable" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ embedding: [0.5] }] }),
+      } as Response);
+
+    const embeddings = new FireworksEmbeddings({
+      apiKey: "test-api-key",
+      maxRetries: 3,
+    });
+
+    await expect(embeddings.embedQuery("hello world")).resolves.toEqual([0.5]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/providers/langchain-fireworks/src/utils/errors.ts
+++ b/libs/providers/langchain-fireworks/src/utils/errors.ts
@@ -1,0 +1,48 @@
+import { getRetryable, stampRetryable } from "@langchain/core/errors";
+
+/** Statuses absent here stay unclassified and keep their default retry behavior. */
+const STATUS_RETRYABILITY: Record<number, boolean> = {
+  400: false,
+  401: false,
+  402: false,
+  403: false,
+  404: false,
+  408: true,
+  413: false,
+  429: true,
+  500: true,
+  502: true,
+  503: true,
+  504: true,
+};
+
+function getStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  if ("status" in error && typeof error.status === "number") {
+    return error.status;
+  }
+  if ("statusCode" in error && typeof error.statusCode === "number") {
+    return error.statusCode;
+  }
+  return undefined;
+}
+
+export function wrapFireworksModelError(error: unknown): unknown {
+  if (getRetryable(error) !== undefined) return error;
+
+  const status = getStatus(error);
+  const retryable = status ? STATUS_RETRYABILITY[status] : undefined;
+  return retryable === undefined ? error : stampRetryable(error, retryable);
+}
+
+export function createFireworksResponseError(
+  status: number,
+  detail: string
+): Error {
+  const error = Object.assign(new Error(`Error ${status}: ${detail}`), {
+    status,
+  });
+
+  const retryable = STATUS_RETRYABILITY[status];
+  return retryable === undefined ? error : stampRetryable(error, retryable);
+}

--- a/libs/providers/langchain-fireworks/src/utils/errors.ts
+++ b/libs/providers/langchain-fireworks/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { getRetryable, stampRetryable } from "@langchain/core/errors";
+import { stampRetryable } from "@langchain/core/errors";
 
 /** Statuses absent here stay unclassified and keep their default retry behavior. */
 const STATUS_RETRYABILITY: Record<number, boolean> = {
@@ -15,25 +15,6 @@ const STATUS_RETRYABILITY: Record<number, boolean> = {
   503: true,
   504: true,
 };
-
-function getStatus(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-  if ("status" in error && typeof error.status === "number") {
-    return error.status;
-  }
-  if ("statusCode" in error && typeof error.statusCode === "number") {
-    return error.statusCode;
-  }
-  return undefined;
-}
-
-export function wrapFireworksModelError(error: unknown): unknown {
-  if (getRetryable(error) !== undefined) return error;
-
-  const status = getStatus(error);
-  const retryable = status ? STATUS_RETRYABILITY[status] : undefined;
-  return retryable === undefined ? error : stampRetryable(error, retryable);
-}
 
 export function createFireworksResponseError(
   status: number,

--- a/libs/providers/langchain-fireworks/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-fireworks/src/utils/tests/errors.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { getRetryable, stampRetryable } from "@langchain/core/errors";
+import {
+  createFireworksResponseError,
+  wrapFireworksModelError,
+} from "../errors.js";
+
+describe("createFireworksResponseError", () => {
+  test("exposes the status as a field", () => {
+    const error = createFireworksResponseError(429, "rate limited");
+
+    expect((error as Error & { status: number }).status).toBe(429);
+  });
+
+  test("keeps the original message format", () => {
+    expect(createFireworksResponseError(401, "unauthorized").message).toBe(
+      "Error 401: unauthorized"
+    );
+  });
+
+  test.each([400, 401, 402, 403, 404, 413])(
+    "marks status %i non-retryable",
+    (status) => {
+      expect(getRetryable(createFireworksResponseError(status, "nope"))).toBe(
+        false
+      );
+    }
+  );
+
+  test.each([408, 429, 500, 502, 503, 504])(
+    "marks status %i retryable",
+    (status) => {
+      expect(getRetryable(createFireworksResponseError(status, "later"))).toBe(
+        true
+      );
+    }
+  );
+
+  test("leaves an unmapped status unclassified", () => {
+    expect(
+      getRetryable(createFireworksResponseError(418, "teapot"))
+    ).toBeUndefined();
+  });
+});
+
+describe("wrapFireworksModelError", () => {
+  test.each([402, 413])(
+    "marks Fireworks-specific status %i non-retryable",
+    (status) => {
+      const error = Object.assign(new Error("nope"), { status });
+
+      expect(getRetryable(wrapFireworksModelError(error))).toBe(false);
+    }
+  );
+
+  test("marks a 408 timeout retryable", () => {
+    const error = Object.assign(new Error("timed out"), { status: 408 });
+
+    expect(getRetryable(wrapFireworksModelError(error))).toBe(true);
+  });
+
+  test("does not override an existing mark", () => {
+    const error = stampRetryable(
+      Object.assign(new Error("nope"), { status: 402 }),
+      true
+    );
+
+    expect(getRetryable(wrapFireworksModelError(error))).toBe(true);
+  });
+
+  test("reads statusCode when status is absent", () => {
+    const error = Object.assign(new Error("nope"), { statusCode: 413 });
+
+    expect(getRetryable(wrapFireworksModelError(error))).toBe(false);
+  });
+
+  test("passes through errors with no status", () => {
+    const error = new Error("who knows");
+
+    expect(wrapFireworksModelError(error)).toBe(error);
+    expect(getRetryable(error)).toBeUndefined();
+  });
+
+  test("passes through non-objects", () => {
+    expect(wrapFireworksModelError(null)).toBeNull();
+    expect(wrapFireworksModelError("boom")).toBe("boom");
+  });
+
+  test("returns the same instance and adds no enumerable property", () => {
+    const error = Object.assign(new Error("nope"), { status: 402 });
+    const wrapped = wrapFireworksModelError(error);
+
+    expect(wrapped).toBe(error);
+    expect(Object.keys(error)).toEqual(["status"]);
+  });
+});

--- a/libs/providers/langchain-fireworks/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-fireworks/src/utils/tests/errors.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { getRetryable, stampRetryable } from "@langchain/core/errors";
-import {
-  createFireworksResponseError,
-  wrapFireworksModelError,
-} from "../errors.js";
+import { getRetryable } from "@langchain/core/errors";
+import { createFireworksResponseError } from "../errors.js";
 
 describe("createFireworksResponseError", () => {
   test("exposes the status as a field", () => {
@@ -40,57 +37,5 @@ describe("createFireworksResponseError", () => {
     expect(
       getRetryable(createFireworksResponseError(418, "teapot"))
     ).toBeUndefined();
-  });
-});
-
-describe("wrapFireworksModelError", () => {
-  test.each([402, 413])(
-    "marks Fireworks-specific status %i non-retryable",
-    (status) => {
-      const error = Object.assign(new Error("nope"), { status });
-
-      expect(getRetryable(wrapFireworksModelError(error))).toBe(false);
-    }
-  );
-
-  test("marks a 408 timeout retryable", () => {
-    const error = Object.assign(new Error("timed out"), { status: 408 });
-
-    expect(getRetryable(wrapFireworksModelError(error))).toBe(true);
-  });
-
-  test("does not override an existing mark", () => {
-    const error = stampRetryable(
-      Object.assign(new Error("nope"), { status: 402 }),
-      true
-    );
-
-    expect(getRetryable(wrapFireworksModelError(error))).toBe(true);
-  });
-
-  test("reads statusCode when status is absent", () => {
-    const error = Object.assign(new Error("nope"), { statusCode: 413 });
-
-    expect(getRetryable(wrapFireworksModelError(error))).toBe(false);
-  });
-
-  test("passes through errors with no status", () => {
-    const error = new Error("who knows");
-
-    expect(wrapFireworksModelError(error)).toBe(error);
-    expect(getRetryable(error)).toBeUndefined();
-  });
-
-  test("passes through non-objects", () => {
-    expect(wrapFireworksModelError(null)).toBeNull();
-    expect(wrapFireworksModelError("boom")).toBe("boom");
-  });
-
-  test("returns the same instance and adds no enumerable property", () => {
-    const error = Object.assign(new Error("nope"), { status: 402 });
-    const wrapped = wrapFireworksModelError(error);
-
-    expect(wrapped).toBe(error);
-    expect(Object.keys(error)).toEqual(["status"]);
   });
 });

--- a/libs/providers/langchain-google/package.json
+++ b/libs/providers/langchain-google/package.json
@@ -35,7 +35,7 @@
     "jose": "^6.2.4"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.0.0"
+    "@langchain/core": "workspace:^"
   },
   "devDependencies": {
     "@langchain/core": "workspace:^",

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -481,7 +481,7 @@ export abstract class BaseChatGoogle<
     let response: Response;
     try {
       response = await this.caller.callWithOptions(
-        { signal: options.signal },
+        { signal: options.signal, maxRetries: options.maxRetries },
         async () => {
           const nextResponse = await this.apiClient.fetch(
             new Request(url, {
@@ -672,7 +672,7 @@ export abstract class BaseChatGoogle<
     let response: Response;
     try {
       response = await this.caller.callWithOptions(
-        { signal: options.signal },
+        { signal: options.signal, maxRetries: options.maxRetries },
         async () => {
           const nextResponse = await this.apiClient.fetch(
             new Request(url, {

--- a/libs/providers/langchain-google/src/utils/errors.ts
+++ b/libs/providers/langchain-google/src/utils/errors.ts
@@ -18,7 +18,6 @@ const RETRYABLE_STATUS_CODES = [
   504, // Gateway Timeout
 ];
 
-/** A missing status code means no response arrived, which we can't call transient. */
 function isRetryableStatus(statusCode?: number): boolean {
   if (!statusCode) return false;
   return RETRYABLE_STATUS_CODES.includes(statusCode);
@@ -88,7 +87,6 @@ export class ConfigurationError extends ns.brand(GoogleError, "configuration") {
 
   constructor(message?: string) {
     super(message);
-    // Invalid setup fails the same way until the configuration itself changes.
     stampRetryable(this, false);
   }
 }
@@ -171,7 +169,6 @@ export class PromptBlockedError extends ns.brand(
     super(message);
     this.blockReason = params.blockReason;
     this.safetyRatings = params.safetyRatings;
-    // The same prompt gets the same safety verdict on every attempt.
     stampRetryable(this, false);
   }
 
@@ -306,7 +303,6 @@ export class AuthError extends ns.brand(GoogleError, "auth") {
     this.statusText = params.statusText;
     this.headers = params.headers;
     this.data = params.data;
-    // A bad credential is permanent, but the auth endpoint itself can fail transiently.
     stampRetryable(this, isRetryableStatus(this.statusCode));
   }
 
@@ -622,7 +618,6 @@ export class InvalidToolError extends ns.brand(GoogleError, "invalid-tool") {
 
     super(message ?? defaultMessage);
     this.tool = tool;
-    // A malformed tool definition is a caller-side mistake, not a transient failure.
     stampRetryable(this, false);
   }
 }
@@ -666,7 +661,6 @@ export class ToolCallNotFoundError extends ns.brand(
 
     super(message ?? defaultMessage);
     this.toolCallId = toolCallId;
-    // The referenced tool call won't appear in history by retrying.
     stampRetryable(this, false);
   }
 }
@@ -754,7 +748,6 @@ export class InvalidInputError extends ns.brand(GoogleError, "invalid-input") {
 
   constructor(message?: string) {
     super(message);
-    // The same invalid input is rejected identically every time.
     stampRetryable(this, false);
   }
 }

--- a/libs/providers/langchain-google/src/utils/errors.ts
+++ b/libs/providers/langchain-google/src/utils/errors.ts
@@ -1,9 +1,28 @@
-import { ns as baseNs, LangChainError } from "@langchain/core/errors";
+import {
+  ns as baseNs,
+  LangChainError,
+  stampRetryable,
+} from "@langchain/core/errors";
 import type { Gemini } from "../chat_models/types.js";
 import { iife } from "./misc.js";
 
 // Internal namespace for all Google provider errors
 const ns = baseNs.sub("google");
+
+const RETRYABLE_STATUS_CODES = [
+  408, // Request Timeout
+  429, // Too Many Requests
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+];
+
+/** A missing status code means no response arrived, which we can't call transient. */
+function isRetryableStatus(statusCode?: number): boolean {
+  if (!statusCode) return false;
+  return RETRYABLE_STATUS_CODES.includes(statusCode);
+}
 
 async function readErrorResponseBody(response: Response): Promise<unknown> {
   return iife(async () => {
@@ -66,6 +85,12 @@ export class GoogleError extends ns.brand(LangChainError) {
  */
 export class ConfigurationError extends ns.brand(GoogleError, "configuration") {
   readonly name = "ConfigurationError";
+
+  constructor(message?: string) {
+    super(message);
+    // Invalid setup fails the same way until the configuration itself changes.
+    stampRetryable(this, false);
+  }
 }
 
 /**
@@ -146,6 +171,8 @@ export class PromptBlockedError extends ns.brand(
     super(message);
     this.blockReason = params.blockReason;
     this.safetyRatings = params.safetyRatings;
+    // The same prompt gets the same safety verdict on every attempt.
+    stampRetryable(this, false);
   }
 
   /**
@@ -279,6 +306,8 @@ export class AuthError extends ns.brand(GoogleError, "auth") {
     this.statusText = params.statusText;
     this.headers = params.headers;
     this.data = params.data;
+    // A bad credential is permanent, but the auth endpoint itself can fail transiently.
+    stampRetryable(this, isRetryableStatus(this.statusCode));
   }
 
   /**
@@ -332,15 +361,6 @@ export class AuthError extends ns.brand(GoogleError, "auth") {
     });
   }
 }
-
-const RETRYABLE_STATUS_CODES = [
-  408, // Request Timeout
-  429, // Too Many Requests
-  500, // Internal Server Error
-  502, // Bad Gateway
-  503, // Service Unavailable
-  504, // Gateway Timeout
-];
 
 /**
  * Parameters for constructing a RequestError
@@ -455,6 +475,7 @@ export class RequestError extends ns.brand(GoogleError, "request") {
     this.statusText = params.statusText;
     this.headers = params.headers;
     this.data = params.data;
+    stampRetryable(this, this.isRetryable());
   }
 
   /**
@@ -480,8 +501,7 @@ export class RequestError extends ns.brand(GoogleError, "request") {
    * ```
    */
   isRetryable(): boolean {
-    if (!this.statusCode) return false;
-    return RETRYABLE_STATUS_CODES.includes(this.statusCode);
+    return isRetryableStatus(this.statusCode);
   }
 
   /**
@@ -602,6 +622,8 @@ export class InvalidToolError extends ns.brand(GoogleError, "invalid-tool") {
 
     super(message ?? defaultMessage);
     this.tool = tool;
+    // A malformed tool definition is a caller-side mistake, not a transient failure.
+    stampRetryable(this, false);
   }
 }
 
@@ -644,6 +666,8 @@ export class ToolCallNotFoundError extends ns.brand(
 
     super(message ?? defaultMessage);
     this.toolCallId = toolCallId;
+    // The referenced tool call won't appear in history by retrying.
+    stampRetryable(this, false);
   }
 }
 
@@ -727,4 +751,10 @@ export class MalformedOutputError extends ns.brand(
  */
 export class InvalidInputError extends ns.brand(GoogleError, "invalid-input") {
   readonly name = "InvalidInputError";
+
+  constructor(message?: string) {
+    super(message);
+    // The same invalid input is rejected identically every time.
+    stampRetryable(this, false);
+  }
 }

--- a/libs/providers/langchain-google/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-google/src/utils/tests/errors.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "vitest";
-import { AuthError, RequestError } from "../errors.js";
+import { getRetryable } from "@langchain/core/errors";
+import {
+  AuthError,
+  ConfigurationError,
+  InvalidInputError,
+  InvalidToolError,
+  MalformedOutputError,
+  NoCandidatesError,
+  PromptBlockedError,
+  RequestError,
+  ToolCallNotFoundError,
+} from "../errors.js";
 
 describe("RequestError.fromResponse", () => {
   test("parses JSON error bodies from text/event-stream responses", async () => {
@@ -67,5 +78,85 @@ describe("AuthError.fromResponse", () => {
     expect(error.data).toEqual({
       error_description: "Service account token exchange failed",
     });
+  });
+});
+
+describe("retryability classification", () => {
+  test.each([408, 429, 500, 502, 503, 504])(
+    "marks RequestError %i retryable",
+    (statusCode) => {
+      const error = new RequestError({
+        message: "boom",
+        url: "https://example.com",
+        statusCode,
+      });
+
+      expect(error.isRetryable()).toBe(true);
+      expect(getRetryable(error)).toBe(true);
+    }
+  );
+
+  test.each([400, 401, 403, 404, 413])(
+    "marks RequestError %i non-retryable",
+    (statusCode) => {
+      const error = new RequestError({
+        message: "boom",
+        url: "https://example.com",
+        statusCode,
+      });
+
+      expect(error.isRetryable()).toBe(false);
+      expect(getRetryable(error)).toBe(false);
+    }
+  );
+
+  test("marks a statusless RequestError non-retryable", () => {
+    const error = new RequestError({
+      message: "boom",
+      url: "https://example.com",
+    });
+
+    expect(getRetryable(error)).toBe(false);
+  });
+
+  test("marks AuthError from a bad credential non-retryable", () => {
+    expect(
+      getRetryable(new AuthError({ message: "bad key", statusCode: 401 }))
+    ).toBe(false);
+  });
+
+  test("marks AuthError from a transient auth failure retryable", () => {
+    expect(
+      getRetryable(new AuthError({ message: "auth down", statusCode: 503 }))
+    ).toBe(true);
+  });
+
+  test("marks deterministic Google errors non-retryable", () => {
+    expect(getRetryable(new ConfigurationError("bad config"))).toBe(false);
+    expect(getRetryable(new InvalidInputError("bad input"))).toBe(false);
+    expect(getRetryable(new InvalidToolError({ nope: true }))).toBe(false);
+    expect(getRetryable(new ToolCallNotFoundError("call_1"))).toBe(false);
+    expect(
+      getRetryable(new PromptBlockedError({ blockReason: "SAFETY" }))
+    ).toBe(false);
+  });
+
+  test("leaves ambiguous Google errors unclassified", () => {
+    expect(getRetryable(new NoCandidatesError())).toBeUndefined();
+    expect(
+      getRetryable(new MalformedOutputError({ message: "bad json" }))
+    ).toBeUndefined();
+  });
+
+  test("preserves the error class when marking", () => {
+    const error = new RequestError({
+      message: "boom",
+      url: "https://example.com",
+      statusCode: 429,
+    });
+
+    expect(RequestError.isInstance(error)).toBe(true);
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.keys(error)).not.toContain("isRetryable");
   });
 });

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -228,7 +228,8 @@ export class ChatOpenAICompletions<
         {
           signal: options?.signal,
           ...options?.options,
-        }
+        },
+        options?.maxRetries
       );
 
       const {
@@ -346,7 +347,11 @@ export class ChatOpenAICompletions<
       stream: true as const,
     };
 
-    const streamIterable = await this.completionWithRetry(params, options);
+    const streamIterable = await this.completionWithRetry(
+      params,
+      options,
+      options.maxRetries
+    );
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
 
     const abortableStream = async function* (
@@ -395,7 +400,11 @@ export class ChatOpenAICompletions<
     };
     let defaultRole: OpenAIClient.Chat.ChatCompletionRole | undefined;
 
-    const streamIterable = await this.completionWithRetry(params, options);
+    const streamIterable = await this.completionWithRetry(
+      params,
+      options,
+      options.maxRetries
+    );
     let usage: OpenAIClient.Completions.CompletionUsage | undefined;
     for await (const data of streamIterable) {
       if (options.signal?.aborted) {
@@ -511,17 +520,20 @@ export class ChatOpenAICompletions<
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<OpenAIClient.Chat.Completions.ChatCompletion>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParams,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<
     | AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
     | OpenAIClient.Chat.Completions.ChatCompletion
@@ -529,24 +541,27 @@ export class ChatOpenAICompletions<
     const clientOptions = this._getClientOptions(requestOptions);
     const isParseableFormat =
       request.response_format && request.response_format.type === "json_schema";
-    return this.caller.call(async () => {
-      try {
-        if (isParseableFormat && !request.stream) {
-          return await this.client.chat.completions.parse(
-            request,
-            clientOptions
-          );
-        } else {
-          return await this.client.chat.completions.create(
-            request,
-            clientOptions
-          );
+    return this.caller.callWithOptions(
+      { maxRetries: callerMaxRetries },
+      async () => {
+        try {
+          if (isParseableFormat && !request.stream) {
+            return await this.client.chat.completions.parse(
+              request,
+              clientOptions
+            );
+          } else {
+            return await this.client.chat.completions.create(
+              request,
+              clientOptions
+            );
+          }
+        } catch (e) {
+          const error = wrapOpenAIClientError(e);
+          throw error;
         }
-      } catch (e) {
-        const error = wrapOpenAIClientError(e);
-        throw error;
       }
-    });
+    );
   }
 
   /**

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -227,9 +227,9 @@ export class ChatOpenAICompletions<
         },
         {
           signal: options?.signal,
+          maxRetries: options?.maxRetries,
           ...options?.options,
-        },
-        options?.maxRetries
+        }
       );
 
       const {
@@ -347,11 +347,7 @@ export class ChatOpenAICompletions<
       stream: true as const,
     };
 
-    const streamIterable = await this.completionWithRetry(
-      params,
-      options,
-      options.maxRetries
-    );
+    const streamIterable = await this.completionWithRetry(params, options);
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
 
     const abortableStream = async function* (
@@ -400,11 +396,7 @@ export class ChatOpenAICompletions<
     };
     let defaultRole: OpenAIClient.Chat.ChatCompletionRole | undefined;
 
-    const streamIterable = await this.completionWithRetry(
-      params,
-      options,
-      options.maxRetries
-    );
+    const streamIterable = await this.completionWithRetry(params, options);
     let usage: OpenAIClient.Completions.CompletionUsage | undefined;
     for await (const data of streamIterable) {
       if (options.signal?.aborted) {
@@ -520,48 +512,45 @@ export class ChatOpenAICompletions<
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<OpenAIClient.Chat.Completions.ChatCompletion>;
 
   async completionWithRetry(
     request: OpenAIClient.Chat.ChatCompletionCreateParams,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<
     | AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
     | OpenAIClient.Chat.Completions.ChatCompletion
   > {
-    const clientOptions = this._getClientOptions(requestOptions);
+    // The SDK has its own `maxRetries`; take it for our caller instead so
+    // the two retry loops don't multiply.
+    const { maxRetries, ...sdkOptions } = requestOptions ?? {};
+    const clientOptions = this._getClientOptions(sdkOptions);
     const isParseableFormat =
       request.response_format && request.response_format.type === "json_schema";
-    return this.caller.callWithOptions(
-      { maxRetries: callerMaxRetries },
-      async () => {
-        try {
-          if (isParseableFormat && !request.stream) {
-            return await this.client.chat.completions.parse(
-              request,
-              clientOptions
-            );
-          } else {
-            return await this.client.chat.completions.create(
-              request,
-              clientOptions
-            );
-          }
-        } catch (e) {
-          const error = wrapOpenAIClientError(e);
-          throw error;
+    return this.caller.callWithOptions({ maxRetries }, async () => {
+      try {
+        if (isParseableFormat && !request.stream) {
+          return await this.client.chat.completions.parse(
+            request,
+            clientOptions
+          );
+        } else {
+          return await this.client.chat.completions.create(
+            request,
+            clientOptions
+          );
         }
+      } catch (e) {
+        const error = wrapOpenAIClientError(e);
+        throw error;
       }
-    );
+    });
   }
 
   /**

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -208,7 +208,8 @@ export class ChatOpenAIResponses<
           ...invocationParams,
           stream: false,
         },
-        { signal: options?.signal, ...options?.options }
+        { signal: options?.signal, ...options?.options },
+        options?.maxRetries
       );
 
       return {
@@ -247,7 +248,8 @@ export class ChatOpenAIResponses<
         }),
         stream: true,
       },
-      options
+      options,
+      options.maxRetries
     );
 
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
@@ -293,7 +295,8 @@ export class ChatOpenAIResponses<
         }),
         stream: true,
       },
-      options
+      options,
+      options.maxRetries
     );
 
     try {
@@ -330,34 +333,40 @@ export class ChatOpenAIResponses<
    */
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
 
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<OpenAIClient.Responses.Response>;
 
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParams,
-    requestOptions?: OpenAIClient.RequestOptions
+    requestOptions?: OpenAIClient.RequestOptions,
+    callerMaxRetries?: number
   ): Promise<
     | AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>
     | OpenAIClient.Responses.Response
   > {
-    return this.caller.call(async () => {
-      const clientOptions = this._getClientOptions(requestOptions);
-      try {
-        // use parse if dealing with json_schema
-        if (request.text?.format?.type === "json_schema" && !request.stream) {
-          return await this.client.responses.parse(request, clientOptions);
+    return this.caller.callWithOptions(
+      { maxRetries: callerMaxRetries },
+      async () => {
+        const clientOptions = this._getClientOptions(requestOptions);
+        try {
+          // use parse if dealing with json_schema
+          if (request.text?.format?.type === "json_schema" && !request.stream) {
+            return await this.client.responses.parse(request, clientOptions);
+          }
+          return await this.client.responses.create(request, clientOptions);
+        } catch (e) {
+          const error = wrapOpenAIClientError(e);
+          throw error;
         }
-        return await this.client.responses.create(request, clientOptions);
-      } catch (e) {
-        const error = wrapOpenAIClientError(e);
-        throw error;
       }
-    });
+    );
   }
 
   /** @internal */

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -208,8 +208,11 @@ export class ChatOpenAIResponses<
           ...invocationParams,
           stream: false,
         },
-        { signal: options?.signal, ...options?.options },
-        options?.maxRetries
+        {
+          signal: options?.signal,
+          maxRetries: options?.maxRetries,
+          ...options?.options,
+        }
       );
 
       return {
@@ -248,8 +251,7 @@ export class ChatOpenAIResponses<
         }),
         stream: true,
       },
-      options,
-      options.maxRetries
+      options
     );
 
     const shouldStreamUsage = this.streamUsage ?? options.streamUsage;
@@ -295,8 +297,7 @@ export class ChatOpenAIResponses<
         }),
         stream: true,
       },
-      options,
-      options.maxRetries
+      options
     );
 
     try {
@@ -333,40 +334,37 @@ export class ChatOpenAIResponses<
    */
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
 
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<OpenAIClient.Responses.Response>;
 
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParams,
-    requestOptions?: OpenAIClient.RequestOptions,
-    callerMaxRetries?: number
+    requestOptions?: OpenAIClient.RequestOptions
   ): Promise<
     | AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>
     | OpenAIClient.Responses.Response
   > {
-    return this.caller.callWithOptions(
-      { maxRetries: callerMaxRetries },
-      async () => {
-        const clientOptions = this._getClientOptions(requestOptions);
-        try {
-          // use parse if dealing with json_schema
-          if (request.text?.format?.type === "json_schema" && !request.stream) {
-            return await this.client.responses.parse(request, clientOptions);
-          }
-          return await this.client.responses.create(request, clientOptions);
-        } catch (e) {
-          const error = wrapOpenAIClientError(e);
-          throw error;
+    // The SDK has its own `maxRetries`; take it for our caller instead so
+    // the two retry loops don't multiply.
+    const { maxRetries, ...sdkOptions } = requestOptions ?? {};
+    const clientOptions = this._getClientOptions(sdkOptions);
+    return this.caller.callWithOptions({ maxRetries }, async () => {
+      try {
+        // use parse if dealing with json_schema
+        if (request.text?.format?.type === "json_schema" && !request.stream) {
+          return await this.client.responses.parse(request, clientOptions);
         }
+        return await this.client.responses.create(request, clientOptions);
+      } catch (e) {
+        const error = wrapOpenAIClientError(e);
+        throw error;
       }
-    );
+    });
   }
 
   /** @internal */

--- a/libs/providers/langchain-openai/src/llms.ts
+++ b/libs/providers/langchain-openai/src/llms.ts
@@ -299,7 +299,8 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
                 stream: true,
                 prompt: subPrompts[i],
               },
-              options
+              options,
+              options.maxRetries
             );
             for await (const message of stream) {
               // on the first message set the response properties
@@ -343,7 +344,8 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
             {
               signal: options.signal,
               ...options.options,
-            }
+            },
+            options.maxRetries
           );
 
       choices.push(...data.choices);
@@ -399,7 +401,11 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
       prompt: input,
       stream: true as const,
     };
-    const stream = await this.completionWithRetry(params, options);
+    const stream = await this.completionWithRetry(
+      params,
+      options,
+      options.maxRetries
+    );
     for await (const data of stream) {
       const choice = data?.choices[0];
       if (!choice) {
@@ -424,39 +430,46 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
    * Calls the OpenAI API with retry logic in case of failures.
    * @param request The request to send to the OpenAI API.
    * @param options Optional configuration for the API call.
+   * @param callerMaxRetries Optional per-call retry limit for LangChain's caller, not the OpenAI SDK's.
    * @returns The response from the OpenAI API.
    */
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<AsyncIterable<OpenAIClient.Completion>>;
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<OpenAIClient.Completions.Completion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.CompletionCreateParamsStreaming
       | OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions
+    options?: OpenAICoreRequestOptions,
+    callerMaxRetries?: number
   ): Promise<
     AsyncIterable<OpenAIClient.Completion> | OpenAIClient.Completions.Completion
   > {
     const requestOptions = this._getClientOptions(options);
-    return this.caller.call(async () => {
-      try {
-        const res = await this.client.completions.create(
-          request,
-          requestOptions
-        );
-        return res;
-      } catch (e) {
-        const error = wrapOpenAIClientError(e);
-        throw error;
+    return this.caller.callWithOptions(
+      { maxRetries: callerMaxRetries },
+      async () => {
+        try {
+          const res = await this.client.completions.create(
+            request,
+            requestOptions
+          );
+          return res;
+        } catch (e) {
+          const error = wrapOpenAIClientError(e);
+          throw error;
+        }
       }
-    });
+    );
   }
 
   /**

--- a/libs/providers/langchain-openai/src/llms.ts
+++ b/libs/providers/langchain-openai/src/llms.ts
@@ -299,8 +299,7 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
                 stream: true,
                 prompt: subPrompts[i],
               },
-              options,
-              options.maxRetries
+              options
             );
             for await (const message of stream) {
               // on the first message set the response properties
@@ -343,9 +342,9 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
             },
             {
               signal: options.signal,
+              maxRetries: options.maxRetries,
               ...options.options,
-            },
-            options.maxRetries
+            }
           );
 
       choices.push(...data.choices);
@@ -401,11 +400,7 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
       prompt: input,
       stream: true as const,
     };
-    const stream = await this.completionWithRetry(
-      params,
-      options,
-      options.maxRetries
-    );
+    const stream = await this.completionWithRetry(params, options);
     for await (const data of stream) {
       const choice = data?.choices[0];
       if (!choice) {
@@ -430,46 +425,42 @@ export class OpenAI<CallOptions extends OpenAICallOptions = OpenAICallOptions>
    * Calls the OpenAI API with retry logic in case of failures.
    * @param request The request to send to the OpenAI API.
    * @param options Optional configuration for the API call.
-   * @param callerMaxRetries Optional per-call retry limit for LangChain's caller, not the OpenAI SDK's.
    * @returns The response from the OpenAI API.
    */
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIClient.Completion>>;
 
   async completionWithRetry(
     request: OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<OpenAIClient.Completions.Completion>;
 
   async completionWithRetry(
     request:
       | OpenAIClient.CompletionCreateParamsStreaming
       | OpenAIClient.CompletionCreateParamsNonStreaming,
-    options?: OpenAICoreRequestOptions,
-    callerMaxRetries?: number
+    options?: OpenAICoreRequestOptions
   ): Promise<
     AsyncIterable<OpenAIClient.Completion> | OpenAIClient.Completions.Completion
   > {
-    const requestOptions = this._getClientOptions(options);
-    return this.caller.callWithOptions(
-      { maxRetries: callerMaxRetries },
-      async () => {
-        try {
-          const res = await this.client.completions.create(
-            request,
-            requestOptions
-          );
-          return res;
-        } catch (e) {
-          const error = wrapOpenAIClientError(e);
-          throw error;
-        }
+    // The SDK has its own `maxRetries`; take it for our caller instead so
+    // the two retry loops don't multiply.
+    const { maxRetries, ...sdkOptions } = options ?? {};
+    const requestOptions = this._getClientOptions(sdkOptions);
+    return this.caller.callWithOptions({ maxRetries }, async () => {
+      try {
+        const res = await this.client.completions.create(
+          request,
+          requestOptions
+        );
+        return res;
+      } catch (e) {
+        const error = wrapOpenAIClientError(e);
+        throw error;
       }
-    );
+    });
   }
 
   /**

--- a/libs/providers/langchain-openai/src/utils/client.ts
+++ b/libs/providers/langchain-openai/src/utils/client.ts
@@ -1,5 +1,5 @@
 import { APIConnectionTimeoutError, APIUserAbortError } from "openai";
-import { ContextOverflowError } from "@langchain/core/errors";
+import { ContextOverflowError, stampRetryable } from "@langchain/core/errors";
 import { addLangChainErrorFields } from "./errors.js";
 
 function _isOpenAIContextOverflowError(e: object): boolean {
@@ -32,6 +32,8 @@ export function wrapOpenAIClientError(e: unknown) {
   ) {
     error = new Error(e.message);
     error.name = "TimeoutError";
+    // This branch discards the original status, so AsyncCaller can't classify it.
+    stampRetryable(error, true);
   } else if (
     e.constructor.name === APIUserAbortError.name &&
     "message" in e &&
@@ -39,7 +41,9 @@ export function wrapOpenAIClientError(e: unknown) {
   ) {
     error = new Error(e.message);
     error.name = "AbortError";
+    stampRetryable(error, false);
   } else if (_isOpenAIContextOverflowError(e)) {
+    // ContextOverflowError marks itself non-retryable at construction.
     error = ContextOverflowError.fromError(e as Error);
   } else if (
     "status" in e &&
@@ -48,13 +52,26 @@ export function wrapOpenAIClientError(e: unknown) {
     typeof e.message === "string" &&
     e.message.includes("tool_calls")
   ) {
-    error = addLangChainErrorFields(e, "INVALID_TOOL_RESULTS");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "INVALID_TOOL_RESULTS"),
+      false
+    );
   } else if ("status" in e && e.status === 401) {
-    error = addLangChainErrorFields(e, "MODEL_AUTHENTICATION");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_AUTHENTICATION"),
+      false
+    );
   } else if ("status" in e && e.status === 429) {
-    error = addLangChainErrorFields(e, "MODEL_RATE_LIMIT");
+    // AsyncCaller runs after this and re-marks false if it's quota exhaustion.
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_RATE_LIMIT"),
+      true
+    );
   } else if ("status" in e && e.status === 404) {
-    error = addLangChainErrorFields(e, "MODEL_NOT_FOUND");
+    error = stampRetryable(
+      addLangChainErrorFields(e, "MODEL_NOT_FOUND"),
+      false
+    );
   } else {
     error = e;
   }

--- a/libs/providers/langchain-openai/src/utils/tests/errors.test.ts
+++ b/libs/providers/langchain-openai/src/utils/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "vitest";
-import { ContextOverflowError } from "@langchain/core/errors";
+import { ContextOverflowError, getRetryable } from "@langchain/core/errors";
 import { wrapOpenAIClientError } from "../client.js";
 
 describe("wrapOpenAIClientError", () => {
@@ -159,5 +159,124 @@ describe("wrapOpenAIClientError", () => {
     const wrapped = wrapOpenAIClientError(originalError);
 
     expect(wrapped).toBe(originalError);
+  });
+});
+
+describe("wrapOpenAIClientError retryability", () => {
+  test("marks a connection timeout retryable", () => {
+    const wrapped = wrapOpenAIClientError({
+      message: "Request timed out.",
+      constructor: { name: "APIConnectionTimeoutError" },
+    });
+
+    expect((wrapped as Error).name).toBe("TimeoutError");
+    expect(getRetryable(wrapped)).toBe(true);
+  });
+
+  test("marks a user abort non-retryable", () => {
+    const wrapped = wrapOpenAIClientError({
+      message: "Request was aborted.",
+      constructor: { name: "APIUserAbortError" },
+    });
+
+    expect((wrapped as Error).name).toBe("AbortError");
+    expect(getRetryable(wrapped)).toBe(false);
+  });
+
+  test("marks context overflow non-retryable", () => {
+    const wrapped = wrapOpenAIClientError({
+      status: 400,
+      message: "This model's maximum context length is 8192 tokens",
+      constructor: { name: "BadRequestError" },
+    });
+
+    expect(wrapped).toBeInstanceOf(ContextOverflowError);
+    expect(getRetryable(wrapped)).toBe(false);
+  });
+
+  test("marks invalid tool results non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapOpenAIClientError({
+          status: 400,
+          message: "invalid tool_calls block",
+          constructor: { name: "BadRequestError" },
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("marks authentication failures non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapOpenAIClientError({
+          status: 401,
+          message: "Unauthorized",
+          constructor: { name: "AuthenticationError" },
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("marks a missing model non-retryable", () => {
+    expect(
+      getRetryable(
+        wrapOpenAIClientError({
+          status: 404,
+          message: "Not Found",
+          constructor: { name: "NotFoundError" },
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("marks rate limits retryable", () => {
+    expect(
+      getRetryable(
+        wrapOpenAIClientError({
+          status: 429,
+          message: "Too Many Requests",
+          constructor: { name: "RateLimitError" },
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("leaves server errors unclassified so they still retry", () => {
+    expect(
+      getRetryable(
+        wrapOpenAIClientError({
+          status: 500,
+          message: "Internal Server Error",
+          constructor: { name: "InternalServerError" },
+        })
+      )
+    ).toBeUndefined();
+  });
+
+  test("marks the original error in place without replacing it", () => {
+    class APIError extends Error {
+      status = 401;
+    }
+    const original = new APIError("Unauthorized");
+    const wrapped = wrapOpenAIClientError(original);
+
+    expect(wrapped).toBe(original);
+    expect(wrapped).toBeInstanceOf(APIError);
+    expect(getRetryable(wrapped)).toBe(false);
+    expect(Object.keys(original as object)).not.toContain("isRetryable");
+  });
+
+  test("marking adds no enumerable property", () => {
+    const raw = {
+      status: 429,
+      message: "Too Many Requests",
+      constructor: { name: "RateLimitError" },
+    };
+    const before = Object.keys(raw);
+    const wrapped = wrapOpenAIClientError(raw) as Record<string, unknown>;
+
+    expect(getRetryable(wrapped)).toBe(true);
+    expect(Object.keys(wrapped)).toEqual([...before, "lc_error_code"]);
   });
 });


### PR DESCRIPTION
## Summary

Retry middleware retried every failure up to `maxRetries`, including deterministic ones like a bad API key or an unknown model. This adds a way to mark an error's retryability and has the retry middleware respect it.

`stampRetryable` sets a non-enumerable `Symbol.for("langchain.errors.retryable")` directly on the error, leaving its class and shape intact, so a provider SDK's own error can be classified in place without breaking `instanceof` for consumers. Errors marked non-retryable now fail on the first attempt; unclassified errors retry exactly as before, and an explicit `retryOn` is unaffected.

## Changes

- Add `stampRetryable(error, retryable)` and `getRetryable(error)` to `@langchain/core/errors`. `getRetryable` returns `undefined` for unclassified errors and follows the `.cause` chain, depth-capped against cycles.
- Mark `ModelAbortError` and `ContextOverflowError` non-retryable at construction, and mark what `AsyncCaller` already classifies — `STATUS_NO_RETRY` codes, aborts, and exhausted quota as non-retryable, rate limits as retryable. It previously acted on these internally with no way to communicate the verdict to an outer retry loop.
- Change the default `retryOn` for `modelRetryMiddleware` and `toolRetryMiddleware` to `getRetryable(error) ?? true`.
- Mark provider errors in Google, OpenAI, Anthropic, and Fireworks — one commit each, covering the statuses each dispatcher already recognizes. Google's `RequestError` publishes the verdict from its existing `isRetryable()`.
- Fix `FireworksEmbeddings` throwing a plain `Error` with the HTTP status only inside the message string, hiding it from both the retry middleware and `AsyncCaller`. The status is now a field; message text is unchanged.
- Move the `@langchain/core` peer range to `workspace:^` for `@langchain/google` and `@langchain/fireworks`.
- Document that a custom `onFailedAttempt` replaces the built-in handler and opts out of its marking.
- Add coverage for symbol semantics, cause-chain traversal, per-provider status mapping, and the middleware behavior change end-to-end.
- Add a changeset: minor for `@langchain/core`, `langchain`, `@langchain/google`, and `@langchain/fireworks`; patch for `@langchain/openai` and `@langchain/anthropic`.