### PR TITLE
fix(anthropic): preserve gateway cost on the native stream path

### DIFF
--- a/.changeset/lucky-doors-listen.md
+++ b/.changeset/lucky-doors-listen.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): preserve gateway cost on the native stream path
+
+`convertAnthropicStream` now surfaces an Anthropic-compatible gateway's numeric `usage.cost` at `response_metadata.usage.cost`, matching the chunk path. Token accounting in `usage_metadata` is unchanged.

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -12,6 +12,7 @@ import { ChatGeneration } from "@langchain/core/outputs";
 import { AnthropicMessageResponse } from "../types.js";
 import { extractToolCalls } from "../output_parsers.js";
 import { _isAnthropicCompactionBlock } from "./content.js";
+import { iife } from "./index.js";
 
 export function _makeMessageChunkFromAnthropicEvent(
   data: Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
@@ -56,18 +57,24 @@ export function _makeMessageChunkFromAnthropicEvent(
       output_tokens: data.usage.output_tokens,
       total_tokens: data.usage.output_tokens,
     };
-    const responseMetadata =
-      "context_management" in data.delta
-        ? { context_management: data.delta.context_management }
-        : undefined;
-    const cost = (data.usage as typeof data.usage & { cost?: unknown })?.cost;
+    const responseMetadata = iife(() => {
+      let output = {};
+      if ("context_management" in data.delta) {
+        output["context_management"] = data.delta.context_management;
+      }
+      if (
+        "usage" in data &&
+        "cost" in data.usage &&
+        typeof data.usage.cost === "number"
+      ) {
+        output["usage"] = { cost: data.usage.cost };
+      }
+      return output;
+    });
     return {
       chunk: new AIMessageChunk({
         content: fields.coerceContentToString ? "" : [],
-        response_metadata:
-          typeof cost === "number"
-            ? { ...responseMetadata, usage: { cost } }
-            : responseMetadata,
+        response_metadata: responseMetadata,
         additional_kwargs: { ...data.delta },
         usage_metadata: fields.streamUsage ? usageMetadata : undefined,
       }),

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -58,7 +58,7 @@ export function _makeMessageChunkFromAnthropicEvent(
       total_tokens: data.usage.output_tokens,
     };
     const responseMetadata = iife(() => {
-      let output = {};
+      const output = {};
       if ("context_management" in data.delta) {
         output["context_management"] = data.delta.context_management;
       }

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -36,7 +36,7 @@ export async function* convertAnthropicStream(
     Record<string, any>
   >();
   let usageSnapshot: UsageMetadata | undefined;
-  let responseMetadata: Record<string, any> | undefined;
+  let responseMetadata: Record<string, unknown> = {};
   let stopReason: string | null = null;
 
   for await (const data of source) {

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -38,7 +38,6 @@ export async function* convertAnthropicStream(
   let usageSnapshot: UsageMetadata | undefined;
   let responseMetadata: Record<string, any> | undefined;
   let stopReason: string | null = null;
-  let gatewayCost: number | undefined;
 
   for await (const data of source) {
     switch (data.type) {
@@ -112,8 +111,7 @@ export async function* convertAnthropicStream(
           reason: mapStopReason(stopReason),
           ...(usageSnapshot ? { usage: usageSnapshot } : {}),
           metadata: { model_provider: "anthropic" },
-          responseMetadata:
-            gatewayCost === undefined ? {} : { usage: { cost: gatewayCost } },
+          responseMetadata,
         };
         break;
       }

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -37,6 +37,7 @@ export async function* convertAnthropicStream(
   >();
   let usageSnapshot: UsageMetadata | undefined;
   let stopReason: string | null = null;
+  let gatewayCost: number | undefined;
 
   for await (const data of source) {
     switch (data.type) {
@@ -62,6 +63,15 @@ export async function* convertAnthropicStream(
 
       case "message_delta": {
         stopReason = data.delta.stop_reason;
+        // Anthropic-compatible gateways (e.g. LiteLLM) may add a numeric `cost` to the terminal
+        // usage object. It is not token accounting, so it is kept out of `usage` and surfaced on
+        // `response_metadata.usage.cost` — the same place the chunk path puts it — and it is read
+        // outside the `streamUsage` gate so disabling token streaming does not discard it.
+        const cost = (data.usage as typeof data.usage & { cost?: unknown })
+          ?.cost;
+        if (typeof cost === "number") {
+          gatewayCost = cost;
+        }
         if (shouldStreamUsage && data.usage) {
           if (!usageSnapshot) {
             usageSnapshot = {
@@ -102,6 +112,8 @@ export async function* convertAnthropicStream(
           reason: mapStopReason(stopReason),
           ...(usageSnapshot ? { usage: usageSnapshot } : {}),
           metadata: { model_provider: "anthropic" },
+          responseMetadata:
+            gatewayCost === undefined ? {} : { usage: { cost: gatewayCost } },
         };
         break;
       }

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -36,6 +36,7 @@ export async function* convertAnthropicStream(
     Record<string, any>
   >();
   let usageSnapshot: UsageMetadata | undefined;
+  let responseMetadata: Record<string, any> | undefined;
   let stopReason: string | null = null;
   let gatewayCost: number | undefined;
 
@@ -63,14 +64,13 @@ export async function* convertAnthropicStream(
 
       case "message_delta": {
         stopReason = data.delta.stop_reason;
-        // Anthropic-compatible gateways (e.g. LiteLLM) may add a numeric `cost` to the terminal
-        // usage object. It is not token accounting, so it is kept out of `usage` and surfaced on
-        // `response_metadata.usage.cost` — the same place the chunk path puts it — and it is read
-        // outside the `streamUsage` gate so disabling token streaming does not discard it.
-        const cost = (data.usage as typeof data.usage & { cost?: unknown })
-          ?.cost;
-        if (typeof cost === "number") {
-          gatewayCost = cost;
+        // Some gateway providers add additional usage values to the final usage object
+        if (
+          "usage" in data &&
+          "cost" in data.usage &&
+          typeof data.usage.cost === "number"
+        ) {
+          responseMetadata = { usage: { cost: data.usage.cost } };
         }
         if (shouldStreamUsage && data.usage) {
           if (!usageSnapshot) {

--- a/libs/providers/langchain-anthropic/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/stream_events.test.ts
@@ -1,0 +1,152 @@
+import { test, expect, describe } from "vitest";
+import { ChatModelStream } from "@langchain/core/language_models/stream";
+import { convertAnthropicStream } from "../stream_events.js";
+
+interface StreamOverrides {
+  cost?: unknown;
+  streamUsage?: boolean;
+}
+
+/** One response's raw Anthropic events, optionally with a gateway `cost` on the terminal usage. */
+function rawEvents({ cost }: StreamOverrides = {}) {
+  return [
+    {
+      type: "message_start" as const,
+      message: {
+        id: "msg_01",
+        type: "message" as const,
+        role: "assistant" as const,
+        content: [],
+        model: "claude-3-5-haiku-latest",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 100, output_tokens: 1 },
+      },
+    },
+    {
+      type: "content_block_start" as const,
+      index: 0,
+      content_block: { type: "text" as const, text: "" },
+    },
+    {
+      type: "content_block_delta" as const,
+      index: 0,
+      delta: { type: "text_delta" as const, text: "hello" },
+    },
+    { type: "content_block_stop" as const, index: 0 },
+    {
+      type: "message_delta" as const,
+      delta: { stop_reason: "end_turn" as const, stop_sequence: null },
+      usage: {
+        output_tokens: 42,
+        ...(cost === undefined ? {} : { cost }),
+      },
+    },
+    { type: "message_stop" as const },
+  ];
+}
+
+async function convert({ cost, streamUsage }: StreamOverrides = {}) {
+  const source = (async function* () {
+    yield* rawEvents({ cost });
+  })();
+  const events = [];
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  for await (const event of convertAnthropicStream(source as any, {
+    streamUsage,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+function messageFinish(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  events: any[]
+) {
+  return events.find((event) => event.event === "message-finish");
+}
+
+describe("convertAnthropicStream", () => {
+  test("surfaces a gateway-provided cost on the message-finish response metadata", async () => {
+    const events = await convert({ cost: 0.0123 });
+
+    expect(messageFinish(events).responseMetadata).toEqual({
+      usage: { cost: 0.0123 },
+    });
+  });
+
+  test("adds no response metadata when no cost is present", async () => {
+    const events = await convert();
+
+    expect(messageFinish(events).responseMetadata).toEqual({});
+  });
+
+  test.each([
+    { case: "a nonnumeric cost", cost: "0.0123" },
+    { case: "a null cost", cost: null },
+  ])("ignores $case", async ({ cost }) => {
+    const events = await convert({ cost });
+
+    expect(messageFinish(events).responseMetadata).toEqual({});
+  });
+
+  test("leaves the rest of the message-finish event untouched", async () => {
+    const events = await convert({ cost: 0.0123 });
+
+    expect(messageFinish(events).reason).toBe("stop");
+    expect(messageFinish(events).metadata).toEqual({
+      model_provider: "anthropic",
+    });
+  });
+
+  test("preserves the cost when streamUsage is false", async () => {
+    const events = await convert({ cost: 0.0123, streamUsage: false });
+
+    expect(messageFinish(events).responseMetadata).toEqual({
+      usage: { cost: 0.0123 },
+    });
+    expect(messageFinish(events).usage).toBeUndefined();
+  });
+
+  test("leaves token accounting untouched", async () => {
+    const events = await convert({ cost: 0.0123 });
+
+    // Cost is not token accounting, so it must not leak into the usage snapshots.
+    expect(messageFinish(events).usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 43,
+      total_tokens: 143,
+      input_token_details: { cache_creation: 0, cache_read: 0 },
+    });
+    for (const event of events.filter((event) => event.usage)) {
+      expect(event.usage).not.toHaveProperty("cost");
+    }
+  });
+
+  test("an empty response metadata leaves the assembled message alone", async () => {
+    const source = (async function* () {
+      yield* rawEvents();
+    })();
+    const message = await new ChatModelStream(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      convertAnthropicStream(source as any) as any
+    );
+
+    expect(message.response_metadata).not.toHaveProperty("usage");
+  });
+
+  test("the cost reaches the assembled message", async () => {
+    const source = (async function* () {
+      yield* rawEvents({ cost: 0.0123 });
+    })();
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = await new ChatModelStream(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      convertAnthropicStream(source as any) as any
+    );
+
+    expect(message.response_metadata.usage).toEqual({ cost: 0.0123 });
+    expect(message.usage_metadata?.output_tokens).toBe(43);
+  });
+});


### PR DESCRIPTION
`convertAnthropicStream` rebuilds usage from token fields only, so a numeric `usage.cost` sent by an Anthropic-compatible gateway (LiteLLM and friends) on the terminal `message_delta` is dropped.

The chunk path preserves it — #11242 put it on `response_metadata.usage.cost` — but the native stream-event path added in 1.5.x does not. Since `_generateUncached` prefers `_streamChatModelEvents` whenever a handler sets `lc_prefer_chat_model_stream_events`, anything driven by LangGraph silently loses cost after upgrading to 1.5.x, while `.stream()` on the same model still reports it.

## The fix

One file, one value: read the numeric `cost` off `message_delta.usage` and put it on the `message-finish` event's `responseMetadata`, which `ChatModelStream._assembleMessage` merges into the message's `response_metadata`. Cost then lands at `response_metadata.usage.cost` — the same accessor the chunk path uses, so both paths agree.

- Read outside the `streamUsage` gate: cost is not token accounting, so disabling token streaming shouldn't discard it.
- `usage`/`usage_metadata` untouched — no chance of a gateway-only field polluting token totals.
- Additive: `responseMetadata` carries the cost when the gateway sends one and is `{}` otherwise, which merges as a no-op. Every existing field on the event, `metadata` included, is unchanged.

## Verification

New `stream_events.test.ts` covers: numeric cost surfaces, absent/non-numeric/null cost yields `{}`, cost survives `streamUsage: false`, token accounting and the rest of the `message-finish` event are untouched, and — through a real `ChatModelStream` — the cost reaches the assembled message while an empty `responseMetadata` leaves it alone.

Also checked against a live Anthropic-compatible gateway: before the fix, `.stream()` reported `response_metadata.usage.cost` and an `invoke()` with a stream-event handler reported nothing; after, both report the identical value, with `usage_metadata` unchanged in both.

Changeset included (`patch`).
