### PR TITLE
fix(aws): use this.caller in ChatBedrockConverse to support retries a…

### DIFF
--- a/.changeset/bedrock-converse-async-caller-retries.md
+++ b/.changeset/bedrock-converse-async-caller-retries.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): use this.caller in ChatBedrockConverse to support maxRetries, timeout, and onFailedAttempt

--- a/libs/providers/langchain-aws/src/chat_models.ts
+++ b/libs/providers/langchain-aws/src/chat_models.ts
@@ -1084,9 +1084,18 @@ export class ChatBedrockConverse
         requestMetadata: options.requestMetadata,
         ...params,
       });
-      const response = await this.client.send(command, {
-        abortSignal: options.signal,
-      });
+      const response = await this.caller.callWithOptions(
+        { signal: options.signal, maxRetries: options.maxRetries },
+        async () => {
+          try {
+            return await this.client.send(command, {
+              abortSignal: options.signal,
+            });
+          } catch (error) {
+            throw normalizeBedrockError(error);
+          }
+        }
+      );
       const { output, ...responseMetadata } = response;
       if (!output?.message) {
         throw new Error("No message found in Bedrock response.");
@@ -1145,12 +1154,21 @@ export class ChatBedrockConverse
         const streamIdleTimeout = resolveStreamIdleTimeout(
           options.streamIdleTimeout ?? this.streamIdleTimeout
         );
-        const response = await withRequestIdleTimeout(
-          this.client.send(command, {
-            abortSignal: abortController.signal,
-          }),
-          streamIdleTimeout,
-          abortController
+        const response = await this.caller.callWithOptions(
+          { signal: abortController.signal, maxRetries: options.maxRetries },
+          async () => {
+            try {
+              return await withRequestIdleTimeout(
+                this.client.send(command, {
+                  abortSignal: abortController.signal,
+                }),
+                streamIdleTimeout,
+                abortController
+              );
+            } catch (error) {
+              throw normalizeBedrockError(error);
+            }
+          }
         );
         if (!response.stream) {
           return;
@@ -1221,12 +1239,21 @@ export class ChatBedrockConverse
         const streamIdleTimeout = resolveStreamIdleTimeout(
           options.streamIdleTimeout ?? this.streamIdleTimeout
         );
-        const response = await withRequestIdleTimeout(
-          this.client.send(command, {
-            abortSignal: abortController.signal,
-          }),
-          streamIdleTimeout,
-          abortController
+        const response = await this.caller.callWithOptions(
+          { signal: abortController.signal, maxRetries: options.maxRetries },
+          async () => {
+            try {
+              return await withRequestIdleTimeout(
+                this.client.send(command, {
+                  abortSignal: abortController.signal,
+                }),
+                streamIdleTimeout,
+                abortController
+              );
+            } catch (error) {
+              throw normalizeBedrockError(error);
+            }
+          }
         );
         if (response.stream) {
           for await (const chunk of withStreamIdleTimeout(

--- a/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.invocation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi, afterEach } from "vitest";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { ChatBedrockConverse } from "../chat_models.js";
 import type {
@@ -25,11 +25,15 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => {
   }
   class BedrockRuntimeClient {
     static lastConfig: unknown;
+    static mockSend?: (command: unknown, options?: unknown) => Promise<unknown>;
     middlewareStack = { add: vi.fn() };
     constructor(config: unknown) {
       BedrockRuntimeClient.lastConfig = config;
     }
-    async send(command: unknown) {
+    async send(command: unknown, options?: unknown) {
+      if (BedrockRuntimeClient.mockSend) {
+        return BedrockRuntimeClient.mockSend(command, options);
+      }
       // Non-stream path
       if (
         (command as { constructor?: unknown })?.constructor === ConverseCommand
@@ -466,6 +470,104 @@ describe("ChatBedrockConverse invocationParams", () => {
     test("does not register middleware when defaultHeaders is absent", () => {
       const model = new ChatBedrockConverse({ ...baseConstructorArgs });
       expect(model.client.middlewareStack.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("retries and AsyncCaller integration", () => {
+    afterEach(() => {
+      BedrockRuntimeClient.mockSend = undefined;
+    });
+
+    test("retries transient failure on invoke when maxRetries is configured", async () => {
+      let attempts = 0;
+      const onFailedAttempt = vi.fn();
+      BedrockRuntimeClient.mockSend = vi.fn(async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw new Error("Temporary network error");
+        }
+        return {
+          output: {
+            message: {
+              role: "assistant",
+              content: [{ text: "Recovered response" }],
+            },
+          },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        };
+      });
+
+      const model = new ChatBedrockConverse({
+        ...baseConstructorArgs,
+        maxRetries: 2,
+        onFailedAttempt,
+      });
+
+      const response = await model.invoke("Hello");
+      expect(response.content).toBe("Recovered response");
+      expect(attempts).toBe(2);
+      expect(onFailedAttempt).toHaveBeenCalledTimes(1);
+    });
+
+    test("retries transient failure on stream when maxRetries is configured", async () => {
+      let attempts = 0;
+      const onFailedAttempt = vi.fn();
+      BedrockRuntimeClient.mockSend = vi.fn(async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw new Error("Temporary stream error");
+        }
+        return {
+          stream: (async function* () {
+            yield {
+              contentBlockDelta: {
+                contentBlockIndex: 0,
+                delta: { text: "Stream recovered" },
+              },
+            };
+          })(),
+        };
+      });
+
+      const model = new ChatBedrockConverse({
+        ...baseConstructorArgs,
+        maxRetries: 2,
+        onFailedAttempt,
+      });
+
+      const chunks = [];
+      for await (const chunk of await model.stream("Hello")) {
+        chunks.push(chunk);
+      }
+      expect(chunks.map((c) => c.text).join("")).toBe("Stream recovered");
+      expect(attempts).toBe(2);
+      expect(onFailedAttempt).toHaveBeenCalledTimes(1);
+    });
+
+    test("respects call-level maxRetries override", async () => {
+      let attempts = 0;
+      const onFailedAttempt = vi.fn();
+      BedrockRuntimeClient.mockSend = vi.fn(async () => {
+        attempts++;
+        throw new Error("Persistent error");
+      });
+
+      const model = new ChatBedrockConverse({
+        ...baseConstructorArgs,
+        maxRetries: 5,
+        onFailedAttempt,
+      });
+
+      await expect(model.invoke("Hello", { maxRetries: 1 })).rejects.toThrow(
+        "Persistent error"
+      );
+      // Initial attempt + 1 retry = 2 attempts total
+      expect(attempts).toBe(2);
+      expect(onFailedAttempt).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -1415,6 +1415,7 @@ describe("audio content block conversion", () => {
 describe("applicationInferenceProfile parameter", () => {
   const baseConstructorArgs = {
     region: "us-east-1",
+    maxRetries: 0,
     credentials: {
       secretAccessKey: "test-secret-key",
       accessKeyId: "test-access-key",


### PR DESCRIPTION
Fixes #11326

### Summary
Fixes an issue where `ChatBedrockConverse` bypassed `this.caller` and called `this.client.send(...)` directly, causing:
1. `maxRetries` (passed via constructor or call options) to be silently ignored during transient network/throttling errors.
2. `onFailedAttempt` hooks to never trigger.
3. Timeout and abort signals to not unify with LangChain's `AsyncCaller` lifecycle.

### Changes
- Wrapped `this.client.send` in `this.caller.callWithOptions({ signal, maxRetries }, ...)` across non-streaming and streaming handlers in `@langchain/aws`.
- Normalized Bedrock errors inside the caller closure so `AsyncCaller` captures clean error messages and causes.
- Added comprehensive unit tests in `chat_models.invocation.test.ts` verifying transient retry recovery on both `invoke()` and `stream()`, as well as call-level `maxRetries` overrides.
- Added changeset (`@langchain/aws`: patch).

### Verification
- Ran vitest unit tests: 8/8 test files passed (129/129 tests).
- Ran oxlint and oxfmt: 0 errors, 0 warnings.
