### PR TITLE
fix: preserve original middleware error properties

### DIFF
--- a/libs/langchain/src/agents/errors.ts
+++ b/libs/langchain/src/agents/errors.ts
@@ -107,6 +107,25 @@ export class MiddlewareError extends Error {
 
     if (error instanceof Error) {
       this.cause = error;
+
+      // Preserve custom fields and the original prototype so middleware can
+      // inspect the original failure (for example, in retry predicates).
+      Object.setPrototypeOf(this, Object.getPrototypeOf(error));
+      for (const key of Reflect.ownKeys(error)) {
+        if (
+          key === "name" ||
+          key === "message" ||
+          key === "cause" ||
+          key === "stack" ||
+          key === "~brand"
+        ) {
+          continue;
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(error, key);
+        if (descriptor) {
+          Object.defineProperty(this, key, descriptor);
+        }
+      }
     }
   }
 

--- a/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelRetry.test.ts
@@ -6,7 +6,7 @@ import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { StructuredTool } from "@langchain/core/tools";
 import { RunnableBinding } from "@langchain/core/runnables";
 
-import { createAgent } from "../../index.js";
+import { createAgent, createMiddleware } from "../../index.js";
 import { modelRetryMiddleware } from "../modelRetry.js";
 import { FakeToolCallingModel } from "../../tests/utils.js";
 import { InvalidRetryConfigError } from "../error.js";
@@ -335,6 +335,51 @@ describe("modelRetryMiddleware", () => {
   });
 
   describe("Retry on specific exceptions", () => {
+    it("should match error constructors through middleware wrappers", async () => {
+      class TimeoutFailureModel extends FakeToolCallingModel {
+        private attempt = 0;
+
+        _generate = vi.fn(
+          async (...args: Parameters<FakeToolCallingModel["_generate"]>) => {
+            this.attempt += 1;
+            if (this.attempt === 1) {
+              throw new TimeoutError("Timeout");
+            }
+            return super._generate(...args);
+          }
+        );
+
+        bindTools(tools: StructuredTool[]) {
+          // oxlint-disable-next-line dot-notation
+          this["tools"] = [...this["tools"], ...tools];
+          return this as unknown as RunnableBinding<any, any, any>;
+        }
+      }
+
+      const model = new TimeoutFailureModel({ toolCalls: [[]] });
+      const retry = modelRetryMiddleware({
+        maxRetries: 1,
+        initialDelayMs: 0,
+        jitter: false,
+        retryOn: [TimeoutError],
+        onFailure: "error",
+      });
+      const passthrough = createMiddleware({
+        name: "passthrough",
+        wrapModelCall: async (request, handler) => handler(request),
+      });
+
+      const agent = createAgent({
+        model,
+        tools: [],
+        middleware: [retry, passthrough] as const,
+      });
+
+      await agent.invoke({ messages: [new HumanMessage("Hello")] });
+
+      expect(model._generate).toHaveBeenCalledTimes(2);
+    });
+
     it("should retry on specified error types", async () => {
       class TimeoutFailureModel extends FakeToolCallingModel {
         private attempt = 0;

--- a/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
+++ b/libs/langchain/src/agents/tests/middlewareErrorHandling.test.ts
@@ -336,6 +336,21 @@ describe("Middleware Error Handling", () => {
       expect((wrapped as MiddlewareError).cause).toBe(error);
     });
 
+    it("should preserve custom properties and the original prototype", () => {
+      class CustomError extends Error {
+        code = "ECONNRESET";
+        $retryable = true;
+      }
+
+      const error = new CustomError("test error");
+      const wrapped = MiddlewareError.wrap(error, "testMiddleware");
+
+      expect(wrapped).toBeInstanceOf(CustomError);
+      expect((wrapped as CustomError).code).toBe("ECONNRESET");
+      expect((wrapped as CustomError).$retryable).toBe(true);
+      expect((wrapped as MiddlewareError).cause).toBe(error);
+    });
+
     it("should wrap non-Error values in MiddlewareError", () => {
       const wrapped = MiddlewareError.wrap("string error", "testMiddleware");
 


### PR DESCRIPTION
Fixes #11324.

## Summary

Preserve custom own properties and the original prototype when MiddlewareError.wrap re-wraps an Error. This keeps class-based and predicate-based retryOn checks working through nested middleware wrappers while retaining the existing cause chain.

## Tests

- Added a MiddlewareError.wrap regression test for custom properties and prototypes.
- Added an agent retry regression test with a passthrough middleware.
- NODE_OPTIONS=--experimental-strip-types pnpm --filter langchain test src/agents/middleware/tests/modelRetry.test.ts src/agents/tests/middlewareErrorHandling.test.ts — 33 passed.
- oxfmt --check and oxlint on changed files — passed.