### PR TITLE
fix(aws): accept Bedrock guardContent blocks on input

### DIFF
--- a/.changeset/aws-guard-content-input.md
+++ b/.changeset/aws-guard-content-input.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+Accept Bedrock `guardContent` blocks on input. `ChatBedrockConverse` threw `Unsupported content block type` while converting messages, so guardrail selective input tagging — scoping a guardrail to only part of a message — was unreachable from the JS binding, though the Converse API accepts it and the Python binding sends it. Both the raw `{ guardContent }` shape and the `{ type: "guard_content", guardContent }` shape this package's own output converter emits now pass through. Unknown blocks still throw.

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -2358,3 +2358,55 @@ describe("document content block conversion", () => {
     expect(name1).not.toBe(name2);
   });
 });
+
+describe("convertToConverseMessages — guardContent", () => {
+  const guardContent = { text: { text: "What is the enrollment target?" } };
+
+  it("passes through the raw Converse guardContent shape", () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: "text", text: "…untrusted RAG context…" },
+          // The shape the Converse API accepts, and what the Python
+          // langchain-aws binding sends. It carries no `type` field.
+          { guardContent } as never,
+        ],
+      }),
+    ]);
+
+    expect(converseMessages).toEqual([
+      {
+        role: BedrockConversationRole.USER,
+        content: [{ text: "…untrusted RAG context…" }, { guardContent }],
+      },
+    ]);
+  });
+
+  it("accepts the typed shape this package's output converter emits", () => {
+    // message_outputs.ts turns a Bedrock `{ guardContent }` block into
+    // `{ type: "guard_content", guardContent }`, so that shape has to survive
+    // being fed back in.
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [{ type: "guard_content", guardContent } as never],
+      }),
+    ]);
+
+    expect(converseMessages).toEqual([
+      {
+        role: BedrockConversationRole.USER,
+        content: [{ guardContent }],
+      },
+    ]);
+  });
+
+  it("still rejects a genuinely unknown block", () => {
+    expect(() =>
+      convertToConverseMessages([
+        new HumanMessage({
+          content: [{ type: "not_a_real_block" } as never],
+        }),
+      ])
+    ).toThrow(/Unsupported content block type/);
+  });
+});

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -25,6 +25,27 @@ import {
 } from "../types.js";
 import { convertFromV1ToChatBedrockConverseMessage } from "./compat.js";
 
+/**
+ * Bedrock guardrail selective input tagging.
+ *
+ * Matches both the raw Converse shape `{ guardContent }` — what the API
+ * accepts, and what the Python `langchain-aws` binding sends — and the
+ * `{ type: "guard_content", guardContent }` shape this package's own output
+ * converter emits, so an assistant turn can be fed straight back in. The
+ * `type` field, when present, carries no extra information here.
+ */
+function isGuardContentBlock(
+  block: unknown
+): block is { guardContent: Bedrock.GuardrailConverseContentBlock } {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    "guardContent" in block &&
+    typeof (block as { guardContent: unknown }).guardContent === "object" &&
+    (block as { guardContent: unknown }).guardContent !== null
+  );
+}
+
 function isDefaultCachePoint(
   block: unknown
 ): block is { cachePoint: Bedrock.CachePointBlock } {
@@ -541,6 +562,10 @@ function convertLangChainContentBlockToConverseContentBlock<
 
   if (isDefaultCachePoint(block)) {
     return convertCachePointBlock(block);
+  }
+
+  if (isGuardContentBlock(block)) {
+    return { guardContent: block.guardContent };
   }
 
   if (onUnknown === "throw") {


### PR DESCRIPTION
Fixes #11217.

## The bug

`convertLangChainContentBlockToConverseContentBlock` has no branch for
`guardContent`, so it falls through to the terminal throw:

```
Error: Unsupported content block type: undefined     // raw { guardContent: … }
Error: Unsupported content block type: guard_content // typed form
```

This happens during message conversion, before any network call — so Bedrock
guardrail **selective input tagging** is unreachable from the JS binding
entirely. That matters for RAG: tagging is the only way to stop a
`PROMPT_ATTACK` filter firing on retrieved context while still guarding the
user's question. The Converse API accepts the block, and the Python
`langchain-aws` binding already sends it, so this is a parity gap.

## The fix

Pass the block through. One guard covers both shapes, because both carry
`guardContent` and the `type` field adds no information here:

- **the raw `{ guardContent }` Converse shape** — what the API takes and what
  Python sends;
- **`{ type: "guard_content", guardContent }`** — which this package's *own*
  output converter already emits (`message_outputs.ts` line 87-88):

  ```ts
  } else if ("guardContent" in c) {
    content.push({ type: "guard_content", guardContent: c.guardContent });
  ```

  So the library was producing a shape its own input converter rejected. Round
  trips now work.

## Verification

Three tests in `chat_models.test.ts`:

1. The raw shape converts to `{ guardContent }` alongside a normal text block.
2. The typed output-converter shape converts to the same thing.
3. A genuinely unknown block **still throws** — this fix does not widen the
   converter into accepting anything with an unrecognized type.

Tests 1 and 2 fail without the source change, with the issue's exact messages
(`Unsupported content block type: undefined` and `: guard_content`). Test 3
passes either way, and is there to pin that the guard did not become too broad.

- `@langchain/aws` unit tests: **129/129 pass**, no type errors
- `pnpm lint` and `pnpm format`: clean
- Changeset included.

## A shape I did not add

The reporter also tried `{ type: "guard_content", text: "…" }`, which is not a
shape this package produces or the API accepts. I left it unsupported rather
than invent new surface area — but it is an easy ergonomic addition if you want
it, mapping to `{ guardContent: { text: { text } } }`. Happy to add it here.
