### PR TITLE
fix(anthropic): preserve generic tool_search_tool_result blocks

### DIFF
--- a/.changeset/tool-search-generic-result-block.md
+++ b/.changeset/tool-search-generic-result-block.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+Preserve the generic `tool_search_tool_result` block type in streaming output and message payload conversion. The Anthropic API emits this un-suffixed type for both tool search variants; previously only the variant-suffixed names were allowlisted, so multi-turn conversations using tool search still failed with INVALID_TOOL_RESULTS after a client-tool round-trip.

--- a/libs/providers/langchain-anthropic/src/tests/chat_models-tool_search.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models-tool_search.test.ts
@@ -76,3 +76,62 @@ test("Tool Search Tool - LangChain message to Anthropic format", () => {
     )
   ).toBe(true);
 });
+
+// On the wire the API emits the un-suffixed `tool_search_tool_result` type for
+// both search variants (also the shape shown in Anthropic's tool-search docs);
+// the variant-suffixed names above are kept for compatibility.
+const genericToolSearchResultBlock = {
+  type: "tool_search_tool_result",
+  tool_use_id: "srvtoolu_01DEF456",
+  content: {
+    type: "tool_search_tool_search_result",
+    tool_references: [{ type: "tool_reference", tool_name: "send_email" }],
+  },
+};
+
+test("Tool Search Tool - generic result block is captured in streaming", () => {
+  const result = _makeMessageChunkFromAnthropicEvent(
+    {
+      type: "content_block_start",
+      index: 1,
+      content_block: genericToolSearchResultBlock,
+    } as unknown as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
+    { streamUsage: true, coerceContentToString: false }
+  );
+
+  expect(result).not.toBeNull();
+  const content = result?.chunk.content;
+  expect(Array.isArray(content)).toBe(true);
+  expect(
+    (content as { type?: string }[]).some(
+      (block) => block.type === "tool_search_tool_result"
+    )
+  ).toBe(true);
+});
+
+test("Tool Search Tool - generic result block survives payload conversion", () => {
+  const langChainMessage = new AIMessage({
+    content: [
+      {
+        type: "server_tool_use",
+        id: "srvtoolu_01DEF456",
+        name: "tool_search_tool_regex",
+        input: { pattern: "email" },
+      },
+      genericToolSearchResultBlock,
+    ],
+  });
+
+  const result = _convertMessagesToAnthropicPayload([
+    new HumanMessage("Email the team the summary"),
+    langChainMessage,
+  ]);
+
+  const assistant = result.messages[1];
+  expect(assistant.role).toBe("assistant");
+  expect(
+    (assistant.content as { type?: string }[]).some(
+      (block) => block.type === "tool_search_tool_result"
+    )
+  ).toBe(true);
+});

--- a/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_inputs.ts
@@ -163,6 +163,7 @@ function* _formatContentBlocks(
     "server_tool_use",
     "text_editor_code_execution_tool_result",
     "tool_result",
+    "tool_search_tool_result",
     "tool_search_tool_bm25_tool_result",
     "tool_search_tool_regex_tool_result",
     "tool_use",

--- a/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
+++ b/libs/providers/langchain-anthropic/src/utils/message_outputs.ts
@@ -86,6 +86,7 @@ export function _makeMessageChunkFromAnthropicEvent(
       "document",
       "server_tool_use",
       "web_search_tool_result",
+      "tool_search_tool_result",
       "tool_search_tool_bm25_tool_result",
       "tool_search_tool_regex_tool_result",
     ].includes(data.content_block.type)


### PR DESCRIPTION
The API emits the un-suffixed tool_search_tool_result type for both tool search variants (observed in live traffic; matches the response format in Anthropic's tool-search docs). 

#11407 allowlisted only the variant-suffixed names, so streaming still drops the block and the next request 400s with INVALID_TOOL_RESULTS. Adds the generic name to both allowlists, mirrors the existing tests for it.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
