### PR TITLE
fix(openai): honor per-call service tier in Responses API

### DIFF
--- a/.changeset/fix-responses-service-tier.md
+++ b/.changeset/fix-responses-service-tier.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Fix per-call `service_tier` options being ignored when using the OpenAI Responses API.

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -99,7 +99,7 @@ export class ChatOpenAIResponses<
       temperature: this.temperature,
       top_p: this.topP,
       user: this.user,
-      service_tier: this.service_tier,
+      service_tier: options?.service_tier ?? this.service_tier,
 
       // if include_usage is set or streamUsage then stream must be set to true.
       stream: this.streaming,

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -133,6 +133,16 @@ describe("service_tier configuration", () => {
     const params = model.invocationParams({});
     expect(params.service_tier).toBe("auto");
   });
+
+  it("prefers per-call service_tier over the model configuration", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+      service_tier: "auto",
+    });
+
+    const params = model.invocationParams({ service_tier: "flex" });
+    expect(params.service_tier).toBe("flex");
+  });
 });
 
 describe("streaming errors", () => {


### PR DESCRIPTION
## Summary

Fixes #11353

- Forward per-call `service_tier` to OpenAI Responses API requests.
- Preserve the model-level `service_tier` as the fallback.
- Add a regression test and a patch changeset for `@langchain/openai`.

## Compatibility

This only changes Responses API request construction when callers provide `service_tier` in invocation options. Existing model-level configuration and calls without the option are unchanged.

## Tests

- `pnpm exec oxfmt --check libs/providers/langchain-openai/src/chat_models/responses.ts libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts` ✅
- `git diff --check` ✅
- `pnpm --filter @langchain/openai test -- src/chat_models/tests/responses.test.ts` ⚠️ Could not run because the workspace package `@langchain/core` was not built.
- `pnpm --filter @langchain/core build` ⚠️ Failed in the local environment because the current toolchain could not load `internal/build/src/index.ts` (`Unknown file extension ".ts"`).

The test itself was written before the production change and is intended to fail on the previous implementation.