### PR TITLE
fix(openai): honour per-call service_tier in the Responses API

### DIFF
--- a/.changeset/olive-pumas-tickle.md
+++ b/.changeset/olive-pumas-tickle.md
@@ -1,0 +1,8 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): honour the per-call `service_tier` in the Responses API
+
+A `service_tier` passed as a call option was silently dropped when `useResponsesApi` was enabled; only
+the value set on the instance reached the request.

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -99,7 +99,7 @@ export class ChatOpenAIResponses<
       temperature: this.temperature,
       top_p: this.topP,
       user: this.user,
-      service_tier: this.service_tier,
+      service_tier: options?.service_tier ?? this.service_tier,
 
       // if include_usage is set or streamUsage then stream must be set to true.
       stream: this.streaming,


### PR DESCRIPTION
`ChatOpenAI` declares `service_tier` as a call option and lists it in `callKeys`, and the Completions
path lets a per-call value override the instance one. The Responses path read it from the instance
only, so `invoke(..., { service_tier })`, `withConfig` and agent `modelSettings` were silently dropped
whenever `useResponsesApi` was enabled — the request went out on the account's default tier.

Fixes #11353 