### PR TITLE
fix(core): treat empty tool call args as `{}` when finalizing v3 stream events

### DIFF
--- a/.changeset/fix-empty-tool-call-args.md
+++ b/.changeset/fix-empty-tool-call-args.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Fix `streamEvents` v3 turning tool calls with no arguments into `invalid_tool_call` by treating empty accumulated args as `{}`

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -508,7 +508,10 @@ export function finalizeContentBlock(block: ContentBlock): ContentBlock {
     const chunk = block as ContentBlock.Tools.ToolCallChunk;
     let parsedArgs: unknown;
     try {
-      parsedArgs = JSON.parse(chunk.args ?? "{}");
+      // A tool that takes no arguments produces no input deltas, leaving
+      // `args` as an empty string. `??` does not catch "", so fall back to
+      // "{}" for empty (or whitespace-only) accumulated args.
+      parsedArgs = JSON.parse(chunk.args?.trim() ? chunk.args : "{}");
     } catch {
       return {
         type: "invalid_tool_call" as const,

--- a/libs/langchain-core/src/language_models/tests/event.test.ts
+++ b/libs/langchain-core/src/language_models/tests/event.test.ts
@@ -10,6 +10,7 @@ import type {
   ProviderEvent,
   StreamErrorEvent,
 } from "../event.js";
+import { finalizeContentBlock } from "../compat.js";
 
 describe("ChatModelStreamEvent types", () => {
   test("MessageStartEvent", () => {
@@ -312,5 +313,93 @@ describe("interleaving semantics", () => {
 
     expect(blockStates.get(0)).toBe("finished");
     expect(blockStates.get(1)).toBe("finished");
+  });
+});
+
+describe("finalizeContentBlock", () => {
+
+  test("finalizes a tool call chunk with empty args as an empty object", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "c1",
+      name: "list_accounts",
+      args: "",
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "c1",
+      name: "list_accounts",
+      args: {},
+    });
+  });
+
+  test("finalizes a tool call chunk with undefined args as an empty object", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "c1",
+      name: "list_accounts",
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "c1",
+      name: "list_accounts",
+      args: {},
+    });
+  });
+
+  test("finalizes a tool call chunk with whitespace-only args as an empty object", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "c1",
+      name: "list_accounts",
+      args: "   ",
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "c1",
+      name: "list_accounts",
+      args: {},
+    });
+  });
+
+  test("finalizes a tool call chunk with valid JSON args", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "c1",
+      name: "search",
+      args: '{"q":"test"}',
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "tool_call",
+      id: "c1",
+      name: "search",
+      args: { q: "test" },
+    });
+  });
+
+  test("keeps invalid JSON args as an invalid tool call", () => {
+    const result = finalizeContentBlock({
+      type: "tool_call_chunk",
+      id: "c1",
+      name: "search",
+      args: '{"q"',
+      index: 0,
+    });
+
+    expect(result).toEqual({
+      type: "invalid_tool_call",
+      id: "c1",
+      name: "search",
+      args: '{"q"',
+      error: "Failed to parse tool call arguments as JSON",
+    });
   });
 });


### PR DESCRIPTION
Fixes #11355.

## Problem

Under `streamEvents({ version: "v3" })`, a tool the model calls with no arguments becomes an `invalid_tool_call` and the run ends. The provider streams no input deltas for a zero-argument tool, so the accumulated `args` stays `""`. In `finalizeContentBlock`, `JSON.parse(chunk.args ?? "{}")` does not catch `""` (`??` only falls back on `null`/`undefined`), `JSON.parse("") throws, and the block is finalized as `{ type: "invalid_tool_call", error: "Failed to parse tool call arguments as JSON" }`.

`invoke()` and `version: "v2"` handle the same call correctly.

## Solution

Fall back to `"{}"` when the accumulated args are empty or whitespace-only:

```ts
parsedArgs = JSON.parse(chunk.args?.trim() ? chunk.args : "{}");
```

This also covers `undefined` args, and preserves the invalid-tool-call behavior for genuinely malformed JSON (e.g. a truncated `{"q"`).

## Tests

Added a `finalizeContentBlock` suite in `event.test.ts` covering: empty string args → `{}`, undefined args → `{}`, whitespace-only args → `{}`, valid JSON args → parsed object, malformed JSON → `invalid_tool_call` (unchanged). Verified non-vacuous: the empty/whitespace tests fail against the previous implementation.

`language_models` suite: 106 tests passing, oxlint clean. Changeset added for `@langchain/core` (patch).