### PR TITLE
fix(openai): avoid duplicate usage metadata in streams

### DIFF
--- a/.changeset/fix-openai-stream-usage-metadata.md
+++ b/.changeset/fix-openai-stream-usage-metadata.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix duplicate usage metadata when OpenAI-compatible providers repeat cumulative usage snapshots during streaming

--- a/.changeset/fix-openai-stream-usage-metadata.md
+++ b/.changeset/fix-openai-stream-usage-metadata.md
@@ -1,4 +1,5 @@
 ---
+"@langchain/core": patch
 "@langchain/openai": patch
 ---
 

--- a/libs/langchain-core/src/language_models/openai_completions_stream.ts
+++ b/libs/langchain-core/src/language_models/openai_completions_stream.ts
@@ -96,6 +96,17 @@ export interface ConvertOpenAICompletionsStreamOptions {
 
 type BlockKey = "text" | "reasoning" | "audio" | `tool:${number}`;
 
+const TOKEN_DETAIL_KEYS = [
+  "audio",
+  "cache_creation",
+  "cache_read",
+  "document",
+  "image",
+  "reasoning",
+  "text",
+  "video",
+] as const;
+
 /**
  * Convert an async iterable of OpenAI Chat Completions-shaped stream chunks into
  * LangChain `ChatModelStreamEvent`s with typed deltas.
@@ -116,7 +127,7 @@ export async function* convertOpenAICompletionsStream(
   const blockKeyToIndex = new Map<BlockKey, number>();
   let nextBlockIndex = 0;
   let messageStarted = false;
-  let usageSnapshot: UsageMetadata | undefined;
+  let lastEmittedUsageSnapshot: UsageMetadata | undefined;
   let finishReason: FinishReason | undefined;
   let responseMetadata: Record<string, unknown> | undefined;
   let emittedProviderMetadata = false;
@@ -161,14 +172,24 @@ export async function* convertOpenAICompletionsStream(
     }
 
     if (data.usage && shouldStreamUsage) {
-      usageSnapshot = buildUsageSnapshot(data.usage);
-      yield { event: "usage" as const, usage: usageSnapshot };
+      const nextUsageSnapshot = buildUsageSnapshot(data.usage);
+      if (
+        !areUsageSnapshotsEqual(lastEmittedUsageSnapshot, nextUsageSnapshot)
+      ) {
+        lastEmittedUsageSnapshot = nextUsageSnapshot;
+        yield { event: "usage" as const, usage: nextUsageSnapshot };
+      }
     }
 
     const groqUsage = data.x_groq?.usage;
     if (groqUsage && shouldStreamUsage) {
-      usageSnapshot = buildGroqUsageSnapshot(groqUsage);
-      yield { event: "usage" as const, usage: usageSnapshot };
+      const nextUsageSnapshot = buildGroqUsageSnapshot(groqUsage);
+      if (
+        !areUsageSnapshotsEqual(lastEmittedUsageSnapshot, nextUsageSnapshot)
+      ) {
+        lastEmittedUsageSnapshot = nextUsageSnapshot;
+        yield { event: "usage" as const, usage: nextUsageSnapshot };
+      }
     }
 
     const choice = data.choices?.[0];
@@ -364,7 +385,7 @@ export async function* convertOpenAICompletionsStream(
   yield {
     event: "message-finish" as const,
     reason: finishReason,
-    ...(usageSnapshot ? { usage: usageSnapshot } : {}),
+    ...(lastEmittedUsageSnapshot ? { usage: lastEmittedUsageSnapshot } : {}),
     ...(responseMetadata ? { responseMetadata } : {}),
   };
 }
@@ -388,6 +409,37 @@ function buildGroqUsageSnapshot(usage: {
     output_tokens: usage.completion_tokens ?? 0,
     total_tokens: usage.total_tokens ?? 0,
   };
+}
+
+function areUsageSnapshotsEqual(
+  left: UsageMetadata | undefined,
+  right: UsageMetadata
+): boolean {
+  if (!left) return false;
+  return (
+    left.input_tokens === right.input_tokens &&
+    left.output_tokens === right.output_tokens &&
+    left.total_tokens === right.total_tokens &&
+    areTokenDetailsEqual(left.input_token_details, right.input_token_details) &&
+    areTokenDetailsEqual(left.output_token_details, right.output_token_details)
+  );
+}
+
+function areTokenDetailsEqual(
+  left:
+    | NonNullable<UsageMetadata["input_token_details"]>
+    | NonNullable<UsageMetadata["output_token_details"]>
+    | undefined,
+  right:
+    | NonNullable<UsageMetadata["input_token_details"]>
+    | NonNullable<UsageMetadata["output_token_details"]>
+    | undefined
+): boolean {
+  const leftDetails = left as Record<string, number | undefined> | undefined;
+  const rightDetails = right as Record<string, number | undefined> | undefined;
+  return TOKEN_DETAIL_KEYS.every(
+    (key) => leftDetails?.[key] === rightDetails?.[key]
+  );
 }
 
 function mapFinishReason(reason: OpenAICompletionsFinishReason): FinishReason {

--- a/libs/langchain-core/src/language_models/tests/openai_completions_stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/openai_completions_stream.test.ts
@@ -102,4 +102,78 @@ describe("convertOpenAICompletionsStream", () => {
     }
     expect(reasoningFinish.content.reasoning).toBe("think");
   });
+
+  test("deduplicates repeated usage snapshots but emits changed snapshots", async () => {
+    const events = await collectEvents([
+      {
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: "Hello" },
+            finish_reason: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 1,
+          total_tokens: 101,
+          prompt_tokens_details: { cached_tokens: 25 },
+        },
+      },
+      {
+        choices: [{ index: 0, delta: { content: " world" } }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 1,
+          total_tokens: 101,
+          prompt_tokens_details: { cached_tokens: 25 },
+        },
+      },
+      {
+        choices: [{ index: 0, delta: { content: "!" } }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 2,
+          total_tokens: 102,
+          prompt_tokens_details: { cached_tokens: 25 },
+        },
+      },
+      {
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 2,
+          total_tokens: 102,
+          prompt_tokens_details: { cached_tokens: 25 },
+        },
+      },
+    ]);
+
+    const usageEvents = events.filter((event) => event.event === "usage");
+    expect(usageEvents).toHaveLength(2);
+    expect(usageEvents.map((event) => event.usage)).toEqual([
+      {
+        input_tokens: 100,
+        output_tokens: 1,
+        total_tokens: 101,
+        input_token_details: { cache_read: 25 },
+      },
+      {
+        input_tokens: 100,
+        output_tokens: 2,
+        total_tokens: 102,
+        input_token_details: { cache_read: 25 },
+      },
+    ]);
+
+    const finish = events.find((event) => event.event === "message-finish");
+    expect(
+      finish?.event === "message-finish" ? finish.usage : undefined
+    ).toEqual({
+      input_tokens: 100,
+      output_tokens: 2,
+      total_tokens: 102,
+      input_token_details: { cache_read: 25 },
+    });
+  });
 });

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -423,6 +423,18 @@ export class ChatOpenAICompletions<
         data,
         defaultRole
       );
+      // OpenAI-compatible providers may repeat a cumulative usage snapshot on
+      // choice chunks. Keep usage on the dedicated final usage chunk so
+      // AIMessageChunk.concat does not sum the same snapshot more than once.
+      const responseMetadata = chunk.response_metadata as
+        | Record<string, unknown>
+        | undefined;
+      if (responseMetadata?.usage !== undefined) {
+        const responseMetadataWithoutUsage = { ...responseMetadata };
+        delete responseMetadataWithoutUsage.usage;
+        chunk.response_metadata =
+          responseMetadataWithoutUsage as typeof chunk.response_metadata;
+      }
       defaultRole = delta.role ?? defaultRole;
       const newTokenIndices = {
         prompt: options.promptIndex ?? 0,

--- a/libs/providers/langchain-openai/src/chat_models/completions.ts
+++ b/libs/providers/langchain-openai/src/chat_models/completions.ts
@@ -429,7 +429,7 @@ export class ChatOpenAICompletions<
       const responseMetadata = chunk.response_metadata as
         | Record<string, unknown>
         | undefined;
-      if (responseMetadata?.usage !== undefined) {
+      if (data.usage != null && responseMetadata?.usage !== undefined) {
         const responseMetadataWithoutUsage = { ...responseMetadata };
         delete responseMetadataWithoutUsage.usage;
         chunk.response_metadata =

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -4,6 +4,7 @@ import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import { HumanMessage, AIMessageChunk } from "@langchain/core/messages";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatOpenAICompletions } from "../completions.js";
+import { AzureChatOpenAICompletions } from "../../azure/chat_models/completions.js";
 
 describe("ChatOpenAICompletions constructor", () => {
   it("supports string model shorthand", () => {
@@ -115,6 +116,134 @@ describe("ChatOpenAICompletions streaming usage_metadata callback", () => {
     expect(lastCallFields.chunk.message.usage_metadata).toBeDefined();
     expect(lastCallFields.chunk.message.usage_metadata?.input_tokens).toBe(10);
   });
+});
+
+describe("Chat Completions streaming usage metadata deduplication", () => {
+  const cumulativeUsage = {
+    prompt_tokens: 100,
+    completion_tokens: 5,
+    total_tokens: 105,
+    prompt_tokens_details: { cached_tokens: 50, cache_write_tokens: 20 },
+    completion_tokens_details: { reasoning_tokens: 2 },
+  };
+
+  const providers = [
+    {
+      name: "OpenAI",
+      create: () =>
+        new ChatOpenAICompletions({
+          model: "gpt-4o-mini",
+          apiKey: "test-key",
+          configuration: { baseURL: "https://api.openai.com/v1" },
+          streaming: true,
+          streamUsage: true,
+          __includeRawResponse: true,
+        }),
+    },
+    {
+      name: "Azure OpenAI",
+      create: () =>
+        new AzureChatOpenAICompletions({
+          model: "gpt-4o-mini",
+          apiKey: "test-key",
+          azureOpenAIApiVersion: "2024-10-21",
+          azureOpenAIApiDeploymentName: "gpt-4o-mini",
+          azureOpenAIEndpoint: "https://example.openai.azure.com",
+          streaming: true,
+          streamUsage: true,
+          __includeRawResponse: true,
+        }),
+    },
+    {
+      name: "LiteLLM-compatible",
+      create: () =>
+        new ChatOpenAICompletions({
+          model: "gpt-5.6-luna",
+          apiKey: "test-key",
+          configuration: { baseURL: "http://litellm.example.test/v1" },
+          streaming: true,
+          streamUsage: true,
+          __includeRawResponse: true,
+        }),
+    },
+  ] as const;
+
+  it.each(providers)(
+    "$name keeps repeated cumulative usage snapshots from being summed",
+    async ({ create }) => {
+      const model = create();
+      const fakeStream = (async function* () {
+        // Some OpenAI-compatible servers attach the same cumulative usage
+        // snapshot to more than one choice-bearing chunk.
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" as const, content: "Hello" },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+          usage: cumulativeUsage,
+          system_fingerprint: null,
+          model: "provider-model",
+          service_tier: null,
+        };
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: { content: "" },
+              finish_reason: "stop",
+              logprobs: null,
+            },
+          ],
+          usage: cumulativeUsage,
+          system_fingerprint: null,
+          model: "provider-model",
+          service_tier: null,
+        };
+      })();
+
+      model.completionWithRetry = vi
+        .fn()
+        .mockResolvedValue(fakeStream) as typeof model.completionWithRetry;
+
+      const chunks = [];
+      for await (const chunk of model._streamResponseChunks(
+        [new HumanMessage("test")],
+        {}
+      )) {
+        chunks.push(chunk);
+      }
+
+      const firstMessage = chunks[0].message as AIMessageChunk;
+      expect(firstMessage.response_metadata.usage).toBeUndefined();
+      expect(
+        (firstMessage.additional_kwargs.__raw_response as { usage: unknown })
+          .usage
+      ).toEqual(cumulativeUsage);
+
+      const finalMessage = chunks
+        .slice(1)
+        .reduce(
+          (message, chunk) => message.concat(chunk.message as AIMessageChunk),
+          firstMessage
+        );
+
+      expect(finalMessage.response_metadata.usage).toEqual(cumulativeUsage);
+      expect(finalMessage.usage_metadata).toEqual({
+        input_tokens: 100,
+        output_tokens: 5,
+        total_tokens: 105,
+        input_token_details: {
+          cache_read: 50,
+          cache_creation: 20,
+        },
+        output_token_details: { reasoning: 2 },
+      });
+    }
+  );
 });
 
 describe("ChatOpenAICompletions cache token usage_metadata", () => {


### PR DESCRIPTION
Fixes #11054

## Summary

Prevent duplicate token usage in both streamed `AIMessageChunk.response_metadata` and native content-block usage events when an OpenAI-compatible provider repeats cumulative usage snapshots.

This provider-agnostic fix applies to raw OpenAI, Azure OpenAI, LiteLLM, OpenRouter, GPTSL, and other adapters using the shared OpenAI Completions stream converter.

Related: #11084 addresses duplicated scalar metadata such as `finish_reason` and `model_name`; this PR addresses the remaining numeric usage aggregation issue from the same class of multi-terminal streams.

## Root cause

`ChatOpenAICompletions` forwarded usage metadata from choice-bearing chunks and then emitted the same usage again on the dedicated final usage chunk. LangChain chunk aggregation adds response metadata, so repeated cumulative usage was counted more than once.

The native content-block converter also emitted every repeated cumulative snapshot as a separate `usage` event. Consumers of `streamEvents()` or the usage sub-stream could therefore observe duplicate telemetry events.

The provider raw usage values are not necessarily wrong. The client must not add or re-emit the same cumulative snapshot repeatedly.

## Changes

- Remove `response_metadata.usage` from choice-bearing chunks and preserve usage on the dedicated final usage chunk.
- Deduplicate identical normalized cumulative usage snapshots in the shared OpenAI Completions stream-event converter while preserving genuinely changed snapshots.
- Keep the latest usage snapshot on the final `message-finish` event.
- Preserve the raw provider response in `additional_kwargs.__raw_response`.
- Avoid per-token metadata cleanup when the raw chunk does not contain usage.
- Add regression coverage for repeated and changing usage snapshots plus OpenAI-compatible, Azure OpenAI, and LiteLLM-compatible configurations.
- Add patch releases for `@langchain/core` and `@langchain/openai`.

## Live validation

### Azure OpenAI through LiteLLM

Tested LiteLLM 1.98.0 routing to the configured Azure OpenAI deployment.

The raw LiteLLM stream contained one usage event: 13 input tokens, 10 output tokens, 23 total tokens.

With the unpatched `@langchain/openai` commit `fca7d2f8b`:

- The stream exposed the same non-empty usage snapshot twice.
- `invoke()` returned response metadata of 26 input, 20 output, and 46 total tokens.
- `usage_metadata` remained 13 input, 10 output, and 23 total tokens.

With this patch, the same path returned one usage snapshot and the correct totals.

### OpenRouter

A live OpenRouter stream reproduced the same behavior with the unpatched client:

- Raw provider usage: 15 input, 9 output, 24 total tokens.
- Unpatched response metadata: 30 input, 18 output, 48 total tokens.
- Patched response metadata: 15 input, 9 output, 24 total tokens.

## Tests

- [x] Focused core converter tests: 3 passed with no type errors.
- [x] Focused OpenAI streaming tests: 14 passed with no type errors.
- [x] Full `@langchain/core` suite: 1,513 passed, 1 skipped, no type errors.
- [x] Full `@langchain/openai` suite executed 329 passing tests; the command still reports 104 pre-existing dependency/API type errors outside this change.
- [x] Package builds passed from the package directories, including `attw` and `publint`.
- [x] Lint, formatting, and `git diff --check` passed.
