### PR TITLE
fix(langchain): execute auto-approved tools when another tool is rejected in HITL

### DIFF
--- a/libs/langchain/src/agents/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middleware/hitl.ts
@@ -675,7 +675,7 @@ export function humanInTheLoopMiddleware(
     name: "HumanInTheLoopMiddleware",
     contextSchema,
     afterModel: {
-      canJumpTo: ["model"],
+      canJumpTo: ["model", "tools"],
       hook: async (state, runtime) => {
         const config = interopParse(contextSchema, {
           ...options,
@@ -850,7 +850,7 @@ export function humanInTheLoopMiddleware(
         }
 
         const jumpTo: JumpToTarget | undefined = hasRejectedToolCalls
-          ? "model"
+          ? "tools"
           : undefined;
         return {
           messages: [lastMessage, ...artificialToolMessages],

--- a/libs/langchain/src/agents/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/hitl.test.ts
@@ -2190,4 +2190,180 @@ describe("humanInTheLoopMiddleware", () => {
       expect(request.runtime.configurable?.thread_id).toBe("test-when-args");
     });
   });
+
+  describe("mixed tool calls with rejection", () => {
+    it("should execute auto-approved tools even when another tool is rejected", async () => {
+      // Configure HITL middleware - only write_file requires approval
+      const hitlMiddleware = humanInTheLoopMiddleware({
+        interruptOn: {
+          write_file: {
+            allowedDecisions: ["approve", "reject"],
+            description: "File write requires approval",
+          },
+        },
+      });
+
+      // Create agent with mocked LLM that calls both tools simultaneously
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          // First call: both calculator (auto-approved) and write_file (needs approval)
+          [
+            {
+              id: "call_1",
+              name: "calculator",
+              args: { a: 42, b: 17, operation: "multiply" },
+            },
+            {
+              id: "call_2",
+              name: "write_file",
+              args: { filename: "test.txt", content: "test" },
+            },
+          ],
+          // Second call: final response after tools execute
+          [],
+        ],
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createAgent({
+        model,
+        checkpointer,
+        systemPrompt: "You are a helpful assistant.",
+        tools: [calculateTool, writeFileTool],
+        middleware: [hitlMiddleware],
+      });
+
+      const config = {
+        configurable: {
+          thread_id: "test-mixed-rejection",
+        },
+      };
+
+      // First invocation - should interrupt for write_file
+      const result = await agent.invoke(
+        {
+          messages: [new HumanMessage("Calculate 42 * 17 and write the result to test.txt")],
+        },
+        config
+      );
+
+      // Should have interrupt
+      expect(result).toHaveProperty("__interrupt__");
+      expect(result.__interrupt__).toHaveLength(1);
+
+      // Resume with rejection of write_file
+      const resume = await agent.invoke(
+        new Command({
+          resume: {
+            decisions: [{ type: "reject", message: "Do not write the file" }],
+          },
+        }),
+        config
+      );
+
+      // The calculator tool should have been called (auto-approved)
+      expect(calculatorFn).toHaveBeenCalledTimes(1);
+      expect(calculatorFn).toHaveBeenCalledWith(
+        { a: 42, b: 17, operation: "multiply" },
+        expect.anything()
+      );
+
+      // The write_file tool should NOT have been called (rejected)
+      expect(writeFileFn).not.toHaveBeenCalled();
+
+      // Final result should include the calculator result and the rejection message
+      const toolMessages = resume.messages.filter(ToolMessage.isInstance);
+      expect(toolMessages).toHaveLength(1);
+      expect(toolMessages[0].status).toBe("error");
+      expect(toolMessages[0].content).toContain("Do not write the file");
+
+      // The AI message should have been called again with the tool results
+      const aiMessages = resume.messages.filter(AIMessage.isInstance);
+      // Should have at least 2 AI messages: first with tool calls, second with final response
+      expect(aiMessages.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("mixed tool calls with rejection", () => {
+    it("should execute auto-approved tools even when another tool is rejected", async () => {
+      const hitlMiddleware = humanInTheLoopMiddleware({
+        interruptOn: {
+          write_file: {
+            allowedDecisions: ["approve", "reject"],
+            description: "File write requires approval",
+          },
+        },
+      });
+
+      const model = new FakeToolCallingModel({
+        toolCalls: [
+          [
+            {
+              id: "call_1",
+              name: "calculator",
+              args: { a: 42, b: 17, operation: "multiply" },
+            },
+            {
+              id: "call_2",
+              name: "write_file",
+              args: { filename: "test.txt", content: "test" },
+            },
+          ],
+          [],
+        ],
+      });
+
+      const checkpointer = new MemorySaver();
+      const agent = createAgent({
+        model,
+        checkpointer,
+        systemPrompt: "You are a helpful assistant.",
+        tools: [calculateTool, writeFileTool],
+        middleware: [hitlMiddleware],
+      });
+
+      const config = { configurable: { thread_id: "test-mixed-rejection" } };
+
+      const result = await agent.invoke(
+        { messages: [new HumanMessage("Calculate 42 * 17 and write to file")] },
+        config
+      );
+
+      expect(result).toHaveProperty("__interrupt__");
+      expect(result.__interrupt__).toHaveLength(1);
+
+      const resume = await agent.invoke(
+        new Command({
+          resume: { decisions: [{ type: "reject", message: "Do not write the file" }] },
+        }),
+        config
+      );
+
+      // Auto-approved calculator tool should still execute
+      expect(calculatorFn).toHaveBeenCalledTimes(1);
+      expect(calculatorFn).toHaveBeenCalledWith(
+        { a: 42, b: 17, operation: "multiply" },
+        expect.anything()
+      );
+
+      // Rejected write_file tool should NOT execute
+      expect(writeFileFn).not.toHaveBeenCalled();
+
+      // Verify tool messages include both calculator result and rejection
+      const toolMessages = resume.messages.filter(ToolMessage.isInstance);
+      expect(toolMessages.length).toBeGreaterThanOrEqual(2);
+
+      const calculatorMessages = toolMessages.filter((tm) => tm.name === "calculator");
+      expect(calculatorMessages).toHaveLength(1);
+
+      const rejectionMessages = toolMessages.filter(
+        (tm) => tm.status === "error" && String(tm.content).includes("Do not write the file")
+      );
+      expect(rejectionMessages).toHaveLength(1);
+
+      // Model should be called again with tool results
+      const aiMessages = resume.messages.filter(AIMessage.isInstance);
+      expect(aiMessages.length).toBeGreaterThanOrEqual(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When using `humanInTheLoopMiddleware` with a mixed set of tool calls (some requiring approval, some auto-approved), rejecting one tool call incorrectly skips execution of ALL tools — including auto-approved ones.

## Root Cause

In `libs/langchain/src/agents/middleware/hitl.ts`, when `hasRejectedToolCalls` is true, the middleware sets `jumpTo: "model"`, which causes the agent to skip the entire tools node. This means any auto-approved tool calls that were part of the same batch are never executed.

## Fix

1. Added `"tools"` to the `canJumpTo` array to allow jumping to the tools node.
2. Changed `jumpTo` from `"model"` to `"tools"` when there are rejected tool calls. This ensures that auto-approved tools still execute before the model is called again with the combined results.

## Test

Added a test case that verifies:
- When one tool requires HITL approval and another is auto-approved
- Rejecting the first tool should NOT prevent the second (auto-approved) tool from executing
- Both the calculator result and the rejection message should appear in the final state
- The model should be called again with all tool results