### PR TITLE
fix(openai): send content null (not []) for tool-call-only v1 assistant messages

### DIFF
--- a/.changeset/four-actors-move.md
+++ b/.changeset/four-actors-move.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): send content null (not []) for tool-call-only v1 assistant messages

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -658,10 +658,13 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       content: message.contentBlocks.filter((block) => block.type === "text"),
     };
   } else if (role === "assistant") {
+    const textContent = message.contentBlocks.filter(
+      (block) => block.type === "text"
+    );
     const completionParam: OpenAIClient.Chat.Completions.ChatCompletionAssistantMessageParam =
       {
         role: "assistant",
-        content: message.contentBlocks.filter((block) => block.type === "text"),
+        content: textContent,
       };
     if (AIMessage.isInstance(message) && !!message.tool_calls?.length) {
       completionParam.tool_calls = message.tool_calls.map(
@@ -670,6 +673,18 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
     } else if (message.additional_kwargs.tool_calls != null) {
       completionParam.tool_calls = message.additional_kwargs
         .tool_calls as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
+    }
+    // The OpenAI Chat Completions API rejects an assistant message whose
+    // `content` is an empty array ("empty array. Expected an array with minimum
+    // length 1"). A tool-call-only AIMessage (all content blocks are tool_call
+    // blocks, so the text filter yields []) must therefore send `content: null`
+    // instead of `[]`; tool_calls carry the payload.
+    if (
+      Array.isArray(completionParam.content) &&
+      completionParam.content.length === 0 &&
+      completionParam.tool_calls != null
+    ) {
+      completionParam.content = null;
     }
     return completionParam;
   } else if (role === "tool" && ToolMessage.isInstance(message)) {

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -349,7 +349,7 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
-    it("should preserve tool_calls for output_version v1 assistant messages", () => {
+    it("should send content null (not []) for output_version v1 tool-call-only assistant messages", () => {
       const message = new AIMessage({
         content: [
           {
@@ -376,9 +376,11 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
 
       expect(result).toHaveLength(1);
+      // Must be `null`, not `[]`: the OpenAI Chat Completions API rejects an
+      // assistant message with an empty content array (issue #11416).
       expect(result[0]).toEqual({
         role: "assistant",
-        content: [],
+        content: null,
         tool_calls: [
           {
             id: "call_123",


### PR DESCRIPTION
## Fixes #11416

### Problem

`convertMessagesToCompletionsMessageParams` (`@langchain/openai`) builds an assistant message's `content` by filtering the message's content blocks down to text blocks:

```ts
content: message.contentBlocks.filter((block) => block.type === "text"),
```

For a v1-output `AIMessage` whose content is **only tool-call blocks** (a tool-call-only turn), that filter yields an empty array, so the outgoing request carries `content: []`. The OpenAI Chat Completions API rejects it:

```
400 Invalid 'messages[..].content': empty array.
Expected an array with minimum length 1, but got an empty array instead.
```

Reproduction (from the issue): an `AIMessage` with `output_version: "v1"` and content consisting solely of a `tool_call` block round-trips through the converter to `content: []` and then fails the API call.

### Fix

After assembling the assistant param, if `content` resolved to an empty array **and** `tool_calls` are present, send `content: null` instead. `null` is a valid value for `ChatCompletionAssistantMessageParam.content`, and the `tool_calls` field carries the actual payload — which is exactly the shape the API expects for a tool-call-only assistant turn.

The change is confined to the `assistant` branch; text-bearing assistant messages, string-content messages, and non-assistant roles are untouched.

### Tests

- Updated the existing test `should preserve tool_calls for output_version v1 assistant messages` — it previously asserted the **buggy** `content: []` output. It now asserts `content: null` (and is renamed to describe the corrected behavior).
- Verified RED/GREEN locally: with the fix removed the test fails with `content: []`; with the fix it passes.
- Full converter test suite green: **112 passed**, no type errors (`vitest run src/converters/`).

### Verification commands

```
# built @langchain/core, then:
cd libs/providers/langchain-openai
npx vitest run src/converters/    # 112 passed, Type Errors: no errors
```
