### PR TITLE
fix(core,langchain): override instanceof where applicable

### DIFF
--- a/.changeset/witty-deserts-drive.md
+++ b/.changeset/witty-deserts-drive.md
@@ -1,0 +1,8 @@
+---
+"@langchain/core": patch
+"langchain": patch
+---
+
+fix: apply [Symbol.hasInstance] method to all comparable properties using .isInstance()
+
+We have some internal schemas that rely on `z.instanceof()`. This uses a strict `instanceof` check which can conflict if there are multiple versions of core installed. This overrides the [Symbol.hasInstance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) method to use the same logic as `.isInstance()` to compare objects at runtime.

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -259,6 +259,10 @@ export class AIMessage<TStructure extends MessageStructure = MessageStructure>
   ): obj is AIMessage<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
   }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }
 
 /**
@@ -492,5 +496,9 @@ export class AIMessageChunk<
     obj: BaseMessage<T> | unknown
   ): obj is AIMessageChunk<T> {
     return super.isInstance(obj) && (obj as { type: string }).type === "ai";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }

--- a/libs/langchain-core/src/messages/base.ts
+++ b/libs/langchain-core/src/messages/base.ts
@@ -375,6 +375,10 @@ export abstract class BaseMessage<
     );
   }
 
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
+
   // this private method is used to update the ID for the runtime
   // value as well as in lc_kwargs for serialisation
   _updateId(value: string | undefined) {
@@ -716,6 +720,10 @@ export abstract class BaseMessageChunk<
       proto = Object.getPrototypeOf(proto);
     }
     return false;
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }
 

--- a/libs/langchain-core/src/messages/chat.ts
+++ b/libs/langchain-core/src/messages/chat.ts
@@ -58,6 +58,10 @@ export class ChatMessage<TStructure extends MessageStructure = MessageStructure>
     return super.isInstance(obj) && obj.type === "generic";
   }
 
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
+
   override get _printableFields(): Record<string, unknown> {
     return {
       ...super._printableFields,
@@ -121,6 +125,10 @@ export class ChatMessageChunk<
 
   static isInstance(obj: unknown): obj is ChatMessageChunk {
     return super.isInstance(obj) && obj.type === "generic";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 
   override get _printableFields(): Record<string, unknown> {

--- a/libs/langchain-core/src/messages/function.ts
+++ b/libs/langchain-core/src/messages/function.ts
@@ -35,6 +35,14 @@ export class FunctionMessage<
     super(fields);
     this.name = fields.name;
   }
+
+  static isInstance(obj: unknown): obj is FunctionMessage {
+    return super.isInstance(obj) && obj.type === "function";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }
 
 /**
@@ -65,6 +73,14 @@ export class FunctionMessageChunk<
       name: this.name ?? "",
       id: this.id ?? chunk.id,
     });
+  }
+
+  static isInstance(obj: unknown): obj is FunctionMessageChunk {
+    return super.isInstance(obj) && obj.type === "function";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }
 

--- a/libs/langchain-core/src/messages/human.ts
+++ b/libs/langchain-core/src/messages/human.ts
@@ -35,6 +35,10 @@ export class HumanMessage<
   static isInstance(obj: unknown): obj is HumanMessage {
     return super.isInstance(obj) && obj.type === "human";
   }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }
 
 /**
@@ -76,6 +80,10 @@ export class HumanMessageChunk<
 
   static isInstance(obj: unknown): obj is HumanMessageChunk {
     return super.isInstance(obj) && obj.type === "human";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }
 

--- a/libs/langchain-core/src/messages/modifier.ts
+++ b/libs/langchain-core/src/messages/modifier.ts
@@ -45,4 +45,8 @@ export class RemoveMessage extends BaseMessage {
   static isInstance(obj: unknown): obj is RemoveMessage {
     return super.isInstance(obj) && obj.type === "remove";
   }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }

--- a/libs/langchain-core/src/messages/system.ts
+++ b/libs/langchain-core/src/messages/system.ts
@@ -70,6 +70,10 @@ export class SystemMessage<
   static isInstance(obj: unknown): obj is SystemMessage {
     return super.isInstance(obj) && obj.type === "system";
   }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }
 
 /**
@@ -111,6 +115,10 @@ export class SystemMessageChunk<
 
   static isInstance(obj: unknown): obj is SystemMessageChunk {
     return super.isInstance(obj) && obj.type === "system";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }
 

--- a/libs/langchain-core/src/messages/tests/base_message.test.ts
+++ b/libs/langchain-core/src/messages/tests/base_message.test.ts
@@ -2,7 +2,10 @@ import { test, describe, it, expect } from "vitest";
 import { ChatPromptTemplate } from "../../prompts/chat.js";
 import {
   HumanMessage,
+  HumanMessageChunk,
   AIMessage,
+  FunctionMessage,
+  FunctionMessageChunk,
   ToolMessage,
   ToolMessageChunk,
   RemoveMessage,
@@ -19,6 +22,29 @@ import { load } from "../../load/index.js";
 import { concat } from "../../utils/stream.js";
 import { ToolCallChunk } from "../tool.js";
 import type { RawInputToolCallChunk } from "../utils.js";
+
+describe("message type instanceof checks", () => {
+  it("distinguishes FunctionMessage instances", () => {
+    expect(new FunctionMessage({ content: "", name: "test" })).toBeInstanceOf(
+      FunctionMessage
+    );
+    expect(new HumanMessage("")).not.toBeInstanceOf(FunctionMessage);
+  });
+
+  it("distinguishes FunctionMessageChunk instances", () => {
+    expect(
+      new FunctionMessageChunk({ content: "", name: "test" })
+    ).toBeInstanceOf(FunctionMessageChunk);
+    expect(new HumanMessageChunk("")).not.toBeInstanceOf(FunctionMessageChunk);
+  });
+
+  it("distinguishes ToolMessageChunk instances", () => {
+    expect(
+      new ToolMessageChunk({ content: "", tool_call_id: "test" })
+    ).toBeInstanceOf(ToolMessageChunk);
+    expect(new HumanMessageChunk("")).not.toBeInstanceOf(ToolMessageChunk);
+  });
+});
 
 test("Test ChatPromptTemplate can format OpenAI content image messages", async () => {
   const message = new HumanMessage({

--- a/libs/langchain-core/src/messages/tool.ts
+++ b/libs/langchain-core/src/messages/tool.ts
@@ -138,6 +138,10 @@ export class ToolMessage<TStructure extends MessageStructure = MessageStructure>
     );
   }
 
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
+
   override get _printableFields(): Record<string, unknown> {
     return {
       ...super._printableFields,

--- a/libs/langchain-core/src/messages/tool.ts
+++ b/libs/langchain-core/src/messages/tool.ts
@@ -208,6 +208,14 @@ export class ToolMessageChunk<
     });
   }
 
+  static isInstance(obj: unknown): obj is ToolMessageChunk {
+    return super.isInstance(obj) && obj.type === "tool";
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
+
   override get _printableFields(): Record<string, unknown> {
     return {
       ...super._printableFields,

--- a/libs/langchain-core/src/utils/namespace.ts
+++ b/libs/langchain-core/src/utils/namespace.ts
@@ -135,6 +135,10 @@ export function createNamespace(path: string): Namespace {
             (obj as Record<symbol, unknown>)[brandSymbol] === true
           );
         }
+
+        static [Symbol.hasInstance](obj: unknown) {
+          return this.isInstance(obj);
+        }
       }
 
       // Inherit the base class's name so "_Branded" doesn't leak

--- a/libs/langchain/src/agents/errors.ts
+++ b/libs/langchain/src/agents/errors.ts
@@ -82,6 +82,10 @@ export class ToolInvocationError extends Error {
       error["~brand"] === "ToolInvocationError"
     );
   }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
+  }
 }
 
 /**
@@ -134,5 +138,9 @@ export class MiddlewareError extends Error {
       "~brand" in error &&
       error["~brand"] === "MiddlewareError"
     );
+  }
+
+  static [Symbol.hasInstance](obj: unknown) {
+    return this.isInstance(obj);
   }
 }


### PR DESCRIPTION
## Summary

Fixes an inheritance problem with summarization middleware in langchain/deepagents where messages couldn't be checked for proper equality at runtime when multiple versions of core are installed.

Uses [`Symbol.hasInstance`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) which is a sanctioned path for overriding the `instanceof` operator.
