### PR TITLE
fix(mistralai): correctly merge streamed tool calls

### DIFF
--- a/.changeset/mistral-glm-stream-tool-calls.md
+++ b/.changeset/mistral-glm-stream-tool-calls.md
@@ -1,0 +1,7 @@
+---
+"@langchain/mistralai": patch
+---
+
+fix(mistralai): correctly merge GLM streamed tool calls
+
+Preserve tool-call indexes from streamed Mistral responses and normalize placeholder IDs such as `"null"` to prevent GLM tool-call fragments from being merged incorrectly. Also add support for the `parallel_tool_calls` call option.

--- a/libs/providers/langchain-mistralai/src/chat_models.ts
+++ b/libs/providers/langchain-mistralai/src/chat_models.ts
@@ -70,6 +70,7 @@ import {
 import {
   _convertToolCallIdToMistralCompatible,
   _mistralContentChunkToMessageContentComplex,
+  _normalizeStreamedToolCallId,
 } from "./utils.js";
 import {
   isSerializableSchema,
@@ -98,6 +99,7 @@ export interface ChatMistralAICallOptions extends Omit<
   };
   tools?: ChatMistralAIToolType[];
   tool_choice?: MistralAIToolChoice;
+  parallel_tool_calls?: boolean;
   /**
    * Whether or not to include token usage in the stream.
    * @default {true}
@@ -475,12 +477,18 @@ function _convertDeltaToMessageChunk(
   // need to insert it here.
   const rawToolCallChunksWithIndex = delta.toolCalls?.length
     ? delta.toolCalls?.map(
-        (toolCall, index): MistralAIToolCall & { index: number } => ({
-          ...toolCall,
-          index,
-          id: toolCall.id ?? uuidv4().replace(/-/g, ""),
-          type: "function",
-        })
+        (
+          toolCall,
+          position
+        ): MistralAIToolCall & { index: number; id?: string } => {
+          const normalizedId = _normalizeStreamedToolCallId(toolCall.id);
+          return {
+            ...toolCall,
+            index: toolCall.index ?? position,
+            id: normalizedId,
+            type: "function",
+          };
+        }
       )
     : undefined;
 
@@ -1048,7 +1056,8 @@ export class ChatMistralAI<
     MistralAIChatCompletionRequest | MistralAIChatCompletionStreamRequest,
     "messages"
   > {
-    const { response_format, tools, tool_choice } = options ?? {};
+    const { response_format, tools, tool_choice, parallel_tool_calls } =
+      options ?? {};
     const mistralAITools: Array<MistralAITool> | undefined = tools?.length
       ? _convertToolToMistralTool(tools)
       : undefined;
@@ -1065,6 +1074,7 @@ export class ChatMistralAI<
       presencePenalty: this.presencePenalty,
       frequencyPenalty: this.frequencyPenalty,
       n: this.numCompletions,
+      parallelToolCalls: parallel_tool_calls,
     };
     return params;
   }

--- a/libs/providers/langchain-mistralai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-mistralai/src/tests/chat_models.test.ts
@@ -14,6 +14,7 @@ import {
   _isValidMistralToolCallId,
   _convertToolCallIdToMistralCompatible,
   _mistralContentChunkToMessageContentComplex,
+  _normalizeStreamedToolCallId,
 } from "../utils.js";
 import { ChatCompletionRequest } from "@mistralai/mistralai/models/components/chatcompletionrequest.js";
 
@@ -344,5 +345,94 @@ describe("Streaming", () => {
     expect(capturedStreamParam).toBe(true);
     expect(chunks.length).toBe(2);
     expect(chunks.join("")).toBe("Hello world!");
+  });
+
+  test("merges streamed tool-call fragments by API index", async () => {
+    const mockStreamFn = vi.fn().mockImplementation(async function* () {
+      for (const toolCall of [
+        {
+          id: "call-abc",
+          index: 2,
+          function: { name: "get_weather", arguments: '{"location":"' },
+        },
+        {
+          id: "null",
+          index: 2,
+          function: { name: "", arguments: 'Paris"}' },
+        },
+      ]) {
+        yield {
+          data: {
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", toolCalls: [toolCall] },
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    const model = new ChatMistralAI({
+      apiKey: "test-api-key",
+      model: "mistral-small-latest",
+    });
+    model.completionWithRetry = (async (
+      _input: unknown,
+      streaming: boolean
+    ) => {
+      if (!streaming) {
+        throw new Error("expected streaming");
+      }
+      return mockStreamFn();
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+    let merged: AIMessageChunk | undefined;
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage("Weather in Paris?")],
+      {}
+    )) {
+      const message = chunk.message as AIMessageChunk;
+      merged = merged ? merged.concat(message) : message;
+    }
+
+    expect(merged?.tool_calls).toHaveLength(1);
+    expect(merged?.tool_calls?.[0]).toMatchObject({
+      id: "call-abc",
+      name: "get_weather",
+      args: { location: "Paris" },
+    });
+    expect(merged?.tool_call_chunks?.[0].index).toBe(2);
+  });
+});
+
+describe("Streamed tool call id normalization", () => {
+  test("drops placeholder ids", () => {
+    expect(_normalizeStreamedToolCallId("null")).toBeUndefined();
+    expect(_normalizeStreamedToolCallId("undefined")).toBeUndefined();
+    expect(_normalizeStreamedToolCallId("")).toBeUndefined();
+    expect(_normalizeStreamedToolCallId("  ")).toBeUndefined();
+    expect(_normalizeStreamedToolCallId(null)).toBeUndefined();
+    expect(_normalizeStreamedToolCallId(undefined)).toBeUndefined();
+    expect(_normalizeStreamedToolCallId("chatcmpl-tool-abc")).toBe(
+      "chatcmpl-tool-abc"
+    );
+  });
+});
+
+describe("invocationParams", () => {
+  test("forwards parallel_tool_calls to parallelToolCalls", () => {
+    const model = new ChatMistralAI({
+      apiKey: "test-api-key",
+      model: "mistral-small-latest",
+    });
+    expect(
+      model.invocationParams({ parallel_tool_calls: false }).parallelToolCalls
+    ).toBe(false);
+    expect(
+      model.invocationParams({ parallel_tool_calls: true }).parallelToolCalls
+    ).toBe(true);
   });
 });

--- a/libs/providers/langchain-mistralai/src/utils.ts
+++ b/libs/providers/langchain-mistralai/src/utils.ts
@@ -32,6 +32,19 @@ function _simpleHash(str: string): number {
   return Math.abs(hash);
 }
 
+export function _normalizeStreamedToolCallId(
+  id: string | null | undefined
+): string | undefined {
+  if (id == null) {
+    return undefined;
+  }
+  const trimmed = id.trim();
+  if (trimmed === "" || trimmed === "null" || trimmed === "undefined") {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export function _convertToolCallIdToMistralCompatible(
   toolCallId: string
 ): string {


### PR DESCRIPTION
## Summary

Fix streamed tool calls in `@langchain/mistralai` for OpenA -compatible models such as `zai-glm-5-2`.

Tool-call continuation chunks may contain placeholder IDs such as `"null"` while relying on their API-provided index. The integration previously replaced that index with the chunk’s array position and treated placeholder IDs as real IDs, corrupting merged tool calls and causing agent loops (it happened)

Also added support for `parallel_tool_calls`, which was missing.

One thing that was not added is cache-creation information in the usage metadata. But since it's outside PR scope, it hasn't been added here.

## Changes

- Preserve API-provided tool-call indexes
- Normalize placeholder streamed IDs to `undefined`
- Add support for the `parallel_tool_calls` call option
- Add regression tests for fragmented tool-call merging
- Add an `@langchain/mistralai` patch changeset

## Test plan

- [x] `pnpm --filter @langchain/mistralai test src/tests/chat_models.test.ts`
- [x] 13 tests passed
- [x] Type checking passed