### PR TITLE
fix(google-common): send functionCallingConfig.mode in uppercase

### DIFF
--- a/.changeset/google-common-uppercase-function-calling-mode.md
+++ b/.changeset/google-common-uppercase-function-calling-mode.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-common": patch
+---
+
+Serialize `toolConfig.functionCallingConfig.mode` in the Gemini enum's uppercase form. The Gemini API's `FunctionCallingConfig.Mode` is case-sensitive (`AUTO`, `ANY`, `NONE`), so the lowercase values sent previously matched no member and were silently ignored — leaving requests in the default AUTO mode. `tool_choice` of `"any"`, `"none"` or a forced function name was therefore a no-op on ChatVertexAI, and forced calls lost ANY-mode schema anchoring. `tool_choice` is still accepted lowercase; only the wire value changes. This matches the newer `@langchain/google` package, which already emits uppercase.

--- a/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-common/src/tests/chat_models.test.ts
@@ -2890,6 +2890,75 @@ describe("Mock ChatGoogle - Gemini", () => {
     );
   });
 
+  test("6. tool_choice serializes functionCallingConfig.mode uppercase", async () => {
+    const myTool = tool(async ({ query }) => `Result for ${query}`, {
+      name: "my_tool",
+      description: "A custom tool",
+      schema: z.object({ query: z.string() }),
+    });
+
+    // The Gemini enum is case-sensitive; a lowercase mode is silently ignored
+    // and the request falls back to AUTO.
+    const cases: [string, string][] = [
+      ["auto", "AUTO"],
+      ["any", "ANY"],
+      ["none", "NONE"],
+    ];
+
+    for (const [toolChoice, expected] of cases) {
+      const record: Record<string, any> = {};
+      const projectId = mockId();
+      const authOptions: MockClientAuthInfo = {
+        record,
+        projectId,
+        resultFile: "chat-6-mock.json",
+      };
+
+      const model = new ChatGoogle({
+        authOptions,
+        modelName: "gemini-2.0-flash",
+        temperature: 0,
+        maxRetries: 0,
+      }).bindTools([myTool], { tool_choice: toolChoice });
+
+      await model.invoke("Search for the latest news about AI");
+
+      expect(record.opts.data.toolConfig.functionCallingConfig.mode).toBe(
+        expected
+      );
+    }
+  });
+
+  test("6. a forced function name serializes mode ANY uppercase", async () => {
+    const record: Record<string, any> = {};
+    const projectId = mockId();
+    const authOptions: MockClientAuthInfo = {
+      record,
+      projectId,
+      resultFile: "chat-6-mock.json",
+    };
+
+    const myTool = tool(async ({ query }) => `Result for ${query}`, {
+      name: "my_tool",
+      description: "A custom tool",
+      schema: z.object({ query: z.string() }),
+    });
+
+    const model = new ChatGoogle({
+      authOptions,
+      modelName: "gemini-2.0-flash",
+      temperature: 0,
+      maxRetries: 0,
+    }).bindTools([myTool], { tool_choice: "my_tool" });
+
+    await model.invoke("Search for the latest news about AI");
+
+    expect(record.opts.data.toolConfig.functionCallingConfig).toEqual({
+      mode: "ANY",
+      allowedFunctionNames: ["my_tool"],
+    });
+  });
+
   test("6. function tool only does not set includeServerSideToolInvocations", async () => {
     const record: Record<string, any> = {};
     const projectId = mockId();

--- a/libs/providers/langchain-google-common/src/types.ts
+++ b/libs/providers/langchain-google-common/src/types.ts
@@ -757,7 +757,12 @@ export interface GeminiRequest {
   tools?: GeminiTool[];
   toolConfig?: {
     functionCallingConfig?: {
-      mode: "auto" | "any" | "none";
+      /**
+       * The Gemini API's `FunctionCallingConfig.Mode` enum. It is
+       * case-sensitive: a lowercase value does not match any member and is
+       * silently ignored, leaving the request in the default AUTO mode.
+       */
+      mode: "AUTO" | "ANY" | "NONE";
       allowedFunctionNames?: string[];
     };
     /**

--- a/libs/providers/langchain-google-common/src/utils/gemini.ts
+++ b/libs/providers/langchain-google-common/src/utils/gemini.ts
@@ -1993,7 +1993,12 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
       if (["auto", "any", "none"].includes(parameters.tool_choice)) {
         config = {
           functionCallingConfig: {
-            mode: parameters.tool_choice as "auto" | "any" | "none",
+            // `tool_choice` is accepted lowercase, but the wire enum is
+            // uppercase and case-sensitive.
+            mode: parameters.tool_choice.toUpperCase() as
+              | "AUTO"
+              | "ANY"
+              | "NONE",
             allowedFunctionNames: parameters.allowed_function_names,
           },
         };
@@ -2001,7 +2006,7 @@ export function getGeminiAPI(config?: GeminiAPIConfig): GoogleAIAPI {
         // force tool choice to be a single function name in case of structured output
         config = {
           functionCallingConfig: {
-            mode: "any",
+            mode: "ANY",
             allowedFunctionNames: [parameters.tool_choice],
           },
         };


### PR DESCRIPTION
Fixes #11265.

## The bug

The Gemini API's `FunctionCallingConfig.Mode` is a case-sensitive enum — `AUTO`,
`ANY`, `NONE`. `formatToolConfig` in `@langchain/google-common` emitted
lowercase in both branches:

```ts
mode: parameters.tool_choice as "auto" | "any" | "none",
// ...and for a forced function name:
mode: "any",
```

A lowercase value matches no enum member, so Vertex AI silently ignores the
field and the request stays in the default AUTO mode. The practical effect is
that `tool_choice` of `"any"`, `"none"`, or a forced function name is a **no-op**
on `ChatVertexAI`: the model may answer in plain text instead of calling the
function, and forced calls lose ANY-mode schema-constrained decoding. Nothing
errors, so it fails quietly.

## The fix

Uppercase the wire value in both branches, and narrow the type in `types.ts`
from `"auto" | "any" | "none"` to the enum's actual members.

`tool_choice` is still accepted lowercase from users — only what goes on the
wire changes.

This also brings the package in line with its sibling: the newer
`@langchain/google` already emits uppercase and even normalizes a lowercase
input (`convertToolChoiceToGeminiConfig`, see
`libs/providers/langchain-google/src/converters/tests/tools.test.ts`).
`google-common` was the outlier.

## One thing to confirm

The `types.ts` change narrows a publicly exported type. Anyone hand-constructing
a `GeminiRequest` with `mode: "any"` will now see a type error — which is the
point, since that value never worked, but it is visible rather than silent. Say
the word if you would rather accept both cases in the type and normalize
internally.

## Verification

Two tests in `chat_models.test.ts`, using the existing mock-request `record`
pattern:

1. `tool_choice` of `auto` / `any` / `none` each serialize to `AUTO` / `ANY` /
   `NONE`.
2. A forced function name serializes to
   `{ mode: "ANY", allowedFunctionNames: ["my_tool"] }`.

Both fail without the source change
(`expected 'auto' to be 'AUTO'`, `expected { mode: 'any', …(1) } to deeply equal { mode: 'ANY', …(1) }`).

- `@langchain/google-common` unit tests: **302/302 pass**, no type errors
- Downstream consumers (`google-gauth`, `google-vertexai`, `google-vertexai-web`,
  `google-webauth`) typecheck clean against the narrowed type
- `pnpm lint` and `pnpm format`: clean
- Changeset included.
