### PR TITLE
fix(google-genai): report Gemini reasoning tokens in usage metadata

### DIFF
--- a/.changeset/olive-moons-reason.md
+++ b/.changeset/olive-moons-reason.md
@@ -1,0 +1,16 @@
+---
+"@langchain/google-genai": patch
+---
+
+Report Gemini reasoning (thinking) tokens in `usage_metadata`
+
+`convertUsageMetadata` never read `thoughtsTokenCount`, so reasoning tokens were
+missing from `output_token_details.reasoning` and excluded from `output_tokens`.
+Because Gemini reports thinking tokens separately from `candidatesTokenCount`,
+this left `input_tokens + output_tokens` short of `total_tokens` on any thinking
+model. Streaming now converts the reasoning count to a per-chunk delta so
+concatenated chunks do not sum the cumulative totals.
+
+Also fixes an operator precedence bug in the `gemini-3-pro-preview` bracket
+tracking, where `?? 0 - 200000` parsed as `?? -200000` and reported the entire
+prompt token count as the amount over 200k.

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -1009,7 +1009,8 @@ export class ChatGoogleGenerativeAI
     let usageMetadata: UsageMetadata | undefined;
     // Keep prior cumulative counts for calculating token deltas while streaming
     let prevPromptTokenCount = 0;
-    let prevCandidatesTokenCount = 0;
+    let prevOutputTokenCount = 0;
+    let prevThoughtsTokenCount = 0;
     let prevTotalTokenCount = 0;
     let index = 0;
     for await (const response of stream) {
@@ -1037,13 +1038,28 @@ export class ChatGoogleGenerativeAI
         );
         prevPromptTokenCount = newPromptTokenCount;
 
-        const newCandidatesTokenCount =
-          response.usageMetadata.candidatesTokenCount ?? 0;
+        // `output_tokens` covers every output token type, so reasoning tokens
+        // count toward it alongside `candidatesTokenCount`. Both are cumulative
+        // on the wire and have to be turned into per-chunk deltas, otherwise
+        // concatenating the chunks sums the running totals.
+        const newThoughtsTokenCount =
+          usageMetadata.output_token_details?.reasoning ?? 0;
+        const newOutputTokenCount =
+          (response.usageMetadata.candidatesTokenCount ?? 0) +
+          newThoughtsTokenCount;
         usageMetadata.output_tokens = Math.max(
           0,
-          newCandidatesTokenCount - prevCandidatesTokenCount
+          newOutputTokenCount - prevOutputTokenCount
         );
-        prevCandidatesTokenCount = newCandidatesTokenCount;
+        prevOutputTokenCount = newOutputTokenCount;
+
+        if (usageMetadata.output_token_details?.reasoning !== undefined) {
+          usageMetadata.output_token_details.reasoning = Math.max(
+            0,
+            newThoughtsTokenCount - prevThoughtsTokenCount
+          );
+        }
+        prevThoughtsTokenCount = newThoughtsTokenCount;
 
         const newTotalTokenCount = response.usageMetadata.totalTokenCount ?? 0;
         usageMetadata.total_tokens = Math.max(

--- a/libs/providers/langchain-google-genai/src/tests/chat_models_stream_usage.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models_stream_usage.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test, vi, afterEach } from "vitest";
+import type { GenerateContentRequest } from "@google/generative-ai";
+import { AIMessageChunk } from "@langchain/core/messages";
+import { ChatGoogleGenerativeAI } from "../chat_models.js";
+
+type TestGoogleGenAIClient = {
+  generateContentStream: (
+    request: GenerateContentRequest,
+    options?: unknown
+  ) => Promise<{ stream: AsyncIterable<Record<string, unknown>> }>;
+};
+
+function getTestClient(model: ChatGoogleGenerativeAI): TestGoogleGenAIClient {
+  return (model as unknown as { client: TestGoogleGenAIClient }).client;
+}
+
+/**
+ * Gemini reports usage cumulatively: every chunk carries the running totals
+ * for the whole request, not that chunk's own contribution.
+ */
+function cumulativeUsageStream() {
+  return (async function* () {
+    yield {
+      candidates: [{ content: { parts: [{ text: "$" }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 2,
+        thoughtsTokenCount: 100,
+        totalTokenCount: 143,
+      },
+    };
+    yield {
+      candidates: [{ content: { parts: [{ text: "0." }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 4,
+        thoughtsTokenCount: 250,
+        totalTokenCount: 295,
+      },
+    };
+    yield {
+      candidates: [{ content: { parts: [{ text: "05" }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 5,
+        thoughtsTokenCount: 381,
+        totalTokenCount: 427,
+      },
+    };
+  })();
+}
+
+function mockGoogleGenAI(stream: AsyncIterable<Record<string, unknown>>) {
+  const model = new ChatGoogleGenerativeAI({
+    apiKey: "fake-key",
+    model: "gemini-2.5-flash",
+  });
+  vi.spyOn(getTestClient(model), "generateContentStream").mockResolvedValue({
+    stream,
+  });
+  return model;
+}
+
+async function mergedUsage(model: ChatGoogleGenerativeAI) {
+  const stream = await model.stream("A bat and a ball cost $1.10 in total.");
+  let merged: AIMessageChunk | undefined;
+  for await (const chunk of stream) {
+    merged = merged ? merged.concat(chunk) : chunk;
+  }
+  return merged?.usage_metadata;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ChatGoogleGenerativeAI streaming usage metadata", () => {
+  test("reports the final reasoning total, not the sum of the running totals", async () => {
+    const usage = await mergedUsage(mockGoogleGenAI(cumulativeUsageStream()));
+
+    // Summing the cumulative per-chunk values would give 100 + 250 + 381 = 731.
+    expect(usage?.output_token_details?.reasoning).toBe(381);
+  });
+
+  test("counts reasoning tokens toward output_tokens exactly once", async () => {
+    const usage = await mergedUsage(mockGoogleGenAI(cumulativeUsageStream()));
+
+    // candidatesTokenCount (5) + thoughtsTokenCount (381)
+    expect(usage?.output_tokens).toBe(386);
+  });
+
+  test("does not inflate the prompt or total counts", async () => {
+    const usage = await mergedUsage(mockGoogleGenAI(cumulativeUsageStream()));
+
+    expect(usage?.input_tokens).toBe(41);
+    expect(usage?.total_tokens).toBe(427);
+  });
+
+  test("keeps the merged counts internally consistent", async () => {
+    const usage = await mergedUsage(mockGoogleGenAI(cumulativeUsageStream()));
+
+    expect((usage?.input_tokens ?? 0) + (usage?.output_tokens ?? 0)).toBe(
+      usage?.total_tokens
+    );
+  });
+});

--- a/libs/providers/langchain-google-genai/src/tests/common.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/common.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   convertResponseContentToChatGenerationChunk,
   convertMessageContentToParts,
+  convertUsageMetadata,
   mapGenerateContentResultToChatResult,
 } from "../utils/common.js";
 import { EmptyContentError } from "../utils/errors.js";
@@ -435,5 +436,112 @@ describe("Missing candidate content", () => {
     expect(
       convertResponseContentToChatGenerationChunk(mockResponse, { index: 0 })
     ).toBeNull();
+  });
+});
+
+// `thoughtsTokenCount` is returned by the API for thinking models but is not
+// declared on the legacy `@google/generative-ai` `UsageMetadata` type.
+type UsageWithThoughts = {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  totalTokenCount?: number;
+  cachedContentTokenCount?: number;
+  thoughtsTokenCount?: number;
+};
+
+const usage = (u: UsageWithThoughts) =>
+  u as Parameters<typeof convertUsageMetadata>[0];
+
+describe("convertUsageMetadata reasoning tokens", () => {
+  test("reports reasoning tokens returned by thinking models", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 41,
+        candidatesTokenCount: 5,
+        thoughtsTokenCount: 381,
+        totalTokenCount: 427,
+      }),
+      "gemini-2.5-flash"
+    );
+
+    expect(result.output_token_details?.reasoning).toBe(381);
+  });
+
+  test("counts reasoning tokens toward output_tokens", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 41,
+        candidatesTokenCount: 5,
+        thoughtsTokenCount: 381,
+        totalTokenCount: 427,
+      }),
+      "gemini-2.5-flash"
+    );
+
+    // `output_tokens` is documented as the sum of all output token types, and
+    // Gemini reports reasoning separately from `candidatesTokenCount`.
+    expect(result.output_tokens).toBe(386);
+  });
+
+  test("keeps the token counts internally consistent", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 41,
+        candidatesTokenCount: 5,
+        thoughtsTokenCount: 381,
+        totalTokenCount: 427,
+      }),
+      "gemini-2.5-flash"
+    );
+
+    expect(result.input_tokens + result.output_tokens).toBe(
+      result.total_tokens
+    );
+  });
+
+  test("omits reasoning details when the model does not think", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      }),
+      "gemini-2.5-flash"
+    );
+
+    expect(result.output_tokens).toBe(20);
+    expect(result.output_token_details?.reasoning).toBeUndefined();
+  });
+});
+
+describe("convertUsageMetadata 200k bracket tracking", () => {
+  test("does not report an overage for prompts under 200k", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 500,
+        candidatesTokenCount: 10,
+        cachedContentTokenCount: 100,
+        totalTokenCount: 510,
+      }),
+      "gemini-3-pro-preview"
+    );
+
+    expect(result.input_token_details?.over_200k).toBeUndefined();
+    expect(result.input_token_details?.cache_read_over_200k).toBeUndefined();
+  });
+
+  test("reports only the amount above 200k", () => {
+    const result = convertUsageMetadata(
+      usage({
+        promptTokenCount: 250000,
+        candidatesTokenCount: 10,
+        cachedContentTokenCount: 220000,
+        totalTokenCount: 250010,
+      }),
+      "gemini-3-pro-preview"
+    );
+
+    expect(result.input_token_details?.over_200k).toBe(50000);
+    expect(result.input_token_details?.cache_read_over_200k).toBe(20000);
   });
 });

--- a/libs/providers/langchain-google-genai/src/utils/common.ts
+++ b/libs/providers/langchain-google-genai/src/utils/common.ts
@@ -974,13 +974,36 @@ export function convertToGenerativeAITools(
   ];
 }
 
+/**
+ * Reads `thoughtsTokenCount` (reasoning tokens on Gemini thinking models).
+ *
+ * The field is present on the wire but is not declared on the legacy
+ * `@google/generative-ai` `UsageMetadata` type, so it must be read defensively
+ * rather than accessed directly.
+ */
+function getThoughtsTokenCount(
+  usageMetadata: GenerateContentResponse["usageMetadata"]
+): number {
+  const count = (usageMetadata as { thoughtsTokenCount?: number } | undefined)
+    ?.thoughtsTokenCount;
+  return typeof count === "number" ? count : 0;
+}
+
 export function convertUsageMetadata(
   usageMetadata: GenerateContentResponse["usageMetadata"],
   model: string
 ): UsageMetadata {
+  // The API returns `thoughtsTokenCount` for thinking models, but the legacy
+  // `@google/generative-ai` `UsageMetadata` type does not declare it, so it has
+  // to be read defensively.
+  const thoughtsTokenCount = getThoughtsTokenCount(usageMetadata);
+  const candidatesTokenCount = usageMetadata?.candidatesTokenCount ?? 0;
+
   const output: UsageMetadata = {
     input_tokens: usageMetadata?.promptTokenCount ?? 0,
-    output_tokens: usageMetadata?.candidatesTokenCount ?? 0,
+    // Gemini reports reasoning tokens separately from `candidatesTokenCount`,
+    // while `output_tokens` is defined as the sum of all output token types.
+    output_tokens: candidatesTokenCount + thoughtsTokenCount,
     total_tokens: usageMetadata?.totalTokenCount ?? 0,
   };
   if (usageMetadata?.cachedContentTokenCount) {
@@ -988,13 +1011,20 @@ export function convertUsageMetadata(
     output.input_token_details.cache_read =
       usageMetadata.cachedContentTokenCount;
   }
+  if (thoughtsTokenCount) {
+    output.output_token_details ??= {};
+    output.output_token_details.reasoning = thoughtsTokenCount;
+  }
   // gemini-3-pro-preview has bracket based tracking of tokens per request
   // FIXME(hntrl): move this usageMetadata calculation elsewhere
   if (model === "gemini-3-pro-preview") {
-    const over200k = Math.max(0, usageMetadata?.promptTokenCount ?? 0 - 200000);
+    const over200k = Math.max(
+      0,
+      (usageMetadata?.promptTokenCount ?? 0) - 200000
+    );
     const cachedOver200k = Math.max(
       0,
-      usageMetadata?.cachedContentTokenCount ?? 0 - 200000
+      (usageMetadata?.cachedContentTokenCount ?? 0) - 200000
     );
     if (over200k) {
       output.input_token_details = {


### PR DESCRIPTION
Fixes #11422

## The problem

For Gemini thinking models, `usage_metadata` omits reasoning tokens and the
object is not internally consistent. A real `gemini-2.5-flash` call:

```json
{ "input_tokens": 41, "output_tokens": 5, "total_tokens": 389 }
```

`41 + 5` is not `389`. The missing 343 tokens are thinking tokens — billed, but
present in no field of the result. Any cost tracker reading `output_tokens` sees
**5** for a call that produced **389** tokens.

After this change, same call:

```json
{
  "input_tokens": 41,
  "output_tokens": 348,
  "total_tokens": 389,
  "output_token_details": { "reasoning": 343 }
}
```

## Root cause

`convertUsageMetadata` never read `thoughtsTokenCount`. The field is not declared
on the legacy `@google/generative-ai` `UsageMetadata` interface — which declares
only `promptTokenCount`, `candidatesTokenCount`, `totalTokenCount` and
`cachedContentTokenCount` — but it does arrive at runtime, so it is now read
defensively via a small helper.

Gemini reports thinking tokens separately from `candidatesTokenCount`
(`prompt + candidates + thoughts == total`), while `UsageMetadata.output_tokens`
is documented as "Sum of all output token types". So reasoning tokens are counted
toward `output_tokens` and broken out in `output_token_details.reasoning`.

This matches what `@langchain/google-common` already does in
[`src/utils/gemini.ts#L1243-L1263`](https://github.com/langchain-ai/langchainjs/blob/main/libs/providers/langchain-google-common/src/utils/gemini.ts#L1243-L1263),
so the two packages now agree.

## Why the streaming change is also required

Fixing `convertUsageMetadata` alone is not sufficient, and on its own it makes
streaming worse.

`_streamResponseChunks` converts `input_tokens` / `output_tokens` /
`total_tokens` into per-chunk deltas *after* `convertUsageMetadata` returns, but
leaves nested detail fields cumulative. `mergeOutputTokenDetails` in
`@langchain/core` sums `reasoning` across chunks, so a cumulative value is added
once per chunk.

With a three-chunk stream carrying cumulative thoughts of 100 / 250 / 381, the
converter-only change reports **731** instead of 381 — the same double-counting
class as #8266. `chat_models_stream_usage.test.ts` covers this specifically and
fails if only the converter is patched.

(The same structural gap is why `input_token_details.cache_read` is wrong while
streaming, reported in #9731. This PR does not change that path.)

## Unrelated fix in the same function

```ts
const over200k = Math.max(0, usageMetadata?.promptTokenCount ?? 0 - 200000);
```

`??` binds looser than `-`, so `0 - 200000` evaluates first and the expression
reads `promptTokenCount ?? -200000`. For any real prompt this is
`Math.max(0, promptTokenCount)`, so a 500-token prompt reported
`over_200k: 500`. Same problem on the next line for `cache_read_over_200k`.
Both are now parenthesized.

Happy to split this into its own PR if you'd prefer it separate.

## Tests

10 new unit tests, no network required:

- `common.test.ts` — reasoning extraction, `output_tokens` inclusion, the
  `input + output == total` invariant, a no-thinking regression guard, and both
  200k bracket cases.
- `chat_models_stream_usage.test.ts` — a stubbed stream carrying cumulative usage,
  asserting the merged result reports the final totals rather than their sum.

Full package suite: **103 passing**, no type errors. `oxlint` and
`oxfmt --check` clean.

Verified end to end against the live Gemini API on `gemini-2.5-flash`, with the
raw SDK's `thoughtsTokenCount` as the reference value.
