### PR TITLE
fix(openai): merge a caller User-Agent into the library user agent

### DIFF
--- a/.changeset/openai-user-agent-header-merge.md
+++ b/.changeset/openai-user-agent-header-merge.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Merge a caller-supplied `User-Agent` into the library user agent instead of emitting two headers. `normalizeHeaders` lowercases header names, so the existing lookup for `User-Agent` never matched and the caller's value was left in the result under `user-agent` alongside the library's `User-Agent`. Transports collapse those into a single comma-joined value, which is not valid `User-Agent` syntax. The two values are now combined into one space-separated header, affecting both OpenAI and Azure OpenAI chat models, embeddings, and LLMs.

--- a/libs/providers/langchain-openai/src/utils/azure.ts
+++ b/libs/providers/langchain-openai/src/utils/azure.ts
@@ -175,13 +175,20 @@ export function getHeadersWithUserAgent(
   isAzure = false,
   version = "1.0.0"
 ): Record<string, string> {
-  const normalizedHeaders = normalizeHeaders(headers);
+  // `normalizeHeaders` lowercases every header name (it builds a `Headers`
+  // instance, which lowercases on construction), so a caller-supplied user
+  // agent is keyed as `user-agent`. Destructure it out of the spread so the
+  // result never carries both `user-agent` and `User-Agent`, which would
+  // otherwise reach the transport as two comma-joined values.
+  const { "user-agent": callerUserAgent, ...normalizedHeaders } =
+    normalizeHeaders(headers);
   const env = getFormattedEnv();
   const library = `langchainjs${isAzure ? "-azure" : ""}-openai`;
+  const libraryUserAgent = `${library}/${version} (${env})`;
   return {
     ...normalizedHeaders,
-    "User-Agent": normalizedHeaders["User-Agent"]
-      ? `${library}/${version} (${env})${normalizedHeaders["User-Agent"]}`
-      : `${library}/${version} (${env})`,
+    "User-Agent": callerUserAgent
+      ? `${libraryUserAgent} ${callerUserAgent}`
+      : libraryUserAgent,
   };
 }

--- a/libs/providers/langchain-openai/src/utils/tests/azure.test.ts
+++ b/libs/providers/langchain-openai/src/utils/tests/azure.test.ts
@@ -1,0 +1,87 @@
+import { test, expect, describe } from "vitest";
+import { getHeadersWithUserAgent, normalizeHeaders } from "../azure.js";
+
+const LIBRARY_UA = /^langchainjs-openai\/1\.0\.0 \(.+\)$/;
+
+/**
+ * Collapse a header record the way a transport does, so duplicate-cased keys
+ * surface as a single comma-joined value.
+ */
+function asTransportUserAgent(headers: Record<string, string>) {
+  return new Headers(headers).get("user-agent");
+}
+
+describe("getHeadersWithUserAgent", () => {
+  test("sets the library user agent when the caller supplies none", () => {
+    const headers = getHeadersWithUserAgent(undefined);
+
+    expect(headers["User-Agent"]).toMatch(LIBRARY_UA);
+  });
+
+  test("uses the azure library name when isAzure is set", () => {
+    const headers = getHeadersWithUserAgent(undefined, true);
+
+    expect(headers["User-Agent"]).toMatch(
+      /^langchainjs-azure-openai\/1\.0\.0 /
+    );
+  });
+
+  test("preserves unrelated headers", () => {
+    const headers = getHeadersWithUserAgent({ "X-Custom": "value" });
+
+    expect(headers["x-custom"]).toBe("value");
+  });
+
+  test("appends a caller user agent after the library one, space separated", () => {
+    const headers = getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" });
+
+    expect(headers["User-Agent"]).toMatch(
+      /^langchainjs-openai\/1\.0\.0 \(.+\) my-app\/1\.2$/
+    );
+  });
+
+  test("emits exactly one user agent key regardless of caller casing", () => {
+    for (const name of ["User-Agent", "user-agent", "USER-AGENT"]) {
+      const headers = getHeadersWithUserAgent({ [name]: "my-app/1.2" });
+
+      const userAgentKeys = Object.keys(headers).filter(
+        (key) => key.toLowerCase() === "user-agent"
+      );
+
+      expect(userAgentKeys).toEqual(["User-Agent"]);
+      expect(headers["User-Agent"]).toContain("my-app/1.2");
+    }
+  });
+
+  test("does not produce a comma-joined user agent at the transport", () => {
+    const headers = getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" });
+
+    expect(asTransportUserAgent(headers)).not.toContain(",");
+  });
+
+  test("handles a Headers instance", () => {
+    const headers = getHeadersWithUserAgent(
+      new Headers([["User-Agent", "my-app/1.2"]])
+    );
+
+    expect(headers["User-Agent"]).toMatch(
+      /^langchainjs-openai\/1\.0\.0 \(.+\) my-app\/1\.2$/
+    );
+  });
+
+  test("handles an array of header pairs", () => {
+    const headers = getHeadersWithUserAgent([["User-Agent", "my-app/1.2"]]);
+
+    expect(headers["User-Agent"]).toMatch(
+      /^langchainjs-openai\/1\.0\.0 \(.+\) my-app\/1\.2$/
+    );
+  });
+});
+
+describe("normalizeHeaders", () => {
+  test("lowercases header names", () => {
+    expect(normalizeHeaders({ "User-Agent": "my-app/1.2" })).toEqual({
+      "user-agent": "my-app/1.2",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #11438

## What

`getHeadersWithUserAgent` merges the library user agent with any user agent the caller supplied. It never actually merged them — it emitted both as separate headers.

`normalizeHeaders` builds a WHATWG `Headers` instance and returns `Object.fromEntries(headers.entries())`. `Headers` lowercases names on construction, so the record is keyed `user-agent`. The lookup used the canonical casing:

```ts
"User-Agent": normalizedHeaders["User-Agent"]   // always undefined
  ? `${library}/${version} (${env})${normalizedHeaders["User-Agent"]}`
  : `${library}/${version} (${env})`,
```

That is always `undefined`, so the truthy branch was unreachable and the caller's value stayed in the spread under `user-agent`, next to the library's `User-Agent`:

```js
getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" })
// { "user-agent": "my-app/1.2",
//   "User-Agent": "langchainjs-openai/1.0.0 (...)" }
```

A transport collapses those two into one value:

```js
new Headers(result).get("user-agent")
// "my-app/1.2, langchainjs-openai/1.0.0 (...)"
```

RFC 9110 §10.1.5 defines `User-Agent` as product tokens separated by whitespace, so the comma-joined form is malformed. The unreachable branch was also missing a separator, and would have produced `...arm64)my-app/1.2`.

## Fix

Read the caller's value from the lowercased key and destructure it out of the spread, so exactly one `User-Agent` is emitted, with the caller's token appended after the library's and separated by a space. The original intent — library first, then the caller's — is preserved.

```js
getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" })
// { "User-Agent": "langchainjs-openai/1.0.0 (...) my-app/1.2" }
```

## Scope

All six call sites go through `defaultHeaders`, so this covers `ChatOpenAI`, `AzureChatOpenAI`, `OpenAIEmbeddings`, `AzureOpenAIEmbeddings`, and both LLM classes — plain OpenAI as well as Azure. No public API change; callers that pass no user agent are unaffected.

## Tests

New `src/utils/tests/azure.test.ts`, 9 cases: default library UA, the Azure library name, unrelated headers preserved, caller UA appended space-separated, a single `User-Agent` key for `User-Agent` / `user-agent` / `USER-AGENT` input, no comma-joined value at the transport, `Headers`-instance and array-of-pairs input, and the lowercasing behaviour of `normalizeHeaders` that this depends on.

Verified fail-without-fix / pass-with-fix: 5 of the 9 fail on `main`, all 9 pass with the change.

Local gate on `libs/providers/langchain-openai`:
- `vitest run` — 29 files, 335 tests passing (was 28/326; the 96 pre-existing `Unhandled Source Error` typecheck errors in unrelated integration tests are unchanged, verified against a clean tree)
- `oxlint` — 0 warnings, 0 errors on both changed files
- `oxfmt --check` — clean
