### PR TITLE
fix(langchain): use unified endpoint for gateway

### DIFF
--- a/.changeset/fuzzy-keys-cross.md
+++ b/.changeset/fuzzy-keys-cross.md
@@ -1,0 +1,6 @@
+---
+"@langchain/core": patch
+"langchain": patch
+---
+
+fix(langchain): use unified endpoint for gateway

--- a/libs/langchain/src/chat_models/tests/universal.test.ts
+++ b/libs/langchain/src/chat_models/tests/universal.test.ts
@@ -47,7 +47,7 @@ describe("initChatModel LangSmith provider", () => {
 
     expect(chat.model).toBe("moonshotai/kimi-k3");
     expect(chat.clientConfig.baseURL).toBe(
-      "https://gateway.smith.langchain.com/openai/v1"
+      "https://gateway.smith.langchain.com/v1"
     );
     expect(chat.apiKey).toBe("gateway-key");
     expect(chat.useResponsesApi).toBe(true);
@@ -72,9 +72,7 @@ describe("initChatModel LangSmith provider", () => {
     });
     const chat = (await model._getModelInstance()) as ChatOpenAI;
 
-    expect(chat.clientConfig.baseURL).toBe(
-      "https://eu.gateway.example.com/openai/v1"
-    );
+    expect(chat.clientConfig.baseURL).toBe("https://eu.gateway.example.com/v1");
     expect(chat.apiKey).toBe("langsmith-key");
     expect(chat.useResponsesApi).toBe(true);
   });

--- a/libs/langchain/src/chat_models/universal.ts
+++ b/libs/langchain/src/chat_models/universal.ts
@@ -49,7 +49,7 @@ function getLangSmithChatModelParams({
 }) {
   const gatewayConfig = resolveLangSmithGatewayConfig({
     baseURL: configuration.baseURL,
-    providerPath: "openai/v1",
+    providerPath: "v1",
   });
 
   return {
@@ -61,8 +61,7 @@ function getLangSmithChatModelParams({
         getEnvironmentVariable("LANGSMITH_API_KEY")),
     configuration: {
       ...configuration,
-      baseURL:
-        gatewayConfig.baseURL ?? `${DEFAULT_LANGSMITH_GATEWAY}/openai/v1`,
+      baseURL: gatewayConfig.baseURL ?? `${DEFAULT_LANGSMITH_GATEWAY}/v1`,
     },
     useResponsesApi: true,
   };


### PR DESCRIPTION
lets us call other models besides openai models with the `langsmith` provider