### PR TITLE
fix(openai): resolve encrypted content with zdr when streaming

### DIFF
--- a/.changeset/fluffy-ravens-send.md
+++ b/.changeset/fluffy-ravens-send.md
@@ -1,0 +1,7 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): resolve encrypted content with zdr when streaming
+
+OpenAI recently changed the disposition of `encrypted_content` to contain the canonical payload on the final `done` event. Encrypted content also does not need to be a parameter in the `include` call options in order to propagate.

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
@@ -868,6 +868,34 @@ describe("reasoning summaries", () => {
     expect(secondResult.content).toBeTruthy();
   };
 
+  test("streams encrypted reasoning for ZDR replay", async () => {
+    const prompt = "What is 3 to the power of 3?";
+    const llm = new ChatOpenAI({
+      model: "o4-mini",
+      reasoning: {
+        effort: "low",
+        summary: "auto",
+      },
+      zdrEnabled: true,
+      maxRetries: 0,
+    });
+
+    const aiMessage = await concatStream(llm.stream(prompt));
+    const reasoning = aiMessage.additional_kwargs
+      .reasoning as ChatOpenAIReasoningSummary;
+
+    expect(reasoning.encrypted_content).toEqual(expect.any(String));
+    expect(reasoning.encrypted_content).not.toHaveLength(0);
+
+    const replay = await llm.invoke([
+      new HumanMessage(prompt),
+      aiMessage,
+      new HumanMessage("What number did I ask you to calculate?"),
+    ]);
+    expect(replay).toBeInstanceOf(AIMessage);
+    expect(replay.content).toBeTruthy();
+  });
+
   test.each(["stream", "invoke"])(
     "normal responses API usage (Zero Data Retention disabled), %s",
     async (requestType) => {

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -732,6 +732,16 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     };
   } else if (
     event.type === "response.output_item.done" &&
+    event.item.type === "reasoning" &&
+    event.item.encrypted_content
+  ) {
+    // Encrypted reasoning content is only complete on the done event. Emit it
+    // separately so it merges with the id and summary from output_item.added.
+    additional_kwargs.reasoning = {
+      encrypted_content: event.item.encrypted_content,
+    };
+  } else if (
+    event.type === "response.output_item.done" &&
     event.item.type === "computer_call"
   ) {
     // Handle computer_call as a tool call so ToolNode can process it
@@ -1520,9 +1530,10 @@ export const convertMessagesToResponsesInput: Converter<
         const reasoning = additional_kwargs?.reasoning;
         const hasEncryptedContent = !!reasoning?.encrypted_content;
         /**
-         * With ZDR enabled, OpenAI does not retain reasoning items, so we only send
-         * them when encrypted content is available (via include: ["reasoning.encrypted_content"]).
-         * With ZDR disabled, we include reasoning item ids so OpenAI can reference them, as it's storing them.
+         * With ZDR enabled, OpenAI returns encrypted reasoning content for stateless
+         * replay, so only send reasoning items when that payload is available.
+         * With ZDR disabled, include reasoning item IDs so OpenAI can reference
+         * the stored items.
          */
         if (reasoning && (!zdrEnabled || hasEncryptedContent)) {
           const reasoningItem =

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -639,6 +639,50 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
   });
 
   describe("reasoning streaming elevation", () => {
+    it("replays encrypted reasoning from streaming responses in ZDR mode", () => {
+      const added = convertResponsesDeltaToChatGenerationChunk({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "reasoning",
+          id: "rs_abc123",
+          summary: [],
+          encrypted_content: "incomplete_payload",
+        },
+      } as any);
+      const done = convertResponsesDeltaToChatGenerationChunk({
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "reasoning",
+          id: "rs_abc123",
+          summary: [],
+          encrypted_content: "canonical_payload",
+        },
+      } as any);
+
+      expect(added).not.toBeNull();
+      expect(done).not.toBeNull();
+
+      const streamedMessage = (added!.message as AIMessageChunk).concat(
+        done!.message as AIMessageChunk
+      );
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      expect(replayInput).toEqual([
+        {
+          id: "rs_abc123",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_payload",
+        },
+      ]);
+    });
+
     it("should elevate reasoning to content on response.output_item.added with reasoning", () => {
       const event = {
         type: "response.output_item.added",


### PR DESCRIPTION
fix(openai): resolve encrypted content with zdr when streaming

OpenAI recently changed the disposition of 
`encrypted_content` to contain the canonical 
payload on the final `done` event. Encrypted 
content also does not need to be a parameter 
in the `include` call options in order to 
propagate.

* fixes this by respecting encrypted content in the `done` streaming path
* adds regression tests
