### PR TITLE
fix(anthropic): round-trip tool search server-tool result blocks

### DIFF
--- a/.changeset/tool-search-result-round-trip.md
+++ b/.changeset/tool-search-result-round-trip.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Round-trip the tool search server-tool result blocks (`tool_search_tool_bm25_tool_result` / `tool_search_tool_regex_tool_result`) through message translation, mirroring `web_search_tool_result`. Without this, a multi-turn conversation using the tool search tool fails on the next request with `400 invalid_request_error … tool use … found without a corresponding … tool_result block`, because the result block was dropped from the assistant message (streaming capture) and on re-send (`toolTypes` passthrough).

--- a/libs/providers/langchain-anthropic/src/tests/chat_models-tool_search.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models-tool_search.test.ts
@@ -1,0 +1,78 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { test, expect } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { _makeMessageChunkFromAnthropicEvent } from "../utils/message_outputs.js";
+import { _convertMessagesToAnthropicPayload } from "../utils/message_inputs.js";
+
+// The `content` shape below is illustrative — the utils pass the server-tool
+// result block through unchanged, so these tests assert preservation, not the
+// internal representation of a discovered tool.
+const toolSearchResultBlock = {
+  type: "tool_search_tool_bm25_tool_result",
+  tool_use_id: "srvtoolu_01ABC123",
+  content: [
+    {
+      type: "tool_search_result",
+      tool_name: "send_email",
+    },
+  ],
+};
+
+test("Tool Search Tool - streaming content_block_start is captured", () => {
+  // A deferred-tool search returns its result as a server-tool result block in
+  // the same assistant turn. The streaming parser must capture it, otherwise the
+  // accumulated message keeps the server_tool_use without its result and the next
+  // request fails with INVALID_TOOL_RESULTS.
+  const result = _makeMessageChunkFromAnthropicEvent(
+    {
+      type: "content_block_start",
+      index: 1,
+      content_block: toolSearchResultBlock,
+    } as unknown as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
+    { streamUsage: true, coerceContentToString: false }
+  );
+
+  expect(result).not.toBeNull();
+  const content = result?.chunk.content;
+  expect(Array.isArray(content)).toBe(true);
+  expect(
+    (content as { type?: string }[]).some(
+      (block) => block.type === "tool_search_tool_bm25_tool_result"
+    )
+  ).toBe(true);
+});
+
+test("Tool Search Tool - LangChain message to Anthropic format", () => {
+  // A follow-up turn replays the prior assistant message. The server-tool result
+  // block must survive the round-trip so its paired server_tool_use is not left
+  // dangling on the next request.
+  const langChainMessage = new AIMessage({
+    content: [
+      {
+        type: "text",
+        text: "Let me find the right tool.",
+        citations: null,
+      },
+      {
+        type: "server_tool_use",
+        id: "srvtoolu_01ABC123",
+        name: "tool_search_tool_bm25",
+        input: { query: "send an email" },
+      },
+      toolSearchResultBlock,
+    ],
+  });
+
+  const result = _convertMessagesToAnthropicPayload([
+    new HumanMessage("Email the team the summary"),
+    langChainMessage,
+  ]);
+
+  const assistant = result.messages[1];
+  expect(assistant.role).toBe("assistant");
+  expect(
+    (assistant.content as { type?: string }[]).some(
+      (block) => block.type === "tool_search_tool_bm25_tool_result"
+    )
+  ).toBe(true);
+});

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -163,6 +163,8 @@ function* _formatContentBlocks(
     "server_tool_use",
     "text_editor_code_execution_tool_result",
     "tool_result",
+    "tool_search_tool_bm25_tool_result",
+    "tool_search_tool_regex_tool_result",
     "tool_use",
     "web_search_result",
     "web_search_tool_result",

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -86,6 +86,8 @@ export function _makeMessageChunkFromAnthropicEvent(
       "document",
       "server_tool_use",
       "web_search_tool_result",
+      "tool_search_tool_bm25_tool_result",
+      "tool_search_tool_regex_tool_result",
     ].includes(data.content_block.type)
   ) {
     const contentBlock = data.content_block;


### PR DESCRIPTION
The tool search tool (`tool_search_tool_bm25_20251119` / `tool_search_tool_regex_20251119`) is a server-side tool. Anthropic runs the search and returns a `server_tool_use` block **and** its paired `tool_search_tool_*_tool_result` block in the same assistant message.

`@langchain/anthropic` already supports the *send* side (tool definitions via `tools.toolSearchBM25_20251119()` / `toolSearchRegex_20251119()`, `defer_loading`, and auto-injecting the beta header), but it does not carry the **result** block through a conversation:
- `_makeMessageChunkFromAnthropicEvent` (streaming) whitelists `content_block_start` types and omits the tool-search result block, so it is dropped from the accumulated `AIMessage`.
- `_convertMessagesToAnthropicPayload` (`_formatContentBlocks`) whitelists `toolTypes` and omits it too, so even a manually-constructed message loses it on re-send.

As a result, any multi-turn (or multi-step tool-loop) conversation that uses tool search fails on the next request with:
```
  400 invalid_request_error: messages.N: tool_search_tool_bm25 tool use with id srvtoolu_...
  was found without a corresponding tool_search_tool_bm25_tool_result block
```

This mirrors the existing handling for web_search_tool_result
