### PR TITLE
fix(google): carry tool call ids through native stream events

### DIFF
--- a/.changeset/google-stream-tool-call-ids.md
+++ b/.changeset/google-stream-tool-call-ids.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Carry tool-call IDs through native Gemini stream events. The `functionCall` branch of `convertGoogleGeminiStream` never set an `id` on the block accumulator, `content-block-start` or `content-block-delta`, so `finalizeContentBlock` produced a `tool_call` block with `id: undefined` and a later `ToolMessage.tool_call_id` had nothing to match. A server-assigned `functionCall.id` is now preserved, and when Gemini omits one the same `lc-tool-call-*` fallback the non-streaming converter uses is generated — one stable id from block start through finalization.

--- a/libs/providers/langchain-google/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google/src/utils/stream_events.ts
@@ -10,6 +10,7 @@ import type {
   FinishReason,
 } from "@langchain/core/language_models/event";
 import type { ContentBlock, UsageMetadata } from "@langchain/core/messages";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import type { Gemini } from "../chat_models/api-types.js";
 
 export type GeminiStreamResponse = Gemini.GenerateContentResponse;
@@ -123,10 +124,17 @@ export async function* convertGoogleGeminiStream(
       } else if (part.functionCall) {
         const key: BlockKey = `tool:${toolIdx}`;
         const args = JSON.stringify(part.functionCall.args ?? {});
+        // One id must survive block start -> delta -> finalization so a later
+        // `ToolMessage.tool_call_id` can match it. Gemini may omit `id`, so
+        // fall back to the same generated shape the non-streaming converter
+        // uses rather than leaving the finalized block without one.
+        const toolCallId =
+          part.functionCall.id ?? `lc-tool-call-${uuidv4().replace(/-/g, "")}`;
         const { index, isNew } = getOrCreateBlockIndex(key, {
           type: "tool_call_chunk",
           name: part.functionCall.name,
           args: "",
+          id: toolCallId,
           index: toolIdx,
         });
         if (isNew) {
@@ -137,6 +145,7 @@ export async function* convertGoogleGeminiStream(
               type: "tool_call_chunk",
               name: part.functionCall.name,
               args: "",
+              id: toolCallId,
               index: toolIdx,
             } as ContentBlock,
           };
@@ -152,6 +161,9 @@ export async function* convertGoogleGeminiStream(
               type: "tool_call_chunk",
               name: acc.name,
               args: acc.args,
+              // Read from the accumulator, not the local: on a reused block
+              // the accumulator holds the id issued at block start.
+              id: acc.id,
             },
           },
         };

--- a/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
@@ -116,3 +116,104 @@ describe("convertGoogleGeminiStream", () => {
     expect(events.filter((e) => e.event === "usage").length).toBe(1);
   });
 });
+
+describe("tool call ids", () => {
+  test("preserves a server-assigned functionCall id across start, delta and finish", async () => {
+    const events = await collectEvents([
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: "server-assigned-id-123",
+                    name: "web_search",
+                    args: { query: "weather" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const start = events.find((e) => e.event === "content-block-start") as
+      | { content: Record<string, unknown> }
+      | undefined;
+    const delta = events.find((e) => e.event === "content-block-delta") as
+      | { delta: { fields: Record<string, unknown> } }
+      | undefined;
+    const finish = events.find((e) => e.event === "content-block-finish") as
+      | { content: Record<string, unknown> }
+      | undefined;
+
+    expect(start?.content.id).toBe("server-assigned-id-123");
+    expect(delta?.delta.fields.id).toBe("server-assigned-id-123");
+    expect(finish?.content).toMatchObject({
+      type: "tool_call",
+      name: "web_search",
+      args: { query: "weather" },
+      id: "server-assigned-id-123",
+    });
+  });
+
+  test("generates a stable fallback id when Gemini omits one", async () => {
+    const events = await collectEvents([
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: "web_search",
+                    args: { query: "weather" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const start = events.find((e) => e.event === "content-block-start") as
+      | { content: Record<string, unknown> }
+      | undefined;
+    const finish = events.find((e) => e.event === "content-block-finish") as
+      | { content: Record<string, unknown> }
+      | undefined;
+
+    // Same generated shape the non-streaming converter uses.
+    expect(start?.content.id).toMatch(/^lc-tool-call-[0-9a-f]{32}$/);
+    // One id, not a fresh one per event.
+    expect(finish?.content.id).toBe(start?.content.id);
+  });
+
+  test("gives concurrent tool calls distinct ids", async () => {
+    const events = await collectEvents([
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { name: "a", args: {} } },
+                { functionCall: { name: "b", args: {} } },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const finished = events
+      .filter((e) => e.event === "content-block-finish")
+      .map((e) => (e as { content: Record<string, unknown> }).content);
+
+    expect(finished).toHaveLength(2);
+    expect(finished[0].id).toBeDefined();
+    expect(finished[0].id).not.toBe(finished[1].id);
+  });
+});


### PR DESCRIPTION
Fixes #11261.

## The bug

The `functionCall` branch of `convertGoogleGeminiStream`
(`libs/providers/langchain-google/src/utils/stream_events.ts`) never set an `id`
— not on the block accumulator, not on `content-block-start`, not on
`content-block-delta`. `finalizeContentBlock` therefore emitted:

```js
{ type: "tool_call", name: "web_search", args: { query: "weather" }, id: undefined }
```

Nothing throws. A later `ToolMessage.tool_call_id` simply has no id to match,
and a server-assigned `functionCall.id` is discarded on the way through.

## The fix

Issue the id once, at block start, and read it from the accumulator afterwards
so one stable value survives start → delta → finalization:

- A server-assigned `functionCall.id` is preserved.
- When Gemini omits one, generate the same `lc-tool-call-*` shape the
  non-streaming converter in this package already uses
  (`convertGeminiPartsToToolCalls`), so both paths now have the same contract.

## Verification

Three tests in `stream_events.test.ts`:

1. A server-assigned id appears on `content-block-start`, on
   `content-block-delta`, and on the finalized `tool_call`.
2. With no id from Gemini, the fallback matches `/^lc-tool-call-[0-9a-f]{32}$/`
   and the finish event carries the **same** id as block start — one id, not a
   fresh one per event.
3. Two concurrent `functionCall` parts get distinct ids.

All three fail without the source change
(`expected undefined to be 'server-assigned-id-123'`, `expected undefined to be defined`).

- `libs/providers/langchain-google` unit tests: **164 pass**, no type errors
- `pnpm lint` and `pnpm format`: clean
- Changeset included.

## Unrelated pre-existing failures

`src/converters/tests/messages.test.ts` has 3 failures on this branch, but they
reproduce identically on a clean `main` with no changes applied:

- `merges consecutive ToolMessages into a single function turn for parallel tool calls (legacy path)`
- `AIMessage with tool_calls produces model turn with functionCall parts (legacy path)`
- `strips type field from executableCode content blocks`

Untouched by this PR — flagging in case they are not already known.
