### PR TITLE
fix(openai): serialize empty v1 assistant content as string

### DIFF
--- a/.changeset/cuddly-tools-smile.md
+++ b/.changeset/cuddly-tools-smile.md
@@ -2,4 +2,4 @@
 "@langchain/openai": patch
 ---
 
-Fix Chat Completions serialization of v1 tool-call-only assistant messages.
+Fix Chat Completions serialization of v1 assistant messages without text content.

--- a/.changeset/cuddly-tools-smile.md
+++ b/.changeset/cuddly-tools-smile.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Fix Chat Completions serialization of v1 tool-call-only assistant messages.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -671,6 +671,13 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       completionParam.tool_calls = message.additional_kwargs
         .tool_calls as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
     }
+    if (
+      Array.isArray(completionParam.content) &&
+      completionParam.content.length === 0 &&
+      completionParam.tool_calls != null
+    ) {
+      completionParam.content = "";
+    }
     return completionParam;
   } else if (role === "tool" && ToolMessage.isInstance(message)) {
     return {

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -673,8 +673,7 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
     }
     if (
       Array.isArray(completionParam.content) &&
-      completionParam.content.length === 0 &&
-      completionParam.tool_calls != null
+      completionParam.content.length === 0
     ) {
       completionParam.content = "";
     }

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -349,7 +349,7 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
-    it("should preserve tool_calls for output_version v1 assistant messages", () => {
+    it("should use empty string content for output_version v1 tool calls", () => {
       const message = new AIMessage({
         content: [
           {
@@ -378,7 +378,7 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         role: "assistant",
-        content: [],
+        content: "",
         tool_calls: [
           {
             id: "call_123",

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -392,6 +392,31 @@ describe("convertCompletionsMessageToBaseMessage", () => {
       });
     });
 
+    it("should use empty string content for output_version v1 reasoning", () => {
+      const message = new AIMessage({
+        content: [
+          {
+            type: "reasoning",
+            reasoning: "Let me think about this...",
+          },
+        ],
+        response_metadata: {
+          output_version: "v1",
+        },
+      });
+
+      const result = convertMessagesToCompletionsMessageParams({
+        messages: [message],
+      });
+
+      expect(result).toEqual([
+        {
+          role: "assistant",
+          content: "",
+        },
+      ]);
+    });
+
     it("should preserve content with function_call in additional_kwargs", () => {
       const message = new AIMessage({
         content: "Let me call a function for you.",


### PR DESCRIPTION
Fixes #11416

V1 assistant messages with no text content now use an empty string instead of an invalid empty array when sent to Chat Completions. This covers both tool-call-only and reasoning-only history.

---

The standard-content converter filters assistant content down to text blocks. When none remain, an empty string keeps the payload valid while preserving any tool calls.

## Release note

`@langchain/openai` now serializes v1 assistant messages without text content as an empty string for Chat Completions.

## AI disclosure

This contribution was implemented and validated with AI assistance.
