### PR TITLE
fix(core,langchain): patch and release core, update peer dependencies

### DIFF
--- a/.changeset/loud-pears-fetch.md
+++ b/.changeset/loud-pears-fetch.md
@@ -1,0 +1,6 @@
+---
+"langchain": patch
+"@langchain/core": patch
+---
+
+fix(core,langchain): patch and release core, update peer dependencies


### PR DESCRIPTION
fixes #11364

we pushed a langchain update without a corresponding core update last night. my fault!
