### PR TITLE
fix(google-common): release endpoint routing fix as patch

### DIFF
--- a/.changeset/perky-hats-wave.md
+++ b/.changeset/perky-hats-wave.md
@@ -1,5 +1,5 @@
 ---
-"@langchain/google-common": major
+"@langchain/google-common": patch
 ---
 
 Fixes endpoint routing and parameter validation for the "eu" multi-region location.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib/
 .turbo
 .eslintcache
 .env
+.env.*
 .env.local
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary

Downgrades the Google Common endpoint-routing fix from a major to a patch release. The change is backwards compatible and should not force a major-version cascade through dependent Google packages.

## Changes

- Update the `@langchain/google-common` changeset from `major` to `patch`.
- Ignore all `.env.*` files to prevent environment-specific credentials from being staged accidentally.
