### PR TITLE
fix(anthropic): preserve context management on the native stream path

### DIFF
--- a/.changeset/bright-clocks-stream.md
+++ b/.changeset/bright-clocks-stream.md
@@ -1,0 +1,7 @@
+---
+"@langchain/anthropic": patch
+---
+
+fix(anthropic): preserve context management on the native stream path
+
+`convertAnthropicStream` now includes Anthropic `context_management` details in the final message's `response_metadata`, matching the legacy chunk path.

--- a/libs/providers/langchain-anthropic/src/utils/stream_events.ts
+++ b/libs/providers/langchain-anthropic/src/utils/stream_events.ts
@@ -69,7 +69,10 @@ export async function* convertAnthropicStream(
           "cost" in data.usage &&
           typeof data.usage.cost === "number"
         ) {
-          responseMetadata = { usage: { cost: data.usage.cost } };
+          responseMetadata = {
+            ...responseMetadata,
+            usage: { cost: data.usage.cost },
+          };
         }
         if (shouldStreamUsage && data.usage) {
           if (!usageSnapshot) {
@@ -95,6 +98,10 @@ export async function* convertAnthropicStream(
           "context_management" in data.delta &&
           data.delta.context_management
         ) {
+          responseMetadata = {
+            ...responseMetadata,
+            context_management: data.delta.context_management,
+          };
           yield {
             event: "provider" as const,
             provider: "anthropic",

--- a/libs/providers/langchain-anthropic/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-anthropic/src/utils/tests/stream_events.test.ts
@@ -4,11 +4,12 @@ import { convertAnthropicStream } from "../stream_events.js";
 
 interface StreamOverrides {
   cost?: unknown;
+  contextManagement?: Record<string, unknown>;
   streamUsage?: boolean;
 }
 
 /** One response's raw Anthropic events, optionally with a gateway `cost` on the terminal usage. */
-function rawEvents({ cost }: StreamOverrides = {}) {
+function rawEvents({ cost, contextManagement }: StreamOverrides = {}) {
   return [
     {
       type: "message_start" as const,
@@ -36,7 +37,13 @@ function rawEvents({ cost }: StreamOverrides = {}) {
     { type: "content_block_stop" as const, index: 0 },
     {
       type: "message_delta" as const,
-      delta: { stop_reason: "end_turn" as const, stop_sequence: null },
+      delta: {
+        stop_reason: "end_turn" as const,
+        stop_sequence: null,
+        ...(contextManagement === undefined
+          ? {}
+          : { context_management: contextManagement }),
+      },
       usage: {
         output_tokens: 42,
         ...(cost === undefined ? {} : { cost }),
@@ -46,9 +53,13 @@ function rawEvents({ cost }: StreamOverrides = {}) {
   ];
 }
 
-async function convert({ cost, streamUsage }: StreamOverrides = {}) {
+async function convert({
+  cost,
+  contextManagement,
+  streamUsage,
+}: StreamOverrides = {}) {
   const source = (async function* () {
-    yield* rawEvents({ cost });
+    yield* rawEvents({ cost, contextManagement });
   })();
   const events = [];
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -148,5 +159,55 @@ describe("convertAnthropicStream", () => {
 
     expect(message.response_metadata.usage).toEqual({ cost: 0.0123 });
     expect(message.usage_metadata?.output_tokens).toBe(43);
+  });
+
+  test("preserves context management on provider and message-finish events", async () => {
+    const contextManagement = {
+      applied_edits: [
+        {
+          type: "clear_tool_uses_20250919",
+          cleared_tool_uses: 1,
+          cleared_input_tokens: 25,
+        },
+      ],
+    };
+    const events = await convert({ contextManagement });
+
+    expect(
+      events.find(
+        (event) =>
+          event.event === "provider" && event.name === "context_management"
+      )
+    ).toMatchObject({
+      provider: "anthropic",
+      payload: contextManagement,
+    });
+    expect(messageFinish(events).responseMetadata).toEqual({
+      context_management: contextManagement,
+    });
+  });
+
+  test("assembles context management alongside gateway cost", async () => {
+    const contextManagement = {
+      applied_edits: [
+        {
+          type: "clear_tool_uses_20250919",
+          cleared_tool_uses: 1,
+          cleared_input_tokens: 25,
+        },
+      ],
+    };
+    const source = (async function* () {
+      yield* rawEvents({ cost: 0.0123, contextManagement });
+    })();
+    const message = await new ChatModelStream(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      convertAnthropicStream(source as any) as any
+    );
+
+    expect(message.response_metadata).toMatchObject({
+      context_management: contextManagement,
+      usage: { cost: 0.0123 },
+    });
   });
 });


### PR DESCRIPTION
`convertAnthropicStream` already emits Anthropic context management details as a provider event, but it does not include them in the `message-finish` event's `responseMetadata`. Since `ChatModelStream` assembles the final `AIMessage` from that metadata, awaiting the native stream drops `response_metadata.context_management`.

This change accumulates `context_management` in the finish response metadata and makes the existing gateway cost update merge with previously collected metadata. The provider event, token usage, and other finish fields are unchanged.

## Verification

The regression tests cover:

- preserving the existing context management provider event;
- including context management in `message-finish.responseMetadata`;
- carrying it into the assembled `AIMessage`;
- preserving both `context_management` and `usage.cost`.

Validation:

- `pnpm --filter @langchain/anthropic test` — 245 tests passed, no type errors
- `pnpm --filter @langchain/anthropic test:standard:unit` — 8 tests passed
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @langchain/anthropic build`

Changeset included (`patch`).

Fixes #11396
