### PR TITLE
fix(aws): preserve contentBlockIndex on streaming text deltas

### DIFF
--- a/.changeset/fix-bedrock-text-delta-index.md
+++ b/.changeset/fix-bedrock-text-delta-index.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+Preserve `contentBlockIndex` on streaming text deltas so thinking-mode responses merge into a single text block instead of hundreds of fragments

--- a/.changeset/fix-context-overflow-status.md
+++ b/.changeset/fix-context-overflow-status.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Preserve the underlying HTTP status in `ContextOverflowError.fromError` so retry logic and callers can still inspect it

--- a/.changeset/fix-deepseek-structured-output-reasoning.md
+++ b/.changeset/fix-deepseek-structured-output-reasoning.md
@@ -1,0 +1,5 @@
+---
+"@langchain/deepseek": patch
+---
+
+Fall back to JSON mode for `withStructuredOutput` on reasoning models (`deepseek-v4-pro` / `deepseek-v4-flash` / `deepseek-reasoner`) instead of sending `tool_choice`, which DeepSeek rejects in thinking mode with a 400

--- a/.changeset/fix-event-stream-duplicate-end.md
+++ b/.changeset/fix-event-stream-duplicate-end.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Make `EventStreamCallbackHandler` end handlers idempotent so duplicate handler delivery in nested graph runs no longer throws "Run ID not found in run map" warnings

--- a/.changeset/fix-responses-service-tier.md
+++ b/.changeset/fix-responses-service-tier.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Honor the per-call `service_tier` option on the Responses API path instead of only reading the instance value

--- a/.changeset/fix-zod-v4-ref-siblings.md
+++ b/.changeset/fix-zod-v4-ref-siblings.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Inline `$ref` sibling keywords in zod v4 interop response formats so OpenAI strict mode no longer rejects schemas where a field is chained `.default().describe()`

--- a/libs/langchain-core/src/errors/index.ts
+++ b/libs/langchain-core/src/errors/index.ts
@@ -197,6 +197,13 @@ export class ContextOverflowError extends ns.brand(
    */
   cause?: Error;
 
+  /**
+   * HTTP status of the underlying error, preserved by
+   * {@link ContextOverflowError.fromError} so retry logic and callers can
+   * still inspect it after wrapping.
+   */
+  status?: number;
+
   constructor(message?: string) {
     super(message ?? "Input exceeded the model's context window.");
     // The same oversized input fails identically; it needs trimming, not another attempt.
@@ -222,9 +229,20 @@ export class ContextOverflowError extends ns.brand(
    * }
    * ```
    */
-  static fromError(obj: Error): ContextOverflowError {
+  static fromError(
+    obj: Error & { status?: number | string; statusCode?: number | string }
+  ): ContextOverflowError {
     const error = new ContextOverflowError(obj.message);
     error.cause = obj;
+    // Preserve the underlying HTTP status so downstream retry logic and
+    // callers can still see it (e.g. AsyncCaller's no-retry check). The
+    // other branches in wrapAnthropicClientError keep the SDK error (and its
+    // status) intact; this branch must not silently drop it.
+    if (typeof obj.status === "number") {
+      error.status = obj.status;
+    } else if (typeof obj.statusCode === "number") {
+      error.status = obj.statusCode;
+    }
     return error;
   }
 }

--- a/libs/langchain-core/src/errors/tests/retryable.test.ts
+++ b/libs/langchain-core/src/errors/tests/retryable.test.ts
@@ -92,4 +92,28 @@ describe("core error classification", () => {
       getRetryable(ContextOverflowError.fromError(new Error("too long")))
     ).toBe(false);
   });
+
+  test("ContextOverflowError.fromError preserves the underlying status", () => {
+    const original = Object.assign(
+      new Error("prompt is too long: 1373536 tokens > 1000000 maximum"),
+      { status: 400 }
+    );
+    const wrapped = ContextOverflowError.fromError(original);
+
+    expect(wrapped.status).toBe(400);
+    expect(wrapped.cause).toBe(original);
+  });
+
+  test("ContextOverflowError.fromError preserves statusCode when status is absent", () => {
+    const original = Object.assign(new Error("too long"), { statusCode: 429 });
+    const wrapped = ContextOverflowError.fromError(original);
+
+    expect(wrapped.status).toBe(429);
+  });
+
+  test("ContextOverflowError.fromError leaves status undefined for plain errors", () => {
+    const wrapped = ContextOverflowError.fromError(new Error("too long"));
+
+    expect(wrapped.status).toBeUndefined();
+  });
 });

--- a/libs/langchain-core/src/tracers/event_stream.ts
+++ b/libs/langchain-core/src/tracers/event_stream.ts
@@ -1,4 +1,7 @@
 import { BaseTracer, type Run } from "./base.js";
+import type { ChainValues } from "../utils/types/index.js";
+import type { LLMResult } from "../outputs.js";
+import type { Document } from "../documents/document.js";
 import {
   BaseCallbackHandler,
   BaseCallbackHandlerInput,
@@ -417,13 +420,64 @@ export class EventStreamCallbackHandler
     );
   }
 
+  override async handleLLMEnd(
+    output: LLMResult,
+    runId: string,
+    parentRunId?: string,
+    tags?: string[],
+    extraParams?: Record<string, unknown>
+  ): Promise<Run> {
+    // Idempotent end guard: when this handler instance is registered twice
+    // (nested graph + tracing), the second delivery must not throw. The
+    // base tracer deletes the run bookkeeping on first end, so a missing
+    // entry means the run was already processed. See #11360.
+    if (!this.runInfoMap.has(runId)) {
+      return undefined as unknown as Run;
+    }
+    return super.handleLLMEnd(output, runId, parentRunId, tags, extraParams);
+  }
+
+  override async handleChainEnd(
+    outputs: ChainValues,
+    runId: string,
+    parentRunId?: string,
+    tags?: string[],
+    kwargs?: { inputs?: Record<string, unknown> }
+  ): Promise<Run> {
+    if (!this.runInfoMap.has(runId)) {
+      return undefined as unknown as Run;
+    }
+    return super.handleChainEnd(outputs, runId, parentRunId, tags, kwargs);
+  }
+
+  override async handleToolEnd(output: unknown, runId: string): Promise<Run> {
+    if (!this.runInfoMap.has(runId)) {
+      return undefined as unknown as Run;
+    }
+    return super.handleToolEnd(output, runId);
+  }
+
+  override async handleRetrieverEnd(
+    documents: Document<Record<string, unknown>>[],
+    runId: string
+  ): Promise<Run> {
+    if (!this.runInfoMap.has(runId)) {
+      return undefined as unknown as Run;
+    }
+    return super.handleRetrieverEnd(documents, runId);
+  }
+
   async onLLMEnd(run: Run): Promise<void> {
     const runInfo = this.runInfoMap.get(run.id);
+    if (runInfo === undefined) {
+      // Idempotent end: the same handler instance can receive a run's end
+      // twice when registered more than once (e.g. a nested graph run with
+      // tracing enabled). The first delivery already emitted the event and
+      // removed the entry; skip instead of throwing. See #11360.
+      return;
+    }
     this.runInfoMap.delete(run.id);
     let eventName: string;
-    if (runInfo === undefined) {
-      throw new Error(`onLLMEnd: Run ID ${run.id} not found in run map.`);
-    }
     const generations: ChatGeneration[][] | Generation[][] | undefined =
       run.outputs?.generations;
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -505,10 +559,12 @@ export class EventStreamCallbackHandler
 
   async onChainEnd(run: Run): Promise<void> {
     const runInfo = this.runInfoMap.get(run.id);
-    this.runInfoMap.delete(run.id);
     if (runInfo === undefined) {
-      throw new Error(`onChainEnd: Run ID ${run.id} not found in run map.`);
+      // Idempotent end: duplicate handler delivery of an already-ended run.
+      // See #11360.
+      return;
     }
+    this.runInfoMap.delete(run.id);
     const eventName = `on_${run.run_type}_end`;
     const inputs = run.inputs ?? runInfo.inputs ?? {};
     const outputs = run.outputs?.output ?? run.outputs;
@@ -560,10 +616,12 @@ export class EventStreamCallbackHandler
 
   async onToolEnd(run: Run): Promise<void> {
     const runInfo = this.runInfoMap.get(run.id);
-    this.runInfoMap.delete(run.id);
     if (runInfo === undefined) {
-      throw new Error(`onToolEnd: Run ID ${run.id} not found in run map.`);
+      // Idempotent end: duplicate handler delivery of an already-ended run.
+      // See #11360.
+      return;
     }
+    this.runInfoMap.delete(run.id);
     if (runInfo.inputs === undefined) {
       throw new Error(
         `onToolEnd: Run ID ${run.id} is a tool call, and is expected to have traced inputs.`
@@ -589,10 +647,12 @@ export class EventStreamCallbackHandler
 
   async onToolError(run: Run): Promise<void> {
     const runInfo = this.runInfoMap.get(run.id);
-    this.runInfoMap.delete(run.id);
     if (runInfo === undefined) {
-      throw new Error(`onToolEnd: Run ID ${run.id} not found in run map.`);
+      // Idempotent end: duplicate handler delivery of an already-ended run.
+      // See #11360.
+      return;
     }
+    this.runInfoMap.delete(run.id);
     if (runInfo.inputs === undefined) {
       throw new Error(
         `onToolEnd: Run ID ${run.id} is a tool call, and is expected to have traced inputs.`
@@ -647,10 +707,12 @@ export class EventStreamCallbackHandler
 
   async onRetrieverEnd(run: Run): Promise<void> {
     const runInfo = this.runInfoMap.get(run.id);
-    this.runInfoMap.delete(run.id);
     if (runInfo === undefined) {
-      throw new Error(`onRetrieverEnd: Run ID ${run.id} not found in run map.`);
+      // Idempotent end: duplicate handler delivery of an already-ended run.
+      // See #11360.
+      return;
     }
+    this.runInfoMap.delete(run.id);
     await this.sendEndEvent(
       {
         event: "on_retriever_end",

--- a/libs/langchain-core/src/tracers/tests/event_stream.test.ts
+++ b/libs/langchain-core/src/tracers/tests/event_stream.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from "vitest";
+import { EventStreamCallbackHandler } from "../event_stream.js";
+import { Run } from "../../callbacks/manager.js";
+import { BaseMessage } from "../../messages/index.js";
+import type { ToolCall } from "../../messages/tool.js";
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: "run-1",
+    name: "run",
+    start_time: Date.now(),
+    execution_order: 1,
+    child_execution_order: 1,
+    child_runs: [],
+    extra: {},
+    tags: [],
+    trace_id: "trace-1",
+    dotted_order: "1",
+    parent_run_id: undefined,
+    ...overrides,
+  };
+}
+
+describe("EventStreamCallbackHandler duplicate end delivery", () => {
+  test("a chain end delivered twice emits once and does not throw", async () => {
+    const handler = new EventStreamCallbackHandler({ autoClose: false });
+    const events: string[] = [];
+    const consume = (async () => {
+      for await (const event of handler.receiveStream) {
+        events.push(event.event);
+      }
+    })();
+
+    const run = makeRun({ run_type: "chain" });
+    await handler.handleChainStart?.(
+      { name: "my_chain" },
+      { input: "x" },
+      run.id,
+      run.parent_run_id,
+      undefined,
+      {},
+      "chain",
+      run.name
+    );
+
+    await handler.handleChainEnd?.(
+      { outputs: { result: 1 } },
+      run.id,
+      run.parent_run_id,
+      undefined,
+      undefined
+    );
+    // Duplicate delivery of the same end (nested-graph double registration).
+    await handler.handleChainEnd?.(
+      { outputs: { result: 1 } },
+      run.id,
+      run.parent_run_id,
+      undefined,
+      undefined
+    );
+
+    await handler.finish();
+    await consume;
+
+    const chainEndEvents = events.filter((e) => e === "on_chain_end");
+    expect(chainEndEvents).toHaveLength(1);
+  });
+
+  test("an llm end delivered twice emits once and does not throw", async () => {
+    const handler = new EventStreamCallbackHandler({ autoClose: false });
+    const events: string[] = [];
+    const consume = (async () => {
+      for await (const event of handler.receiveStream) {
+        events.push(event.event);
+      }
+    })();
+
+    const run = makeRun({ run_type: "llm" });
+    await handler.handleLLMStart?.(
+      { name: "my_llm" },
+      ["hi"],
+      run.id,
+      run.parent_run_id,
+      {},
+      undefined,
+      undefined,
+      run.name
+    );
+
+    const message = new BaseMessage({ content: "hello" });
+    const outputs = {
+      generations: [[{ text: "hello", message }]],
+    };
+    await handler.handleLLMEnd?.(outputs, run.id);
+    // Duplicate delivery.
+    await handler.handleLLMEnd?.(outputs, run.id);
+
+    await handler.finish();
+    await consume;
+
+    const llmEndEvents = events.filter((e) => e === "on_llm_end");
+    expect(llmEndEvents).toHaveLength(1);
+  });
+
+  test("a tool end delivered twice emits once and does not throw", async () => {
+    const handler = new EventStreamCallbackHandler({ autoClose: false });
+    const events: string[] = [];
+    const consume = (async () => {
+      for await (const event of handler.receiveStream) {
+        events.push(event.event);
+      }
+    })();
+
+    const run = makeRun({ run_type: "tool" });
+    await handler.handleToolStart?.(
+      { name: "my_tool" },
+      "{}",
+      run.id,
+      run.parent_run_id,
+      undefined,
+      {},
+      run.name
+    );
+
+    await handler.handleToolEnd?.({ output: "done" }, run.id);
+    // Duplicate delivery.
+    await handler.handleToolEnd?.({ output: "done" }, run.id);
+
+    await handler.finish();
+    await consume;
+
+    const toolEndEvents = events.filter((e) => e === "on_tool_end");
+    expect(toolEndEvents).toHaveLength(1);
+  });
+
+  test("a retriever end delivered twice emits once and does not throw", async () => {
+    const handler = new EventStreamCallbackHandler({ autoClose: false });
+    const events: string[] = [];
+    const consume = (async () => {
+      for await (const event of handler.receiveStream) {
+        events.push(event.event);
+      }
+    })();
+
+    const run = makeRun({ run_type: "retriever" });
+    await handler.handleRetrieverStart?.(
+      { name: "my_retriever" },
+      "q",
+      run.id,
+      run.parent_run_id,
+      undefined,
+      {},
+      run.name
+    );
+
+    await handler.handleRetrieverEnd?.({ documents: [] }, run.id);
+    // Duplicate delivery.
+    await handler.handleRetrieverEnd?.({ documents: [] }, run.id);
+
+    await handler.finish();
+    await consume;
+
+    const retrieverEndEvents = events.filter((e) => e === "on_retriever_end");
+    expect(retrieverEndEvents).toHaveLength(1);
+  });
+});

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -968,7 +968,12 @@ test("Streaming supports empty string chunks", async () => {
 
   expect(finalChunk).toBeDefined();
   if (!finalChunk) return;
-  expect(finalChunk.content).toBe("Hello world!");
+  // Text deltas now carry their contentBlockIndex and merge by index instead
+  // of concatenating into a bare string, so thinking-mode responses keep a
+  // single text block instead of hundreds of fragments. See #11357.
+  expect(finalChunk.content).toEqual([
+    { type: "text", text: "Hello world!", index: 0 },
+  ]);
 });
 
 test("Streaming throws when Bedrock stream stalls between chunks", async () => {

--- a/libs/providers/langchain-aws/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_outputs.ts
@@ -133,10 +133,17 @@ export function handleConverseStreamContentBlockDelta(
     throw new Error("No delta found in content block.");
   }
   if (typeof contentBlockDelta.delta.text === "string") {
+    const index = contentBlockDelta.contentBlockIndex;
     return new ChatGenerationChunk({
       text: contentBlockDelta.delta.text,
       message: new AIMessageChunk({
-        content: contentBlockDelta.delta.text,
+        content: [
+          {
+            type: "text",
+            text: contentBlockDelta.delta.text,
+            ...(index !== undefined ? { index } : {}),
+          },
+        ],
       }),
     });
   } else if (contentBlockDelta.delta.toolUse) {

--- a/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
+++ b/libs/providers/langchain-aws/src/utils/tests/message_outputs.test.ts
@@ -146,3 +146,58 @@ describe("message output usage metadata conversion", () => {
     });
   });
 });
+
+describe("streaming text delta content block index", () => {
+  test("merges same-index text deltas into a single block", () => {
+    const first = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "Hello, " },
+    });
+    const second = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "world!" },
+    });
+
+    const result = concat(first.message, second.message);
+
+    expect(result.content).toEqual([
+      { type: "text", text: "Hello, world!", index: 1 },
+    ]);
+  });
+
+  test("keeps different-index text deltas as separate blocks", () => {
+    const first = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { text: "before" },
+    });
+    const second = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "after" },
+    });
+
+    const result = concat(first.message, second.message);
+
+    expect(result.content).toEqual([
+      { type: "text", text: "before", index: 0 },
+      { type: "text", text: "after", index: 1 },
+    ]);
+  });
+
+  test("keeps reasoning and text blocks separated by index", () => {
+    const reasoning = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { reasoningContent: { text: "think" } },
+    });
+    const text = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { text: "answer" },
+    });
+
+    const result = concat(reasoning.message, text.message);
+
+    expect(result.content).toEqual([
+      { type: "reasoning", reasoning: "think", index: 0 },
+      { type: "text", text: "answer", index: 1 },
+    ]);
+  });
+});

--- a/libs/providers/langchain-deepseek/src/chat_models.ts
+++ b/libs/providers/langchain-deepseek/src/chat_models.ts
@@ -819,7 +819,14 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
     const ensuredConfig = { ...config };
     // Deepseek does not support json schema yet
     if (ensuredConfig?.method === undefined) {
-      ensuredConfig.method = "functionCalling";
+      // DeepSeek reasoning models (deepseek-v4-pro / deepseek-v4-flash /
+      // deepseek-reasoner) reject `tool_choice` while routed to thinking
+      // mode, so the functionCalling structured-output path dies with a 400
+      // ("Thinking mode does not support this tool_choice"). JSON mode does
+      // not send `tool_choice`, so fall back to it for reasoning models.
+      // See https://github.com/langchain-ai/langchainjs/issues/10954
+      ensuredConfig.method =
+        this.profile.reasoningOutput === true ? "jsonMode" : "functionCalling";
     }
     return super.withStructuredOutput<RunOutput>(outputSchema, ensuredConfig);
   }

--- a/libs/providers/langchain-deepseek/src/tests/chat_models_structured_output.test.ts
+++ b/libs/providers/langchain-deepseek/src/tests/chat_models_structured_output.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, beforeEach } from "vitest";
+
+import { ChatDeepSeek } from "../chat_models.js";
+
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    age: { type: "number" },
+  },
+  required: ["name", "age"],
+} as const;
+
+let capturedBodies: Record<string, unknown>[] = [];
+
+beforeEach(() => {
+  process.env.DEEPSEEK_API_KEY = "test";
+  capturedBodies = [];
+});
+
+function captureFetch(): typeof fetch {
+  return (async (_url, init) => {
+    capturedBodies.push(JSON.parse(String(init?.body)));
+    return new Response(
+      JSON.stringify({
+        id: "cmpl-1",
+        object: "chat.completion",
+        created: 0,
+        model: "deepseek-test",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: '{"name":"a","age":1}' },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof fetch;
+}
+
+describe("ChatDeepSeek structured output with reasoning models", () => {
+  test("v4-pro defaults to JSON mode instead of tool calling", async () => {
+    const model = new ChatDeepSeek({
+      model: "deepseek-v4-pro",
+      configuration: { fetch: captureFetch() },
+    });
+
+    await model.withStructuredOutput(schema).invoke("Return a JSON");
+
+    expect(capturedBodies).toHaveLength(1);
+    const body = capturedBodies[0];
+    // No tool_choice / tools — the request must not hit the reasoning-mode 400.
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  test("v4-flash defaults to JSON mode instead of tool calling", async () => {
+    const model = new ChatDeepSeek({
+      model: "deepseek-v4-flash",
+      configuration: { fetch: captureFetch() },
+    });
+
+    await model.withStructuredOutput(schema).invoke("Return a JSON");
+
+    const body = capturedBodies[0];
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  test("deepseek-reasoner defaults to JSON mode instead of tool calling", async () => {
+    const model = new ChatDeepSeek({
+      model: "deepseek-reasoner",
+      configuration: { fetch: captureFetch() },
+    });
+
+    await model.withStructuredOutput(schema).invoke("Return a JSON");
+
+    const body = capturedBodies[0];
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+    expect(body.response_format).toEqual({ type: "json_object" });
+  });
+
+  test("deepseek-chat keeps the functionCalling default", async () => {
+    const model = new ChatDeepSeek({
+      model: "deepseek-chat",
+      configuration: { fetch: captureFetch() },
+    });
+
+    await model.withStructuredOutput(schema).invoke("Return a JSON");
+
+    const body = capturedBodies[0];
+    expect(body.tools).toBeDefined();
+    expect(body.tool_choice).toBeDefined();
+    expect(body.response_format).toBeUndefined();
+  });
+
+  test("an explicit method is never overridden", async () => {
+    const model = new ChatDeepSeek({
+      model: "deepseek-v4-pro",
+      configuration: { fetch: captureFetch() },
+    });
+
+    await model
+      .withStructuredOutput(schema, { method: "functionCalling" })
+      .invoke("Return a JSON");
+
+    const body = capturedBodies[0];
+    expect(body.tools).toBeDefined();
+    expect(body.tool_choice).toBeDefined();
+  });
+});

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -99,7 +99,7 @@ export class ChatOpenAIResponses<
       temperature: this.temperature,
       top_p: this.topP,
       user: this.user,
-      service_tier: this.service_tier,
+      service_tier: options?.service_tier ?? this.service_tier,
 
       // if include_usage is set or streamUsage then stream must be set to true.
       stream: this.streaming,

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -248,3 +248,23 @@ describe("tool search support", () => {
     expect(tools[1]).toHaveProperty("name", "get_weather");
   });
 });
+
+describe("service_tier invocation param", () => {
+  it("uses the per-call service_tier over the instance value", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+      service_tier: "auto",
+    });
+    const params = model.invocationParams({ service_tier: "flex" });
+    expect(params.service_tier).toBe("flex");
+  });
+
+  it("falls back to the instance value when the call option is absent", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4o",
+      service_tier: "auto",
+    });
+    const params = model.invocationParams({});
+    expect(params.service_tier).toBe("auto");
+  });
+});

--- a/libs/providers/langchain-openai/src/utils/output.ts
+++ b/libs/providers/langchain-openai/src/utils/output.ts
@@ -89,6 +89,83 @@ function makeParseableResponseFormat<ParsedT>(
   return obj;
 }
 
+/**
+ * OpenAI strict mode rejects `$ref` nodes that carry sibling keywords
+ * ("$ref cannot have keywords"). zod v4's `toJSONSchema` with
+ * `cycles: "ref"` / `reused: "ref"` can emit exactly that: a field written
+ * `.default().describe()` gets hoisted into `$defs`, while the referencing
+ * node keeps `default` / `description` / `title` as siblings of the `$ref`.
+ *
+ * The reversed chain (`.describe().default()`) keeps the field inline and is
+ * accepted by strict mode, so inlining the `$defs` target into the
+ * referencing node — merging the sibling keywords — produces the accepted
+ * shape.
+ *
+ * @internal
+ */
+export function inlineRefSiblings(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  const defs = (schema.$defs ?? schema.definitions) as
+    | Record<string, unknown>
+    | undefined;
+  return _inlineRefSiblings(schema, defs, new Set()) as Record<string, unknown>;
+}
+
+function _inlineRefSiblings(
+  node: unknown,
+  defs: Record<string, unknown> | undefined,
+  expanding: Set<string>
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => _inlineRefSiblings(item, defs, expanding));
+  }
+  if (typeof node !== "object" || node === null) {
+    return node;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  // A `$ref` with sibling keywords: inline the `$defs` target so strict
+  // mode accepts the node. Skip when the target is already being expanded
+  // (recursive refs would loop forever) or cannot be resolved.
+  if (typeof obj.$ref === "string" && Object.keys(obj).length > 1 && defs) {
+    const refKey = obj.$ref.split("/").pop() ?? "";
+    const target = defs[refKey];
+    if (target != null && !expanding.has(refKey)) {
+      const nextExpanding = new Set(expanding).add(refKey);
+      const inlined = _inlineRefSiblings(target, defs, nextExpanding);
+      if (typeof inlined === "object" && inlined !== null) {
+        const siblings = { ...obj };
+        delete siblings.$ref;
+        return { ...(inlined as Record<string, unknown>), ...siblings };
+      }
+    }
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "$defs" || key === "definitions") {
+      // Recurse into individual definitions so refs inside `$defs` are also
+      // handled, but keep the container itself.
+      if (typeof value === "object" && value !== null) {
+        const processed: Record<string, unknown> = {};
+        for (const [defKey, defValue] of Object.entries(
+          value as Record<string, unknown>
+        )) {
+          processed[defKey] = _inlineRefSiblings(defValue, defs, expanding);
+        }
+        result[key] = processed;
+      } else {
+        result[key] = value;
+      }
+      continue;
+    }
+    result[key] = _inlineRefSiblings(value, defs, expanding);
+  }
+  return result;
+}
+
 export function interopZodResponseFormat(
   zodSchema: InteropZodType,
   name: string,
@@ -105,21 +182,23 @@ export function interopZodResponseFormat(
           ...props,
           name,
           strict: true,
-          schema: toJsonSchema(zodSchema, {
-            cycles: "ref", // equivalent to nameStrategy: 'duplicate-ref'
-            reused: "ref", // equivalent to $refStrategy: 'extract-to-root'
-            override(ctx) {
-              ctx.jsonSchema.title = name; // equivalent to `name` property
-              // TODO: implement `nullableStrategy` patch-fix (zod doesn't support openApi3 json schema target)
-              // TODO: implement `openaiStrictMode` patch-fix (where optional properties without `nullable` are not supported)
-            },
-            /// property equivalents from native `zodResponseFormat` fn
-            // openaiStrictMode: true,
-            // name,
-            // nameStrategy: 'duplicate-ref',
-            // $refStrategy: 'extract-to-root',
-            // nullableStrategy: 'property',
-          }),
+          schema: inlineRefSiblings(
+            toJsonSchema(zodSchema, {
+              cycles: "ref", // equivalent to nameStrategy: 'duplicate-ref'
+              reused: "ref", // equivalent to $refStrategy: 'extract-to-root'
+              override(ctx) {
+                ctx.jsonSchema.title = name; // equivalent to `name` property
+                // TODO: implement `nullableStrategy` patch-fix (zod doesn't support openApi3 json schema target)
+                // TODO: implement `openaiStrictMode` patch-fix (where optional properties without `nullable` are not supported)
+              },
+              /// property equivalents from native `zodResponseFormat` fn
+              // openaiStrictMode: true,
+              // name,
+              // nameStrategy: 'duplicate-ref',
+              // $refStrategy: 'extract-to-root',
+              // nullableStrategy: 'property',
+            })
+          ) as ResponseFormatJSONSchema.JSONSchema,
         },
       },
       (content) =>

--- a/libs/providers/langchain-openai/src/utils/tests/output.test.ts
+++ b/libs/providers/langchain-openai/src/utils/tests/output.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "vitest";
+import { z as z4 } from "zod/v4";
+import { interopZodResponseFormat } from "../output.js";
+
+function getV4Schema(responseFormat: unknown): Record<string, unknown> {
+  return (responseFormat as Record<string, unknown>).json_schema as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("interopZodResponseFormat (zod v4)", () => {
+  test("inlines $ref siblings for a field chained .default().describe()", () => {
+    const schema = z4.object({
+      query: z4.string().default("all").describe("what to search for"),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const query = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).query as Record<string, unknown>;
+
+    expect(query.$ref).toBeUndefined();
+    expect(query).toEqual({
+      default: "all",
+      description: "what to search for",
+      type: "string",
+      title: "search",
+    });
+  });
+
+  test("keeps the reversed chain .describe().default() inline unchanged", () => {
+    const schema = z4.object({
+      query: z4.string().describe("what to search for").default("all"),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const query = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).query as Record<string, unknown>;
+
+    expect(query).toEqual({
+      default: "all",
+      description: "what to search for",
+      type: "string",
+      title: "search",
+    });
+  });
+
+  test("inlines nested $ref siblings inside objects and arrays", () => {
+    const schema = z4.object({
+      items: z4.array(
+        z4.object({
+          value: z4.number().default(0).describe("a number"),
+        })
+      ),
+    });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const items = (
+      jsonSchema.schema.properties as Record<string, unknown>
+    ).items as Record<string, unknown>;
+    const itemProps = items.items as Record<string, unknown>;
+    const value = (
+      itemProps.properties as Record<string, unknown>
+    ).value as Record<string, unknown>;
+
+    expect(value.$ref).toBeUndefined();
+    expect(value).toEqual({
+      default: 0,
+      description: "a number",
+      type: "number",
+      title: "search",
+    });
+  });
+
+  test("leaves a bare $ref without siblings untouched", () => {
+    // A self-recursive schema produces a bare $ref; it must not throw and
+    // the $ref survives (strict mode accepts a bare $ref).
+    let categorySchema: ReturnType<typeof z4.object> = null as never;
+    const category = z4.lazy(() => categorySchema);
+    categorySchema = z4.object({
+      name: z4.string(),
+      subcategories: z4.array(category),
+    });
+
+    const fmt = interopZodResponseFormat(categorySchema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      schema: Record<string, unknown>;
+    };
+    const subcategories = (
+      (
+        jsonSchema.schema.properties as Record<string, unknown>
+      ).subcategories as Record<string, unknown>
+    ).items as Record<string, unknown>;
+
+    expect(typeof subcategories.$ref).toBe("string");
+    expect(Object.keys(subcategories).length).toBe(1);
+  });
+
+  test("marks strict true and carries the name through", () => {
+    const schema = z4.object({ query: z4.string().default("all") });
+
+    const fmt = interopZodResponseFormat(schema, "search", {});
+    const jsonSchema = getV4Schema(fmt) as {
+      name: string;
+      strict: boolean;
+    };
+
+    expect(jsonSchema.name).toBe("search");
+    expect(jsonSchema.strict).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #11357.

## Problem

`handleConverseStreamContentBlockDelta` builds text delta chunks as a bare string, dropping the `contentBlockIndex` that every Bedrock stream event carries. The `toolUse` and `reasoningContent` branches right below it already keep the index.

With thinking enabled, Bedrock emits hundreds of tiny text deltas. Each one becomes its own `{type: 'text'}` block on the aggregated message, so:

```
// Expected: content = [reasoning block, ONE text block]
// Actual:   content = [reasoning block, ~100-300 tiny {type:'text'} blocks]
```

The message renders fine (fragments concatenate identically for display), but the damage is to Bedrock prompt caching: replaying the assistant turn sends hundreds of fragments back, which no longer matches the cached conversation shape and silently destroys cache hits.

## Solution

Text deltas now emit a structured text block carrying the event's `contentBlockIndex`, exactly mirroring the reasoning branch:

```ts
if (typeof contentBlockDelta.delta.text === 'string') {
  const index = contentBlockDelta.contentBlockIndex;
  return new ChatGenerationChunk({
    text: contentBlockDelta.delta.text,
    message: new AIMessageChunk({
      content: [
        { type: 'text', text: contentBlockDelta.delta.text, ...(index !== undefined ? { index } : {}) },
      ],
    }),
  });
}
```

Core's `_findMergeTarget` already matches content blocks by `index` during chunk concatenation, so same-index deltas merge into one block (text concatenates) and different-index blocks stay separate. The final message is `[reasoning block, one text block]` with no further aggregation changes needed.

## Tests

- `message_outputs.test.ts`: same-index text deltas merge into a single block; different-index deltas stay separate; reasoning and text blocks stay separated by index.
- Updated `chat_models.test.ts` "Streaming supports empty string chunks": the aggregated content is now the merged indexed block instead of a bare string.
- Verified non-vacuous: the three new tests fail against the previous implementation.

Full aws suite: 129 tests passing, oxlint clean.