### PR TITLE
feat(google): add gateway support for genai

### DIFF
--- a/.changeset/tidy-lions-shine.md
+++ b/.changeset/tidy-lions-shine.md
@@ -1,0 +1,6 @@
+---
+"@langchain/google-genai": patch
+"@langchain/google": patch
+---
+
+Add LangSmith gateway support for Google Gemini (Developer API) models. When `LANGSMITH_GATEWAY` is set, `ChatGoogleGenerativeAI` and `ChatGoogle` (and `initChatModel("google-genai:...")`) route requests through the gateway's Gemini path, using the gateway key (falling back to `LANGSMITH_API_KEY`). An explicit `baseUrl`/`endpoint`, an explicit `apiKey`, or a Vertex AI configuration suppress gateway routing. Also adds `GEMINI_API_KEY` as a fallback env var for `ChatGoogleGenerativeAI`.

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -23,6 +23,7 @@ import {
 } from "@langchain/core/messages";
 import { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { resolveLangSmithGatewayConfig } from "@langchain/core/utils/gateway";
 import {
   BaseChatModel,
   type BaseChatModelCallOptions,
@@ -634,6 +635,8 @@ export class ChatGoogleGenerativeAI
 
   apiKey?: string;
 
+  baseUrl?: string;
+
   streaming = false;
 
   json?: boolean;
@@ -702,11 +705,21 @@ export class ChatGoogleGenerativeAI
 
     this.stopSequences = fields.stopSequences ?? this.stopSequences;
 
-    this.apiKey = fields.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
+    const gatewayConfig = resolveLangSmithGatewayConfig({
+      baseURL: fields.baseUrl,
+      providerPath: "gemini",
+    });
+    this.baseUrl = gatewayConfig.baseURL;
+
+    this.apiKey =
+      fields.apiKey ??
+      gatewayConfig.apiKey ??
+      (getEnvironmentVariable("GOOGLE_API_KEY") ||
+        getEnvironmentVariable("GEMINI_API_KEY"));
     if (!this.apiKey) {
       throw new Error(
         "Please set an API key for Google GenerativeAI " +
-          "in the environment variable GOOGLE_API_KEY " +
+          "in the environment variable GOOGLE_API_KEY or GEMINI_API_KEY " +
           "or in the `apiKey` field of the " +
           "ChatGoogleGenerativeAI constructor"
       );
@@ -747,7 +760,7 @@ export class ChatGoogleGenerativeAI
       },
       {
         apiVersion: fields.apiVersion,
-        baseUrl: fields.baseUrl,
+        baseUrl: this.baseUrl,
         customHeaders: fields.customHeaders,
       }
     );

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -773,12 +773,20 @@ export class ChatGoogleGenerativeAI
     requestOptions?: RequestOptions
   ): void {
     if (!this.apiKey) return;
+    // Preserve the resolved request options (notably `baseUrl`) so cached-content
+    // requests keep routing through the configured LangSmith gateway. Without
+    // this, a gateway-enabled model would rebuild the client against Google's
+    // default endpoint while using the gateway key, and fail authentication.
+    const resolvedRequestOptions: RequestOptions = {
+      baseUrl: this.baseUrl,
+      ...requestOptions,
+    };
     this.client = new GenerativeAI(
       this.apiKey
     ).getGenerativeModelFromCachedContent(
       cachedContent,
       modelParams,
-      requestOptions
+      resolvedRequestOptions
     );
   }
 

--- a/libs/providers/langchain-google-genai/src/tests/gateway.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/gateway.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ChatGoogleGenerativeAI } from "../chat_models.js";
+
+describe("ChatGoogleGenerativeAI LangSmith gateway", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("routes through the gateway Gemini path via env config", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+    vi.stubEnv("GOOGLE_API_KEY", "provider-key");
+
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+
+    expect(model.apiKey).toBe("gateway-key");
+    expect(model.baseUrl).toBe("https://gateway.smith.langchain.com/gemini");
+  });
+
+  test("supports a custom gateway root", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "https://gw.example.com/");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+    vi.stubEnv("GOOGLE_API_KEY", "provider-key");
+
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+
+    expect(model.baseUrl).toBe("https://gw.example.com/gemini");
+  });
+
+  test("falls back to LANGSMITH_API_KEY for the gateway key", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "");
+    vi.stubEnv("LANGSMITH_API_KEY", "ls-key");
+    vi.stubEnv("GOOGLE_API_KEY", "provider-key");
+
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+
+    expect(model.apiKey).toBe("ls-key");
+  });
+
+  test("an explicit baseUrl suppresses gateway routing", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+    vi.stubEnv("GOOGLE_API_KEY", "provider-key");
+
+    const model = new ChatGoogleGenerativeAI({
+      model: "gemini-2.5-flash",
+      baseUrl: "https://my.proxy.example.com",
+    });
+
+    expect(model.baseUrl).toBe("https://my.proxy.example.com");
+    expect(model.apiKey).toBe("provider-key");
+  });
+
+  test("an explicit apiKey wins over the gateway key", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const model = new ChatGoogleGenerativeAI({
+      model: "gemini-2.5-flash",
+      apiKey: "user-key",
+    });
+
+    expect(model.apiKey).toBe("user-key");
+    expect(model.baseUrl).toBe("https://gateway.smith.langchain.com/gemini");
+  });
+
+  test("no gateway: falls back to GEMINI_API_KEY when GOOGLE_API_KEY is unset", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "");
+    vi.stubEnv("GOOGLE_API_KEY", "");
+    vi.stubEnv("GEMINI_API_KEY", "gemini-env-key");
+
+    const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+
+    expect(model.apiKey).toBe("gemini-env-key");
+    expect(model.baseUrl).toBeUndefined();
+  });
+});

--- a/libs/providers/langchain-google-genai/src/tests/gateway.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/gateway.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 import { ChatGoogleGenerativeAI } from "../chat_models.js";
 
 describe("ChatGoogleGenerativeAI LangSmith gateway", () => {
@@ -74,5 +75,55 @@ describe("ChatGoogleGenerativeAI LangSmith gateway", () => {
 
     expect(model.apiKey).toBe("gemini-env-key");
     expect(model.baseUrl).toBeUndefined();
+  });
+
+  test("useCachedContent preserves the gateway baseUrl", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const spy = vi
+      .spyOn(
+        GoogleGenerativeAI.prototype,
+        "getGenerativeModelFromCachedContent"
+      )
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockReturnValue({} as any);
+
+    try {
+      const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+      model.useCachedContent({ name: "cached/abc" } as never);
+
+      const requestOptions = spy.mock.calls[0]?.[2];
+      expect(requestOptions?.baseUrl).toBe(
+        "https://gateway.smith.langchain.com/gemini"
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("useCachedContent lets an explicit baseUrl win over the gateway", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const spy = vi
+      .spyOn(
+        GoogleGenerativeAI.prototype,
+        "getGenerativeModelFromCachedContent"
+      )
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockReturnValue({} as any);
+
+    try {
+      const model = new ChatGoogleGenerativeAI({ model: "gemini-2.5-flash" });
+      model.useCachedContent({ name: "cached/abc" } as never, undefined, {
+        baseUrl: "https://explicit.example.com",
+      });
+
+      const requestOptions = spy.mock.calls[0]?.[2];
+      expect(requestOptions?.baseUrl).toBe("https://explicit.example.com");
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -76,9 +76,32 @@ import {
 } from "@langchain/core/language_models/structured_output";
 import { iife } from "../utils/misc";
 import { resolveLangSmithGatewayConfig } from "@langchain/core/utils/gateway";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import ServiceTier = Gemini.ServiceTier;
 
 export type GooglePlatformType = "gai" | "gcp";
+
+/**
+ * Returns true when the params (or environment) configure Vertex AI /
+ * service-account authentication, which the LangSmith gateway does not proxy.
+ *
+ * This covers the cases `convertParamsToPlatformType` cannot see: explicit
+ * service-account `credentials`, the `GOOGLE_CLOUD_CREDENTIALS` env var, and
+ * Node-only `googleAuthOptions` (Application Default Credentials). Without this
+ * check a credentials-only model would resolve to `gcp` today, but injecting a
+ * gateway API key below would flip it to `gai` and misroute the request to the
+ * Gemini Developer API gateway path.
+ */
+function hasVertexCredentials(params: {
+  credentials?: unknown;
+  googleAuthOptions?: unknown;
+}): boolean {
+  return (
+    typeof params.credentials !== "undefined" ||
+    typeof params.googleAuthOptions !== "undefined" ||
+    typeof getEnvironmentVariable("GOOGLE_CLOUD_CREDENTIALS") !== "undefined"
+  );
+}
 
 /**
  * Resolves LangSmith gateway routing for Google chat model params.
@@ -86,13 +109,17 @@ export type GooglePlatformType = "gai" | "gcp";
  * The LangSmith gateway proxies the **Gemini Developer API** (the API-key,
  * `gai` platform), not Vertex AI. So this only applies when the resolved
  * platform is `gai` and the caller has not set an explicit `endpoint`. An
- * explicit `endpoint`, or a Vertex configuration (`vertexai: true` /
- * `platformType: "gcp"`), suppresses gateway routing entirely.
+ * explicit `endpoint`, a Vertex configuration (`vertexai: true` /
+ * `platformType: "gcp"`), or service-account credentials (`credentials`,
+ * `googleAuthOptions`, or `GOOGLE_CLOUD_CREDENTIALS`) suppress gateway routing
+ * entirely.
  *
  * When `LANGSMITH_GATEWAY` is set, this rewrites `endpoint` to the gateway
- * host (scheme-less, since the URL builders prepend `https://`) and lets the
- * gateway key take precedence over the provider key (which then rides as the
- * `x-goog-api-key` header via the ApiClient).
+ * host and lets the gateway key take precedence over the provider key (which
+ * then rides as the `x-goog-api-key` header via the ApiClient). The default
+ * `https` gateway host is written scheme-less (the URL builders prepend
+ * `https://`); a non-`https` custom gateway keeps its scheme so it is not
+ * forced to TLS.
  *
  * This function is pure: it never mutates `params`. It returns a new object
  * with the gateway overrides applied when routing is active, or an unchanged
@@ -106,15 +133,17 @@ export function applyGeminiGatewayParams<
     endpoint?: string;
     platformType?: GooglePlatformType;
     vertexai?: boolean;
+    credentials?: unknown;
+    googleAuthOptions?: unknown;
   },
->(params: TParams): TParams {
+>(params: TParams): TParams & { apiKey?: string; endpoint?: string } {
   // An explicit endpoint always wins; a Vertex config is out of scope (the
   // gateway proxies the Gemini Developer API, not Vertex AI).
   if (typeof params.endpoint !== "undefined") {
     return { ...params };
   }
   const explicitPlatform = convertParamsToPlatformType(params);
-  if (explicitPlatform === "gcp") {
+  if (explicitPlatform === "gcp" || hasVertexCredentials(params)) {
     return { ...params };
   }
 
@@ -128,13 +157,22 @@ export function applyGeminiGatewayParams<
   // When routing through the gateway with no explicitly requested platform and
   // no credentials that would imply Vertex, treat this as a Gemini Developer
   // API (`gai`) call. A provider key still wins over the gateway key.
-  // The URL builders compose `https://${endpoint}/${apiVersion}/...`, so the
-  // endpoint must be scheme-less: host (with port) plus the provider path.
   const gatewayUrl = new URL(gatewayConfig.baseURL);
+  const path = gatewayUrl.pathname.replace(/\/+$/, "");
+  // The URL builders compose `https://${endpoint}/${apiVersion}/...`. For the
+  // default `https` gateway, keep the endpoint scheme-less (host + path) so the
+  // builder's `https://` prefix produces the right URL. For a non-`https`
+  // custom gateway (e.g. `http://localhost:8080`), keep the full scheme so the
+  // builder does not force TLS; `buildUrlGemini` skips its prefix when the
+  // endpoint already includes a scheme.
+  const endpoint =
+    gatewayUrl.protocol === "https:"
+      ? `${gatewayUrl.host}${path}`
+      : `${gatewayUrl.protocol}//${gatewayUrl.host}${path}`;
   return {
     ...params,
     apiKey: params.apiKey ?? gatewayConfig.apiKey,
-    endpoint: `${gatewayUrl.host}${gatewayUrl.pathname.replace(/\/+$/, "")}`,
+    endpoint,
   };
 }
 
@@ -353,9 +391,22 @@ export abstract class BaseChatGoogle<
   }
 
   protected async buildUrlGemini(urlMethod?: string): Promise<string> {
-    return `https://${this.endpoint}/${this.apiVersion}/models/${this.model}:${
-      urlMethod ?? this.urlMethod
-    }`;
+    // `endpoint` is normally scheme-less (e.g. `generativelanguage.googleapis.com`)
+    // and defaults to `https`, but a gateway endpoint may already carry a scheme
+    // and a base path (e.g. a custom `http://` LangSmith gateway). Let `URL`
+    // resolve the scheme so a custom `http://` gateway is not forced to TLS.
+    const url = this.endpoint.includes("://")
+      ? new URL(this.endpoint)
+      : new URL(`https://${this.endpoint}`);
+    // `urlMethod` may include a query string (e.g. `streamGenerateContent?alt=sse`);
+    // split it out so `URL` keeps it as a query rather than encoding the `?`.
+    const [method, search] = (urlMethod ?? this.urlMethod).split("?", 2);
+    const basePath = url.pathname.replace(/\/+$/, "");
+    url.pathname = `${basePath}/${this.apiVersion}/models/${this.model}:${method}`;
+    if (search) {
+      url.search = search;
+    }
+    return url.toString();
   }
 
   protected async buildUrlVertexExpress(urlMethod?: string): Promise<string> {

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -75,9 +75,68 @@ import {
   createFunctionCallingParser,
 } from "@langchain/core/language_models/structured_output";
 import { iife } from "../utils/misc";
+import { resolveLangSmithGatewayConfig } from "@langchain/core/utils/gateway";
 import ServiceTier = Gemini.ServiceTier;
 
 export type GooglePlatformType = "gai" | "gcp";
+
+/**
+ * Resolves LangSmith gateway routing for Google chat model params.
+ *
+ * The LangSmith gateway proxies the **Gemini Developer API** (the API-key,
+ * `gai` platform), not Vertex AI. So this only applies when the resolved
+ * platform is `gai` and the caller has not set an explicit `endpoint`. An
+ * explicit `endpoint`, or a Vertex configuration (`vertexai: true` /
+ * `platformType: "gcp"`), suppresses gateway routing entirely.
+ *
+ * When `LANGSMITH_GATEWAY` is set, this rewrites `endpoint` to the gateway
+ * host (scheme-less, since the URL builders prepend `https://`) and lets the
+ * gateway key take precedence over the provider key (which then rides as the
+ * `x-goog-api-key` header via the ApiClient).
+ *
+ * This function is pure: it never mutates `params`. It returns a new object
+ * with the gateway overrides applied when routing is active, or an unchanged
+ * shallow copy otherwise.
+ *
+ * @returns a new params object with gateway routing applied when applicable.
+ */
+export function applyGeminiGatewayParams<
+  TParams extends {
+    apiKey?: string;
+    endpoint?: string;
+    platformType?: GooglePlatformType;
+    vertexai?: boolean;
+  },
+>(params: TParams): TParams {
+  // An explicit endpoint always wins; a Vertex config is out of scope (the
+  // gateway proxies the Gemini Developer API, not Vertex AI).
+  if (typeof params.endpoint !== "undefined") {
+    return { ...params };
+  }
+  const explicitPlatform = convertParamsToPlatformType(params);
+  if (explicitPlatform === "gcp") {
+    return { ...params };
+  }
+
+  const gatewayConfig = resolveLangSmithGatewayConfig({
+    providerPath: "gemini",
+  });
+  if (typeof gatewayConfig.baseURL === "undefined") {
+    return { ...params };
+  }
+
+  // When routing through the gateway with no explicitly requested platform and
+  // no credentials that would imply Vertex, treat this as a Gemini Developer
+  // API (`gai`) call. A provider key still wins over the gateway key.
+  // The URL builders compose `https://${endpoint}/${apiVersion}/...`, so the
+  // endpoint must be scheme-less: host (with port) plus the provider path.
+  const gatewayUrl = new URL(gatewayConfig.baseURL);
+  return {
+    ...params,
+    apiKey: params.apiKey ?? gatewayConfig.apiKey,
+    endpoint: `${gatewayUrl.host}${gatewayUrl.pathname.replace(/\/+$/, "")}`,
+  };
+}
 
 export function getPlatformType(
   platform: GooglePlatformType | undefined,

--- a/libs/providers/langchain-google/src/chat_models/index.ts
+++ b/libs/providers/langchain-google/src/chat_models/index.ts
@@ -1,6 +1,7 @@
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import { WebApiClient } from "../clients/index.js";
 import {
+  applyGeminiGatewayParams,
   BaseChatGoogle,
   BaseChatGoogleCallOptions,
   BaseChatGoogleParams,
@@ -46,7 +47,11 @@ export class ChatGoogle extends BaseChatGoogle<ChatGoogleCallOptions> {
     modelOrParams: string | ChatGoogleParams,
     paramsArg?: Omit<ChatGoogleParams, "model">
   ) {
-    const params = getGoogleChatModelParams(modelOrParams, paramsArg);
+    let params = getGoogleChatModelParams(modelOrParams, paramsArg);
+    // Route through the LangSmith gateway (Gemini Developer API path) when
+    // configured, before falling back to the provider API-key env var so the
+    // gateway key can take precedence.
+    params = applyGeminiGatewayParams(params);
     params.apiKey = params?.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
     const apiClient = params?.apiClient ?? new WebApiClient(params);
     super({ ...params, apiClient });

--- a/libs/providers/langchain-google/src/chat_models/node.ts
+++ b/libs/providers/langchain-google/src/chat_models/node.ts
@@ -1,6 +1,7 @@
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 import { ChatGoogleParams } from "./index.js";
 import {
+  applyGeminiGatewayParams,
   BaseChatGoogle,
   getGoogleChatModelParams,
   getPlatformType,
@@ -22,8 +23,13 @@ class ChatGoogleNode extends BaseChatGoogle {
     modelOrParams: string | ChatGoogleNodeParams,
     paramsArg?: Omit<ChatGoogleNodeParams, "model">
   ) {
-    const params = getGoogleChatModelParams(modelOrParams, paramsArg);
+    let params = getGoogleChatModelParams(modelOrParams, paramsArg);
     if (!params.googleAuthOptions) {
+      // Route through the LangSmith gateway (Gemini Developer API path) when
+      // configured, before falling back to the provider API-key env var so the
+      // gateway key can take precedence. Skipped when Vertex OAuth
+      // (`googleAuthOptions`) is used, which the gateway does not proxy.
+      params = applyGeminiGatewayParams(params);
       params.apiKey = params.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
     }
     const requiredScopes: string[] = getRequiredAuthScopes(params);

--- a/libs/providers/langchain-google/src/chat_models/tests/gateway.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/gateway.test.ts
@@ -109,6 +109,47 @@ describe("applyGeminiGatewayParams", () => {
     expect(vertexByPlatform.endpoint).toBeUndefined();
   });
 
+  test("service-account credentials are not routed through the gateway", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const byCredentials = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      credentials: { client_email: "svc@example.iam.gserviceaccount.com" },
+    });
+    expect(byCredentials.endpoint).toBeUndefined();
+    expect(byCredentials.apiKey).toBeUndefined();
+
+    const byAuthOptions = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      googleAuthOptions: {
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      },
+    });
+    expect(byAuthOptions.endpoint).toBeUndefined();
+  });
+
+  test("GOOGLE_CLOUD_CREDENTIALS env is not routed through the gateway", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+    vi.stubEnv("GOOGLE_CLOUD_CREDENTIALS", '{"type":"service_account"}');
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    expect(params.endpoint).toBeUndefined();
+    expect(params.apiKey).toBeUndefined();
+  });
+
+  test("a non-https custom gateway keeps its scheme", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "http://localhost:8080/custom");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    // Scheme preserved (host+port+path) so the URL builder does not force TLS.
+    expect(params.endpoint).toBe("http://localhost:8080/custom/gemini");
+  });
+
   test("no-op when the gateway is disabled", () => {
     vi.stubEnv("LANGSMITH_GATEWAY", "false");
 
@@ -146,6 +187,19 @@ describe("ChatGoogle gateway routing (end to end)", () => {
 
     expect(apiClient.request?.url).toBe(
       "https://gateway.smith.langchain.com/gemini/v1beta/models/gemini-2.5-flash:generateContent"
+    );
+  });
+
+  test("a non-https custom gateway is not forced to TLS", async () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "http://localhost:8080/custom");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const apiClient = new RecordingApiClient();
+    const model = new ChatGoogle({ model: "gemini-2.5-flash", apiClient });
+    await model.invoke("hi");
+
+    expect(apiClient.request?.url).toBe(
+      "http://localhost:8080/custom/gemini/v1beta/models/gemini-2.5-flash:generateContent"
     );
   });
 });

--- a/libs/providers/langchain-google/src/chat_models/tests/gateway.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/gateway.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as fs from "node:fs";
+import { ApiClient } from "../../clients/index.js";
+import { ChatGoogle } from "../index.js";
+import { ChatGoogle as ChatGoogleNode } from "../node.js";
+import { applyGeminiGatewayParams } from "../base.js";
+
+/**
+ * Minimal ApiClient that records the outgoing request URL and reports that an
+ * API key is present, so the model resolves to the Gemini Developer API (`gai`)
+ * platform and uses `buildUrlGemini`.
+ */
+class RecordingApiClient extends ApiClient {
+  request?: Request;
+
+  hasApiKey(): boolean {
+    return true;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    this.request = request;
+    const bodyText = fs.readFileSync(
+      "src/chat_models/tests/data/mock/gemini-chat-001.json",
+      "utf-8"
+    );
+    return new Response(bodyText, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+describe("applyGeminiGatewayParams", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("routes the gai path through the gateway endpoint", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    // Scheme-less host + provider path; the URL builders prepend `https://`.
+    expect(params.endpoint).toBe("gateway.smith.langchain.com/gemini");
+    expect(params.apiKey).toBe("gateway-key");
+  });
+
+  test("supports a custom gateway root", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "https://gw.example.com/");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    expect(params.endpoint).toBe("gw.example.com/gemini");
+  });
+
+  test("falls back to LANGSMITH_API_KEY", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "");
+    vi.stubEnv("LANGSMITH_API_KEY", "ls-key");
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    expect(params.apiKey).toBe("ls-key");
+  });
+
+  test("an explicit apiKey still wins over the gateway key", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const params = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      apiKey: "user-key",
+    });
+
+    expect(params.endpoint).toBe("gateway.smith.langchain.com/gemini");
+    expect(params.apiKey).toBe("user-key");
+  });
+
+  test("an explicit endpoint suppresses gateway routing", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const params = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      endpoint: "my.proxy.example.com",
+      apiKey: "user-key",
+    });
+
+    expect(params.endpoint).toBe("my.proxy.example.com");
+    expect(params.apiKey).toBe("user-key");
+  });
+
+  test("Vertex configuration is not routed through the gateway", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const vertexByFlag = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      vertexai: true,
+    });
+    expect(vertexByFlag.endpoint).toBeUndefined();
+
+    const vertexByPlatform = applyGeminiGatewayParams({
+      model: "gemini-2.5-flash",
+      platformType: "gcp",
+    });
+    expect(vertexByPlatform.endpoint).toBeUndefined();
+  });
+
+  test("no-op when the gateway is disabled", () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "false");
+
+    const params = applyGeminiGatewayParams({ model: "gemini-2.5-flash" });
+
+    expect(params.endpoint).toBeUndefined();
+  });
+});
+
+describe("ChatGoogle gateway routing (end to end)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("web wrapper builds the gateway URL for the gai path", async () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const apiClient = new RecordingApiClient();
+    const model = new ChatGoogle({ model: "gemini-2.5-flash", apiClient });
+    await model.invoke("hi");
+
+    expect(apiClient.request?.url).toBe(
+      "https://gateway.smith.langchain.com/gemini/v1beta/models/gemini-2.5-flash:generateContent"
+    );
+  });
+
+  test("node wrapper builds the gateway URL for the gai path", async () => {
+    vi.stubEnv("LANGSMITH_GATEWAY", "true");
+    vi.stubEnv("LANGSMITH_GATEWAY_API_KEY", "gateway-key");
+
+    const apiClient = new RecordingApiClient();
+    const model = new ChatGoogleNode({ model: "gemini-2.5-flash", apiClient });
+    await model.invoke("hi");
+
+    expect(apiClient.request?.url).toBe(
+      "https://gateway.smith.langchain.com/gemini/v1beta/models/gemini-2.5-flash:generateContent"
+    );
+  });
+});


### PR DESCRIPTION
* adds gateway support to google-genai + google packages (followup to https://github.com/langchain-ai/langchainjs/pull/11369 and https://github.com/langchain-ai/langchainjs/pull/11362)

we notably don't support vertex routing since the url construction is a little more complex there