### PR TITLE
fix(core): do not present repaired partial JSON as a finished tool call

### DIFF
--- a/.changeset/fix-truncated-tool-args.md
+++ b/.changeset/fix-truncated-tool-args.md
@@ -1,0 +1,14 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): do not present repaired partial JSON as a finished tool call
+
+When a stream is truncated mid-argument (`finish_reason: "length"`), partial
+JSON like `{"path":"/etc/hosts","content":"line1` is repaired by
+`parsePartialJson` into a valid-looking object and lands in `tool_calls`, so a
+tool bound to that message could act on a truncated input with no signal that
+it was cut off. `collapseToolCallChunks` now accepts a `truncated` flag;
+`AIMessageChunk` passes it through based on `response_metadata.finish_reason`,
+and truncated streams only keep strictly-complete arguments as finished tool
+calls, routing repaired partial JSON to `invalid_tool_calls` instead.

--- a/libs/langchain-core/src/messages/ai.ts
+++ b/libs/langchain-core/src/messages/ai.ts
@@ -337,7 +337,12 @@ export class AIMessageChunk<
             : undefined,
       };
     } else {
-      const collapsed = collapseToolCallChunks(fields.tool_call_chunks ?? []);
+      const collapsed = collapseToolCallChunks(
+        fields.tool_call_chunks ?? [],
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        (fields.response_metadata as Record<string, unknown> | undefined)
+          ?.finish_reason === "length"
+      );
       initParams = {
         ...fields,
         tool_call_chunks: collapsed.tool_call_chunks,

--- a/libs/langchain-core/src/messages/tests/ai.test.ts
+++ b/libs/langchain-core/src/messages/tests/ai.test.ts
@@ -336,6 +336,87 @@ describe("AIMessageChunk", () => {
       ]);
     });
 
+    describe("truncated streams (finish_reason: length)", () => {
+      it("moves repaired partial JSON to invalid_tool_calls", () => {
+        const result = new AIMessageChunk({
+          content: "",
+          tool_call_chunks: [
+            {
+              name: "write",
+              args: '{"path":"/etc/hosts","content":"line1',
+              id: "c1",
+              index: 0,
+              type: "tool_call_chunk",
+            },
+          ],
+          response_metadata: { finish_reason: "length" },
+        });
+
+        expect(result.tool_calls?.length).toBe(0);
+        expect(result.invalid_tool_calls).toEqual([
+          {
+            type: "invalid_tool_call",
+            id: "c1",
+            name: "write",
+            args: '{"path":"/etc/hosts","content":"line1',
+            error: "Truncated tool call args.",
+          },
+        ]);
+      });
+
+      it("keeps strictly-complete args in tool_calls", () => {
+        const result = new AIMessageChunk({
+          content: "",
+          tool_call_chunks: [
+            {
+              name: "get_weather",
+              args: '{"city":"SF"}',
+              id: "call_1",
+              index: 0,
+              type: "tool_call_chunk",
+            },
+          ],
+          response_metadata: { finish_reason: "length" },
+        });
+
+        expect(result.tool_calls).toEqual([
+          {
+            type: "tool_call",
+            id: "call_1",
+            name: "get_weather",
+            args: { city: "SF" },
+          },
+        ]);
+        expect(result.invalid_tool_calls?.length).toBe(0);
+      });
+
+      it("still repairs partial args for non-truncated streams", () => {
+        const result = new AIMessageChunk({
+          content: "",
+          tool_call_chunks: [
+            {
+              name: "write",
+              args: '{"path":"/etc/hosts","content":"line1',
+              id: "c1",
+              index: 0,
+              type: "tool_call_chunk",
+            },
+          ],
+          response_metadata: { finish_reason: "stop" },
+        });
+
+        expect(result.tool_calls).toEqual([
+          {
+            type: "tool_call",
+            id: "c1",
+            name: "write",
+            args: { path: "/etc/hosts", content: "line1" },
+          },
+        ]);
+        expect(result.invalid_tool_calls?.length).toBe(0);
+      });
+    });
+
     it("can concatenate tool call chunks without IDs", () => {
       const chunk = new AIMessageChunk({
         id: "chatcmpl-x",

--- a/libs/langchain-core/src/messages/utils.ts
+++ b/libs/langchain-core/src/messages/utils.ts
@@ -559,8 +559,15 @@ export function convertToChunk(message: BaseMessage) {
  * 2. Attempts to parse the concatenated string as JSON
  * 3. Validates that the result is a non-null object with a valid id
  * 4. Creates either a `ToolCall` (if valid) or `InvalidToolCall` (if invalid)
+ *
+ * When `truncated` is true (e.g. a stream ended with `finish_reason: "length"`),
+ * partially-repaired arguments are treated as invalid instead of being presented
+ * as a finished tool call: only strictly-complete JSON survives.
  */
-export function collapseToolCallChunks(chunks: ToolCallChunk[]): {
+export function collapseToolCallChunks(
+  chunks: ToolCallChunk[],
+  truncated?: boolean
+): {
   tool_call_chunks: ToolCallChunk[];
   tool_calls: ToolCall[];
   invalid_tool_calls: InvalidToolCall[];
@@ -604,6 +611,22 @@ export function collapseToolCallChunks(chunks: ToolCallChunk[]): {
     const joinedArgs = usesRawInputArgs ? joinedArgsRaw : joinedArgsRaw.trim();
     const argsStr = joinedArgs.length ? joinedArgs : "{}";
     const id = chunks.find((c) => c.id)?.id ?? chunks[0]?.id;
+    if (truncated) {
+      // A truncated stream must not present repaired partial JSON as a
+      // finished tool call; only strictly-complete arguments survive.
+      try {
+        JSON.parse(argsStr);
+      } catch {
+        invalidToolCalls.push({
+          name,
+          args: argsStr,
+          id,
+          error: "Truncated tool call args.",
+          type: "invalid_tool_call",
+        });
+        continue;
+      }
+    }
     if (usesRawInputArgs && id) {
       toolCalls.push({
         name,


### PR DESCRIPTION
Fixes #11469

## Problem

When a stream is cut short mid-argument (`finish_reason: "length"`), `collapseToolCallChunks` repairs the partial JSON via `parsePartialJson` and the result lands in `tool_calls` as a complete call. In the issue's example, `{"path":"/etc/hosts","content":"line1` becomes `content: "line1"`, byte-identical to a legitimately finished call — so a tool bound to that message would act on truncated input, with `invalid_tool_calls` empty and only the message-level `finish_reason` hinting at the problem.

## Fix

`collapseToolCallChunks` now accepts a `truncated` flag. `AIMessageChunk` passes it through based on `response_metadata.finish_reason === "length"` (available once chunks are merged via `concat`). When truncated, only strictly-complete arguments (`JSON.parse` succeeds) survive as finished `tool_calls`; repaired partial JSON is routed to `invalid_tool_calls` with `error: "Truncated tool call args."`.

Behavior is unchanged for non-truncated streams — partial parsing still works while arguments are arriving, and on a normal `finish_reason` repaired args are kept as before.

## Tests

Added three cases in `ai.test.ts`:
- truncated stream + partial JSON → `invalid_tool_calls`, `tool_calls` empty
- truncated stream + strictly-complete args → stays in `tool_calls`
- non-truncated stream + partial JSON → still repaired (existing behavior)