### PR TITLE
fix(langchain): skip thought text blocks in ProviderStrategy.parse

### DIFF
--- a/.changeset/tidy-jars-warn.md
+++ b/.changeset/tidy-jars-warn.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+fix(agents): ignore thought/reasoning text blocks when parsing structured output in `ProviderStrategy`

--- a/libs/langchain/src/agents/responses.ts
+++ b/libs/langchain/src/agents/responses.ts
@@ -255,11 +255,15 @@ export class ProviderStrategy<T = unknown> {
           block !== null &&
           "type" in block &&
           block.type === "text" &&
+          // Skip reasoning/thought summaries (e.g. Gemini represents these as
+          // `{ type: "text", thought: true }`), which are not the structured
+          // response and would otherwise fail JSON parsing.
+          !("thought" in block && block.thought === true) &&
           "text" in block &&
           typeof block.text === "string"
         ) {
           textContent = block.text;
-          break; // Use the first text block found
+          break; // Use the first non-thought text block found
         }
       }
     }

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -714,6 +714,48 @@ describe("structured output handling", () => {
       });
     });
 
+    describe("ProviderStrategy.parse", () => {
+      const parseSchema = z.object({ result: z.string() });
+
+      it("should parse structured output from a plain string response", () => {
+        const strategy = providerStrategy(parseSchema);
+        const parsed = strategy.parse(
+          new AIMessage({ content: JSON.stringify({ result: "ok" }) })
+        );
+        expect(parsed).toEqual({ result: "ok" });
+      });
+
+      it("should parse structured output from the first text block in array content", () => {
+        const strategy = providerStrategy(parseSchema);
+        const parsed = strategy.parse(
+          new AIMessage({
+            content: [{ type: "text", text: JSON.stringify({ result: "ok" }) }],
+          })
+        );
+        expect(parsed).toEqual({ result: "ok" });
+      });
+
+      it("should skip a leading thought text block and parse the structured response", () => {
+        // Regression test for #11435: @langchain/google represents a Gemini
+        // thought summary as `{ type: "text", thought: true }` followed by the
+        // structured JSON block. parse() must ignore the thought block.
+        const strategy = providerStrategy(parseSchema);
+        const parsed = strategy.parse(
+          new AIMessage({
+            content: [
+              {
+                type: "text",
+                thought: true,
+                text: "A returned thought summary.",
+              },
+              { type: "text", text: JSON.stringify({ result: "ok" }) },
+            ],
+          })
+        );
+        expect(parsed).toEqual({ result: "ok" });
+      });
+    });
+
     describe("ToolStrategy.fromSchema with Standard Schema", () => {
       it("should create a ToolStrategy from a Standard Schema", () => {
         const schema = makeSerializableSchema({


### PR DESCRIPTION
## What

Closes #11435.

`ProviderStrategy.parse()` selects the first `text` content block from an array-content `AIMessage` to parse structured output. `@langchain/google` represents a Gemini **thought summary** as a `{ type: "text", thought: true }` block, emitted *before* the structured JSON block. `parse()` picked the thought summary, tried to `JSON.parse` it, and returned `undefined`, so structured output failed with:

```
Failed to parse structured output for tool 'providerStrategy':
  - Model output did not satisfy the provided response schema.
```

The first-`text`-block selection was introduced in #9623 assuming reasoning used a distinct block *type*; Gemini instead marks a `text` block with `thought: true`.

## Fix

Exclude thought/reasoning blocks from the selection predicate in `libs/langchain/src/agents/responses.ts`:

```diff
 block.type === "text" &&
+!("thought" in block && block.thought === true) &&
 "text" in block
```

The first *non-thought* text block is used instead.

## Tests

Added a `ProviderStrategy.parse` describe block in `responses.test.ts` covering: plain-string content, first-text-block array content, and the regression case (leading thought block + structured JSON block).

## Validation (real results on this machine)

Node 22.14, pnpm 9.15, built `@langchain/core` + `@langchain/openai` + `@langchain/anthropic`, then:

```
$ npx vitest run src/agents/tests/responses.test.ts
 ✓ src/agents/tests/responses.test.ts (39 tests) 802ms
 Test Files  1 passed (1)
      Tests  39 passed (39)
Type Errors  no errors
```

Verified genuine RED→GREEN — reverting only the source change (keeping the new test) makes the regression case fail with exactly the reported symptom:

```
$ git stash push libs/langchain/src/agents/responses.ts
$ npx vitest run src/agents/tests/responses.test.ts -t "thought"
 × should skip a leading thought text block and parse the structured response
   AssertionError: expected undefined to deeply equal { result: 'ok' }
```

Restoring the fix → green. Ran `oxfmt` on the changed files. Added a changeset (`langchain`: patch).

First-time contributor here — happy to adjust naming/placement or anything else.
