### PR TITLE
fix(openrouter): preserve model metadata in streaming

### DIFF
--- a/libs/providers/langchain-openrouter/src/converters/messages.ts
+++ b/libs/providers/langchain-openrouter/src/converters/messages.ts
@@ -133,7 +133,9 @@ export function convertOpenRouterDeltaToBaseMessageChunk(
 
   chunk.response_metadata = {
     ...chunk.response_metadata,
+    model: rawChunk.model,
     model_provider: "openrouter",
+    model_name: rawChunk.model,
   };
 
   return chunk;

--- a/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
@@ -123,7 +123,7 @@ describe("convertOpenRouterResponseToBaseMessage metadata", () => {
 });
 
 describe("convertOpenRouterDeltaToBaseMessageChunk metadata", () => {
-  it("patches response_metadata with model_provider", () => {
+  it("patches response_metadata with openrouter fields", () => {
     const delta: OpenRouter.ChatStreamingMessageChunk = {
       role: "assistant",
       content: "hi",
@@ -143,7 +143,9 @@ describe("convertOpenRouterDeltaToBaseMessageChunk metadata", () => {
     );
 
     const meta = chunk.response_metadata as Record<string, unknown>;
+    expect(meta.model).toBe("openai/gpt-4o");
     expect(meta.model_provider).toBe("openrouter");
+    expect(meta.model_name).toBe("openai/gpt-4o");
   });
 });
 


### PR DESCRIPTION
## Description

Preserves the actual model returned by OpenRouter in `response_metadata` when streaming.

Non-streaming responses already expose both `model` and `model_name`, while streaming responses only set `model_provider`. This causes the actual model to be lost when using features such as OpenRouter Auto Router.

This change aligns streaming response metadata with the non-streaming behavior.

## Testing

Added assertions to the existing streaming metadata test to verify that `model` and `model_name` are preserved.

Fixes #11409