### PR TITLE
fix(mcp-adapters): drop regex patterns that fail to compile under the u flag

### DIFF
--- a/.changeset/mcp-adapters-unicode-pattern.md
+++ b/.changeset/mcp-adapters-unicode-pattern.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mcp-adapters": patch
+---
+
+Drop MCP tool JSON-schema regex patterns that fail to compile under the `u` flag. Such patterns (e.g. Annex B identity escapes like `\:`) are valid in a plain `RegExp` but throw a `SyntaxError` under the `u` flag that `@cfworker/json-schema` uses, which previously made every invocation of the tool fail.

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -710,6 +710,58 @@ describe("Simplified Tool Adapter Tests", () => {
       expect(result).toBe("Event created");
     });
 
+    test("drops regex patterns that fail to compile under the Unicode flag", async () => {
+      // `\:` is a legal identity escape in a plain RegExp but throws under the
+      // "u" flag that @cfworker/json-schema compiles patterns with, which
+      // previously made every invocation of a tool carrying such a pattern fail
+      // with a SyntaxError. See issue #11351.
+      const schemaWithInvalidUnicodePattern = {
+        type: "object" as const,
+        additionalProperties: false,
+        properties: {
+          ratio: {
+            type: "string",
+            pattern: "^\\d+\\:\\d+$",
+          },
+        },
+        patternProperties: {
+          "^x\\:": { type: "string" },
+        },
+        required: ["ratio"],
+      };
+
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({
+          tools: [
+            {
+              name: "set_ratio",
+              description: "Set an aspect ratio",
+              inputSchema: schemaWithInvalidUnicodePattern,
+            },
+          ],
+        })
+      );
+
+      mockClient.callTool.mockImplementation(() => {
+        return Promise.resolve({
+          content: [{ type: "text", text: "Ratio set" }],
+        });
+      });
+
+      const tools = await loadMcpTools(
+        "mockServer(invalid unicode pattern)",
+        mockClient as Client
+      );
+
+      expect(tools.length).toBe(1);
+
+      // Before the fix this threw a SyntaxError while compiling the `\:` pattern
+      // under the "u" flag; the unenforceable pattern is now dropped so the call
+      // succeeds.
+      const result = await tools[0].invoke({ ratio: "16:9" });
+      expect(result).toBe("Ratio set");
+    });
+
     test("should simplify schemas with anyOf at top level", async () => {
       // Test anyOf at the TOP level (where OpenAI restriction applies)
       // Note: type: "object" is added to the anyOf items, and the final schema

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -471,7 +471,52 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
     );
   }
 
+  // Drop regex patterns that fail to compile under the "u" flag. Tool-input
+  // validation runs through @cfworker/json-schema, which compiles every `pattern`
+  // with `new RegExp(pattern, "u")`. Patterns using Annex B identity escapes
+  // (e.g. `\:`) are legal in plain ECMAScript but throw a SyntaxError under "u",
+  // which surfaces as a failure on every invocation of the tool. Removing the
+  // unenforceable constraint keeps the tool usable rather than permanently broken.
+  if (typeof result.pattern === "string" && !isUnicodeCompilableRegex(result.pattern)) {
+    delete result.pattern;
+  }
+  if (
+    typeof result.patternProperties === "object" &&
+    result.patternProperties !== null
+  ) {
+    const patternProps = result.patternProperties as Record<string, unknown>;
+    let removedInvalidPattern = false;
+    for (const patternKey of Object.keys(patternProps)) {
+      if (!isUnicodeCompilableRegex(patternKey)) {
+        delete patternProps[patternKey];
+        removedInvalidPattern = true;
+      }
+    }
+    // A dropped patternProperties key must not turn into a rejection of keys that
+    // previously validated, so relax additionalProperties: false at this level.
+    if (removedInvalidPattern && result.additionalProperties === false) {
+      delete result.additionalProperties;
+    }
+    if (Object.keys(patternProps).length === 0) {
+      delete result.patternProperties;
+    }
+  }
+
   return result;
+}
+
+/**
+ * Whether a JSON Schema `pattern` compiles under the Unicode ("u") flag that
+ * @cfworker/json-schema uses. Patterns that only compile without "u" (e.g. Annex B
+ * identity escapes such as `\:`) would otherwise throw on every tool invocation.
+ */
+function isUnicodeCompilableRegex(pattern: string): boolean {
+  try {
+    void new RegExp(pattern, "u");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #11351

## What

MCP tools whose JSON Schema carries a regex `pattern` (or a `patternProperties` key) that is valid in a plain `RegExp` but invalid under the `u` flag — e.g. an Annex B identity escape like `\:` — fail on **every** invocation with a `SyntaxError`.

## Why

Tool-input validation runs through `@cfworker/json-schema`, which compiles each `pattern` with `new RegExp(pattern, "u")`. `simplifyJsonSchemaForLLM` in `libs/langchain-mcp-adapters/src/tools.ts` strips several unsupported keywords but passes `pattern`/`patternProperties` through untouched, so an unenforceable-under-`u` pattern reaches the validator and throws, leaving the tool permanently unusable.

## How

At the end of `simplifyJsonSchemaForLLM`, drop any `pattern` (and any `patternProperties` key) that fails to compile under the `u` flag, via a small `isUnicodeCompilableRegex` helper. When a `patternProperties` key is removed, `additionalProperties: false` at that level is relaxed so the dropped constraint doesn't turn into a rejection of keys that previously validated. The simplifier already recurses into nested schemas, so nested patterns are covered too.

## Testing

Added `drops regex patterns that fail to compile under the Unicode flag` to `libs/langchain-mcp-adapters/src/tests/tools.test.ts`: it loads a tool whose schema carries a `\:` pattern and invokes it. Before the change the invocation throws `SyntaxError: Invalid regular expression: /^\d+\:\d+$/u: Invalid escape`; after, it succeeds. The full test file passes (16) with no type errors.

![before: SyntaxError on invoke / after: 16 passed](https://github.com/user-attachments/assets/0b0fb09f-471b-4ffe-853b-be3b2b218995)
