### PR TITLE
docs: add Corridor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This document provides guidance for AI coding agents working with the LangChain.js codebase.
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 ## Project Overview
 
 LangChain.js is a TypeScript framework for building LLM-powered applications. It provides standard interfaces for agents, models, embeddings, vector stores, and more, enabling developers to chain together interoperable components and third-party integrations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document provides guidance for AI coding agents working with the LangChain.
 
 ## Corridor security analysis
 
-Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
 
 </corridor>
 


### PR DESCRIPTION
Add a repository-wide `<corridor>` block to `AGENTS.md` requiring agents to plan first and run Corridor `analyzePlan` before generating or modifying code.

This mirrors langchain-ai/deepagents#5740. The tags are explicit and balanced so Corridor-specific guidance remains scoped.

---

Validation: `git diff --check` and a tag-balance assertion.