### PR TITLE
fix(google): keep ToolMessage and following HumanMessage in separate Gemini user turns

### DIFF
--- a/.changeset/gemini-tool-human-merge.md
+++ b/.changeset/gemini-tool-human-merge.md
@@ -1,0 +1,9 @@
+---
+"@langchain/google": patch
+---
+
+Fix `convertMessagesToGeminiContents` merging a `ToolMessage` (functionResponse)
+with a following `HumanMessage` (text) into one `user` content. Both map to the
+`user` role, and Vertex/Gemini rejects a single `user` content that mixes a
+`functionResponse` with text, so a tool result followed by a user message would
+fail with a 400. Adjacent tool results (parallel tool calls) still merge.

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -849,7 +849,18 @@ export const convertMessagesToGeminiContents: Converter<
     });
     if (content) {
       const prev = contents[contents.length - 1];
-      if (prev && prev.role === content.role) {
+      // Merge adjacent contents of the same role, but do NOT merge a content
+      // carrying a functionResponse (a converted ToolMessage) with one that
+      // does not (e.g. a following HumanMessage's text). Both map to the
+      // `user` role, and Gemini/Vertex rejects a single `user` content that
+      // mixes a functionResponse with text. Two functionResponse contents
+      // (parallel tool results) still merge, as do two plain contents.
+      // See issue #11444.
+      if (
+        prev &&
+        prev.role === content.role &&
+        hasFunctionResponse(prev) === hasFunctionResponse(content)
+      ) {
         prev.parts.push(...content.parts);
       } else {
         contents.push(content);
@@ -859,6 +870,14 @@ export const convertMessagesToGeminiContents: Converter<
 
   return contents;
 };
+
+/**
+ * Returns true if any part of the given content is a functionResponse part
+ * (i.e. it was produced from a ToolMessage).
+ */
+function hasFunctionResponse(content: Gemini.Content): boolean {
+  return content.parts.some((part) => "functionResponse" in part);
+}
 
 /**
  * Converts LangChain system messages to Gemini API system instruction format.

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -283,6 +283,56 @@ describe("convertMessagesToGeminiContents", () => {
     expect(responses[1].functionResponse!.id).toBe("call-london");
   });
 
+  test("keeps a ToolMessage and a following HumanMessage in separate user turns (legacy path)", () => {
+    // A ToolMessage (functionResponse) and a following HumanMessage (text) both
+    // map to the `user` role. They must NOT be merged into one content: Gemini /
+    // Vertex rejects a single `user` content that mixes a functionResponse with
+    // text (see issue #11444). Expected: user, model, user(functionResponse),
+    // user(text) — four separate contents.
+    const messages = [
+      new HumanMessage("read it"),
+      new AIMessage({
+        content: "Reading the agreement now.",
+        tool_calls: [
+          {
+            name: "read_document_pages",
+            args: { fileId: "f1" },
+            id: "call_1",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: "page text",
+        tool_call_id: "call_1",
+        name: "read_document_pages",
+      }),
+      new HumanMessage("continue"),
+    ];
+
+    const contents = convertMessagesToGeminiContents(messages);
+
+    expect(contents).toHaveLength(4);
+
+    expect(contents[0].role).toBe("user");
+    expect(contents[0].parts.some((p) => "text" in p)).toBe(true);
+    expect(contents[0].parts.some((p) => "functionResponse" in p)).toBe(false);
+
+    expect(contents[1].role).toBe("model");
+
+    // The tool response turn carries ONLY the functionResponse, no text.
+    expect(contents[2].role).toBe("user");
+    expect(contents[2].parts.some((p) => "functionResponse" in p)).toBe(true);
+    expect(contents[2].parts.some((p) => "text" in p)).toBe(false);
+
+    // The following human turn is its own user content with just the text.
+    expect(contents[3].role).toBe("user");
+    expect(contents[3].parts.some((p) => "functionResponse" in p)).toBe(false);
+    expect(
+      (contents[3].parts.find((p) => "text" in p) as Gemini.Part.Text).text
+    ).toBe("continue");
+  });
+
   test("falls back to ToolMessage.name when tool call lookup succeeds (legacy path)", () => {
     // Even when ToolMessage has a name, the tool_calls lookup should take priority
     const messages = [


### PR DESCRIPTION
## What

Closes #11444.

`convertMessagesToGeminiContents` merged every pair of adjacent contents that
shared a role. A `ToolMessage` converts to `role: "user"` with a
`functionResponse` part, and a following `HumanMessage` converts to
`role: "user"` with a text part, so the two were folded into a single `user`
content:

```json
{ "role": "user", "parts": [ { "functionResponse": ... }, { "text": "continue" } ] }
```

Vertex/Gemini rejects a `user` content that mixes a `functionResponse` with
text and returns a 400 ("request ends with a model turn" — misleading, the
converted payload actually ends with `user`). This happens for the ordinary
history shape `ai(text + tool_call), tool, human`, e.g. when a user sends a
follow-up message after a tool has run. Once that pair is in the history every
subsequent turn on the thread fails.

## Fix

Only merge adjacent same-role contents when both carry a `functionResponse` or
neither does. A tool result therefore stays in its own `user` turn and is not
combined with a following human text message. Adjacent tool results (parallel
tool calls) still merge into one turn, as before.

The fix matches the maintainer-facing diagnosis in the issue: split the merged
content into two separate `user` contents.

## Tests

Added `keeps a ToolMessage and a following HumanMessage in separate user turns
(legacy path)` in
`libs/providers/langchain-google/src/converters/tests/messages.test.ts`,
reproducing the issue's exact failing sequence and asserting four separate
contents (`user`, `model`, `user`(functionResponse), `user`(text)).

## Validation (real results on this machine)

Node 22.14.0, `pnpm@10.14.0`, built `@langchain/core` locally, then:

```
pnpm exec vitest run src/converters/tests/messages.test.ts
```

- With the fix: **21 passed**, my new test green.
- RED→GREEN: reverting only `converters/messages.ts` makes the new test fail
  ("expected length 3 to be 4" — the functionResponse and human text are merged);
  restoring it makes it pass.
- `oxlint` on `src/converters/` — clean; `oxfmt` — no changes.

I could not run the live Vertex integration test (needs Google Cloud
credentials), so the behavior is verified at the converter level via the unit
test above, which is where the merge happens.

Note: three tests in this file (`merges consecutive ToolMessages…`, `AIMessage
with tool_calls produces model turn…`, `strips type field from executableCode…`)
fail identically on a clean `main` checkout in my local setup (a
`response_metadata is undefined` error unrelated to this change) and are outside
this diff; this PR changes only the adjacent-merge condition and adds one test.

First-time contributor here — happy to adjust naming or the merge condition if
you'd prefer a different shape.
