### PR TITLE
fix(deps): patch deepmerge-ts stack exhaustion advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
       "lodash": ">=4.18.0",
       "path-to-regexp": ">=8.4.0",
       "brace-expansion": ">=5.0.9",
+      "deepmerge-ts": ">=8.0.0",
       "micromatch>picomatch": "2.3.2",
       "anymatch>picomatch": "2.3.2",
       "readdirp>picomatch": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ overrides:
   lodash: '>=4.18.0'
   path-to-regexp: '>=8.4.0'
   brace-expansion: '>=5.0.9'
+  deepmerge-ts: '>=8.0.0'
   micromatch>picomatch: 2.3.2
   anymatch>picomatch: 2.3.2
   readdirp>picomatch: 2.3.2
@@ -7789,8 +7790,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -15710,7 +15711,7 @@ snapshots:
   '@prisma/config@7.9.1(magicast@0.3.5)':
     dependencies:
       c12: 3.3.4(magicast@0.3.5)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -15719,7 +15720,7 @@ snapshots:
   '@prisma/config@7.9.1(magicast@0.5.4)':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -18840,7 +18841,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 


### PR DESCRIPTION
## Summary

- add a root pnpm override requiring `deepmerge-ts >=8.0.0`
- resolve the transitive Prisma dependency from `7.1.5` to `8.0.1`
- address GHSA-ggr8-5vv4-36mx / Dependabot alert #557

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm why deepmerge-ts --recursive` resolves only `8.0.1`
- [x] Prisma CLI loads successfully in `examples` and `@langchain/classic`
- [x] advisory cycle PoC returns safely without `RangeError`
- [x] `pnpm exec oxfmt --check package.json`
- [x] `git diff --check`

Scoped to the vulnerable transitive dependency and lockfile only.
