### PR TITLE
fix(aws): preserve Bedrock stream content indices

### DIFF
--- a/.changeset/quiet-beds-stream.md
+++ b/.changeset/quiet-beds-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): preserve Bedrock text block indices when streaming

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -133,10 +133,20 @@ export function handleConverseStreamContentBlockDelta(
     throw new Error("No delta found in content block.");
   }
   if (typeof contentBlockDelta.delta.text === "string") {
+    const index = contentBlockDelta.contentBlockIndex;
     return new ChatGenerationChunk({
       text: contentBlockDelta.delta.text,
       message: new AIMessageChunk({
-        content: contentBlockDelta.delta.text,
+        content:
+          index === undefined || index === 0
+            ? contentBlockDelta.delta.text
+            : [
+                {
+                  type: "text",
+                  text: contentBlockDelta.delta.text,
+                  index,
+                },
+              ],
       }),
     });
   } else if (contentBlockDelta.delta.toolUse) {

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -99,6 +99,40 @@ describe("reasoning output conversion", () => {
       },
     ]);
   });
+
+  test("preserves a reasoning signature after streamed text", () => {
+    const reasoning = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { text: "Reasoning summary" } },
+    });
+    const signature = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { signature: "opaque-signature" } },
+    });
+    const text = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "Answer" },
+    });
+
+    const result = concat(
+      concat(reasoning.message, signature.message),
+      text.message
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        signature: "opaque-signature",
+        index: 0,
+      },
+      {
+        type: "text",
+        text: "Answer",
+        index: 1,
+      },
+    ]);
+  });
 });
 
 describe("message output usage metadata conversion", () => {

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -66,6 +66,39 @@ describe("reasoning output conversion", () => {
     ]);
     expect(result.response_metadata).not.toHaveProperty("output_version");
   });
+
+  test("merges streaming text deltas after a reasoning block", () => {
+    const reasoning = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { text: "Reasoning summary" } },
+    });
+    const firstText = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "Hello" },
+    });
+    const secondText = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: " world" },
+    });
+
+    const result = concat(
+      concat(reasoning.message, firstText.message),
+      secondText.message
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "reasoning",
+        reasoning: "Reasoning summary",
+        index: 0,
+      },
+      {
+        type: "text",
+        text: "Hello world",
+        index: 1,
+      },
+    ]);
+  });
 });
 
 describe("message output usage metadata conversion", () => {


### PR DESCRIPTION
Fixes #11357
Fixes #11352

## Summary

- preserve Bedrock contentBlockIndex on streamed text deltas that follow another content block
- allow LangChain indexed content merge to combine text deltas into a single block after reasoning
- preserve the Bedrock reasoning signature through the same streamed reasoning-to-text sequence used by agent replay
- keep the existing string content shape for ordinary index-0 text-only streams
- add a patch changeset for @langchain/aws

## Root cause

The text branch of handleConverseStreamContentBlockDelta emitted plain string content and discarded contentBlockIndex. Once a reasoning block changed the aggregate content to an array, later text deltas were appended as separate blocks instead of being merged by index. That sequence could also lose the reasoning signature required when Bedrock replays the message.

## Testing

- pnpm --filter @langchain/aws test -- src/utils/tests/message_outputs.test.ts - 127 tests passed
- pnpm --filter @langchain/aws build
- targeted oxfmt --check and oxlint on the changed TypeScript files