### PR TITLE
fix(google): route Vertex multi-region endpoints

### DIFF
--- a/.changeset/bright-zebras-listen.md
+++ b/.changeset/bright-zebras-listen.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Fix Vertex AI endpoint routing for multi-region locations such as `eu` and `us`.

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -360,7 +360,7 @@ export abstract class BaseChatGoogle<
     } else if (this.location === "global") {
       // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#use_the_global_endpoint
       return "aiplatform.googleapis.com";
-    } else if (["eu", "us"].includes(this.location)) {
+    } else if (!this.location.includes("-")) {
       return `aiplatform.${this.location}.rep.googleapis.com`;
     } else {
       return `${this.location}-aiplatform.googleapis.com`;

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -360,6 +360,8 @@ export abstract class BaseChatGoogle<
     } else if (this.location === "global") {
       // See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#use_the_global_endpoint
       return "aiplatform.googleapis.com";
+    } else if (["eu", "us"].includes(this.location)) {
+      return `aiplatform.${this.location}.rep.googleapis.com`;
     } else {
       return `${this.location}-aiplatform.googleapis.com`;
     }

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -499,6 +499,22 @@ describe.each(coreModelInfo)(
       expect(result.response_metadata.serviceTier).toEqual("standard");
     });
 
+    test.runIf(testConfig?.node === true && model === "gemini-2.5-flash")(
+      "invoke from the Vertex multi-region endpoint",
+      async () => {
+        const llm = newChatGoogle({
+          platformType: "gcp",
+          location: "eu",
+        });
+
+        await llm.invoke("What is 1 + 1?");
+
+        expect(recorder.request?.url).toContain(
+          "https://aiplatform.eu.rep.googleapis.com/"
+        );
+      }
+    );
+
     test("invoke seed", async () => {
       const llm = newChatGoogle({
         seed: 6,

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -319,6 +319,27 @@ describe("Google Mock", () => {
     );
   });
 
+  test.each(["eu", "us"])(
+    "uses the Vertex %s multi-region endpoint",
+    async (location) => {
+      const apiClient = new MockApiClient({
+        fileName: "gemini-chat-001.json",
+      });
+      const llm = new ChatGoogle({
+        model: "gemini-2.5-flash",
+        platformType: "gcp",
+        location,
+        apiClient,
+      });
+
+      await llm.invoke("What is 1+1?");
+
+      expect(apiClient.request.url).toBe(
+        `https://aiplatform.${location}.rep.googleapis.com/v1/projects/unknown-project-id/locations/${location}/publishers/google/models/gemini-2.5-flash:generateContent`
+      );
+    }
+  );
+
   test("handleLLMEnd exposes camelCase tokenUsage for invoke", async () => {
     let callbackResult: LLMResult | undefined;
 


### PR DESCRIPTION
Fixes #11432

---

`@langchain/google` generated standard regional Vertex hostnames for the `eu` and `us` multi-regions. Vertex instead exposes those locations through `aiplatform.<location>.rep.googleapis.com`, as documented by Google Cloud and already handled by the sibling `@langchain/google-common` package in #11032.

This change:

- routes the explicit `eu` and `us` locations through their multi-region endpoints;
- verifies both full request URLs through the public `ChatGoogle.invoke()` path;
- adds a credentialed Node/Vertex integration assertion for the `eu` endpoint;
- includes a patch changeset.

Verification:

- `pnpm --filter @langchain/google exec vitest run src/chat_models/tests/index.test.ts` — 91 passed, type errors 0
- `pnpm exec oxlint libs/providers/langchain-google/src` — passed
- `pnpm --filter @langchain/google build` — passed, including attw and publint
- full package test — 162 passed; the 3 converter failures were reproduced unchanged on a clean `origin/main` worktree (161 passed, same 3 failures)
- credentialed integration test was not run locally because Google credentials are unavailable

## Release note

`@langchain/google` now routes Vertex AI multi-region locations `eu` and `us` through their supported multi-region endpoints.

Prepared with AI assistance and reviewed and tested by the contributor.
