### PR TITLE
fix(openrouter): guard missing choices in ChatOpenRouter._generate (#11417)

### DIFF
--- a/.changeset/openrouter-missing-choices.md
+++ b/.changeset/openrouter-missing-choices.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Guard against a 200 response with no `choices` key in `ChatOpenRouter._generate`. It previously read `data.choices[0]` without optional chaining, throwing a bare `TypeError` before the `if (!choice)` guard could raise the intended `OpenRouterError("No choices returned in response.")`. Now uses `data.choices?.[0]`, matching the streaming path. Fixes #11417.

--- a/libs/providers/langchain-openrouter/src/chat_models/index.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/index.ts
@@ -430,7 +430,10 @@ export class ChatOpenRouter extends BaseChatModel<
     );
 
     const data: OpenRouter.ChatResponse = await response.json();
-    const choice = data.choices[0];
+    // Use optional chaining so a 200 body with no `choices` key surfaces the
+    // intended OpenRouterError below instead of a bare TypeError one line up
+    // (the streaming path already does this). See #11417.
+    const choice = data.choices?.[0];
 
     if (!choice) {
       throw new OpenRouterError("No choices returned in response.");

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
@@ -12,7 +12,7 @@ import { AIMessage } from "@langchain/core/messages";
 import { OutputParserException } from "@langchain/core/output_parsers";
 import { ChatOpenRouter } from "../index.js";
 import type { ChatOpenRouterCallOptions } from "../types.js";
-import { OpenRouterAuthError } from "../../utils/errors.js";
+import { OpenRouterError, OpenRouterAuthError } from "../../utils/errors.js";
 
 let savedKey: string | undefined;
 let savedSessionId: string | undefined;
@@ -543,6 +543,35 @@ describe("retry behavior", () => {
         rateLimitReason: "quota_message",
       });
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe("missing choices in a 200 response (#11417)", () => {
+  it("throws OpenRouterError, not a bare TypeError, when the body has no choices", async () => {
+    const model = new ChatOpenRouter({ model: "openai/gpt-4o-mini" });
+
+    // A 200 body with no `choices` key at all — some providers do this.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: "chatcmpl-1", model: "openai/gpt-4o-mini" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    try {
+      let thrown: unknown;
+      try {
+        await model.invoke("Hello");
+      } catch (e) {
+        thrown = e;
+      }
+      // Without optional chaining this is a bare `TypeError: Cannot read
+      // properties of undefined (reading '0')` rather than the intended error.
+      expect(OpenRouterError.isInstance(thrown)).toBe(true);
+      expect((thrown as Error).message).toBe("No choices returned in response.");
     } finally {
       fetchSpy.mockRestore();
     }


### PR DESCRIPTION
Fixes #11417

## Problem

`ChatOpenRouter._generate` reads `data.choices[0]` without optional chaining:

```ts
const data: OpenRouter.ChatResponse = await response.json();
const choice = data.choices[0];      // throws here when `choices` is undefined

if (!choice) {
  throw new OpenRouterError("No choices returned in response.");
}
```

When a provider returns HTTP 200 with a body that has **no `choices` key at all**, this throws a bare `TypeError: Cannot read properties of undefined (reading '0')` instead of the intended `OpenRouterError`. The `if (!choice)` guard only catches an *empty array* — it is unreachable when `choices` is `undefined`, because the crash happens one line earlier.

## Fix

Use optional chaining so the guard is reachable:

```ts
const choice = data.choices?.[0];
```

This mirrors `_streamResponseChunks`, which already uses `data.choices?.[0]`.

## Tests

Added a unit test (following the existing `fetch`-mock pattern in `index.test.ts`): a 200 response whose JSON body has no `choices` key now rejects with an `OpenRouterError` ("No choices returned in response."), not a bare `TypeError`.

Changeset included (`@langchain/openrouter` patch).