### PR TITLE
fix(core): route Zod v3 schemas through zodToJsonSchema regardless of ~standard.jsonSchema

### DIFF
--- a/libs/langchain-core/src/utils/json_schema.ts
+++ b/libs/langchain-core/src/utils/json_schema.ts
@@ -61,7 +61,15 @@ export function toJsonSchema(
 
   let result: JSONSchema;
 
-  if (isStandardJsonSchema(schema) && !isZodSchemaV4(schema)) {
+  // Zod v3 schemas (including ZodDefault, ZodEffects, etc.) may implement
+  // the Standard Schema spec in newer Zod releases (v3.24+) by adding a
+  // `~standard.jsonSchema` property. However, that implementation returns
+  // raw Zod internals (the `_def` tree) rather than a proper JSON Schema for
+  // wrapped types like ZodDefault(ZodEffects(ZodObject)), which causes the
+  // Anthropic API to reject the tool definition with "Field required: type".
+  // Always route Zod v3 through `zodToJsonSchema` (the `zod-to-json-schema`
+  // library), which handles all Zod v3 wrapper types correctly.
+  if (isStandardJsonSchema(schema) && !isZodSchemaV4(schema) && !isZodSchemaV3(schema)) {
     result = schema["~standard"].jsonSchema.input({
       target: "draft-07",
     }) as JSONSchema;

--- a/libs/langchain-core/src/utils/tests/json_schema.test.ts
+++ b/libs/langchain-core/src/utils/tests/json_schema.test.ts
@@ -297,4 +297,42 @@ describe("toJsonSchema", () => {
       expect(result1.parameters).toBe(result2.parameters);
     });
   });
+
+  describe("with ZodDefault-wrapped zod v3 schemas", () => {
+    // https://github.com/langchain-ai/langchainjs/issues/11240
+    // Zod v3.24+ adds a `~standard.jsonSchema` property to Zod schemas,
+    // causing isStandardJsonSchema() to return true for them. However,
+    // ~standard.jsonSchema.input() on ZodDefault(ZodEffects(ZodObject)) returns
+    // the raw Zod _def structure instead of a valid JSON Schema, which causes
+    // the Anthropic API to reject the tool definition with "Field required: type".
+    it("should produce a valid JSON schema (with a type field) for ZodDefault(ZodObject)", () => {
+      const schema = z.object({ count: z.number() }).default({ count: 0 });
+      const jsonSchema = toJsonSchema(schema);
+      expect(jsonSchema).toMatchObject({
+        type: "object",
+        properties: { count: { type: "number" } },
+        required: ["count"],
+      });
+      // Must not expose raw Zod internals
+      expect(jsonSchema).not.toHaveProperty("_def");
+    });
+
+    it("should produce a valid JSON schema for ZodDefault(ZodEffects(ZodObject))", () => {
+      // This is the exact shape that n8n's built-in Think tool produces:
+      // ZodDefault wrapping a ZodEffects (transform) wrapping a ZodObject
+      const inner = z.object({}).catchall(z.never());
+      const schema = inner.transform((v) => v).default(() => ({}));
+      const jsonSchema = toJsonSchema(schema);
+      // Must have a top-level "type" — Anthropic rejects schemas without it
+      expect(jsonSchema).toHaveProperty("type");
+      expect(jsonSchema).not.toHaveProperty("_def");
+    });
+
+    it("should produce a valid JSON schema for ZodDefault(ZodString)", () => {
+      const schema = z.string().default("hello");
+      const jsonSchema = toJsonSchema(schema);
+      expect(jsonSchema).toMatchObject({ type: "string" });
+      expect(jsonSchema).not.toHaveProperty("_def");
+    });
+  });
 });


### PR DESCRIPTION
Closes #11240

## Problem

Zod v3.24+ added Standard Schema v1 support (`~standard.jsonSchema`) to all Zod schemas. This caused `toJsonSchema()` to route Zod v3 schemas through the `~standard.jsonSchema.input()` branch instead of the `zodToJsonSchema()` branch for most (but not all) cases.

For wrapper types like `ZodDefault(ZodEffects(ZodObject))` — which is the exact shape of **n8n's built-in Think tool** — `~standard.jsonSchema.input()` serializes the raw Zod `_def` tree rather than producing a valid JSON Schema:

```json
// before — raw Zod internals, no "type" field
{ "default": { "_def": { "innerType": { "_def": { ... } }, ... } }, "$schema": "..." }

// after — valid JSON Schema
{ "type": "object", "properties": {}, "additionalProperties": false, "default": {}, "$schema": "..." }
```

The Anthropic API rejects the former with:
> `tools.0.custom.input_schema.type: Field required`

## Fix

Add `!isZodSchemaV3(schema)` to the standard-schema branch guard in `toJsonSchema()`:

```diff
-if (isStandardJsonSchema(schema) && !isZodSchemaV4(schema)) {
+if (isStandardJsonSchema(schema) && !isZodSchemaV4(schema) && !isZodSchemaV3(schema)) {
```

Zod v3 schemas (including all wrapper types: `ZodDefault`, `ZodEffects`, `ZodOptional`, etc.) now always go through `zodToJsonSchema()` from the `zod-to-json-schema` library, which handles every Zod v3 type correctly.

## Tests

Added 3 regression tests covering:
- `ZodDefault(ZodObject)` — the simplest failing case
- `ZodDefault(ZodEffects(ZodObject))` — the exact shape that triggered the bug
- `ZodDefault(ZodString)` — a scalar wrapper case