### PR TITLE
fix(langchain): skip thought summaries in ProviderStrategy.parse

### DIFF
--- a/.changeset/provider-strategy-skip-thought-summaries.md
+++ b/.changeset/provider-strategy-skip-thought-summaries.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Skip thought summaries when `ProviderStrategy.parse` looks for structured output. Gemini returns thought summaries as text blocks flagged with `thought`, so they are indistinguishable from the real payload by `type` alone. `parse` took the first text block and stopped, so it read the summary — prose, never valid JSON — and returned `undefined` while the structured block sat untouched behind it.

--- a/libs/langchain/src/agents/responses.ts
+++ b/libs/langchain/src/agents/responses.ts
@@ -256,7 +256,12 @@ export class ProviderStrategy<T = unknown> {
           "type" in block &&
           block.type === "text" &&
           "text" in block &&
-          typeof block.text === "string"
+          typeof block.text === "string" &&
+          // Gemini returns thought summaries as text blocks flagged with
+          // `thought`, so they cannot be told apart by `type` alone. They are
+          // prose, never the structured payload, and taking one here means the
+          // real output block is never reached.
+          !("thought" in block && block.thought)
         ) {
           textContent = block.text;
           break; // Use the first text block found

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -537,6 +537,55 @@ describe("structured output handling", () => {
       });
     });
 
+    describe("thought summary blocks", () => {
+      it("parses the structured block, not a Gemini thought summary ahead of it", () => {
+        const responseSchema = z.object({ result: z.string() });
+        const message = new AIMessage({
+          content: [
+            // Gemini flags thought summaries with `thought`, keeping type
+            // "text", so they are indistinguishable by type alone.
+            {
+              text: "A returned thought summary.",
+              thought: true,
+              type: "text",
+            },
+            {
+              text: JSON.stringify({ result: "Structured response." }),
+              type: "text",
+            },
+          ],
+        });
+
+        expect(providerStrategy(responseSchema).parse(message)).toEqual({
+          result: "Structured response.",
+        });
+      });
+
+      it("still parses a lone unflagged text block", () => {
+        const responseSchema = z.object({ result: z.string() });
+        const message = new AIMessage({
+          content: [
+            { text: JSON.stringify({ result: "Only block." }), type: "text" },
+          ],
+        });
+
+        expect(providerStrategy(responseSchema).parse(message)).toEqual({
+          result: "Only block.",
+        });
+      });
+
+      it("returns undefined when every text block is a thought summary", () => {
+        const responseSchema = z.object({ result: z.string() });
+        const message = new AIMessage({
+          content: [
+            { text: "Only thinking out loud.", thought: true, type: "text" },
+          ],
+        });
+
+        expect(providerStrategy(responseSchema).parse(message)).toBeUndefined();
+      });
+    });
+
     describe("error handling on parse failure", () => {
       const errorMessage = /did not satisfy the provided response/;
 


### PR DESCRIPTION
Fixes #11435.

## The bug

`ProviderStrategy.parse` walks the content blocks looking for text:

```ts
if (block.type === "text" && typeof block.text === "string") {
  textContent = block.text;
  break; // Use the first text block found
}
```

Gemini returns thought summaries as **text blocks flagged with `thought`**, not
as a distinct block type — so they cannot be told apart by `type` alone. The
first match is therefore the summary, which is prose, fails `JSON.parse`, and
`parse` returns `undefined` while the structured block sits untouched behind it.

## The fix

Skip blocks carrying a truthy `thought`. This matches the convention already
established in core's Google block translators
(`libs/langchain-core/src/messages/block_translators/google.ts`):

```ts
if (block.type === "text" && !block.thought) { ... }
if ("thought" in block && block.thought) { ... }
```

## Scope

Deliberately minimal: it still takes the first *eligible* text block rather than
trying each until one parses. That keeps the change to the reported defect. If
you would rather it fall through to later text blocks on a parse failure, that
is a small follow-up and I am happy to do it.

## Verification

Three tests in `responses.test.ts`:

1. The reporter's exact shape — thought summary followed by the structured block
   — now parses to the structured value.
2. A lone unflagged text block still parses (no regression for the common case).
3. Content that is *only* thought summaries still returns `undefined`.

Verified test 1 fails without the source change:
`AssertionError: expected undefined to deeply equal { result: 'Structured response.' }`
Tests 2 and 3 pass either way — they are there to pin the surrounding behaviour.

- `libs/langchain` `src/agents/tests/responses.test.ts`: **39/39 pass**, no type errors
- `pnpm lint` and `pnpm format`: clean
- Changeset included.
