### PR TITLE
fix(examples): use fileURLToPath for createAgent graph PNG output path (fixes Windows ENOENT)

### DIFF
--- a/.changeset/windows-examples-graph-png-path.md
+++ b/.changeset/windows-examples-graph-png-path.md
@@ -1,0 +1,6 @@
+---
+---
+
+fix(examples): use `fileURLToPath` for the `createAgent` graph PNG output path so it works on Windows.
+
+Only touches files under `examples/`, which is a private, unpublished package (ignored by changesets), so no package version bump is intended.

--- a/examples/src/createAgent/accessExternalContext.ts
+++ b/examples/src/createAgent/accessExternalContext.ts
@@ -23,6 +23,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, dynamicSystemPromptMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -154,7 +155,7 @@ console.log(
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await supportAgent.drawMermaidPng());

--- a/examples/src/createAgent/accessExternalContextInTools.ts
+++ b/examples/src/createAgent/accessExternalContextInTools.ts
@@ -22,6 +22,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool } from "langchain";
 import {
   getContextVariable,
@@ -203,7 +204,7 @@ await handleUserRequest("", "Show me my purchases");
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await ecommerceAgent.drawMermaidPng());

--- a/examples/src/createAgent/accessLongTermMemory.ts
+++ b/examples/src/createAgent/accessLongTermMemory.ts
@@ -24,6 +24,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, dynamicSystemPromptMiddleware, tool } from "langchain";
 import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
@@ -297,7 +298,7 @@ console.log(
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await codingAssistant.drawMermaidPng());

--- a/examples/src/createAgent/accessLongTermMemoryInTools.ts
+++ b/examples/src/createAgent/accessLongTermMemoryInTools.ts
@@ -19,6 +19,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool } from "langchain";
 import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
@@ -307,7 +308,7 @@ console.log(johnResult3.messages.at(-1)?.content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/accessThreadLevelState.ts
+++ b/examples/src/createAgent/accessThreadLevelState.ts
@@ -16,6 +16,7 @@
  * prompt always includes the current TODOs so the model can plan next steps.
  */
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, dynamicSystemPromptMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -102,7 +103,7 @@ console.log(result.messages[result.messages.length - 1].content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/accessThreadLevelStateInTools.ts
+++ b/examples/src/createAgent/accessThreadLevelStateInTools.ts
@@ -18,6 +18,7 @@
  * returns a polished result back to the supervisor.
  */
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -123,7 +124,7 @@ console.log(actions.messages[actions.messages.length - 1].content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/controlOverMessagePreparation.ts
+++ b/examples/src/createAgent/controlOverMessagePreparation.ts
@@ -34,6 +34,7 @@
  * append a reminder before each LLM call to ensure compliance.
  */
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, createMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -157,7 +158,7 @@ console.log(
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await customerServiceAgent.drawMermaidPng());

--- a/examples/src/createAgent/customSystemPrompts.ts
+++ b/examples/src/createAgent/customSystemPrompts.ts
@@ -16,6 +16,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, dynamicSystemPromptMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -125,7 +126,7 @@ console.log(response2.messages[response2.messages.length - 1].content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await customerServiceAgent.drawMermaidPng());

--- a/examples/src/createAgent/streaming.ts
+++ b/examples/src/createAgent/streaming.ts
@@ -17,6 +17,7 @@
  */
 
 import fs from "fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool, HumanMessage } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -229,7 +230,7 @@ for await (const chunk of structuredStream) {
 /**
  * Save visualization
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/structuredOutput.ts
+++ b/examples/src/createAgent/structuredOutput.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool, HumanMessage } from "langchain";
 
 import { ChatOpenAI } from "@langchain/openai";
@@ -33,7 +34,7 @@ console.log(response.structuredResponse.result);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/updateLongTermMemoryInTools.ts
+++ b/examples/src/createAgent/updateLongTermMemoryInTools.ts
@@ -16,6 +16,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, createMiddleware, tool } from "langchain";
 import { InMemoryStore } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
@@ -566,7 +567,7 @@ Memory utilization: ${memoryStats.retrievalCount > 0 ? "High" : "Low"}
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/updateModelBeforeCall.ts
+++ b/examples/src/createAgent/updateModelBeforeCall.ts
@@ -27,6 +27,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, createMiddleware } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -129,7 +130,7 @@ console.log("Context Prefer:", contextPrefer.messages.at(-1)?.content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/updateThreadLevel.ts
+++ b/examples/src/createAgent/updateThreadLevel.ts
@@ -18,6 +18,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, createMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -106,7 +107,7 @@ console.log(result.messages.at(-1)?.content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/updateThreadLevelInTools.ts
+++ b/examples/src/createAgent/updateThreadLevelInTools.ts
@@ -19,6 +19,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -422,7 +423,7 @@ console.log(result5.messages[result5.messages.length - 1].content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());

--- a/examples/src/createAgent/updateToolsBeforeModelCall.ts
+++ b/examples/src/createAgent/updateToolsBeforeModelCall.ts
@@ -31,6 +31,7 @@
  */
 
 import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createAgent, createMiddleware, tool } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -206,7 +207,7 @@ console.log("Turn 4:", turn4.messages.at(-1)?.content);
 /**
  * Get the current file's path and derive the output PNG path
  */
-const currentFilePath = new URL(import.meta.url).pathname;
+const currentFilePath = fileURLToPath(import.meta.url);
 const outputPath = currentFilePath.replace(/\.ts$/, ".png");
 console.log(`\nSaving visualization to: ${outputPath}`);
 await fs.writeFile(outputPath, await agent.drawMermaidPng());


### PR DESCRIPTION
## What

Closes #11464.

The `createAgent` examples derive their graph-PNG output path with:

```ts
const currentFilePath = new URL(import.meta.url).pathname;
const outputPath = currentFilePath.replace(/\.ts$/, ".png");
await fs.writeFile(outputPath, await agent.drawMermaidPng());
```

A file URL's `.pathname` is not a portable filesystem path:

- **Windows:** it starts with `/C:/…`, which Node resolves to `C:\C:\…`, so every affected example fails with `ENOENT` after the agent run instead of saving its visualization.
- **Any platform:** percent-encoded characters (e.g. `%20` for a space) are left encoded, so the PNG is written to the wrong file.

## Fix

Switch the 15 affected examples under `examples/src/createAgent/` to the cross-platform conversion Node provides — and which this repo already uses in `examples/src/index.ts`:

```ts
import { fileURLToPath } from "node:url";

const currentFilePath = fileURLToPath(import.meta.url);
```

Each file: one added import, one changed line. No behavior change on the happy POSIX-no-space path; the fix is correct spaces/Windows handling.

## Tests / Validation

There is no unit suite for the examples, so I proved the path-conversion behavior directly with Node 22 (`fileURLToPath` vs `new URL(...).pathname`), including a real filesystem RED→GREEN:

- **POSIX, real fs:** created a temp dir whose name contains a space, built its `file://` URL, and wrote via both strings. `new URL(url).pathname` keeps `%20` and points at a **different** file (a stray `%20` file); `fileURLToPath(url)` yields the exact intended path and the write lands there. All assertions green.
- **Windows drive letter:** `new URL("file:///C:/Users/u/.../graph.ts").pathname` → `/C:/Users/…` (bogus leading slash → `C:\C:\…`); `fileURLToPath(url, { windows: true })` → `C:\Users\u\…\graph.ts`. Green.

Repo tooling on the 15 changed files:

```
npx oxfmt --check <files>   # All matched files use the correct format.
npx oxlint <files>          # exit 0, no findings
```

I could not run the examples end-to-end (they call an LLM / require API keys), so validation is the path-conversion proof above plus the repo's own formatter/linter.

First-time contributor here — happy to adjust naming or split this if you'd prefer.
