### PR TITLE
fix(core,google-genai): report correct token usage in streaming llmOutput

### DIFF
--- a/.changeset/brave-otters-listen.md
+++ b/.changeset/brave-otters-listen.md
@@ -1,0 +1,22 @@
+---
+"@langchain/core": patch
+"@langchain/google-genai": patch
+---
+
+Fix `llmOutput` token usage on the streaming paths
+
+`_streamIterator` reassigned `llmOutput` on every chunk, so the value that
+survived was the final chunk's usage. That is correct for providers that report
+cumulative totals on a last usage chunk, but for providers emitting per-chunk
+deltas it truncated the result to the final delta — a streamed Gemini call
+reported 3 total tokens instead of 458. It now derives the counts from the
+concatenated chunk, which is already summed correctly for both conventions.
+
+`ChatGoogleGenerativeAI._generate` also returned
+`llmOutput: { estimatedTokenUsage: {} }` on its streaming branch: an object that
+was declared, never populated, and keyed differently from the non-streaming path
+of the same class. It now reports the real counts under `tokenUsage`, matching
+`mapGenerateContentResultToChatResult`.
+
+Callback-based token tracking reads `llmOutput`, so both paths previously
+under-reported usage while `message.usage_metadata` was correct.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -818,18 +818,6 @@ export abstract class BaseChatModel<
           } else {
             aggregated = concat(aggregated, chunk);
           }
-          if (
-            isAIMessageChunk(chunk.message) &&
-            chunk.message.usage_metadata !== undefined
-          ) {
-            llmOutput = {
-              tokenUsage: {
-                promptTokens: chunk.message.usage_metadata.input_tokens,
-                completionTokens: chunk.message.usage_metadata.output_tokens,
-                totalTokens: chunk.message.usage_metadata.total_tokens,
-              },
-            };
-          }
         }
         // Check if stream ended due to abort (provider returned early)
         if (parsedOptions.signal?.aborted) {
@@ -843,6 +831,21 @@ export abstract class BaseChatModel<
         }
         if (aggregated === undefined) {
           throw new Error("Received empty response from chat model call.");
+        }
+        // As in `_streamIterator`, derive usage from the aggregated chunk so
+        // providers that emit per-chunk deltas are summed rather than reduced
+        // to their final delta.
+        if (
+          isAIMessageChunk(aggregated.message) &&
+          aggregated.message.usage_metadata !== undefined
+        ) {
+          llmOutput = {
+            tokenUsage: {
+              promptTokens: aggregated.message.usage_metadata.input_tokens,
+              completionTokens: aggregated.message.usage_metadata.output_tokens,
+              totalTokens: aggregated.message.usage_metadata.total_tokens,
+            },
+          };
         }
         if (outputVersion === "v1") {
           aggregated.message = castStandardMessageContent(

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -583,18 +583,25 @@ export abstract class BaseChatModel<
           } else {
             generationChunk = generationChunk.concat(chunk);
           }
-          if (
-            isAIMessageChunk(chunk.message) &&
-            chunk.message.usage_metadata !== undefined
-          ) {
-            llmOutput = {
-              tokenUsage: {
-                promptTokens: chunk.message.usage_metadata.input_tokens,
-                completionTokens: chunk.message.usage_metadata.output_tokens,
-                totalTokens: chunk.message.usage_metadata.total_tokens,
-              },
-            };
-          }
+        }
+        // Derive token usage from the concatenated chunk rather than from the
+        // last chunk seen. Providers differ: some report cumulative totals on a
+        // final usage chunk, others emit per-chunk deltas. Reading the last
+        // chunk is only correct for the former, and truncates the latter to its
+        // final delta. `generationChunk` has already summed either shape.
+        if (
+          generationChunk !== undefined &&
+          isAIMessageChunk(generationChunk.message) &&
+          generationChunk.message.usage_metadata !== undefined
+        ) {
+          llmOutput = {
+            tokenUsage: {
+              promptTokens: generationChunk.message.usage_metadata.input_tokens,
+              completionTokens:
+                generationChunk.message.usage_metadata.output_tokens,
+              totalTokens: generationChunk.message.usage_metadata.total_tokens,
+            },
+          };
         }
         // Throw error if stream ended due to abort (provider returned early)
         callOptions.signal?.throwIfAborted();

--- a/libs/langchain-core/src/language_models/tests/chat_models_stream_llmoutput.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models_stream_llmoutput.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import { BaseChatModel } from "../chat_models.js";
+import { BaseCallbackHandler } from "../../callbacks/base.js";
 import { AIMessageChunk } from "../../messages/ai.js";
 import { ChatGenerationChunk } from "../../outputs.js";
 import type { ChatResult, LLMResult } from "../../outputs.js";
@@ -122,6 +123,47 @@ describe("streaming llmOutput token usage", () => {
       promptTokens: merged?.usage_metadata?.input_tokens,
       completionTokens: merged?.usage_metadata?.output_tokens,
       totalTokens: merged?.usage_metadata?.total_tokens,
+    });
+  });
+});
+
+/**
+ * A handler that opts into implicit streaming, which routes `invoke()` through
+ * `_generateUncached`'s streaming branch rather than `_generate`.
+ */
+class StreamingPreferringHandler extends BaseCallbackHandler {
+  name = "streaming-preferring-handler";
+
+  lc_prefer_streaming = true;
+
+  captured: LLMResult["llmOutput"];
+
+  handleLLMEnd(output: LLMResult) {
+    this.captured = output.llmOutput;
+  }
+}
+
+describe("implicit streaming llmOutput token usage", () => {
+  test("sums deltas when invoke() streams for a streaming-preferring handler", async () => {
+    const handler = new StreamingPreferringHandler();
+    const model = new UsageStreamingChatModel([
+      {
+        text: "a",
+        usage: { input_tokens: 4, output_tokens: 6, total_tokens: 10 },
+      },
+      {
+        text: "b",
+        usage: { input_tokens: 0, output_tokens: 3, total_tokens: 3 },
+      },
+    ]);
+
+    await model.invoke("hi", { callbacks: [handler] });
+
+    // Keeping only the final chunk would report 0 / 3 / 3.
+    expect(handler.captured?.tokenUsage).toEqual({
+      promptTokens: 4,
+      completionTokens: 9,
+      totalTokens: 13,
     });
   });
 });

--- a/libs/langchain-core/src/language_models/tests/chat_models_stream_llmoutput.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models_stream_llmoutput.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "vitest";
+import { BaseChatModel } from "../chat_models.js";
+import { AIMessageChunk } from "../../messages/ai.js";
+import { ChatGenerationChunk } from "../../outputs.js";
+import type { ChatResult, LLMResult } from "../../outputs.js";
+import type { UsageMetadata } from "../../messages/metadata.js";
+
+type Delta = { text: string; usage?: UsageMetadata };
+
+/** Minimal streaming model that emits a caller-supplied usage shape. */
+class UsageStreamingChatModel extends BaseChatModel {
+  constructor(private readonly deltas: Delta[]) {
+    super({});
+  }
+
+  _llmType() {
+    return "usage-streaming-fake";
+  }
+
+  async _generate(): Promise<ChatResult> {
+    throw new Error("not used by these tests");
+  }
+
+  async *_streamResponseChunks(): AsyncGenerator<ChatGenerationChunk> {
+    for (const delta of this.deltas) {
+      yield new ChatGenerationChunk({
+        text: delta.text,
+        message: new AIMessageChunk({
+          content: delta.text,
+          usage_metadata: delta.usage,
+        }),
+      });
+    }
+  }
+}
+
+async function llmOutputFromStream(deltas: Delta[]) {
+  let captured: LLMResult["llmOutput"];
+  const model = new UsageStreamingChatModel(deltas);
+  const stream = await model.stream("hi", {
+    callbacks: [
+      {
+        handleLLMEnd(output: LLMResult) {
+          captured = output.llmOutput;
+        },
+      },
+    ],
+  });
+  for await (const _ of stream) {
+    // drain
+  }
+  return captured;
+}
+
+describe("streaming llmOutput token usage", () => {
+  test("sums per-chunk deltas rather than keeping the last chunk", async () => {
+    const llmOutput = await llmOutputFromStream([
+      {
+        text: "a",
+        usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 },
+      },
+      {
+        text: "b",
+        usage: { input_tokens: 0, output_tokens: 2, total_tokens: 2 },
+      },
+      {
+        text: "c",
+        usage: { input_tokens: 0, output_tokens: 3, total_tokens: 3 },
+      },
+    ]);
+
+    // Keeping only the final chunk would report 0 / 3 / 3.
+    expect(llmOutput?.tokenUsage).toEqual({
+      promptTokens: 10,
+      completionTokens: 6,
+      totalTokens: 16,
+    });
+  });
+
+  test("still reports totals from providers that only send usage on the last chunk", async () => {
+    const llmOutput = await llmOutputFromStream([
+      { text: "a" },
+      { text: "b" },
+      {
+        text: "c",
+        usage: { input_tokens: 10, output_tokens: 6, total_tokens: 16 },
+      },
+    ]);
+
+    expect(llmOutput?.tokenUsage).toEqual({
+      promptTokens: 10,
+      completionTokens: 6,
+      totalTokens: 16,
+    });
+  });
+
+  test("agrees with the concatenated message usage_metadata", async () => {
+    const deltas: Delta[] = [
+      {
+        text: "a",
+        usage: { input_tokens: 41, output_tokens: 100, total_tokens: 141 },
+      },
+      {
+        text: "b",
+        usage: { input_tokens: 0, output_tokens: 150, total_tokens: 150 },
+      },
+      {
+        text: "c",
+        usage: { input_tokens: 0, output_tokens: 167, total_tokens: 167 },
+      },
+    ];
+    const llmOutput = await llmOutputFromStream(deltas);
+
+    const model = new UsageStreamingChatModel(deltas);
+    const stream = await model.stream("hi");
+    let merged: AIMessageChunk | undefined;
+    for await (const chunk of stream) {
+      merged = merged ? merged.concat(chunk) : chunk;
+    }
+
+    expect(llmOutput?.tokenUsage).toEqual({
+      promptTokens: merged?.usage_metadata?.input_tokens,
+      completionTokens: merged?.usage_metadata?.output_tokens,
+      totalTokens: merged?.usage_metadata?.total_tokens,
+    });
+  });
+});

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -18,6 +18,7 @@ import type { ChatModelStreamEvent } from "@langchain/core/language_models/event
 import { convertGoogleGenAIStream } from "./utils/stream_events.js";
 import {
   AIMessageChunk,
+  isAIMessageChunk,
   BaseMessage,
   UsageMetadata,
 } from "@langchain/core/messages";
@@ -912,7 +913,6 @@ export class ChatGoogleGenerativeAI
 
     // Handle streaming
     if (this.streaming) {
-      const tokenUsage: TokenUsage = {};
       const stream = this._streamResponseChunks(messages, options, runManager);
       const finalChunks: ChatGenerationChunk[] = [];
 
@@ -929,7 +929,26 @@ export class ChatGoogleGenerativeAI
         (c): c is ChatGenerationChunk => c !== undefined
       );
 
-      return { generations, llmOutput: { estimatedTokenUsage: tokenUsage } };
+      // Mirror the non-streaming path, which reports the counts the API
+      // returned under `tokenUsage`. `finalChunks` entries are already
+      // concatenated, so their usage metadata is summed across the stream.
+      const tokenUsage: TokenUsage = {};
+      for (const generation of generations) {
+        const usage = isAIMessageChunk(generation.message)
+          ? generation.message.usage_metadata
+          : undefined;
+        if (usage === undefined) {
+          continue;
+        }
+        tokenUsage.promptTokens =
+          (tokenUsage.promptTokens ?? 0) + usage.input_tokens;
+        tokenUsage.completionTokens =
+          (tokenUsage.completionTokens ?? 0) + usage.output_tokens;
+        tokenUsage.totalTokens =
+          (tokenUsage.totalTokens ?? 0) + usage.total_tokens;
+      }
+
+      return { generations, llmOutput: { tokenUsage } };
     }
 
     const res = await this.completionWithRetry(

--- a/libs/providers/langchain-google-genai/src/tests/chat_models_llmoutput.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models_llmoutput.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi, afterEach } from "vitest";
+import type { GenerateContentRequest } from "@google/generative-ai";
+import type { LLMResult } from "@langchain/core/outputs";
+import { ChatGoogleGenerativeAI } from "../chat_models.js";
+
+type TestGoogleGenAIClient = {
+  generateContentStream: (
+    request: GenerateContentRequest,
+    options?: unknown
+  ) => Promise<{ stream: AsyncIterable<Record<string, unknown>> }>;
+};
+
+function getTestClient(model: ChatGoogleGenerativeAI): TestGoogleGenAIClient {
+  return (model as unknown as { client: TestGoogleGenAIClient }).client;
+}
+
+/** Gemini reports usage cumulatively on every streamed chunk. */
+function cumulativeUsageStream() {
+  return (async function* () {
+    yield {
+      candidates: [{ content: { parts: [{ text: "$" }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 2,
+        totalTokenCount: 143,
+      },
+    };
+    yield {
+      candidates: [{ content: { parts: [{ text: "0." }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 4,
+        totalTokenCount: 295,
+      },
+    };
+    yield {
+      candidates: [{ content: { parts: [{ text: "05" }] } }],
+      usageMetadata: {
+        promptTokenCount: 41,
+        candidatesTokenCount: 5,
+        totalTokenCount: 427,
+      },
+    };
+  })();
+}
+
+async function llmOutputFromStreamingInvoke() {
+  const model = new ChatGoogleGenerativeAI({
+    apiKey: "fake-key",
+    model: "gemini-2.5-flash",
+    streaming: true,
+  });
+  vi.spyOn(getTestClient(model), "generateContentStream").mockResolvedValue({
+    stream: cumulativeUsageStream(),
+  });
+
+  let captured: LLMResult | undefined;
+  const result = await model.invoke("A bat and a ball cost $1.10 in total.", {
+    callbacks: [
+      {
+        handleLLMEnd(output: LLMResult) {
+          captured = output;
+        },
+      },
+    ],
+  });
+
+  return { llmOutput: captured?.llmOutput, usage: result.usage_metadata };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("llmOutput on the streaming _generate path", () => {
+  test("reports token usage under the same key as the non-streaming path", async () => {
+    const { llmOutput } = await llmOutputFromStreamingInvoke();
+
+    expect(llmOutput?.tokenUsage).toBeDefined();
+  });
+
+  test("agrees with the message usage metadata", async () => {
+    const { llmOutput, usage } = await llmOutputFromStreamingInvoke();
+
+    expect(llmOutput?.tokenUsage).toEqual({
+      promptTokens: usage?.input_tokens,
+      completionTokens: usage?.output_tokens,
+      totalTokens: usage?.total_tokens,
+    });
+  });
+
+  test("does not report an empty usage object", async () => {
+    const { llmOutput } = await llmOutputFromStreamingInvoke();
+
+    expect(Object.keys(llmOutput?.tokenUsage ?? {})).not.toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #11424

## The problem

`message.usage_metadata` is correct on every call path. `llmOutput` is not — and
`llmOutput` is what callback-based token accounting reads.

Measured on `gemini-2.5-flash`:

| call path | `llmOutput` | true usage |
| --- | --- | --- |
| `invoke()`, streaming off | `tokenUsage: { 41, 366, 407 }` | 407 |
| `invoke()`, `streaming: true` | `estimatedTokenUsage: {}` | 401 |
| `.stream()` | `tokenUsage: { 0, 3, 3 }` | 458 |

Three tokens reported for a call that used 458. A missing field reads as broken
and gets noticed; `3` renders fine on a dashboard and does not.

Sentry's JavaScript LangChain integration, for example, reads token counts only
from `llmOutput.tokenUsage` with no `usage_metadata` fallback, so streamed
Gemini calls are recorded as either nothing or a small fraction of actual usage.

## Two independent causes

### `langchain-core` — the last chunk wins instead of the accumulation

`_streamIterator` **assigned** `llmOutput` inside the chunk loop, so the value
that survived was whatever the final chunk carried. That is correct for
providers reporting cumulative totals on a final usage chunk (the OpenAI
convention) and wrong for providers emitting per-chunk deltas, where the
survivor is the last delta.

The loop already maintains `generationChunk`, whose `usage_metadata` is summed
correctly for either convention, so the counts are now derived from it after the
loop. Providers on the cumulative convention are unaffected — there is a test
covering that case explicitly.

### `@langchain/google-genai` — an object that was never filled in

```ts
const tokenUsage: TokenUsage = {};
const stream = this._streamResponseChunks(messages, options, runManager);
// ... loop concatenates chunks; tokenUsage is never touched ...
return { generations, llmOutput: { estimatedTokenUsage: tokenUsage } };
```

Declared empty, never written to, and returned under a key the non-streaming
path of the same class does not use — `mapGenerateContentResultToChatResult`
returns `tokenUsage`. The concatenated `generations` already carry correct
usage metadata, so they now populate it under the matching key.

`estimatedTokenUsage` is a real convention elsewhere (`@langchain/cohere` uses it
for client-side estimates and reads it back in `_combineLLMOutput`), but these
are exact counts from the API, and nothing in this package ever read the value —
`_combineLLMOutput` here returns `[]`.

## Tests

6 new unit tests, no network required.

`langchain-core`:
- delta-emitting provider — merged counts, not the final delta
- cumulative-final provider — unchanged behaviour, guarding the OpenAI convention
- `llmOutput` agrees with the concatenated `usage_metadata`

`@langchain/google-genai`:
- streaming `_generate` reports usage under `tokenUsage`
- the values agree with the message usage metadata
- the usage object is not empty

Suites: `@langchain/core` **1515 passing**, `@langchain/google-genai`
**96 passing**, no type errors. `oxlint` and `oxfmt --check` clean.

## Note

Separate from #11422 / #11423, which fix reasoning tokens going missing from
`usage_metadata`. The measurements above were taken with that patch applied, so
the `usage_metadata` values are already correct there; these `llmOutput`
problems are independent and this PR branches from `main`.

Happy to split the core and provider changes into separate PRs if you would
rather review them apart.
