### PR TITLE
fix(google): surface grounding metadata on native stream events

### DIFF
--- a/.changeset/google-stream-grounding-metadata.md
+++ b/.changeset/google-stream-grounding-metadata.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+Surface grounding and citation provenance on native Gemini streams. `convertGoogleGeminiStream` read only `finishReason` and content parts off the candidate, so `groundingMetadata`, `citationMetadata` and `groundingAttributions` never reached the caller — a `googleSearch`-grounded answer arrived with no citations, while the non-streaming converter exposed all three on `response_metadata`. They are now carried onto the `message-finish` event under the same snake_case keys, and omitted entirely when the response is not grounded.

--- a/libs/providers/langchain-google/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google/src/utils/stream_events.ts
@@ -35,6 +35,7 @@ export async function* convertGoogleGeminiStream(
   let messageStarted = false;
   let usageSnapshot: UsageMetadata | undefined;
   let finishReason: FinishReason = "stop";
+  let provenanceMetadata: Record<string, unknown> | undefined;
 
   const getOrCreateBlockIndex = (
     key: BlockKey,
@@ -71,6 +72,21 @@ export async function* convertGoogleGeminiStream(
     const candidate = response.candidates?.[0];
     if (candidate?.finishReason) {
       finishReason = mapGeminiFinishReason(candidate.finishReason);
+    }
+
+    // Grounding and citation provenance arrives on the candidate, usually on
+    // the last chunk. The non-streaming converter surfaces it on
+    // `response_metadata`; without this the native stream dropped it, so a
+    // googleSearch-grounded answer reached the caller with no citations.
+    // Later chunks win: Gemini resends the accumulated metadata.
+    for (const [key, value] of [
+      ["grounding_metadata", candidate?.groundingMetadata],
+      ["citation_metadata", candidate?.citationMetadata],
+      ["grounding_attributions", candidate?.groundingAttributions],
+    ] as const) {
+      if (value !== undefined) {
+        provenanceMetadata = { ...provenanceMetadata, [key]: value };
+      }
     }
 
     const parts = candidate?.content?.parts;
@@ -172,7 +188,7 @@ export async function* convertGoogleGeminiStream(
     event: "message-finish" as const,
     reason: finishReason,
     ...(usageSnapshot ? { usage: usageSnapshot } : {}),
-    responseMetadata: { model_provider: "google" },
+    responseMetadata: { model_provider: "google", ...provenanceMetadata },
   };
 }
 

--- a/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
+++ b/libs/providers/langchain-google/src/utils/tests/stream_events.test.ts
@@ -116,3 +116,61 @@ describe("convertGoogleGeminiStream", () => {
     expect(events.filter((e) => e.event === "usage").length).toBe(1);
   });
 });
+
+describe("grounding provenance", () => {
+  const groundingMetadata = {
+    webSearchQueries: ["who won the 2024 world series"],
+    groundingChunks: [
+      { web: { uri: "https://example.com/a", title: "example.com" } },
+    ],
+    groundingSupports: [
+      { segment: { startIndex: 0, endIndex: 12 }, groundingChunkIndices: [0] },
+    ],
+  };
+
+  test("surfaces grounding and citation metadata on message-finish", async () => {
+    const events = await collectEvents([
+      { candidates: [{ content: { parts: [{ text: "The Dodgers" }] } }] },
+      {
+        candidates: [
+          {
+            content: { parts: [{ text: " won." }] },
+            finishReason: "STOP",
+            groundingMetadata,
+            citationMetadata: {
+              citationSources: [{ uri: "https://example.com/a" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const finish = events.find((e) => e.event === "message-finish") as
+      | { responseMetadata: Record<string, unknown> }
+      | undefined;
+
+    expect(finish?.responseMetadata).toMatchObject({
+      model_provider: "google",
+      grounding_metadata: groundingMetadata,
+      citation_metadata: {
+        citationSources: [{ uri: "https://example.com/a" }],
+      },
+    });
+  });
+
+  test("omits the keys entirely when the response is not grounded", async () => {
+    const events = await collectEvents([
+      {
+        candidates: [
+          { content: { parts: [{ text: "no search" }] }, finishReason: "STOP" },
+        ],
+      },
+    ]);
+
+    const finish = events.find((e) => e.event === "message-finish") as
+      | { responseMetadata: Record<string, unknown> }
+      | undefined;
+
+    expect(finish?.responseMetadata).toEqual({ model_provider: "google" });
+  });
+});


### PR DESCRIPTION
Fixes #11210.

## What I found

The report had no repro, so I traced it. The non-streaming converter already
surfaces the provenance fields (`converters/messages.ts`):

```ts
const response_metadata = {
  model_provider: "google",
  citation_metadata: candidate.citationMetadata,
  grounding_metadata: candidate.groundingMetadata,
  grounding_attributions: candidate.groundingAttributions,
  ...
```

The **native stream path does not**. `convertGoogleGeminiStream` reads exactly
two things off the candidate — `finishReason` and `content.parts` — and emits:

```ts
responseMetadata: { model_provider: "google" },
```

So on a streamed call, a `googleSearch`-grounded answer reaches the caller with
no citations, no grounding supports, and no search queries. The model says it is
grounded and the provenance is simply discarded in transit. That matches the
report's "responses indicate that they are grounded, but [the data] is clearly
not present anywhere".

## The fix

Accumulate `groundingMetadata`, `citationMetadata` and `groundingAttributions`
across chunks and merge them into the `message-finish` `responseMetadata`, under
the same snake_case keys the non-streaming path already uses — so callers do not
have to branch on whether they streamed.

Later chunks win, since Gemini resends the accumulated metadata rather than
diffing it. Keys are omitted entirely when the response is not grounded, so
nothing changes shape for ungrounded calls.

## Scope

Limited to the three provenance fields the issue is about. The non-streaming
converter also exposes `safety_ratings`, `avg_logprobs`, `url_context_metadata`
and others that streaming likewise drops — that is the same class of gap, but I
did not widen this PR into it. Happy to follow up if you want full parity.

## Verification

Two tests in `stream_events.test.ts`:

1. A two-chunk stream where the final chunk carries `groundingMetadata` and
   `citationMetadata` — both appear on `message-finish` alongside
   `model_provider`.
2. An ungrounded stream still yields exactly `{ model_provider: "google" }`, so
   no empty keys are introduced.

Test 1 fails without the source change:
`AssertionError: expected { model_provider: 'google' } to match object { model_provider: 'google', …(2) }`

- `stream_events.test.ts`: **6/6 pass**, no type errors
- `pnpm lint` and `pnpm format`: clean
- Changeset included.

## Unrelated pre-existing failures

`src/converters/tests/messages.test.ts` has 3 failures on this branch, but they
reproduce identically on a clean `main` with nothing applied (same three I
flagged in #11453):

- `merges consecutive ToolMessages into a single function turn for parallel tool calls (legacy path)`
- `AIMessage with tool_calls produces model turn with functionCall parts (legacy path)`
- `strips type field from executableCode content blocks`
