### PR TITLE
fix(openai): preserve Azure deployment model in wrapped callbacks

### DIFF
--- a/.changeset/fix-azure-callback-models.md
+++ b/.changeset/fix-azure-callback-models.md
@@ -2,4 +2,4 @@
 "@langchain/openai": patch
 ---
 
-Preserve Azure OpenAI deployment names in callback metadata and invocation parameters for bare, configured, and tool-bound chat model calls.
+Preserve Azure OpenAI deployment names as request models for bare, configured, and tool-bound chat model calls.

--- a/.changeset/fix-azure-callback-models.md
+++ b/.changeset/fix-azure-callback-models.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Preserve Azure OpenAI deployment names in callback metadata and invocation parameters for bare, configured, and tool-bound chat model calls.

--- a/libs/providers/langchain-openai/src/azure/chat_models/common.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/common.ts
@@ -49,6 +49,55 @@ export interface AzureChatOpenAIFields
   useResponsesApi?: boolean;
 }
 
+const DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo";
+
+function getAzureChatOpenAIModelName(
+  modelName: string | undefined,
+  deploymentName: string | undefined,
+  modelWasExplicitlyConfigured: boolean
+) {
+  if (
+    !modelWasExplicitlyConfigured &&
+    modelName === DEFAULT_OPENAI_MODEL &&
+    deploymentName
+  ) {
+    return deploymentName;
+  }
+  return modelName;
+}
+
+export function getAzureChatOpenAILsParams(
+  params: ReturnType<BaseChatOpenAI["getLsParams"]>,
+  deploymentName: string | undefined,
+  modelWasExplicitlyConfigured: boolean
+) {
+  params.ls_provider = "azure";
+  params.ls_model_name = getAzureChatOpenAIModelName(
+    params.ls_model_name,
+    deploymentName,
+    modelWasExplicitlyConfigured
+  );
+  return params;
+}
+
+export function getAzureChatOpenAIInvocationParams<
+  Params extends { model?: string },
+>(
+  params: Params,
+  deploymentName: string | undefined,
+  modelWasExplicitlyConfigured: boolean
+) {
+  return {
+    ...params,
+    model: getAzureChatOpenAIModelName(
+      params.model,
+      deploymentName,
+      modelWasExplicitlyConfigured
+    ),
+    azureOpenAIApiDeploymentName: deploymentName,
+  };
+}
+
 export function getAzureChatOpenAIParams(
   modelOrFields?: string | AzureChatOpenAIFields,
   fieldsArg?: Omit<

--- a/libs/providers/langchain-openai/src/azure/chat_models/common.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/common.ts
@@ -94,7 +94,6 @@ export function getAzureChatOpenAIInvocationParams<
       deploymentName,
       modelWasExplicitlyConfigured
     ),
-    azureOpenAIApiDeploymentName: deploymentName,
   };
 }
 

--- a/libs/providers/langchain-openai/src/azure/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/completions.ts
@@ -13,7 +13,9 @@ import {
   AZURE_SECRETS,
   AZURE_SERIALIZABLE_KEYS,
   AzureChatOpenAIFields,
+  getAzureChatOpenAIInvocationParams,
   getAzureChatOpenAIParams,
+  getAzureChatOpenAILsParams,
 } from "./common.js";
 
 export class AzureChatOpenAICompletions<
@@ -36,6 +38,8 @@ export class AzureChatOpenAICompletions<
   azureOpenAIBasePath?: string;
 
   azureOpenAIEndpoint?: string;
+
+  private readonly modelWasExplicitlyConfigured: boolean;
 
   _llmType(): string {
     return "azure_openai";
@@ -60,9 +64,22 @@ export class AzureChatOpenAICompletions<
   }
 
   getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {
-    const params = super.getLsParams(options);
-    params.ls_provider = "azure";
-    return params;
+    return getAzureChatOpenAILsParams(
+      super.getLsParams(options),
+      this.azureOpenAIApiDeploymentName,
+      this.modelWasExplicitlyConfigured
+    );
+  }
+
+  override invocationParams(
+    options?: this["ParsedCallOptions"],
+    extra?: { streaming?: boolean }
+  ) {
+    return getAzureChatOpenAIInvocationParams(
+      super.invocationParams(options, extra),
+      this.azureOpenAIApiDeploymentName,
+      this.modelWasExplicitlyConfigured
+    );
   }
 
   constructor(
@@ -82,6 +99,7 @@ export class AzureChatOpenAICompletions<
   ) {
     const fields = getAzureChatOpenAIParams(deploymentOrFields, fieldsArg);
     super(fields);
+    this.modelWasExplicitlyConfigured = fields?.model != null;
     _constructAzureFields.call(this, fields);
   }
 

--- a/libs/providers/langchain-openai/src/azure/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/responses.ts
@@ -13,7 +13,9 @@ import {
   AZURE_SECRETS,
   AZURE_SERIALIZABLE_KEYS,
   AzureChatOpenAIFields,
+  getAzureChatOpenAIInvocationParams,
   getAzureChatOpenAIParams,
+  getAzureChatOpenAILsParams,
 } from "./common.js";
 
 export class AzureChatOpenAIResponses<
@@ -36,6 +38,8 @@ export class AzureChatOpenAIResponses<
   azureOpenAIBasePath?: string;
 
   azureOpenAIEndpoint?: string;
+
+  private readonly modelWasExplicitlyConfigured: boolean;
 
   _llmType(): string {
     return "azure_openai";
@@ -60,9 +64,19 @@ export class AzureChatOpenAIResponses<
   }
 
   getLsParams(options: this["ParsedCallOptions"]): LangSmithParams {
-    const params = super.getLsParams(options);
-    params.ls_provider = "azure";
-    return params;
+    return getAzureChatOpenAILsParams(
+      super.getLsParams(options),
+      this.azureOpenAIApiDeploymentName,
+      this.modelWasExplicitlyConfigured
+    );
+  }
+
+  override invocationParams(options?: this["ParsedCallOptions"]) {
+    return getAzureChatOpenAIInvocationParams(
+      super.invocationParams(options),
+      this.azureOpenAIApiDeploymentName,
+      this.modelWasExplicitlyConfigured
+    );
   }
 
   constructor(
@@ -82,6 +96,7 @@ export class AzureChatOpenAIResponses<
   ) {
     const fields = getAzureChatOpenAIParams(deploymentOrFields, fieldsArg);
     super(fields);
+    this.modelWasExplicitlyConfigured = fields?.model != null;
     _constructAzureFields.call(this, fields);
   }
 

--- a/libs/providers/langchain-openai/src/azure/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/tests/index.test.ts
@@ -262,13 +262,12 @@ describe("Azure OpenAI callback model attribution", () => {
       });
       expect(invocationParams).toMatchObject({
         model: deploymentName,
-        azureOpenAIApiDeploymentName: deploymentName,
       });
       const requestBody = JSON.parse(
         String(mockFetch.mock.calls[0]?.[1]?.body)
       ) as Record<string, unknown>;
       expect(requestBody.model).toBe(deploymentName);
-      expect(requestBody.azureOpenAIApiDeploymentName).toBe(deploymentName);
+      expect(requestBody).not.toHaveProperty("azureOpenAIApiDeploymentName");
     }
   );
 
@@ -285,7 +284,6 @@ describe("Azure OpenAI callback model attribution", () => {
       });
       expect(chat.invocationParams({})).toMatchObject({
         model: explicitModel,
-        azureOpenAIApiDeploymentName: deploymentName,
       });
     }
   );

--- a/libs/providers/langchain-openai/src/azure/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/azure/chat_models/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach } from "vitest";
+import { test, expect, beforeEach, describe, vi } from "vitest";
 
 import { env } from "../../../tests/utils.js";
 import { AzureChatOpenAI } from "../index.js";
@@ -76,5 +76,217 @@ test("Test Azure OpenAI serialization from instance name", async () => {
   });
   expect(JSON.stringify(chat)).toEqual(
     `{"lc":1,"type":"constructor","id":["langchain","chat_models","azure_openai","AzureChatOpenAI"],"kwargs":{"azure_open_ai_api_instance_name":"foobar","deployment_name":"gpt-4o","openai_api_version":"2024-08-01-preview","azure_open_ai_api_key":{"lc":1,"type":"secret","id":["AZURE_OPENAI_API_KEY"]},"azure_endpoint":"https://foobar.openai.azure.com/"}}`
+  );
+});
+
+describe("Azure OpenAI callback model attribution", () => {
+  const deploymentName = "deployment-gpt-4o-mini";
+  const tool = {
+    type: "function" as const,
+    function: {
+      name: "get_weather",
+      description: "Get weather for a city.",
+      parameters: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+    },
+  };
+
+  function createCompletionsResponse() {
+    return {
+      id: "chatcmpl_test",
+      object: "chat.completion",
+      created: 0,
+      model: deploymentName,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "It is sunny.",
+            refusal: null,
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 4,
+        total_tokens: 9,
+      },
+    };
+  }
+
+  function createResponsesResponse() {
+    return {
+      id: "resp_test",
+      object: "response",
+      created_at: 0,
+      status: "completed",
+      error: null,
+      incomplete_details: null,
+      instructions: null,
+      max_output_tokens: null,
+      model: deploymentName,
+      output: [
+        {
+          id: "msg_test",
+          type: "message",
+          status: "completed",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "It is sunny.",
+              annotations: [],
+              logprobs: [],
+            },
+          ],
+        },
+      ],
+      parallel_tool_calls: true,
+      previous_response_id: null,
+      reasoning: { effort: null, summary: null },
+      service_tier: "default",
+      store: true,
+      temperature: 1,
+      text: { format: { type: "text" } },
+      tool_choice: "auto",
+      tools: [],
+      top_p: 1,
+      truncation: "disabled",
+      usage: {
+        input_tokens: 5,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: 4,
+        output_tokens_details: { reasoning_tokens: 0 },
+        total_tokens: 9,
+      },
+      user: null,
+      metadata: {},
+    };
+  }
+
+  function createModel(useResponsesApi: boolean, model?: string) {
+    const mockFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify(
+            useResponsesApi
+              ? createResponsesResponse()
+              : createCompletionsResponse()
+          ),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+    );
+    const chat = new AzureChatOpenAI({
+      ...(model ? { model } : {}),
+      azureOpenAIEndpoint: "https://foobar.openai.azure.com/",
+      azureOpenAIApiDeploymentName: deploymentName,
+      azureOpenAIApiVersion: "2024-08-01-preview",
+      azureOpenAIApiKey: "foo",
+      useResponsesApi,
+      maxRetries: 0,
+      configuration: { fetch: mockFetch },
+    });
+    return { chat, mockFetch };
+  }
+
+  test.each([
+    ["Chat Completions", "bare", false, (chat: AzureChatOpenAI) => chat],
+    [
+      "Chat Completions",
+      "withConfig",
+      false,
+      (chat: AzureChatOpenAI) => chat.withConfig({ tags: ["configured"] }),
+    ],
+    [
+      "Chat Completions",
+      "bindTools",
+      false,
+      (chat: AzureChatOpenAI) => chat.bindTools([tool]),
+    ],
+    ["Responses API", "bare", true, (chat: AzureChatOpenAI) => chat],
+    [
+      "Responses API",
+      "withConfig",
+      true,
+      (chat: AzureChatOpenAI) => chat.withConfig({ tags: ["configured"] }),
+    ],
+    [
+      "Responses API",
+      "bindTools",
+      true,
+      (chat: AzureChatOpenAI) => chat.bindTools([tool]),
+    ],
+  ])(
+    "%s %s publishes the deployment in callbacks",
+    async (_protocol, _scenario, useResponsesApi, wrap) => {
+      const { chat, mockFetch } = createModel(useResponsesApi);
+      const runnable = wrap(chat);
+      let metadata: Record<string, unknown> | undefined;
+      let invocationParams: Record<string, unknown> | undefined;
+
+      const result = await runnable.invoke("What is the weather?", {
+        callbacks: [
+          {
+            handleLLMStart: (
+              _llm,
+              _prompts,
+              _runId,
+              _parentRunId,
+              extraParams,
+              _tags,
+              runMetadata
+            ) => {
+              invocationParams = extraParams?.invocation_params as
+                | Record<string, unknown>
+                | undefined;
+              metadata = runMetadata;
+            },
+          },
+        ],
+      });
+
+      expect(result.text).toBe("It is sunny.");
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(metadata).toMatchObject({
+        ls_model_name: deploymentName,
+        ls_provider: "azure",
+      });
+      expect(invocationParams).toMatchObject({
+        model: deploymentName,
+        azureOpenAIApiDeploymentName: deploymentName,
+      });
+      const requestBody = JSON.parse(
+        String(mockFetch.mock.calls[0]?.[1]?.body)
+      ) as Record<string, unknown>;
+      expect(requestBody.model).toBe(deploymentName);
+      expect(requestBody.azureOpenAIApiDeploymentName).toBe(deploymentName);
+    }
+  );
+
+  test.each([false, true])(
+    "preserves an explicit model for useResponsesApi=%s",
+    (useResponsesApi) => {
+      const explicitModel = "explicit-model";
+      const { chat } = createModel(useResponsesApi, explicitModel);
+      expect(
+        chat.getLsParams({} as Parameters<typeof chat.getLsParams>[0])
+      ).toMatchObject({
+        ls_model_name: explicitModel,
+        ls_provider: "azure",
+      });
+      expect(chat.invocationParams({})).toMatchObject({
+        model: explicitModel,
+        azureOpenAIApiDeploymentName: deploymentName,
+      });
+    }
   );
 });


### PR DESCRIPTION
## Summary

Fixes #10874 by preserving the configured Azure deployment as the request model in LangChain callback metadata for every `AzureChatOpenAI` execution path.

The existing #10886 approach patches only the outer `AzureChatOpenAI` class. `withConfig()` and `bindTools()` delegate to `AzureChatOpenAICompletions` or `AzureChatOpenAIResponses`, so those wrapped calls still report the inherited `gpt-3.5-turbo` default. This change applies the correction in both delegate classes.

## Changes

- use the Azure deployment for `ls_model_name` and invocation `model` when `model` was not explicitly configured
- preserve explicitly configured model values
- cover bare, `withConfig()`, and `bindTools()` for both Chat Completions and Responses API
- verify unsupported Azure metadata is not leaked into provider request bodies
- add a patch changeset for `@langchain/openai`

## Validation

- focused Azure callback suite: 13 passed with no type errors
- `@langchain/openai` build passed
- targeted formatting and lint checks passed
- live Azure OpenAI + Application Insights validation for bare, `withConfig()`, and `bindTools()` Chat Completions calls:
  - span name: `chat gpt-4o-mini`
  - `gen_ai.request.model`: `gpt-4o-mini`
  - `gen_ai.response.model`: `gpt-4o-mini-2024-07-18`
  - all three calls succeeded

The Responses API delegate is covered through the same real callback pipeline with only provider transport mocked because the validation Azure resource does not expose the Responses endpoint through `AzureChatOpenAI`.