### PR TITLE
fix(openai): inline $ref sibling keywords in zod v4 interop response formats

### DIFF
--- a/.changeset/fix-zod-v4-ref-siblings.md
+++ b/.changeset/fix-zod-v4-ref-siblings.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Inline `$ref` sibling keywords in zod v4 interop response formats so OpenAI strict mode no longer rejects schemas where a field is chained `.default().describe()`

--- a/libs/providers/langchain-openai/src/utils/output.ts
+++ b/libs/providers/langchain-openai/src/utils/output.ts
@@ -89,6 +89,83 @@ function makeParseableResponseFormat<ParsedT>(
   return obj;
 }
 
+/**
+ * OpenAI strict mode rejects `$ref` nodes that carry sibling keywords
+ * ("$ref cannot have keywords"). zod v4's `toJSONSchema` with
+ * `cycles: "ref"` / `reused: "ref"` can emit exactly that: a field written
+ * `.default().describe()` gets hoisted into `$defs`, while the referencing
+ * node keeps `default` / `description` / `title` as siblings of the `$ref`.
+ *
+ * The reversed chain (`.describe().default()`) keeps the field inline and is
+ * accepted by strict mode, so inlining the `$defs` target into the
+ * referencing node — merging the sibling keywords — produces the accepted
+ * shape.
+ *
+ * @internal
+ */
+export function inlineRefSiblings(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const defs = (schema.$defs ?? schema.definitions) as
+    | Record<string, unknown>
+    | undefined;
+  return _inlineRefSiblings(schema, defs, new Set()) as Record<string, unknown>;
+}
+
+function _inlineRefSiblings(
+  node: unknown,
+  defs: Record<string, unknown> | undefined,
+  expanding: Set<string>
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => _inlineRefSiblings(item, defs, expanding));
+  }
+  if (typeof node !== "object" || node === null) {
+    return node;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  // A `$ref` with sibling keywords: inline the `$defs` target so strict
+  // mode accepts the node. Skip when the target is already being expanded
+  // (recursive refs would loop forever) or cannot be resolved.
+  if (typeof obj.$ref === "string" && Object.keys(obj).length > 1 && defs) {
+    const refKey = obj.$ref.split("/").pop() ?? "";
+    const target = defs[refKey];
+    if (target != null && !expanding.has(refKey)) {
+      const nextExpanding = new Set(expanding).add(refKey);
+      const inlined = _inlineRefSiblings(target, defs, nextExpanding);
+      if (typeof inlined === "object" && inlined !== null) {
+        const siblings = { ...obj };
+        delete siblings.$ref;
+        return { ...(inlined as Record<string, unknown>), ...siblings };
+      }
+    }
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "$defs" || key === "definitions") {
+      // Recurse into individual definitions so refs inside `$defs` are also
+      // handled, but keep the container itself.
+      if (typeof value === "object" && value !== null) {
+        const processed: Record<string, unknown> = {};
+        for (const [defKey, defValue] of Object.entries(
+          value as Record<string, unknown>
+        )) {
+          processed[defKey] = _inlineRefSiblings(defValue, defs, expanding);
+        }
+        result[key] = processed;
+      } else {
+        result[key] = value;
+      }
+      continue;
+    }
+    result[key] = _inlineRefSiblings(value, defs, expanding);
+  }
+  return result;
+}
+
 export function interopZodResponseFormat(
   zodSchema: InteropZodType,
   name: string,
@@ -105,21 +182,23 @@ export function interopZodResponseFormat(
           ...props,
           name,
           strict: true,
-          schema: toJsonSchema(zodSchema, {
-            cycles: "ref", // equivalent to nameStrategy: 'duplicate-ref'
-            reused: "ref", // equivalent to $refStrategy: 'extract-to-root'
-            override(ctx) {
-              ctx.jsonSchema.title = name; // equivalent to `name` property
-              // TODO: implement `nullableStrategy` patch-fix (zod doesn't support openApi3 json schema target)
-              // TODO: implement `openaiStrictMode` patch-fix (where optional properties without `nullable` are not supported)
-            },
-            /// property equivalents from native `zodResponseFormat` fn
-            // openaiStrictMode: true,
-            // name,
-            // nameStrategy: 'duplicate-ref',
-            // $refStrategy: 'extract-to-root',
-            // nullableStrategy: 'property',
-          }),
+          schema: inlineRefSiblings(
+            toJsonSchema(zodSchema, {
+              cycles: "ref", // equivalent to nameStrategy: 'duplicate-ref'
+              reused: "ref", // equivalent to $refStrategy: 'extract-to-root'
+              override(ctx) {
+                ctx.jsonSchema.title = name; // equivalent to `name` property
+                // TODO: implement `nullableStrategy` patch-fix (zod doesn't support openApi3 json schema target)
+                // TODO: implement `openaiStrictMode` patch-fix (where optional properties without `nullable` are not supported)
+              },
+              /// property equivalents from native `zodResponseFormat` fn
+              // openaiStrictMode: true,
+              // name,
+              // nameStrategy: 'duplicate-ref',
+              // $refStrategy: 'extract-to-root',
+              // nullableStrategy: 'property',
+            })
+          ) as ResponseFormatJSONSchema.JSONSchema,
         },
       },
       (content) =>

--- a/libs/providers/langchain-openai/src/utils/tests/output.test.ts
+++ b/libs/providers/langchain-openai/src/utils/tests/output.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "vitest";
+import { z as z4 } from "zod/v4";
+import { interopZodResponseFormat } from "../output.js";
+
+function getV4Schema(responseFormat: unknown): Record<string, unknown> {
+  return (responseFormat as Record<string, unknown>).json_schema as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("interopZodResponseFormat (zod v4)", () => {
+  test("inlines $ref siblings for a field chained .default().describe()", () => {
+    const schema = z4.object({
+      query: z4.string().default("all").describe("what to search for"),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const query = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).query as Record<string, unknown>;
+
+    expect(query.$ref).toBeUndefined();
+    expect(query).toEqual({
+      default: "all",
+      description: "what to search for",
+      type: "string",
+      title: "search",
+    });
+  });
+
+  test("keeps the reversed chain .describe().default() inline unchanged", () => {
+    const schema = z4.object({
+      query: z4.string().describe("what to search for").default("all"),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const query = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).query as Record<string, unknown>;
+
+    expect(query).toEqual({
+      default: "all",
+      description: "what to search for",
+      type: "string",
+      title: "search",
+    });
+  });
+
+  test("inlines nested $ref siblings inside objects and arrays", () => {
+    const schema = z4.object({
+      items: z4.array(
+        z4.object({
+          value: z4.number().default(0).describe("a number"),
+        })
+      ),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const items = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).items as Record<string, unknown>;
+    const itemProps = items.items as Record<string, unknown>;
+    const value = (
+      itemProps.properties as Record<string, unknown>
+    ).value as Record<string, unknown>;
+
+    expect(value.$ref).toBeUndefined();
+    expect(value).toEqual({
+      default: 0,
+      description: "a number",
+      type: "number",
+      title: "search",
+    });
+  });
+
+  test("leaves a bare $ref without siblings untouched", () => {
+    // A self-recursive schema produces a bare $ref; it must not throw and
+    // the $ref survives (strict mode accepts a bare $ref).
+    let categorySchema: ReturnType<typeof z4.object> = null as never;
+    const category = z4.lazy(() => categorySchema);
+    categorySchema = z4.object({
+      name: z4.string(),
+      subcategories: z4.array(category),
+    });
+
+    const fmt = interopZodResponseFormat(categorySchema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const subcategories = (
+      (
+        jsonSchema.schema.properties as Record<string, unknown>
+      ).subcategories as Record<string, unknown>
+    ).items as Record<string, unknown>;
+
+    expect(typeof subcategories.$ref).toBe("string");
+    expect(Object.keys(subcategories).length).toBe(1);
+  });
+
+  test("marks strict true and carries the name through", () => {
+    const schema = z4.object({ query: z4.string().default("all") });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      name: string;
+      strict: boolean;
+    };
+
+    expect(jsonSchema.name).toBe("search");
+    expect(jsonSchema.strict).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #11381.

## Problem

With a zod v4 schema, `interopZodResponseFormat` converts via `toJsonSchema` with `cycles: "ref"` / `reused: "ref"`. Under those options a field chained `.default().describe()` gets hoisted into `$defs`, while the referencing node keeps `default` / `description` / `title` as siblings of the `$ref`:

```json
"query": {
  "default": "all",
  "description": "what to search for",
  "$ref": "#/$defs/__schema0",
  "title": "search"
}
```

OpenAI strict mode rejects `$ref` nodes with sibling keywords, so the request dies with `400 Invalid schema for response_format: $ref cannot have keywords {'default', 'description', 'title'}` before the model runs. The reversed chain `.describe().default()` keeps the field inline and succeeds, so the failure feels arbitrary from the caller's side.

The zod v3 path is unaffected (it goes through OpenAI's own `zodResponseFormat`).

## Solution

Post-process the generated schema in the v4 branch: wherever a `$ref` carries sibling keywords, inline the `$defs` target into the node and merge the siblings — the same shape the reversed chain produces, which strict mode accepts:

```json
"query": {
  "default": "all",
  "description": "what to search for",
  "type": "string",
  "title": "search"
}
```

Cycle safety: a `Set` of keys currently being expanded prevents infinite recursion on self-referential schemas; a bare `$ref` (no siblings) is left untouched since strict mode already accepts it.

## Tests

Added `output.test.ts` covering: `.default().describe()` inlines to the strict-accepted shape; the reversed chain is unchanged; nested inlining through objects/arrays; a recursive schema's bare `$ref` survives; `strict: true` and the name still flow through. Verified non-vacuous: the inlining tests fail against the previous implementation.

`src/utils` suite: 33 tests passing, oxlint clean. Changeset added for `@langchain/openai` (patch).