### PR TITLE
fix(core): preserve status on ContextOverflowError

### DIFF
--- a/.changeset/quiet-errors-wait.md
+++ b/.changeset/quiet-errors-wait.md
@@ -1,0 +1,8 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve HTTP status on context overflow errors
+
+`ContextOverflowError.fromError` now keeps the provider error's HTTP status so
+`AsyncCaller` does not retry non-retryable context overflow responses.

--- a/libs/langchain-core/src/errors/index.ts
+++ b/libs/langchain-core/src/errors/index.ts
@@ -152,6 +152,13 @@ export class ContextOverflowError extends ns.brand(
    */
   cause?: Error;
 
+  /**
+   * The HTTP status from the underlying provider error, if one was provided.
+   * Keeping this on the wrapper lets retry handlers classify the error without
+   * needing to know about the original error's shape.
+   */
+  status?: number;
+
   constructor(message?: string) {
     super(message ?? "Input exceeded the model's context window.");
   }
@@ -178,6 +185,12 @@ export class ContextOverflowError extends ns.brand(
   static fromError(obj: Error): ContextOverflowError {
     const error = new ContextOverflowError(obj.message);
     error.cause = obj;
+
+    const status = (obj as Error & { status?: unknown }).status;
+    if (typeof status === "number") {
+      error.status = status;
+    }
+
     return error;
   }
 }

--- a/libs/langchain-core/src/utils/tests/async_caller.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi } from "vitest";
+import { ContextOverflowError } from "../../errors/index.js";
 import {
   AsyncCaller,
   parseRetryAfterMs,
@@ -114,6 +115,20 @@ describe("AsyncCaller", () => {
 
     await expect(() => caller.call(callable)).rejects.toThrow("Bad Request");
     expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("defaultFailedAttemptHandler treats wrapped context overflow errors as non-retryable", async () => {
+    const caller = new AsyncCaller({ maxRetries: 2 });
+
+    const err = Object.assign(new Error("prompt is too long"), { status: 400 });
+    const wrapped = ContextOverflowError.fromError(err);
+    const callable = vi.fn(async () => Promise.reject(wrapped));
+
+    await expect(() => caller.call(callable)).rejects.toThrow(
+      "prompt is too long"
+    );
+    expect(callable).toHaveBeenCalledTimes(1);
+    expect(wrapped.status).toBe(400);
   });
 
   test("defaultFailedAttemptHandler retries on 5xx errors with direct status", async () => {


### PR DESCRIPTION
## Summary

`ContextOverflowError.fromError()` currently keeps the provider exception only in `cause`, which drops its HTTP status before the error reaches `AsyncCaller`. A deterministic context-overflow response can therefore be retried through the full backoff window instead of failing immediately.

This preserves a numeric `status` on the wrapper so the existing non-retryable status handling can classify the error on the first attempt.

Fixes #11339

## Validation

- `@langchain/core` regression test: 29 tests passed with no type errors
- `oxfmt --check`: passed
- `oxlint`: passed
- The full `@langchain/core` suite passed once (99 files, 1472 tests passed, 1 skipped, no type errors). A repeat run later hit an unrelated timeout in `src/utils/tests/math_utils.test.ts`; the changed test remains green.
