### PR TITLE
fix(langchain): drop foreign provider built-in tools on model fallback

### DIFF
--- a/.changeset/wild-pugs-listen.md
+++ b/.changeset/wild-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Drop provider built-in tools (OpenAI Responses tools, Anthropic server tools, Gemini built-ins) from `modelFallbackMiddleware` retries that target a different provider, and warn when a fallback attempt starts.

--- a/libs/langchain/src/agents/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middleware/modelFallback.ts
@@ -15,7 +15,7 @@ type BuiltinToolProvider = "anthropic" | "openai" | "google";
  * dated variants (`web_search_preview_2025_03_11`); Anthropic tools carry a dated
  * `type` (`web_search_20250305`) plus a few undated ones; Gemini built-ins are keyed
  * payloads (`{ google_search: {} }`) in either snake or camel case. Client tools and
- * plain function payloads match none of these shapes and are never dropped.
+ * provider-neutral function payloads match none of these shapes and are never dropped.
  */
 const OPENAI_BUILTIN_TOOL_TYPES = [
   "apply_patch",
@@ -37,14 +37,22 @@ const ANTHROPIC_BUILTIN_TOOL_TYPES = new Set([
   "tool_search_tool_regex",
 ]);
 const ANTHROPIC_DATED_BUILTIN_TOOL_TYPE = /_\d{8}$/;
-const GOOGLE_BUILTIN_TOOL_KEYS = new Set([
+/**
+ * Every field of the Gemini `Tool` payload, `functionDeclarations` included: a Gemini
+ * tool object is Gemini-shaped in all of its parts, so no other provider can read one
+ * even when it carries function declarations.
+ */
+const GOOGLE_TOOL_KEYS = new Set([
   "codeexecution",
   "computeruse",
   "enterprisewebsearch",
   "filesearch",
+  "functiondeclarations",
   "googlemaps",
   "googlesearch",
   "googlesearchretrieval",
+  "mcpservers",
+  "retrieval",
   "urlcontext",
 ]);
 
@@ -106,12 +114,10 @@ function getBuiltinToolProvider(
       return "openai";
     return undefined;
   }
-  // A payload mixing built-ins with `functionDeclarations` keeps its function tools
-  // rather than being dropped whole, so every key must be a built-in to qualify.
   const keys = Object.keys(payload);
   if (
     keys.length > 0 &&
-    keys.every((key) => GOOGLE_BUILTIN_TOOL_KEYS.has(normalizeKey(key)))
+    keys.every((key) => GOOGLE_TOOL_KEYS.has(normalizeKey(key)))
   )
     return "google";
   return undefined;

--- a/libs/langchain/src/agents/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middleware/modelFallback.ts
@@ -127,19 +127,20 @@ function getBuiltinToolProvider(
 function withoutForeignBuiltinTools(
   tools: readonly (ClientTool | ServerTool)[] | undefined,
   model: LanguageModelLike
-): (ClientTool | ServerTool)[] | undefined {
-  if (!tools?.length) return tools as (ClientTool | ServerTool)[] | undefined;
+): (ClientTool | ServerTool)[] {
+  const current = tools ?? [];
+  if (current.length === 0) return [];
 
   const provider = getModelProvider(model);
-  const kept = tools.filter((tool) => {
+  const kept = current.filter((tool) => {
     const owner = getBuiltinToolProvider(tool);
     return owner === undefined || owner === provider;
   });
-  if (kept.length === tools.length) return tools as (ClientTool | ServerTool)[];
+  if (kept.length === current.length) return [...current];
 
   console.warn(
     `modelFallbackMiddleware: dropped ${
-      tools.length - kept.length
+      current.length - kept.length
     } provider built-in tool(s) not supported by fallback model ${model.getName()}`
   );
   return kept;

--- a/libs/langchain/src/agents/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middleware/modelFallback.ts
@@ -1,6 +1,111 @@
+import type { ClientTool, ServerTool } from "@langchain/core/tools";
+import { isLangChainTool } from "@langchain/core/utils/function_calling";
 import type { AgentLanguageModelLike as LanguageModelLike } from "../model.js";
-import { initChatModel } from "../../chat_models/universal.js";
+import {
+  initChatModel,
+  type ConfigurableModel,
+} from "../../chat_models/universal.js";
 import { createMiddleware } from "../middleware.js";
+
+type BuiltinToolProvider = "anthropic" | "openai" | "google";
+
+/**
+ * Provider built-in tools are plain records and are only accepted by the provider
+ * that defines them: OpenAI Responses built-ins are bare `{ type }` entries,
+ * Anthropic server tools carry a dated `type` (`web_search_20250305`), and Gemini
+ * built-ins are single-key payloads (`{ google_search: {} }`). Client tools match
+ * none of those shapes and are never touched.
+ */
+const OPENAI_BUILTIN_TOOL_TYPES = new Set([
+  "code_interpreter",
+  "computer_use_preview",
+  "file_search",
+  "image_generation",
+  "mcp",
+  "web_search",
+  "web_search_preview",
+]);
+const ANTHROPIC_BUILTIN_TOOL_TYPE = /_\d{8}$/;
+const GOOGLE_BUILTIN_TOOL_KEYS = new Set([
+  "code_execution",
+  "enterprise_web_search",
+  "google_search",
+  "google_search_retrieval",
+  "url_context",
+]);
+
+function getModelProvider(
+  model: LanguageModelLike
+): BuiltinToolProvider | undefined {
+  const name = model.getName();
+  const configured =
+    name === "ConfigurableModel"
+      ? (model as ConfigurableModel)._defaultConfig?.modelProvider
+      : undefined;
+  if (name === "ChatAnthropic" || configured === "anthropic")
+    return "anthropic";
+  if (
+    name === "ChatOpenAI" ||
+    name === "AzureChatOpenAI" ||
+    configured === "openai" ||
+    configured === "azure_openai"
+  )
+    return "openai";
+  if (
+    name === "ChatGoogleGenerativeAI" ||
+    name === "ChatVertexAI" ||
+    configured === "google_genai" ||
+    configured === "google_vertexai"
+  )
+    return "google";
+  return undefined;
+}
+
+/** The provider that defines this built-in tool, or `undefined` for client tools. */
+function getBuiltinToolProvider(
+  tool: ClientTool | ServerTool
+): BuiltinToolProvider | undefined {
+  if (isLangChainTool(tool)) return undefined;
+  const payload = tool as Record<string, unknown>;
+  const type = payload.type;
+  if (typeof type === "string") {
+    if (OPENAI_BUILTIN_TOOL_TYPES.has(type)) return "openai";
+    if (ANTHROPIC_BUILTIN_TOOL_TYPE.test(type)) return "anthropic";
+    return undefined;
+  }
+  const keys = Object.keys(payload);
+  if (keys.length === 1 && GOOGLE_BUILTIN_TOOL_KEYS.has(keys[0]))
+    return "google";
+  return undefined;
+}
+
+/**
+ * Drop built-in tools the fallback model's provider does not define.
+ *
+ * An unrecognized fallback provider drops them too: a built-in tool only exists
+ * on its own provider's API, so losing the capability on a retry beats failing
+ * the retry outright on an unknown tool type.
+ */
+function withoutForeignBuiltinTools(
+  tools: readonly (ClientTool | ServerTool)[] | undefined,
+  model: LanguageModelLike
+): (ClientTool | ServerTool)[] | undefined {
+  if (!tools?.length) return tools as (ClientTool | ServerTool)[] | undefined;
+
+  const provider = getModelProvider(model);
+  const kept = tools.filter((tool) => {
+    const owner = getBuiltinToolProvider(tool);
+    return owner === undefined || owner === provider;
+  });
+  if (kept.length === tools.length) return tools as (ClientTool | ServerTool)[];
+
+  console.warn(
+    `modelFallbackMiddleware: dropped ${
+      tools.length - kept.length
+    } provider built-in tool(s) not supported by fallback model ${model.getName()}`
+  );
+  return kept;
+}
 
 /**
  * Middleware that provides automatic model fallback on errors.
@@ -60,9 +165,16 @@ export function modelFallbackMiddleware(
                 ? await initChatModel(fallbackModel)
                 : fallbackModel;
 
+            console.warn(
+              `modelFallbackMiddleware: model call failed (${
+                error instanceof Error ? error.name : typeof error
+              }); retrying with fallback model ${model.getName()}`
+            );
+
             return await handler({
               ...request,
               model,
+              tools: withoutForeignBuiltinTools(request.tools, model),
             });
           } catch (fallbackError) {
             /**

--- a/libs/langchain/src/agents/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middleware/modelFallback.ts
@@ -11,28 +11,46 @@ type BuiltinToolProvider = "anthropic" | "openai" | "google";
 
 /**
  * Provider built-in tools are plain records and are only accepted by the provider
- * that defines them: OpenAI Responses built-ins are bare `{ type }` entries,
- * Anthropic server tools carry a dated `type` (`web_search_20250305`), and Gemini
- * built-ins are single-key payloads (`{ google_search: {} }`). Client tools match
- * none of those shapes and are never touched.
+ * that defines them. OpenAI Responses built-ins are `{ type: <name> }` entries, with
+ * dated variants (`web_search_preview_2025_03_11`); Anthropic tools carry a dated
+ * `type` (`web_search_20250305`) plus a few undated ones; Gemini built-ins are keyed
+ * payloads (`{ google_search: {} }`) in either snake or camel case. Client tools and
+ * plain function payloads match none of these shapes and are never dropped.
  */
-const OPENAI_BUILTIN_TOOL_TYPES = new Set([
+const OPENAI_BUILTIN_TOOL_TYPES = [
+  "apply_patch",
   "code_interpreter",
   "computer_use_preview",
   "file_search",
   "image_generation",
+  "local_shell",
   "mcp",
+  "shell",
+  "tool_search",
   "web_search",
   "web_search_preview",
+];
+const ANTHROPIC_BUILTIN_TOOL_TYPES = new Set([
+  "mcp_toolset",
+  "tool_search_tool_bm25",
+  "tool_search_tool_regex",
 ]);
-const ANTHROPIC_BUILTIN_TOOL_TYPE = /_\d{8}$/;
+const ANTHROPIC_DATED_BUILTIN_TOOL_TYPE = /_\d{8}$/;
 const GOOGLE_BUILTIN_TOOL_KEYS = new Set([
-  "code_execution",
-  "enterprise_web_search",
-  "google_search",
-  "google_search_retrieval",
-  "url_context",
+  "codeexecution",
+  "computeruse",
+  "enterprisewebsearch",
+  "filesearch",
+  "googlemaps",
+  "googlesearch",
+  "googlesearchretrieval",
+  "urlcontext",
 ]);
+
+/** Fold a Gemini tool key so snake and camel spellings compare equal. */
+function normalizeKey(key: string): string {
+  return key.replaceAll("_", "").toLowerCase();
+}
 
 function getModelProvider(
   model: LanguageModelLike
@@ -61,7 +79,12 @@ function getModelProvider(
   return undefined;
 }
 
-/** The provider that defines this built-in tool, or `undefined` for client tools. */
+/**
+ * The provider that defines this built-in tool, or `undefined` for client tools.
+ *
+ * Anthropic is matched before OpenAI: `tool_search_tool_bm25_20251119` would also
+ * match the `tool_search` prefix, and `web_search_20250305` the `web_search` one.
+ */
 function getBuiltinToolProvider(
   tool: ClientTool | ServerTool
 ): BuiltinToolProvider | undefined {
@@ -69,12 +92,26 @@ function getBuiltinToolProvider(
   const payload = tool as Record<string, unknown>;
   const type = payload.type;
   if (typeof type === "string") {
-    if (OPENAI_BUILTIN_TOOL_TYPES.has(type)) return "openai";
-    if (ANTHROPIC_BUILTIN_TOOL_TYPE.test(type)) return "anthropic";
+    if (
+      ANTHROPIC_BUILTIN_TOOL_TYPES.has(type) ||
+      ANTHROPIC_DATED_BUILTIN_TOOL_TYPE.test(type)
+    )
+      return "anthropic";
+    if (
+      OPENAI_BUILTIN_TOOL_TYPES.some(
+        (name) => type === name || type.startsWith(`${name}_`)
+      )
+    )
+      return "openai";
     return undefined;
   }
+  // A payload mixing built-ins with `functionDeclarations` keeps its function tools
+  // rather than being dropped whole, so every key must be a built-in to qualify.
   const keys = Object.keys(payload);
-  if (keys.length === 1 && GOOGLE_BUILTIN_TOOL_KEYS.has(keys[0]))
+  if (
+    keys.length > 0 &&
+    keys.every((key) => GOOGLE_BUILTIN_TOOL_KEYS.has(normalizeKey(key)))
+  )
     return "google";
   return undefined;
 }

--- a/libs/langchain/src/agents/middleware/modelFallback.ts
+++ b/libs/langchain/src/agents/middleware/modelFallback.ts
@@ -20,6 +20,7 @@ type BuiltinToolProvider = "anthropic" | "openai" | "google";
 const OPENAI_BUILTIN_TOOL_TYPES = [
   "apply_patch",
   "code_interpreter",
+  "computer",
   "computer_use_preview",
   "file_search",
   "image_generation",

--- a/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
@@ -144,6 +144,7 @@ describe("modelFallbackMiddleware built-in tools", () => {
     [{ type: "web_search" }, "openai"],
     [{ type: "web_search_preview_2025_03_11" }, "openai"],
     [{ type: "apply_patch" }, "openai"],
+    [{ type: "computer" }, "openai"],
     [{ type: "tool_search" }, "openai"],
     [{ type: "web_search_20250305", name: "web_search" }, "anthropic"],
     [{ type: "mcp_toolset", mcp_servers: [] }, "anthropic"],

--- a/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
@@ -152,6 +152,8 @@ describe("modelFallbackMiddleware built-in tools", () => {
     [{ type: "tool_search_tool_bm25_20251119" }, "anthropic"],
     [{ google_search: {} }, "google"],
     [{ googleSearch: {}, urlContext: {} }, "google"],
+    [{ mcpServers: [] }, "google"],
+    [{ googleSearch: {}, functionDeclarations: [] }, "google"],
   ])("keeps %o only for its own provider (%s)", async (builtinTool, owner) => {
     const primary = createMockModel("ChatOpenAI", "openai");
     const fallback = createMockModel(
@@ -180,9 +182,10 @@ describe("modelFallbackMiddleware built-in tools", () => {
     expect(fallbackRequest.tools).toEqual(kept);
   });
 
-  it("keeps a Gemini payload that also declares function tools", async () => {
+  it("drops a Gemini payload that also declares function tools", async () => {
     const primary = createMockModel("ChatGoogleGenerativeAI", "google");
     const fallback = createMockModel("ChatOpenAI", "openai");
+    // Both keys are Gemini-shaped, so OpenAI cannot read either half.
     const mixedTool = { googleSearch: {}, functionDeclarations: [] };
     const middleware = modelFallbackMiddleware(fallback);
     const handler = vi.fn(async (req: { model: unknown }) => {
@@ -200,7 +203,7 @@ describe("modelFallbackMiddleware built-in tools", () => {
     const fallbackRequest = handler.mock.calls[1][0] as unknown as {
       tools: unknown[];
     };
-    expect(fallbackRequest.tools).toEqual([mixedTool]);
+    expect(fallbackRequest.tools).toEqual([]);
   });
 
   it("keeps built-in tools when the fallback is the same provider", async () => {

--- a/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
@@ -140,6 +140,68 @@ describe("modelFallbackMiddleware built-in tools", () => {
     expect(request.tools).toEqual([clientTool]);
   });
 
+  it.each([
+    [{ type: "web_search" }, "openai"],
+    [{ type: "web_search_preview_2025_03_11" }, "openai"],
+    [{ type: "apply_patch" }, "openai"],
+    [{ type: "tool_search" }, "openai"],
+    [{ type: "web_search_20250305", name: "web_search" }, "anthropic"],
+    [{ type: "mcp_toolset", mcp_servers: [] }, "anthropic"],
+    [{ type: "tool_search_tool_bm25" }, "anthropic"],
+    [{ type: "tool_search_tool_bm25_20251119" }, "anthropic"],
+    [{ google_search: {} }, "google"],
+    [{ googleSearch: {}, urlContext: {} }, "google"],
+  ])("keeps %o only for its own provider (%s)", async (builtinTool, owner) => {
+    const primary = createMockModel("ChatOpenAI", "openai");
+    const fallback = createMockModel(
+      owner === "anthropic" ? "ChatAnthropic" : "ChatGoogleGenerativeAI",
+      owner
+    );
+    const middleware = modelFallbackMiddleware(fallback);
+    const handler = vi.fn(async (req: { model: unknown }) => {
+      if (req.model === primary) throw new Error("Model error");
+      return new AIMessage("fallback response");
+    });
+
+    await middleware.wrapModelCall!(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      { model: primary, tools: [clientTool, builtinTool] } as any,
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      handler as any
+    );
+
+    const fallbackRequest = handler.mock.calls[1][0] as unknown as {
+      tools: unknown[];
+    };
+    const kept = owner === "openai" ? [clientTool] : [clientTool, builtinTool];
+    // An OpenAI built-in never survives a non-OpenAI fallback; the others do
+    // reach the provider that defines them.
+    expect(fallbackRequest.tools).toEqual(kept);
+  });
+
+  it("keeps a Gemini payload that also declares function tools", async () => {
+    const primary = createMockModel("ChatGoogleGenerativeAI", "google");
+    const fallback = createMockModel("ChatOpenAI", "openai");
+    const mixedTool = { googleSearch: {}, functionDeclarations: [] };
+    const middleware = modelFallbackMiddleware(fallback);
+    const handler = vi.fn(async (req: { model: unknown }) => {
+      if (req.model === primary) throw new Error("Model error");
+      return new AIMessage("fallback response");
+    });
+
+    await middleware.wrapModelCall!(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      { model: primary, tools: [mixedTool] } as any,
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      handler as any
+    );
+
+    const fallbackRequest = handler.mock.calls[1][0] as unknown as {
+      tools: unknown[];
+    };
+    expect(fallbackRequest.tools).toEqual([mixedTool]);
+  });
+
   it("keeps built-in tools when the fallback is the same provider", async () => {
     const request = await fallbackTools("ChatOpenAI", "openai");
     expect(request.tools).toEqual([clientTool, openaiBuiltinTool]);

--- a/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/modelFallback.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, vi } from "vitest";
+import { expect, describe, it, vi, afterEach } from "vitest";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
 import { LanguageModelLike } from "@langchain/core/language_models/base";
 
@@ -93,5 +93,70 @@ describe("modelFallbackMiddleware", () => {
     await expect(
       agent.invoke({ messages: [new HumanMessage("Hello, world!")] })
     ).rejects.toThrow("Model error");
+  });
+});
+
+describe("modelFallbackMiddleware built-in tools", () => {
+  const clientTool = {
+    name: "lookup",
+    description: "client tool that must survive every fallback attempt",
+    schema: { type: "object", properties: {} },
+  };
+  const openaiBuiltinTool = { type: "web_search" };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function fallbackTools(
+    fallbackModelName: string,
+    fallbackProvider: string
+  ) {
+    const primary = createMockModel("ChatOpenAI", "openai");
+    const fallback = createMockModel(fallbackModelName, fallbackProvider);
+    const middleware = modelFallbackMiddleware(fallback);
+    const handler = vi.fn(async (req: { model: unknown }) => {
+      if (req.model === primary) throw new Error("Model error");
+      return new AIMessage("fallback response");
+    });
+
+    await middleware.wrapModelCall!(
+      {
+        model: primary,
+        tools: [clientTool, openaiBuiltinTool],
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      handler as any
+    );
+
+    return handler.mock.calls[1][0] as unknown as {
+      tools: unknown[];
+    };
+  }
+
+  it("drops built-in tools the fallback provider does not define", async () => {
+    const request = await fallbackTools("ChatAnthropic", "anthropic");
+    expect(request.tools).toEqual([clientTool]);
+  });
+
+  it("keeps built-in tools when the fallback is the same provider", async () => {
+    const request = await fallbackTools("ChatOpenAI", "openai");
+    expect(request.tools).toEqual([clientTool, openaiBuiltinTool]);
+  });
+
+  it("drops built-in tools when the fallback provider is unrecognized", async () => {
+    const request = await fallbackTools("ChatFireworks", "fireworks");
+    expect(request.tools).toEqual([clientTool]);
+  });
+
+  it("warns when a fallback attempt starts", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await fallbackTools("ChatAnthropic", "anthropic");
+    expect(
+      warn.mock.calls.some(([message]) =>
+        String(message).includes("retrying with fallback model ChatAnthropic")
+      )
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
An agent bound to a provider built-in tool — OpenAI's `{ type: "web_search" }`, an Anthropic server tool, Gemini's `{ google_search: {} }` — re-sent that tool verbatim on every `modelFallbackMiddleware` retry. When the fallback model is a different provider, that tool type does not exist on its API, so the fallback attempt failed on an unknown tool instead of recovering.

Fallback attempts now drop built-in tools the fallback model's provider does not define, using the same `getName()`/`ConfigurableModel` provider detection as `providerToolSearchMiddleware`. Client tools (anything `isLangChainTool` recognizes) always pass through. An unrecognized fallback provider drops built-ins too: losing a provider capability on a retry beats failing the retry outright.

Also warns on every fallback attempt, naming the failure and the fallback model — the model swap was previously silent.

Python equivalent: https://github.com/langchain-ai/langchain/pull/39788
