### PR TITLE
fix(core): include tool_call blocks and skip empty text blocks in ChatVertexAI contentBlocks

### DIFF
--- a/.changeset/tame-buses-jam.md
+++ b/.changeset/tame-buses-jam.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Fix ChatVertexAI/ChatGoogle content blocks: include `tool_call` blocks from `message.tool_calls` and skip spurious empty `text` blocks in `contentBlocks`.

--- a/libs/langchain-core/src/messages/block_translators/google_vertexai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_vertexai.ts
@@ -79,16 +79,16 @@ function convertToV1FromChatVertexMessage(
       }
       yield { type: "non_standard", value: block };
     }
+    for (const toolCall of message.tool_calls ?? []) {
+      yield {
+        type: "tool_call",
+        id: toolCall.id,
+        name: toolCall.name,
+        args: toolCall.args,
+      };
+    }
   }
-  const toolCallBlocks: ContentBlock.Standard[] = (
-    message.tool_calls ?? []
-  ).map((toolCall) => ({
-    type: "tool_call",
-    id: toolCall.id,
-    name: toolCall.name,
-    args: toolCall.args,
-  }));
-  return [...iterateContent(), ...toolCallBlocks];
+  return Array.from(iterateContent());
 }
 
 export const ChatVertexTranslator: StandardContentBlockTranslator = {

--- a/libs/langchain-core/src/messages/block_translators/google_vertexai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_vertexai.ts
@@ -49,6 +49,9 @@ function convertToV1FromChatVertexMessage(
         };
         continue;
       } else if (_isContentBlock(block, "text") && _isString(block.text)) {
+        if (block.text === "") {
+          continue;
+        }
         yield { type: "text", text: block.text };
         continue;
       } else if (_isContentBlock(block, "image_url")) {
@@ -77,7 +80,15 @@ function convertToV1FromChatVertexMessage(
       yield { type: "non_standard", value: block };
     }
   }
-  return Array.from(iterateContent());
+  const toolCallBlocks: ContentBlock.Standard[] = (
+    message.tool_calls ?? []
+  ).map((toolCall) => ({
+    type: "tool_call",
+    id: toolCall.id,
+    name: toolCall.name,
+    args: toolCall.args,
+  }));
+  return [...iterateContent(), ...toolCallBlocks];
 }
 
 export const ChatVertexTranslator: StandardContentBlockTranslator = {

--- a/libs/langchain-core/src/messages/block_translators/tests/google_vertexai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google_vertexai.test.ts
@@ -101,4 +101,62 @@ describe("ChatVertexTranslator", () => {
       },
     ]);
   });
+
+  it("should translate tool_calls to tool_call content blocks", () => {
+    const message = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          id: "call_1",
+          name: "get_weather",
+          args: { location: "San Francisco" },
+        },
+      ],
+      response_metadata: { model_provider: "google-vertexai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "call_1",
+        name: "get_weather",
+        args: { location: "San Francisco" },
+      },
+    ]);
+  });
+
+  it("should translate text alongside tool_calls without a spurious empty text block", () => {
+    const message = new AIMessage({
+      content: "Let me check the weather for you.",
+      tool_calls: [
+        {
+          id: "call_1",
+          name: "get_weather",
+          args: { location: "San Francisco" },
+        },
+        {
+          id: "call_2",
+          name: "get_weather",
+          args: { location: "New York" },
+        },
+      ],
+      response_metadata: { model_provider: "google-vertexai" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      { type: "text", text: "Let me check the weather for you." },
+      {
+        type: "tool_call",
+        id: "call_1",
+        name: "get_weather",
+        args: { location: "San Francisco" },
+      },
+      {
+        type: "tool_call",
+        id: "call_2",
+        name: "get_weather",
+        args: { location: "New York" },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #9950

- `ChatVertexTranslator.translateContent` only read `message.content`, never `message.tool_calls`, so Vertex/Gemini tool calls surfaced as an empty `{type: "text", text: ""}` block instead of a `tool_call block`, unlike OpenAI/GoogleGenAI.
- Adds a `tool_call` block per entry in `message.tool_calls` (matches OpenAI's field shape: `id`, `name`, `args`).

- Skips empty `text` blocks in the same translator, removing the spurious block that was masking the missing tool call.