### PR TITLE
fix(openai): only include raw response when requested

### DIFF
--- a/.changeset/calm-owls-opt-in.md
+++ b/.changeset/calm-owls-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Fixes `__includeRawResponse: false` including raw response data in non-streaming Chat Completions messages.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -291,7 +291,7 @@ export const convertCompletionsMessageToBaseMessage: Converter<
         function_call: message.function_call,
         tool_calls: rawToolCalls,
       };
-      if (includeRawResponse !== undefined) {
+      if (includeRawResponse) {
         additional_kwargs.__raw_response = rawResponse;
       }
       if (providerReasoningContent !== undefined) {

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -11,6 +11,47 @@ import {
 } from "../completions.js";
 
 describe("convertCompletionsMessageToBaseMessage", () => {
+  const mockMessage = {
+    role: "assistant" as const,
+    content: "Hello",
+  };
+
+  const mockRawResponse = {
+    id: "chatcmpl-raw-response",
+    model: "gpt-5.4",
+    choices: [{ index: 0, message: mockMessage }],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+
+  it("includes the raw response when explicitly requested", () => {
+    const result = convertCompletionsMessageToBaseMessage({
+      message: mockMessage as ChatCompletionMessage,
+      rawResponse: mockRawResponse as any,
+      includeRawResponse: true,
+    }) as AIMessage;
+
+    expect(result.additional_kwargs.__raw_response).toBe(mockRawResponse);
+  });
+
+  it.each([false, undefined])(
+    "does not include the raw response when includeRawResponse is %s",
+    (includeRawResponse) => {
+      const result = convertCompletionsMessageToBaseMessage({
+        message: mockMessage as ChatCompletionMessage,
+        rawResponse: mockRawResponse as any,
+        includeRawResponse,
+      }) as AIMessage;
+
+      expect(Object.hasOwn(result.additional_kwargs, "__raw_response")).toBe(
+        false
+      );
+    }
+  );
+
   it("preserves assistant reasoning_content in additional_kwargs", () => {
     const mockMessage = {
       role: "assistant" as const,


### PR DESCRIPTION
### Summary

The non-streaming Chat Completions converter treated any defined `includeRawResponse` value as enabled. As a result, `__includeRawResponse: false` still added `__raw_response` to `additional_kwargs`.

Require the flag to be truthy, matching the streaming converter and the original opt-in behavior. Add converter tests covering `true`, `false`, and `undefined`, along with a patch changeset.

### Tests

- `pnpm --filter @langchain/openai test src/converters/tests/completions.test.ts`
- `pnpm --filter @langchain/openai exec vitest run --typecheck.enabled=false`
- `pnpm --filter @langchain/openai test:standard:unit`
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @langchain/openai build`

The default provider test command executed all 323 tests successfully, but exits nonzero because Vitest reports 88 existing experimental source typecheck diagnostics in files outside this change.

Fixes #11395
