### PR TITLE
fix(langchain): honor documented prompt caching middleware_context

### DIFF
--- a/.changeset/prompt-caching-middleware-context.md
+++ b/.changeset/prompt-caching-middleware-context.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Honor documented `configurable.middleware_context` when resolving agent middleware invoke context, so prompt-caching `enableCaching` overrides take effect.

--- a/libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts
+++ b/libs/langchain/src/agents/middleware/provider/anthropic/promptCaching.ts
@@ -117,14 +117,16 @@ class PromptCachingMiddlewareError extends Error {
  *   ]
  * });
  *
- * // Disable caching for specific requests
+ * // Disable caching for a specific request (canonical invoke context)
  * await agent.invoke(
  *   { messages: [new HumanMessage("Process this without caching")] },
- *   {
- *     configurable: {
- *       middleware_context: { enableCaching: false }
- *     }
- *   }
+ *   { context: { enableCaching: false } }
+ * );
+ *
+ * // Equivalent: `configurable.middleware_context` is also honored
+ * await agent.invoke(
+ *   { messages: [new HumanMessage("Process this without caching")] },
+ *   { configurable: { middleware_context: { enableCaching: false } } }
  * );
  * ```
  *

--- a/libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts
+++ b/libs/langchain/src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts
@@ -344,4 +344,77 @@ describe("anthropicPromptCachingMiddleware", () => {
       ._lastBindToolsOptions;
     expect(bindToolsOptions?.cache_control).toBeUndefined();
   });
+
+  it("should honor configurable.middleware_context enableCaching override", async () => {
+    const model = createMockModel();
+    const middleware = anthropicPromptCachingMiddleware({
+      ttl: "5m",
+      minMessagesToCache: 3,
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    const messages = [
+      new HumanMessage("Hello"),
+      new AIMessage("Hi there!"),
+      new HumanMessage("How are you?"),
+      new AIMessage("I'm doing well, thanks!"),
+      new HumanMessage("What's the weather like?"),
+    ];
+
+    await agent.invoke(
+      { messages },
+      {
+        configurable: {
+          middleware_context: { enableCaching: false },
+        },
+      }
+    );
+
+    const bindToolsOptions = (model as ReturnType<typeof createMockModel>)
+      ._lastBindToolsOptions;
+    expect(bindToolsOptions?.cache_control).toBeUndefined();
+  });
+
+  it("should let invoke context override middleware_context", async () => {
+    const model = createMockModel();
+    const middleware = anthropicPromptCachingMiddleware({
+      ttl: "5m",
+      minMessagesToCache: 3,
+    });
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    const messages = [
+      new HumanMessage("Hello"),
+      new AIMessage("Hi there!"),
+      new HumanMessage("How are you?"),
+      new AIMessage("I'm doing well, thanks!"),
+      new HumanMessage("What's the weather like?"),
+    ];
+
+    await agent.invoke(
+      { messages },
+      {
+        context: { enableCaching: true },
+        configurable: {
+          middleware_context: { enableCaching: false },
+        },
+      }
+    );
+
+    const bindToolsOptions = (model as ReturnType<typeof createMockModel>)
+      ._lastBindToolsOptions;
+    expect(bindToolsOptions).toHaveProperty("cache_control");
+    expect(bindToolsOptions?.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "5m",
+    });
+  });
 });

--- a/libs/langchain/src/agents/middleware/provider/aws/promptCaching.ts
+++ b/libs/langchain/src/agents/middleware/provider/aws/promptCaching.ts
@@ -122,14 +122,16 @@ class BedrockPromptCachingMiddlewareError extends Error {
  *   ]
  * });
  *
- * // Disable caching for specific requests
+ * // Disable caching for a specific request (canonical invoke context)
  * await agent.invoke(
  *   { messages: [new HumanMessage("Process this without caching")] },
- *   {
- *     configurable: {
- *       middleware_context: { enableCaching: false }
- *     }
- *   }
+ *   { context: { enableCaching: false } }
+ * );
+ *
+ * // Equivalent: `configurable.middleware_context` is also honored
+ * await agent.invoke(
+ *   { messages: [new HumanMessage("Process this without caching")] },
+ *   { configurable: { middleware_context: { enableCaching: false } } }
  * );
  * ```
  *

--- a/libs/langchain/src/agents/middleware/provider/aws/tests/promptCaching.test.ts
+++ b/libs/langchain/src/agents/middleware/provider/aws/tests/promptCaching.test.ts
@@ -394,4 +394,35 @@ describe("bedrockPromptCachingMiddleware", () => {
       ._lastBindToolsOptions;
     expect(bindToolsOptions?.cache_control).toBeUndefined();
   });
+
+  it("should honor configurable.middleware_context enableCaching override", async () => {
+    const model = createMockModel();
+    const middleware = bedrockPromptCachingMiddleware();
+
+    const agent = createAgent({
+      model,
+      middleware: [middleware],
+    });
+
+    const messages = [
+      new HumanMessage("Hello"),
+      new AIMessage("Hi there!"),
+      new HumanMessage("How are you?"),
+      new AIMessage("I'm doing well, thanks!"),
+      new HumanMessage("What's the weather like?"),
+    ];
+
+    await agent.invoke(
+      { messages },
+      {
+        configurable: {
+          middleware_context: { enableCaching: false },
+        },
+      }
+    );
+
+    const bindToolsOptions = (model as ReturnType<typeof createMockModel>)
+      ._lastBindToolsOptions;
+    expect(bindToolsOptions?.cache_control).toBeUndefined();
+  });
 });

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -36,7 +36,11 @@ import {
   isClientTool,
 } from "../utils.js";
 import { isConfigurableModel } from "../model.js";
-import { mergeAbortSignals, toPartialZodObject } from "../nodes/utils.js";
+import {
+  mergeAbortSignals,
+  resolveInvokeContext,
+  toPartialZodObject,
+} from "../nodes/utils.js";
 import { CreateAgentParams } from "../types.js";
 import type { InternalAgentState, Runtime } from "../runtime.js";
 import type {
@@ -505,7 +509,7 @@ export class AgentNode<
           const context = currentMiddleware.contextSchema
             ? interopParse(
                 currentMiddleware.contextSchema,
-                lgConfig?.context || {}
+                resolveInvokeContext(lgConfig)
               )
             : lgConfig?.context;
 

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -13,7 +13,7 @@ import type {
   AnyAgentMiddleware,
   MiddlewareResult,
 } from "../middleware/types.js";
-import { derivePrivateState } from "./utils.js";
+import { derivePrivateState, resolveInvokeContext } from "./utils.js";
 import { getHookConstraint } from "../middleware/utils.js";
 
 /**
@@ -67,7 +67,7 @@ export abstract class MiddlewareNode<
       );
       if (schemaShape) {
         const relevantContext: Record<string, unknown> = {};
-        const invokeContext = config?.context || {};
+        const invokeContext = resolveInvokeContext(config);
         for (const key of Object.keys(schemaShape)) {
           if (key in invokeContext) {
             relevantContext[key] = invokeContext[key];

--- a/libs/langchain/src/agents/nodes/tests/utils.test.ts
+++ b/libs/langchain/src/agents/nodes/tests/utils.test.ts
@@ -3,7 +3,11 @@ import { z as z3 } from "zod/v3";
 import { z as z4 } from "zod/v4";
 import { StateSchema } from "@langchain/langgraph";
 import { getInteropZodObjectShape } from "@langchain/core/utils/types";
-import { initializeMiddlewareStates, derivePrivateState } from "../utils.js";
+import {
+  initializeMiddlewareStates,
+  derivePrivateState,
+  resolveInvokeContext,
+} from "../utils.js";
 import type { AgentMiddleware } from "../../middleware/types.js";
 
 const baseState = { messages: [] };
@@ -50,6 +54,47 @@ describe("initializeMiddlewareStates", () => {
     await expect(
       initializeMiddlewareStates([middleware], baseState)
     ).rejects.toThrow(/requiredField/);
+  });
+});
+
+describe("resolveInvokeContext", () => {
+  it("returns an empty object when config is missing", () => {
+    expect(resolveInvokeContext()).toEqual({});
+    expect(resolveInvokeContext({})).toEqual({});
+  });
+
+  it("uses config.context", () => {
+    expect(resolveInvokeContext({ context: { enableCaching: false } })).toEqual(
+      { enableCaching: false }
+    );
+  });
+
+  it("uses configurable.middleware_context", () => {
+    expect(
+      resolveInvokeContext({
+        configurable: { middleware_context: { enableCaching: false } },
+      })
+    ).toEqual({ enableCaching: false });
+  });
+
+  it("lets config.context override middleware_context on overlapping keys", () => {
+    expect(
+      resolveInvokeContext({
+        context: { enableCaching: true, ttl: "1h" },
+        configurable: {
+          middleware_context: { enableCaching: false, ttl: "5m" },
+        },
+      })
+    ).toEqual({ enableCaching: true, ttl: "1h" });
+  });
+
+  it("ignores a non-object middleware_context", () => {
+    expect(
+      resolveInvokeContext({
+        configurable: { middleware_context: "nope" },
+        context: { a: 1 },
+      })
+    ).toEqual({ a: 1 });
   });
 });
 

--- a/libs/langchain/src/agents/nodes/utils.ts
+++ b/libs/langchain/src/agents/nodes/utils.ts
@@ -16,6 +16,48 @@ import { END, StateSchema, ReducedValue } from "@langchain/langgraph";
 import type { JumpTo } from "../types.js";
 import type { AnyAgentMiddleware } from "../middleware/types.js";
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Read `configurable.middleware_context` from a LangGraph invoke config.
+ *
+ * Prompt-caching middleware historically documented this nested key as the way
+ * to pass per-call context. Typed invoke context (`config.context`) is the
+ * canonical API; this helper exists so the documented alias still works.
+ *
+ * @see https://github.com/langchain-ai/langchainjs/issues/9871
+ */
+function getConfigurableMiddlewareContext(
+  configurable: unknown
+): Record<string, unknown> {
+  if (!isPlainRecord(configurable)) {
+    return {};
+  }
+  const raw = configurable.middleware_context;
+  if (!isPlainRecord(raw)) {
+    return {};
+  }
+  return raw;
+}
+
+/**
+ * Resolve middleware invoke context from LangGraph config.
+ *
+ * Merges `configurable.middleware_context` with `context`. When both define
+ * the same key, `context` wins.
+ */
+export function resolveInvokeContext(config?: {
+  context?: unknown;
+  configurable?: unknown;
+}): Record<string, unknown> {
+  return {
+    ...getConfigurableMiddlewareContext(config?.configurable),
+    ...(isPlainRecord(config?.context) ? config.context : {}),
+  };
+}
+
 /**
  * Helper function to initialize middleware state defaults.
  * This is used to ensure all middleware state properties are initialized.

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -190,6 +190,42 @@ describe("middleware", () => {
     );
   });
 
+  it("should read middleware context from configurable.middleware_context", async () => {
+    const model = new FakeToolCallingChatModel({
+      responses: [new AIMessage("Hello")],
+    });
+    const middleware = createMiddleware({
+      name: "middleware",
+      contextSchema: z.object({
+        customMiddlewareContext: z.string(),
+      }),
+      beforeModel: (_, { context }) => {
+        expect(context).toEqual({
+          customMiddlewareContext: "from-middleware-context",
+        });
+      },
+    });
+
+    const agent = createAgent({
+      model,
+      tools: [],
+      middleware: [middleware],
+    });
+
+    await agent.invoke(
+      {
+        messages: [new HumanMessage("Hello, world!")],
+      },
+      {
+        configurable: {
+          middleware_context: {
+            customMiddlewareContext: "from-middleware-context",
+          },
+        },
+      }
+    );
+  });
+
   describe("control actions", () => {
     it("should terminate the agent in beforeModel hook", async () => {
       const model = new FakeToolCallingChatModel({


### PR DESCRIPTION
## Fixes #9871

Prompt caching middleware documented disabling cache via:

```ts
await agent.invoke(input, {
  configurable: { middleware_context: { enableCaching: false } },
});
```

`wrapModelCall` and middleware hooks only parsed LangGraph `config.context`, so that documented path was ignored and `cache_control` stayed on. `#9854` already fixed the streaming `tool_use.id` 400; this is the remaining `enableCaching` context bug.

### Fix

Merge `configurable.middleware_context` into invoke context when building middleware `runtime.context`. Overlapping keys prefer `context` (the canonical API). JSDoc now shows both forms.

### Tests

- Anthropic / AWS prompt caching: `configurable.middleware_context.enableCaching: false` no longer attaches `cache_control`
- `context` still wins when both are set
- `beforeModel` reads the same alias
- `resolveInvokeContext` unit tests

```
pnpm --filter langchain test \
  src/agents/nodes/tests/utils.test.ts \
  src/agents/middleware/provider/anthropic/tests/promptCaching.test.ts \
  src/agents/middleware/provider/aws/tests/promptCaching.test.ts \
  src/agents/tests/middleware.test.ts
```

102 passed. `pnpm format:check` and `pnpm lint` also pass.


Made with [Cursor](https://cursor.com)