### PR TITLE
fix(openai): retain cache_write_tokens, update to v7 sdk

### DIFF
--- a/.changeset/eleven-hands-guess.md
+++ b/.changeset/eleven-hands-guess.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+update to v7 openai sdk

--- a/.changeset/quiet-otters-invite.md
+++ b/.changeset/quiet-otters-invite.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Map OpenAI's `cache_write_tokens` to `cache_creation` in `usage_metadata.input_token_details`, mirroring the existing `cached_tokens` -> `cache_read` mapping across the Chat Completions and Responses APIs. Previously, prompt cache-write token counts were silently dropped.

--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/libs/providers/langchain-openai/package.json
+++ b/libs/providers/langchain-openai/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "js-tiktoken": "^1.0.12",
-    "openai": "^6.41.0",
+    "openai": "^7.5.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -255,9 +255,15 @@ export class ChatOpenAICompletions<
           (usageMetadata.total_tokens ?? 0) + totalTokens;
       }
 
+      const cacheWriteTokens = (
+        promptTokensDetails as
+          | { cache_write_tokens?: number | null }
+          | undefined
+      )?.cache_write_tokens;
       if (
         promptTokensDetails?.audio_tokens !== null ||
-        promptTokensDetails?.cached_tokens !== null
+        promptTokensDetails?.cached_tokens !== null ||
+        cacheWriteTokens !== null
       ) {
         usageMetadata.input_token_details = {
           ...(promptTokensDetails?.audio_tokens !== null && {
@@ -265,6 +271,9 @@ export class ChatOpenAICompletions<
           }),
           ...(promptTokensDetails?.cached_tokens !== null && {
             cache_read: promptTokensDetails?.cached_tokens,
+          }),
+          ...(cacheWriteTokens !== null && {
+            cache_creation: cacheWriteTokens,
           }),
         };
       }
@@ -459,12 +468,20 @@ export class ChatOpenAICompletions<
       );
     }
     if (usage) {
+      const cacheWriteTokens = (
+        usage.prompt_tokens_details as
+          | { cache_write_tokens?: number | null }
+          | undefined
+      )?.cache_write_tokens;
       const inputTokenDetails = {
         ...(usage.prompt_tokens_details?.audio_tokens !== null && {
           audio: usage.prompt_tokens_details?.audio_tokens,
         }),
         ...(usage.prompt_tokens_details?.cached_tokens !== null && {
           cache_read: usage.prompt_tokens_details?.cached_tokens,
+        }),
+        ...(cacheWriteTokens !== null && {
+          cache_creation: cacheWriteTokens,
         }),
       };
       const outputTokenDetails = {

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -255,15 +255,10 @@ export class ChatOpenAICompletions<
           (usageMetadata.total_tokens ?? 0) + totalTokens;
       }
 
-      const cacheWriteTokens = (
-        promptTokensDetails as
-          | { cache_write_tokens?: number | null }
-          | undefined
-      )?.cache_write_tokens;
       if (
         promptTokensDetails?.audio_tokens !== null ||
         promptTokensDetails?.cached_tokens !== null ||
-        cacheWriteTokens != null
+        promptTokensDetails?.cache_write_tokens != null
       ) {
         usageMetadata.input_token_details = {
           ...(promptTokensDetails?.audio_tokens !== null && {
@@ -272,8 +267,8 @@ export class ChatOpenAICompletions<
           ...(promptTokensDetails?.cached_tokens !== null && {
             cache_read: promptTokensDetails?.cached_tokens,
           }),
-          ...(cacheWriteTokens != null && {
-            cache_creation: cacheWriteTokens,
+          ...(promptTokensDetails?.cache_write_tokens != null && {
+            cache_creation: promptTokensDetails?.cache_write_tokens,
           }),
         };
       }
@@ -468,11 +463,6 @@ export class ChatOpenAICompletions<
       );
     }
     if (usage) {
-      const cacheWriteTokens = (
-        usage.prompt_tokens_details as
-          | { cache_write_tokens?: number | null }
-          | undefined
-      )?.cache_write_tokens;
       const inputTokenDetails = {
         ...(usage.prompt_tokens_details?.audio_tokens !== null && {
           audio: usage.prompt_tokens_details?.audio_tokens,
@@ -480,8 +470,8 @@ export class ChatOpenAICompletions<
         ...(usage.prompt_tokens_details?.cached_tokens !== null && {
           cache_read: usage.prompt_tokens_details?.cached_tokens,
         }),
-        ...(cacheWriteTokens != null && {
-          cache_creation: cacheWriteTokens,
+        ...(usage.prompt_tokens_details?.cache_write_tokens != null && {
+          cache_creation: usage.prompt_tokens_details?.cache_write_tokens,
         }),
       };
       const outputTokenDetails = {

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -263,7 +263,7 @@ export class ChatOpenAICompletions<
       if (
         promptTokensDetails?.audio_tokens !== null ||
         promptTokensDetails?.cached_tokens !== null ||
-        cacheWriteTokens !== null
+        cacheWriteTokens != null
       ) {
         usageMetadata.input_token_details = {
           ...(promptTokensDetails?.audio_tokens !== null && {
@@ -272,7 +272,7 @@ export class ChatOpenAICompletions<
           ...(promptTokensDetails?.cached_tokens !== null && {
             cache_read: promptTokensDetails?.cached_tokens,
           }),
-          ...(cacheWriteTokens !== null && {
+          ...(cacheWriteTokens != null && {
             cache_creation: cacheWriteTokens,
           }),
         };
@@ -480,7 +480,7 @@ export class ChatOpenAICompletions<
         ...(usage.prompt_tokens_details?.cached_tokens !== null && {
           cache_read: usage.prompt_tokens_details?.cached_tokens,
         }),
-        ...(cacheWriteTokens !== null && {
+        ...(cacheWriteTokens != null && {
           cache_creation: cacheWriteTokens,
         }),
       };

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -117,6 +117,100 @@ describe("ChatOpenAICompletions streaming usage_metadata callback", () => {
   });
 });
 
+describe("ChatOpenAICompletions cache token usage_metadata", () => {
+  it("should map cache_write_tokens to cache_creation for streaming responses", async () => {
+    const model = new ChatOpenAICompletions({
+      model: "gpt-4o-mini",
+      apiKey: "test-key",
+      streaming: true,
+      streamUsage: true,
+    });
+
+    const fakeStream = (async function* () {
+      yield {
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" as const, content: "Hello" },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+        usage: null,
+        system_fingerprint: null,
+        model: "gpt-4o-mini",
+        service_tier: null,
+      };
+      yield {
+        choices: [],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 5,
+          total_tokens: 105,
+          prompt_tokens_details: { cached_tokens: 50, cache_write_tokens: 20 },
+          completion_tokens_details: null,
+        },
+        system_fingerprint: null,
+        model: "gpt-4o-mini",
+        service_tier: null,
+      };
+    })();
+
+    model.completionWithRetry = vi
+      .fn()
+      .mockResolvedValue(fakeStream) as typeof model.completionWithRetry;
+
+    const chunks = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage("test")],
+      {}
+    )) {
+      chunks.push(chunk);
+    }
+
+    const usageChunk = chunks[chunks.length - 1];
+    const usageMessage = usageChunk.message as AIMessageChunk;
+    expect(usageMessage.usage_metadata?.input_token_details).toEqual({
+      cache_read: 50,
+      cache_creation: 20,
+    });
+  });
+
+  it("should map cache_write_tokens to cache_creation for non-streaming responses", async () => {
+    const model = new ChatOpenAICompletions({
+      model: "gpt-4o-mini",
+      apiKey: "test-key",
+    });
+
+    model.completionWithRetry = vi.fn().mockResolvedValue({
+      id: "chatcmpl-test",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Hello" },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 5,
+        total_tokens: 105,
+        prompt_tokens_details: { cached_tokens: 50, cache_write_tokens: 20 },
+        completion_tokens_details: null,
+      },
+    }) as typeof model.completionWithRetry;
+
+    const result = await model._generate([new HumanMessage("test")], {});
+
+    const message = result.generations[0].message as AIMessageChunk;
+    expect(message.usage_metadata?.input_token_details).toEqual({
+      cache_read: 50,
+      cache_creation: 20,
+    });
+  });
+});
+
 describe("ChatOpenAICompletions reasoning_content compatibility", () => {
   it("should preserve reasoning_content on streamed assistant chunks", async () => {
     const model = new ChatOpenAICompletions({

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -209,6 +209,41 @@ describe("ChatOpenAICompletions cache token usage_metadata", () => {
       cache_creation: 20,
     });
   });
+
+  it("should omit cache_creation when cache_write_tokens is absent (non-streaming)", async () => {
+    const model = new ChatOpenAICompletions({
+      model: "gpt-4o-mini",
+      apiKey: "test-key",
+    });
+
+    model.completionWithRetry = vi.fn().mockResolvedValue({
+      id: "chatcmpl-test",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "Hello" },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 5,
+        total_tokens: 105,
+        // No cache_write_tokens key at all, as returned by models that
+        // don't support explicit prompt caching.
+        prompt_tokens_details: { cached_tokens: 0, audio_tokens: null },
+        completion_tokens_details: null,
+      },
+    }) as typeof model.completionWithRetry;
+
+    const result = await model._generate([new HumanMessage("test")], {});
+
+    const message = result.generations[0].message as AIMessageChunk;
+    expect(message.usage_metadata?.input_token_details).not.toHaveProperty(
+      "cache_creation"
+    );
+  });
 });
 
 describe("ChatOpenAICompletions reasoning_content compatibility", () => {

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -1019,6 +1019,38 @@ describe("ChatOpenAI", () => {
         output_token_details: {},
       });
     });
+
+    it("should convert OpenAI Responses usage to LangChain format with cache write tokens", () => {
+      const usage = {
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        input_tokens_details: {
+          cached_tokens: 75,
+          cache_write_tokens: 30,
+          text_tokens: 25,
+        },
+        output_tokens_details: {
+          reasoning_tokens: 10,
+          text_tokens: 40,
+        },
+      };
+
+      const result = _convertOpenAIResponsesUsageToLangChainUsage(usage as any);
+
+      expect(result).toEqual({
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        input_token_details: {
+          cache_read: 75,
+          cache_creation: 30,
+        },
+        output_token_details: {
+          reasoning: 10,
+        },
+      });
+    });
   });
 
   describe("moderateContent", () => {

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -224,6 +224,7 @@ export type ResponsesInputItem = OpenAIClient.Responses.ResponseInputItem;
  *   - `total_tokens`: Combined total of input and output tokens (defaults to 0 if not provided)
  *   - `input_token_details`: Object containing detailed input token information:
  *     - `cache_read`: Number of tokens read from cache (only included if available)
+ *     - `cache_creation`: Number of tokens written to cache (only included if available)
  *   - `output_token_details`: Object containing detailed output token information:
  *     - `reasoning`: Number of tokens used for reasoning (only included if available)
  *
@@ -233,7 +234,7 @@ export type ResponsesInputItem = OpenAIClient.Responses.ResponseInputItem;
  *   input_tokens: 100,
  *   output_tokens: 50,
  *   total_tokens: 150,
- *   input_tokens_details: { cached_tokens: 20 },
+ *   input_tokens_details: { cached_tokens: 20, cache_write_tokens: 30 },
  *   output_tokens_details: { reasoning_tokens: 10 }
  * };
  *
@@ -243,7 +244,7 @@ export type ResponsesInputItem = OpenAIClient.Responses.ResponseInputItem;
  * //   input_tokens: 100,
  * //   output_tokens: 50,
  * //   total_tokens: 150,
- * //   input_token_details: { cache_read: 20 },
+ * //   input_token_details: { cache_read: 20, cache_creation: 30 },
  * //   output_token_details: { reasoning: 10 }
  * // }
  * ```
@@ -251,8 +252,8 @@ export type ResponsesInputItem = OpenAIClient.Responses.ResponseInputItem;
  * @remarks
  * - The function safely handles undefined or null values by using optional chaining
  *   and nullish coalescing operators
- * - Detailed token information (cache_read, reasoning) is only included in the result
- *   if the corresponding values are present in the input
+ * - Detailed token information (cache_read, cache_creation, reasoning) is only included
+ *   in the result if the corresponding values are present in the input
  * - Token counts default to 0 if not provided in the usage object
  * - This converter is specifically designed for OpenAI's Responses API format and
  *   may differ from other OpenAI API endpoints
@@ -261,9 +262,17 @@ export const convertResponsesUsageToUsageMetadata: Converter<
   OpenAIClient.Responses.ResponseUsage | undefined,
   UsageMetadata
 > = (usage) => {
+  const cacheWriteTokens = (
+    usage?.input_tokens_details as
+      | { cache_write_tokens?: number | null }
+      | undefined
+  )?.cache_write_tokens;
   const inputTokenDetails = {
     ...(usage?.input_tokens_details?.cached_tokens != null && {
       cache_read: usage?.input_tokens_details?.cached_tokens,
+    }),
+    ...(cacheWriteTokens != null && {
+      cache_creation: cacheWriteTokens,
     }),
   };
   const outputTokenDetails = {

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -262,17 +262,12 @@ export const convertResponsesUsageToUsageMetadata: Converter<
   OpenAIClient.Responses.ResponseUsage | undefined,
   UsageMetadata
 > = (usage) => {
-  const cacheWriteTokens = (
-    usage?.input_tokens_details as
-      | { cache_write_tokens?: number | null }
-      | undefined
-  )?.cache_write_tokens;
   const inputTokenDetails = {
     ...(usage?.input_tokens_details?.cached_tokens != null && {
       cache_read: usage?.input_tokens_details?.cached_tokens,
     }),
-    ...(cacheWriteTokens != null && {
-      cache_creation: cacheWriteTokens,
+    ...(usage?.input_tokens_details?.cache_write_tokens != null && {
+      cache_creation: usage?.input_tokens_details?.cache_write_tokens,
     }),
   };
   const outputTokenDetails = {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -68,6 +68,38 @@ describe("convertResponsesUsageToUsageMetadata", () => {
     });
   });
 
+  it("should convert OpenAI Responses usage to LangChain format with cache write tokens", () => {
+    const usage = {
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      input_tokens_details: {
+        cached_tokens: 75,
+        cache_write_tokens: 30,
+        text_tokens: 25,
+      },
+      output_tokens_details: {
+        reasoning_tokens: 10,
+        text_tokens: 40,
+      },
+    };
+
+    const result = convertResponsesUsageToUsageMetadata(usage as any);
+
+    expect(result).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      input_token_details: {
+        cache_read: 75,
+        cache_creation: 30,
+      },
+      output_token_details: {
+        reasoning: 10,
+      },
+    });
+  });
+
   it("should handle undefined usage", () => {
     const result = convertResponsesUsageToUsageMetadata(undefined);
 

--- a/libs/providers/langchain-openai/src/utils/output.ts
+++ b/libs/providers/langchain-openai/src/utils/output.ts
@@ -169,17 +169,12 @@ export function handleMultiModalOutput(
 export function _convertOpenAIResponsesUsageToLangChainUsage(
   usage?: OpenAIClient.Responses.ResponseUsage
 ): UsageMetadata {
-  const cacheWriteTokens = (
-    usage?.input_tokens_details as
-      | { cache_write_tokens?: number | null }
-      | undefined
-  )?.cache_write_tokens;
   const inputTokenDetails = {
     ...(usage?.input_tokens_details?.cached_tokens != null && {
       cache_read: usage?.input_tokens_details?.cached_tokens,
     }),
-    ...(cacheWriteTokens != null && {
-      cache_creation: cacheWriteTokens,
+    ...(usage?.input_tokens_details?.cache_write_tokens != null && {
+      cache_creation: usage?.input_tokens_details?.cache_write_tokens,
     }),
   };
   const outputTokenDetails = {

--- a/libs/providers/langchain-openai/src/utils/output.ts
+++ b/libs/providers/langchain-openai/src/utils/output.ts
@@ -169,9 +169,17 @@ export function handleMultiModalOutput(
 export function _convertOpenAIResponsesUsageToLangChainUsage(
   usage?: OpenAIClient.Responses.ResponseUsage
 ): UsageMetadata {
+  const cacheWriteTokens = (
+    usage?.input_tokens_details as
+      | { cache_write_tokens?: number | null }
+      | undefined
+  )?.cache_write_tokens;
   const inputTokenDetails = {
     ...(usage?.input_tokens_details?.cached_tokens != null && {
       cache_read: usage?.input_tokens_details?.cached_tokens,
+    }),
+    ...(cacheWriteTokens != null && {
+      cache_creation: cacheWriteTokens,
     }),
   };
   const outputTokenDetails = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,7 +699,7 @@ importers:
         version: 6.1.2
       typeorm:
         specifier: ^1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.11.1)(mongodb@7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9))(mysql2@3.15.3)(pg@8.22.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.21))(@types/node@26.1.2)(typescript@7.0.2))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.11.1)(mongodb@7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9))(mysql2@3.15.3)(pg@8.23.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.21))(@types/node@26.1.2)(typescript@7.0.2))
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
@@ -1022,7 +1022,7 @@ importers:
         version: 1.0.21
       langsmith:
         specifier: '>=0.5.0 <1.0.0'
-        version: 0.7.14(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.1(bufferutil@4.1.0))
+        version: 0.7.14(@opentelemetry/api@1.9.1)(openai@7.5.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.1(bufferutil@4.1.0))
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1949,8 +1949,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.21
       openai:
-        specifier: ^6.41.0
-        version: 6.41.0(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6)
+        specifier: ^7.5.0
+        version: 7.5.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6)
       zod:
         specifier: ^3.25.76 || ^4
         version: 4.3.6
@@ -4276,6 +4276,13 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
@@ -7113,6 +7120,10 @@ packages:
     resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
     engines: {node: '>=20.19.0'}
 
+  bson@7.3.2:
+    resolution: {integrity: sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==}
+    engines: {node: '>=20.19.0'}
+
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
@@ -9930,8 +9941,8 @@ packages:
       socks:
         optional: true
 
-  mongoose@9.9.1:
-    resolution: {integrity: sha512-hI00baDVPjV5VfYA3j+oLuPvLfmCQICWot9zJZgkuDMXnWEYhIx9xCPEOt2IC3lDJz6ajsz2bpgO24E+xsP6wg==}
+  mongoose@9.9.3:
+    resolution: {integrity: sha512-9dQaKct05LNgVkunDzFPZsGGBhinobl3Qc5B5KYJkLNG5lBLgqESUEItl1EUIkVaCwZJGBgTuvJiFAjjIATCiw==}
     engines: {node: '>=20.19.0'}
 
   mpath@0.9.0:
@@ -10260,6 +10271,27 @@ packages:
       zod:
         optional: true
 
+  openai@7.5.0:
+    resolution: {integrity: sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: '>=8.20.1'
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -10512,12 +10544,24 @@ packages:
   pg-protocol@1.15.0:
     resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
 
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
   pg@8.22.0:
     resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -15337,6 +15381,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodable/entities@2.1.1':
     optional: true
 
@@ -15947,7 +15998,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.2.0':
@@ -18067,6 +18118,8 @@ snapshots:
   bson@7.2.0: {}
 
   bson@7.3.1: {}
+
+  bson@7.3.2: {}
 
   buffer-crc32@0.2.13:
     optional: true
@@ -20674,6 +20727,14 @@ snapshots:
       openai: 6.41.0(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6)
       ws: 8.21.1(bufferutil@4.1.0)
 
+  langsmith@0.7.14(@opentelemetry/api@1.9.1)(openai@7.5.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6))(ws@8.21.1(bufferutil@4.1.0)):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      openai: 7.5.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6)
+      ws: 8.21.1(bufferutil@4.1.0)
+
   langsmith@0.8.9(@opentelemetry/api@1.9.1)(openai@6.41.0(ws@5.2.7(bufferutil@4.1.0))(zod@4.3.6))(ws@5.2.7(bufferutil@4.1.0)):
     dependencies:
       p-queue: 6.6.2
@@ -21201,13 +21262,13 @@ snapshots:
   mongodb@7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9):
     dependencies:
       '@mongodb-js/saslprep': 1.4.13
-      bson: 7.3.1
+      bson: 7.3.2
       mongodb-connection-string-url: 7.0.2
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.1034.0
       socks: 2.8.9
 
-  mongoose@9.9.1(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9):
+  mongoose@9.9.3(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9):
     dependencies:
       '@standard-schema/spec': 1.1.0
       kareem: 3.3.0
@@ -21273,8 +21334,8 @@ snapshots:
       apparatus: 0.0.10
       dotenv: 17.4.2
       memjs: 1.3.2
-      mongoose: 9.9.1(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9)
-      pg: 8.22.0
+      mongoose: 9.9.3(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9)
+      pg: 8.23.0
       redis: 5.12.1(@opentelemetry/api@1.9.1)
       safe-stable-stringify: 2.5.0
       stopwords-iso: 1.1.0
@@ -21685,6 +21746,13 @@ snapshots:
       ws: 8.21.1(bufferutil@4.1.0)
       zod: 4.3.6
 
+  openai@7.5.0(@aws-sdk/credential-provider-node@3.972.77)(@smithy/signature-v4@5.6.12)(ws@8.21.1(bufferutil@4.1.0))(zod@4.3.6):
+    optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.77
+      '@smithy/signature-v4': 5.6.12
+      ws: 8.21.1(bufferutil@4.1.0)
+      zod: 4.3.6
+
   openapi-types@12.1.3: {}
 
   optionator@0.9.4:
@@ -21974,7 +22042,13 @@ snapshots:
     dependencies:
       pg: 8.22.0
 
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
   pg-protocol@1.15.0: {}
+
+  pg-protocol@1.16.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -21989,6 +22063,16 @@ snapshots:
       pg-connection-string: 2.14.0
       pg-pool: 3.14.0(pg@8.22.0)
       pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
@@ -23526,7 +23610,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.11.1)(mongodb@7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9))(mysql2@3.15.3)(pg@8.22.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.21))(@types/node@26.1.2)(typescript@7.0.2)):
+  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.11.1)(mongodb@7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9))(mysql2@3.15.3)(pg@8.23.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.21))(@types/node@26.1.2)(typescript@7.0.2)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
@@ -23543,7 +23627,7 @@ snapshots:
       ioredis: 5.11.1
       mongodb: 7.5.0(@aws-sdk/credential-providers@3.1034.0)(socks@2.8.9)
       mysql2: 3.15.3
-      pg: 8.22.0
+      pg: 8.23.0
       redis: 5.12.1(@opentelemetry/api@1.9.1)
       ts-node: 10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.21))(@types/node@26.1.2)(typescript@7.0.2)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
OpenAI's prompt caching GPT-5.6+ returns `cache_write_tokens` alongside `cached_tokens`, but it never gets read, so `cache_creation` is silently dropped from `usage_metadata.input_token_details`. This adds the same `cache_write_tokens` > `cache_creation` mapping everywhere `cached_tokens` > `cache_read` is already handled, across both the Chat Completions and Responses APIs.

## Test plan
- [x] Added unit tests covering all four mapping locations
- [x] Full test suite passes, lint/format clean