### PR TITLE
fix(core): convert every content block when formatting for tracing

### DIFF
--- a/.changeset/format-for-tracing-all-blocks.md
+++ b/.changeset/format-for-tracing-all-blocks.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Convert every URL and base64 content block when formatting messages for tracing, not just the first. `_formatForTracing` only built its shallow copy for the first convertible block, and each copy sliced from the original `message.content`, so a message carrying two images or two files traced the first converted and the rest in their original shape.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -173,22 +173,26 @@ function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   for (const message of messages) {
     let messageToTrace = message;
     if (Array.isArray(message.content)) {
-      for (let idx = 0; idx < message.content.length; idx++) {
-        const block = message.content[idx];
+      const content = message.content;
+      // Collect every conversion into one copy. Converting in place against a
+      // freshly sliced `message.content` per block would discard the previous
+      // block's conversion, so a message carrying two images or two files
+      // traced only the first.
+      let convertedContent: typeof content | undefined;
+      for (let idx = 0; idx < content.length; idx++) {
+        const block = content[idx];
         if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
+          convertedContent ??= [...content];
+          convertedContent[idx] = convertToOpenAIImageBlock(block);
         }
+      }
+      if (convertedContent !== undefined) {
+        // Also shallow-copy content
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        messageToTrace = new (message.constructor as any)({
+          ...message,
+          content: convertedContent,
+        });
       }
     }
     messagesToTrace.push(messageToTrace);

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -15,6 +15,8 @@ import type { ChatModelStream } from "../stream.js";
 import type { IterableReadableStream } from "../../utils/stream.js";
 import type { StreamEvent } from "../../tracers/event_stream.js";
 import type { LangSmithTracingClientInterface } from "langsmith";
+import type { BaseMessage } from "../../messages/base.js";
+import type { Serialized } from "../../load/serializable.js";
 
 test("Test ChatModel accepts array shorthand for messages", async () => {
   const model = new FakeChatModel({});
@@ -615,4 +617,56 @@ test("Test ChatModel applies v1 outputVersion after implicit streaming aggregati
       text: "Hello world!",
     },
   ]);
+});
+
+test("Tracing converts every base64 content block, not just the first", async () => {
+  class CaptureInputHandler extends BaseCallbackHandler {
+    name = "CaptureInputHandler";
+
+    messages: BaseMessage[] | undefined;
+
+    async handleChatModelStart(
+      _llm: Serialized,
+      messages: BaseMessage[][]
+    ): Promise<void> {
+      this.messages = messages[0];
+    }
+  }
+
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "two PDFs" },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjQK",
+      },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjUK",
+      },
+    ],
+  });
+
+  const handler = new CaptureInputHandler();
+  await new FakeListChatModel({ responses: ["ok"] }).invoke([message], {
+    callbacks: [handler],
+  });
+
+  const traced = handler.messages?.[0];
+  expect(Array.isArray(traced?.content)).toBe(true);
+  const blocks = traced?.content as Record<string, unknown>[];
+
+  // The untouched text block is carried through unchanged.
+  expect(blocks[0]).toEqual({ type: "text", text: "two PDFs" });
+  // Both file blocks convert — the second one used to be left in its original
+  // shape because the copy was only made for the first convertible block.
+  for (const idx of [1, 2]) {
+    expect(blocks[idx]).not.toHaveProperty("source_type");
+    expect(blocks[idx].type).toBe("image_url");
+  }
+  expect(blocks[1]).not.toEqual(blocks[2]);
 });


### PR DESCRIPTION
Fixes #11291.

## The bug

`_formatForTracing` (`libs/langchain-core/src/language_models/chat_models.ts`)
guards its shallow copy with `messageToTrace === message`:

```ts
if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
  if (messageToTrace === message) {
    messageToTrace = new (message.constructor as any)({ ... });
  }
}
```

After the first convertible block the guard is false, so every later block is
skipped. A message carrying two images or two files traces the first converted
and the rest in their original shape.

There is a second latent problem in the same expression: each copy slices from
the original `message.content`, so even with the guard removed a second
conversion would have discarded the first.

## The fix

Collect the conversions into one copy of the content array, then construct the
traced message once, and only when something actually changed. Messages with no
convertible blocks are still passed through by reference, exactly as before.

## Verification

- Added a test using the reporter's repro shape — a `HumanMessage` with a text
  block and two base64 PDF blocks — asserting both file blocks convert and the
  text block is carried through untouched.
- Verified it fails without the source change:
  `AssertionError: expected { type: 'file', …(3) } to not have property "source_type"`
- `libs/langchain-core` `src/language_models/`: **102/102 tests pass**, no type errors
- `pnpm lint` and `pnpm format:check`: clean
- Changeset included.
