### PR TITLE
fix(google): stop losing/mangling ToolMessage content in Gemini function responses

### DIFF
--- a/.changeset/fix-tool-message-media-lost-in-function-response.md
+++ b/.changeset/fix-tool-message-media-lost-in-function-response.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+fix: keep image/audio/video content in ToolMessages as sibling Gemini parts instead of losing it inside functionResponse.response.result JSON (#10297)

--- a/.changeset/fix-tool-message-media-lost-in-function-response.md
+++ b/.changeset/fix-tool-message-media-lost-in-function-response.md
@@ -2,4 +2,4 @@
 "@langchain/google": patch
 ---
 
-fix: keep image/audio/video content in ToolMessages as sibling Gemini parts instead of losing it inside functionResponse.response.result JSON (#10297)
+fix: keep image/audio/video content in ToolMessages as sibling Gemini parts instead of losing it inside functionResponse.response.result JSON, and stop double-stringifying non-string tool results (#10297, #10439)

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -753,6 +753,138 @@ describe.each(coreModelInfo)(
       }
     });
 
+    test("function reply with image content is sent as a sibling part, not lost in JSON (#10297)", async () => {
+      const dataPath = "src/chat_models/tests/data/blue-square.png";
+      const dataType = "image/png";
+      const data = await fs.readFile(dataPath);
+      const data64 = data.toString("base64");
+      const dataUri = `data:${dataType};base64,${data64}`;
+
+      const tools: Gemini.Tool[] = [
+        {
+          functionDeclarations: [
+            {
+              name: "get_screenshot",
+              description: "Get a screenshot of the current screen.",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      ];
+      const llm = newChatGoogle().bindTools(tools);
+      const messages: BaseMessage[] = [
+        new HumanMessage(
+          "Take a screenshot of the current screen and tell me what color it is."
+        ),
+        new AIMessage({
+          tool_calls: [
+            {
+              type: "tool_call",
+              id: "lc-tool-call-screenshot-id",
+              name: "get_screenshot",
+              args: {},
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: [
+            { type: "text", text: "Screenshot captured successfully." },
+            { type: "image_url", image_url: dataUri },
+          ],
+          tool_call_id: "lc-tool-call-screenshot-id",
+        }),
+      ];
+
+      const res = await llm.invoke(messages);
+      expect(res).toBeDefined();
+
+      const sentContents = recorder.request?.body?.contents as
+        | Gemini.Content[]
+        | undefined;
+      expect(sentContents).toBeDefined();
+      const toolResponseContent = sentContents!.find((c) =>
+        c.parts?.some((p) => "functionResponse" in p)
+      );
+      expect(toolResponseContent).toBeDefined();
+
+      const functionResponsePart = toolResponseContent!.parts!.find(
+        (p) => "functionResponse" in p && p.functionResponse
+      ) as Gemini.Part.FunctionResponse;
+      const resultStr = JSON.stringify(
+        functionResponsePart.functionResponse!.response
+      );
+      expect(resultStr).not.toContain(data64);
+
+      const inlineDataPart = toolResponseContent!.parts!.find(
+        (p) => "inlineData" in p && p.inlineData
+      ) as Gemini.Part.InlineData;
+      expect(inlineDataPart).toBeDefined();
+      expect(inlineDataPart.inlineData!.data).toBe(data64);
+    });
+
+    test("function reply with non-string content is sent as JSON, not double-stringified (#10439)", async () => {
+      const tools: Gemini.Tool[] = [
+        {
+          functionDeclarations: [
+            {
+              name: "get_video_captions",
+              description: "Get captions for a video.",
+              parameters: {
+                type: "object",
+                properties: {
+                  url: { type: "string", description: "The video URL." },
+                },
+                required: ["url"],
+              },
+            },
+          ],
+        },
+      ];
+      const llm = newChatGoogle().bindTools(tools);
+      const toolResult = [
+        {
+          url: "https://www.youtube.com/watch?v=redacted",
+          error: "All 5 caption URLs failed",
+        },
+      ];
+      const messages: BaseMessage[] = [
+        new HumanMessage("Get the captions for this video."),
+        new AIMessage({
+          tool_calls: [
+            {
+              type: "tool_call",
+              id: "lc-tool-call-captions-id",
+              name: "get_video_captions",
+              args: { url: "https://www.youtube.com/watch?v=redacted" },
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: toolResult as unknown as string,
+          tool_call_id: "lc-tool-call-captions-id",
+        }),
+      ];
+
+      const res = await llm.invoke(messages);
+      expect(res).toBeDefined();
+
+      const sentContents = recorder.request?.body?.contents as
+        | Gemini.Content[]
+        | undefined;
+      expect(sentContents).toBeDefined();
+      const toolResponseContent = sentContents!.find((c) =>
+        c.parts?.some((p) => "functionResponse" in p)
+      );
+      expect(toolResponseContent).toBeDefined();
+
+      const functionResponsePart = toolResponseContent!.parts!.find(
+        (p) => "functionResponse" in p && p.functionResponse
+      ) as Gemini.Part.FunctionResponse;
+      const result = functionResponsePart.functionResponse!.response!.result;
+      expect(typeof result).not.toBe("string");
+      expect(result).toEqual(toolResult);
+    });
+
     test("function - force tool", async () => {
       const llm = newChatGoogle();
       const llmWithTools: Runnable = llm.bindTools(

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -278,6 +278,35 @@ export const geminiContentBlockConverter: StandardContentBlockConverter<{
   },
 };
 
+const MEDIA_BLOCK_TYPES = new Set([
+  "media",
+  "image",
+  "audio",
+  "video",
+  "file",
+  "text-plain",
+]);
+
+function isMediaContentBlock(item: unknown): boolean {
+  if (typeof item !== "object" || item === null) {
+    return false;
+  }
+  if (isDataContentBlock(item)) {
+    return item.source_type !== "text";
+  }
+  if ("image_url" in item || "inlineData" in item || "fileData" in item) {
+    return true;
+  }
+  return MEDIA_BLOCK_TYPES.has((item as { type?: unknown }).type as string);
+}
+
+function stripMediaBlocksForFunctionResponse(content: unknown): unknown {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  return content.filter((item) => !isMediaContentBlock(item));
+}
+
 function convertStandardDataContentBlockToGeminiPart(
   block: ContentBlock.Multimodal.Data
 ): Gemini.Part | null {
@@ -452,10 +481,9 @@ function convertStandardContentMessageToGeminiContent(
 
   // Handle tool messages as function responses
   if (ToolMessage.isInstance(message) && message.tool_call_id) {
-    const responseContent =
-      typeof message.content === "string"
-        ? message.content
-        : JSON.stringify(message.content);
+    const responseContent = stripMediaBlocksForFunctionResponse(
+      message.content
+    );
     // Find the matching tool call in a preceding AIMessage to get the function name
     const aiMsg = messages
       .filter(AIMessage.isInstance)
@@ -750,10 +778,9 @@ function convertLegacyContentMessageToGeminiContent(
 
   // Handle tool messages as function responses
   if (ToolMessage.isInstance(message) && message.tool_call_id) {
-    const responseContent =
-      typeof message.content === "string"
-        ? message.content
-        : JSON.stringify(message.content);
+    const responseContent = stripMediaBlocksForFunctionResponse(
+      message.content
+    );
     // Find the matching tool call in a preceding AIMessage to get the function name
     const aiMsg = messages
       .filter(AIMessage.isInstance)
@@ -775,9 +802,14 @@ function convertLegacyContentMessageToGeminiContent(
       },
     });
 
-    // For tool messages, only keep functionResponse parts since the text content
-    // is already included in the functionResponse.response.result
-    parts = parts.filter((part) => "functionResponse" in part);
+    // For tool messages, drop the redundant text parts - their content is
+    // already folded into functionResponse.response.result above - but keep
+    // any media parts (inlineData/fileData) as siblings so images/audio/video
+    // reach Gemini as real parts instead of being lost inside the JSON string.
+    parts = parts.filter(
+      (part) =>
+        "functionResponse" in part || "inlineData" in part || "fileData" in part
+    );
   }
 
   // Only add content if we have parts

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -740,6 +740,320 @@ describe("convertMessagesToGeminiContents", () => {
       (userContent!.parts[3] as Gemini.Part.FileData).fileData!.fileUri
     ).toBe("gs://bucket/report.pdf");
   });
+
+  test("ToolMessage image content becomes a sibling inlineData part, not inline JSON (legacy path)", () => {
+    const imageDataUri = "data:image/png;base64,iVBORw0KGgo=";
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "get_screenshot",
+            args: {},
+            id: "call-image",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: "text", text: "Here is the screenshot." },
+          { type: "image_url", image_url: imageDataUri },
+        ],
+        tool_call_id: "call-image",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    expect(functionResponsePart).toBeDefined();
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).toContain("Here is the screenshot.");
+    expect(resultStr).not.toContain("iVBORw0KGgo=");
+
+    const inlineDataPart = toolResponseContent!.parts.find(
+      (p) => "inlineData" in p && p.inlineData
+    ) as Gemini.Part.InlineData;
+    expect(inlineDataPart).toBeDefined();
+    expect(inlineDataPart.inlineData!.mimeType).toBe("image/png");
+    expect(inlineDataPart.inlineData!.data).toBe("iVBORw0KGgo=");
+  });
+
+  test("ToolMessage media content becomes a sibling part, not inline JSON (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "get_recording",
+            args: {},
+            id: "call-media",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: "text", text: "Here is the recording." },
+          { type: "media", mimeType: "audio/mp3", data: "ZmFrZS1hdWRpbw==" },
+        ],
+        tool_call_id: "call-media",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).toContain("Here is the recording.");
+    expect(resultStr).not.toContain("ZmFrZS1hdWRpbw==");
+
+    const inlineDataPart = toolResponseContent!.parts.find(
+      (p) => "inlineData" in p && p.inlineData
+    ) as Gemini.Part.InlineData;
+    expect(inlineDataPart).toBeDefined();
+    expect(inlineDataPart.inlineData!.mimeType).toBe("audio/mp3");
+    expect(inlineDataPart.inlineData!.data).toBe("ZmFrZS1hdWRpbw==");
+  });
+
+  test("ToolMessage image content becomes a sibling inlineData part, not inline JSON (v1 path)", () => {
+    const imageDataUri = "data:image/png;base64,iVBORw0KGgo=";
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_screenshot",
+          args: {},
+          id: "call-image-v1",
+          type: "tool_call",
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: [
+          { type: "text", text: "Here is the screenshot." },
+          { type: "image_url", image_url: { url: imageDataUri } },
+        ],
+        tool_call_id: "call-image-v1",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).not.toContain("iVBORw0KGgo=");
+
+    const inlineDataPart = toolResponseContent!.parts.find(
+      (p) => "inlineData" in p && p.inlineData
+    ) as Gemini.Part.InlineData;
+    expect(inlineDataPart).toBeDefined();
+    expect(inlineDataPart.inlineData!.mimeType).toBe("image/png");
+    expect(inlineDataPart.inlineData!.data).toBe("iVBORw0KGgo=");
+  });
+
+  test("ToolMessage v1 standard image content block is excluded from functionResponse.result (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_screenshot",
+          args: {},
+          id: "call-v1-block",
+          type: "tool_call",
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+    const messages = [
+      new HumanMessage("hello"),
+      aiMsg,
+      new ToolMessage({
+        content: [
+          { type: "text", text: "Here is the screenshot." },
+          { type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" },
+        ],
+        tool_call_id: "call-v1-block",
+        response_metadata: { output_version: "v1" },
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).not.toContain("iVBORw0KGgo=");
+  });
+
+  test("ToolMessage native inlineData content item is excluded from functionResponse.result (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "get_screenshot",
+            args: {},
+            id: "call-native-inline",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: "text", text: "Here is the screenshot." },
+          { inlineData: { mimeType: "image/png", data: "iVBORw0KGgo=" } },
+        ],
+        tool_call_id: "call-native-inline",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).not.toContain("iVBORw0KGgo=");
+
+    const inlineDataPart = toolResponseContent!.parts.find(
+      (p) => "inlineData" in p && p.inlineData
+    ) as Gemini.Part.InlineData;
+    expect(inlineDataPart).toBeDefined();
+    expect(inlineDataPart.inlineData!.data).toBe("iVBORw0KGgo=");
+  });
+
+  test("ToolMessage plain-text file block is preserved in functionResponse.result, not treated as media (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "read_file",
+            args: {},
+            id: "call-file-text",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [{ type: "file", source_type: "text", text: "line one" }],
+        tool_call_id: "call-file-text",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const resultStr = JSON.stringify(
+      functionResponsePart.functionResponse!.response
+    );
+    expect(resultStr).toContain("line one");
+  });
+
+  test("ToolMessage non-string content is passed through as a JSON object, not double-stringified (legacy path)", () => {
+    const messages = [
+      new HumanMessage("hello"),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "get_video_captions",
+            args: {},
+            id: "call-captions",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          {
+            url: "https://www.youtube.com/watch?v=redacted",
+            error: "All 5 caption URLs failed",
+          },
+        ] as unknown as string,
+        tool_call_id: "call-captions",
+      }),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const toolResponseContent = contents.find(
+      (c) => c.role === "user" && c.parts.some((p) => "functionResponse" in p)
+    );
+    expect(toolResponseContent).toBeDefined();
+
+    const functionResponsePart = toolResponseContent!.parts.find(
+      (p) => "functionResponse" in p && p.functionResponse
+    ) as Gemini.Part.FunctionResponse;
+    const result = functionResponsePart.functionResponse!.response!.result;
+    expect(typeof result).not.toBe("string");
+    expect(result).toEqual([
+      {
+        url: "https://www.youtube.com/watch?v=redacted",
+        error: "All 5 caption URLs failed",
+      },
+    ]);
+  });
 });
 
 describe("executableCode and codeExecutionResult round-trip", () => {


### PR DESCRIPTION
Fixes #10297
Fixes #10439

ToolMessage content sent to Gemini as a `functionResponse` had two related bugs: media content (images/audio/video/files) was getting JSON-stringified into `response.result`, where Gemini can't interpret it; and non-string JSON content (objects/arrays) was double-stringified instead of being passed through as the JSON object Gemini's API actually accepts.

* Keep media content blocks out of `functionResponse.response.result`
* Preserve them as sibling `inlineData`/`fileData` Gemini parts instead of discarding them
* Pass non-string ToolMessage content straight through as the JSON object/array Gemini expects, instead of double-stringifying it
* Applies to both the legacy (v0) and v1 content conversion paths