### PR TITLE
fix(openai): honour per-call service_tier on the Responses API

### DIFF
--- a/.changeset/responses-per-call-service-tier.md
+++ b/.changeset/responses-per-call-service-tier.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Honour a per-call `service_tier` on the Responses API. `ChatOpenAIResponses.invocationParams` read only the constructor value, so `model.invoke(input, { service_tier: "flex" })` was silently dropped when `useResponsesApi` was true, while the completions path applied it. The per-call value now takes precedence, with the constructor value as the fallback.

--- a/libs/providers/langchain-openai/src/chat_models/responses.ts
+++ b/libs/providers/langchain-openai/src/chat_models/responses.ts
@@ -99,7 +99,10 @@ export class ChatOpenAIResponses<
       temperature: this.temperature,
       top_p: this.topP,
       user: this.user,
-      service_tier: this.service_tier,
+      // Per-call value wins over the constructor default, matching the
+      // completions path. `service_tier` is declared on the call options and
+      // listed in `callKeys`, so it reaches here already parsed.
+      service_tier: options?.service_tier ?? this.service_tier,
 
       // if include_usage is set or streamUsage then stream must be set to true.
       stream: this.streaming,

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.test.ts
@@ -248,3 +248,36 @@ describe("tool search support", () => {
     expect(tools[1]).toHaveProperty("name", "get_weather");
   });
 });
+
+describe("service_tier", () => {
+  type Options = Parameters<ChatOpenAIResponses["invocationParams"]>[0];
+
+  it("prefers the per-call value over the constructor default", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4.1-mini",
+      apiKey: "sk-not-used",
+      service_tier: "default",
+    });
+    const params = model.invocationParams({
+      service_tier: "flex",
+    } as Options);
+    expect(params.service_tier).toBe("flex");
+  });
+
+  it("falls back to the constructor value when the call omits one", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4.1-mini",
+      apiKey: "sk-not-used",
+      service_tier: "default",
+    });
+    expect(model.invocationParams({} as Options).service_tier).toBe("default");
+  });
+
+  it("is undefined when neither the call nor the constructor sets one", () => {
+    const model = new ChatOpenAIResponses({
+      model: "gpt-4.1-mini",
+      apiKey: "sk-not-used",
+    });
+    expect(model.invocationParams({} as Options).service_tier).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #11353.

## The bug

`ChatOpenAIResponses.invocationParams` builds the request with:

```ts
service_tier: this.service_tier,
```

Only the constructor value. `service_tier` is declared on the call options and
listed in `callKeys`, so it arrives already parsed — it was simply never read.
The result is that `model.invoke(input, { service_tier: "flex" })` is silently
dropped whenever `useResponsesApi` is true, while the same call on the
completions path works.

The completions path already does both, per-call winning:

```ts
if (this.service_tier !== undefined) params.service_tier = this.service_tier;
if (options?.service_tier !== undefined) params.service_tier = options.service_tier;
```

## The fix

```ts
service_tier: options?.service_tier ?? this.service_tier,
```

Same precedence as completions: per-call wins, constructor is the fallback,
`undefined` when neither is set (so the key is omitted from the request exactly
as before for callers who set neither).

## Verification

- Three tests in `responses.test.ts` covering the precedence table: per-call
  over constructor, constructor when the call omits one, and `undefined` when
  neither is set.
- Verified the first fails without the source change:
  `AssertionError: expected 'default' to be 'flex'`
- `libs/providers/langchain-openai` `src/chat_models/`: **121/121 tests pass**,
  no type errors
- `pnpm lint` and `pnpm format:check`: clean
- Changeset included.
