### PR TITLE
fix(openai): use resolved model metadata for response streams

### DIFF
--- a/.changeset/calm-models-resolve.md
+++ b/.changeset/calm-models-resolve.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Use the resolved model snapshot in streamed Responses API metadata.

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -782,14 +782,13 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
   } else if (event.type === "response.created") {
     id = event.response.id;
     response_metadata.id = event.response.id;
-    response_metadata.model_name = event.response.model;
-    response_metadata.model = event.response.model;
   } else if (
     event.type === "response.completed" ||
     event.type === "response.incomplete"
   ) {
     id = event.response.id;
     const msg = convertResponsesMessageToAIMessage(event.response);
+    response_metadata.model_name = event.response.model;
 
     usage_metadata = convertResponsesUsageToUsageMetadata(event.response.usage);
 

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -414,6 +414,40 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
     expect(aggregated.response_metadata.id).toBe("resp_top_level");
   });
 
+  it.each(["response.completed", "response.incomplete"] as const)(
+    "uses the resolved model metadata from %s",
+    (type) => {
+      const created = convertResponsesDeltaToChatGenerationChunk({
+        type: "response.created",
+        response: {
+          id: "resp_1",
+          model: "gpt-5.4",
+          object: "response",
+          status: "in_progress",
+          output: [],
+        },
+      } as any);
+      const finished = convertResponsesDeltaToChatGenerationChunk({
+        type,
+        response: {
+          id: "resp_1",
+          model: "gpt-5.4-2026-03-05",
+          created_at: 1234567890,
+          object: "response",
+          status: type === "response.completed" ? "completed" : "incomplete",
+          output: [],
+        },
+      } as any);
+
+      const aggregated = created!.message.concat(finished!.message);
+
+      expect(aggregated.response_metadata.model).toBe("gpt-5.4-2026-03-05");
+      expect(aggregated.response_metadata.model_name).toBe(
+        "gpt-5.4-2026-03-05"
+      );
+    }
+  );
+
   describe("custom tool streaming delta handling", () => {
     it("should preserve custom tool metadata from response.output_item.added events", () => {
       const customToolStart = {


### PR DESCRIPTION
## Summary

Fixes #11466

- defer streamed Responses API model metadata until the completed or incomplete response carries the resolved snapshot
- cover both terminal response event types with a regression test

## Testing

- `pnpm vitest run src/converters/tests/responses.test.ts` (92 passed)
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`
- `pnpm --filter @langchain/openai build` (attw and publint passed)

## AI Disclosure

This bug was investigated and fixed with AI assistance.