### PR TITLE
fix(openai): keep tool calls on streaming deltas with an empty-string role

### DIFF
--- a/.changeset/fix-empty-role-stream-deltas.md
+++ b/.changeset/fix-empty-role-stream-deltas.md
@@ -1,0 +1,11 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): keep tool calls on streaming deltas with an empty-string role
+
+Some OpenAI-compatible servers send `role: ""` instead of `"assistant"` on
+streaming deltas. `delta.role ?? defaultRole` treated the empty string as a
+real role, so the delta was converted to a generic `ChatMessageChunk` and any
+`tool_calls` on it were silently dropped. Coalesce with `||` and fall back to
+the inferred assistant role when no usable role is present.

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -397,7 +397,14 @@ export const convertCompletionsDeltaToBaseMessageChunk: Converter<
   },
   BaseMessageChunk
 > = ({ delta, rawResponse, includeRawResponse, defaultRole }) => {
-  const role = delta.role ?? defaultRole;
+  const isAssistantDelta = Boolean(
+    delta.tool_calls ||
+      delta.function_call ||
+      delta.reasoning_content !== undefined ||
+      delta.audio
+  );
+  const role =
+    (delta.role || defaultRole) ?? (isAssistantDelta ? "assistant" : undefined);
   const content = delta.content ?? "";
   let additional_kwargs: Record<string, unknown>;
   if (delta.function_call) {

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -88,6 +88,42 @@ describe("convertCompletionsMessageToBaseMessage", () => {
     expect(result.additional_kwargs.reasoning_content).toBe("The user");
   });
 
+  it("keeps tool calls on deltas with an empty-string role", () => {
+    const delta = {
+      role: "" as const,
+      content: "",
+      tool_calls: [
+        {
+          index: 0,
+          id: "call_1",
+          type: "function",
+          function: { name: "get_weather", arguments: '{"city":"BJ"}' },
+        },
+      ],
+    };
+    const rawResponse = {
+      id: "chatcmpl-empty-role",
+      choices: [{ index: 0, delta, finish_reason: "tool_calls" }],
+      usage: { total_tokens: 0, total_characters: 0 },
+    };
+
+    const result = convertCompletionsDeltaToBaseMessageChunk({
+      delta,
+      rawResponse: rawResponse as any,
+    }) as AIMessageChunk;
+
+    expect(result).toBeInstanceOf(AIMessageChunk);
+    expect(result.tool_call_chunks).toEqual([
+      {
+        name: "get_weather",
+        args: '{"city":"BJ"}',
+        id: "call_1",
+        index: 0,
+        type: "tool_call_chunk",
+      },
+    ]);
+  });
+
   describe("OpenRouter image response handling", () => {
     it("Should correctly parse OpenRouter-style image responses", () => {
       // Mock message with images from OpenRouter


### PR DESCRIPTION
Fixes #11468

## Problem

Some OpenAI-compatible servers send `role: ""` instead of `"assistant"` on streaming deltas. `convertCompletionsDeltaToBaseMessageChunk` resolved the role with `delta.role ?? defaultRole`, and `??` only falls back on `null`/`undefined` — so an empty string reached the final branch and the delta was converted to a generic `ChatMessageChunk` rather than an `AIMessageChunk`. Any `tool_calls` on that delta were silently discarded, and `tool_call_chunks` came out `undefined` while plain text still streamed normally.

## Fix

Coalesce with `||` so an empty-string role falls back to `defaultRole`, and when no usable role is present infer `"assistant"` for deltas carrying assistant-only fields (`tool_calls`, `function_call`, `reasoning_content`, `audio`). Explicit `"tool"` / `"system"` / `"user"` roles are truthy and keep working.

This complements #11157 (which covers a missing `role` but keeps `??`, so the empty-string variant still fails there).

## Tests

Added a regression test in `completions.test.ts` asserting an empty-string role delta with `tool_calls` produces an `AIMessageChunk` with the expected `tool_call_chunks`.