### PR TITLE
fix(core): handle empty streamed tool arguments

### DIFF
--- a/.changeset/quiet-tools-call.md
+++ b/.changeset/quiet-tools-call.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Handle streamed tool calls with no arguments as empty argument objects.

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -508,7 +508,7 @@ export function finalizeContentBlock(block: ContentBlock): ContentBlock {
     const chunk = block as ContentBlock.Tools.ToolCallChunk;
     let parsedArgs: unknown;
     try {
-      parsedArgs = JSON.parse(chunk.args ?? "{}");
+      parsedArgs = JSON.parse(chunk.args || "{}");
     } catch {
       return {
         type: "invalid_tool_call" as const,

--- a/libs/langchain-core/src/language_models/tests/event.test.ts
+++ b/libs/langchain-core/src/language_models/tests/event.test.ts
@@ -10,8 +10,25 @@ import type {
   ProviderEvent,
   StreamErrorEvent,
 } from "../event.js";
+import { finalizeContentBlock } from "../compat.js";
 
 describe("ChatModelStreamEvent types", () => {
+  test("finalizes a zero-argument tool call with empty args", () => {
+    expect(
+      finalizeContentBlock({
+        type: "tool_call_chunk",
+        id: "call_empty",
+        name: "ping",
+        args: "",
+      })
+    ).toEqual({
+      type: "tool_call",
+      id: "call_empty",
+      name: "ping",
+      args: {},
+    });
+  });
+
   test("MessageStartEvent", () => {
     const event: MessageStartEvent = {
       event: "message-start",


### PR DESCRIPTION
## Summary

- Treat an empty streamed tool-call argument payload as `{}`.
- Add a regression test for zero-argument streamed tools.
- Add the required `@langchain/core` patch changeset.

## Verification

- Regression test failed on the parent commit with `invalid_tool_call`.
- The same focused Vitest passes with this change.

Fixes #11355
