### PR TITLE
fix(aws): preserve Bedrock reasoning signatures in stream events

### DIFF
--- a/.changeset/quiet-trees-reason.md
+++ b/.changeset/quiet-trees-reason.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+Preserve reasoning signatures in Bedrock Converse stream events.

--- a/libs/providers/langchain-aws/src/utils/stream_events.ts
+++ b/libs/providers/langchain-aws/src/utils/stream_events.ts
@@ -96,7 +96,7 @@ export async function* convertBedrockConverseStream(
           },
         };
       } else if (delta.reasoningContent) {
-        const text = delta.reasoningContent.text;
+        const { text, signature } = delta.reasoningContent;
         if (typeof text === "string") {
           if (!blockAccumulators.has(index)) {
             const initial = { type: "reasoning" as const, reasoning: "" };
@@ -113,6 +113,29 @@ export async function* convertBedrockConverseStream(
             event: "content-block-delta" as const,
             index,
             delta: { type: "reasoning-delta" as const, reasoning: text },
+          };
+        } else if (typeof signature === "string") {
+          if (!blockAccumulators.has(index)) {
+            const initial = { type: "reasoning" as const, reasoning: "" };
+            blockAccumulators.set(index, { ...initial });
+            yield {
+              event: "content-block-start" as const,
+              index,
+              content: initial as ContentBlock,
+            };
+          }
+          const acc = blockAccumulators.get(index)!;
+          acc.signature = (acc.signature ?? "") + signature;
+          yield {
+            event: "content-block-delta" as const,
+            index,
+            delta: {
+              type: "block-delta" as const,
+              fields: {
+                type: "reasoning",
+                signature: acc.signature,
+              },
+            },
           };
         }
       }

--- a/libs/providers/langchain-aws/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/stream_events.test.ts
@@ -43,6 +43,44 @@ describe("convertBedrockConverseStream", () => {
     });
   });
 
+  test("preserves reasoning signatures", async () => {
+    const events = await collectEvents([
+      {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { reasoningContent: { text: "Let me check. " } },
+        },
+      },
+      {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { reasoningContent: { signature: "sig-abc-123" } },
+        },
+      },
+    ]);
+
+    expect(
+      events.find(
+        (event) =>
+          event.event === "content-block-delta" &&
+          event.delta.type === "block-delta"
+      )
+    ).toMatchObject({
+      delta: {
+        fields: { type: "reasoning", signature: "sig-abc-123" },
+      },
+    });
+    expect(
+      events.find((event) => event.event === "content-block-finish")
+    ).toMatchObject({
+      content: {
+        type: "reasoning",
+        reasoning: "Let me check. ",
+        signature: "sig-abc-123",
+      },
+    });
+  });
+
   test("usage metadata", async () => {
     const events = await collectEvents([
       {


### PR DESCRIPTION
## Summary

- preserve signature-only Bedrock reasoning deltas in `convertBedrockConverseStream`
- accumulate split signatures on the finalized reasoning block
- add a regression test for a text delta followed by a signature-only delta

Fixes #11341

## Tests

- `git diff origin/main...HEAD --check`
- The targeted Vitest run was attempted, but local dependency installation is currently blocked by the registry not providing `is-interactive@1.0.6`; the cached fallback also lacks this checkout's `dotenv` and workspace package links. No integration credentials were used.