### PR TITLE
feat(anthropic): add claude-sonnet-5 model support

### DIFF
--- a/.changeset/brave-moons-smile.md
+++ b/.changeset/brave-moons-smile.md
@@ -1,0 +1,5 @@
+---
+"@langchain/anthropic": patch
+---
+
+feat(anthropic): add claude-sonnet-5 support

--- a/libs/providers/langchain-anthropic/src/chat_models.ts
+++ b/libs/providers/langchain-anthropic/src/chat_models.ts
@@ -89,6 +89,7 @@ const MODEL_DEFAULT_MAX_OUTPUT_TOKENS: Partial<
 > = {
   // Claude 5 — 128K max output
   "claude-opus-5": 16384,
+  "claude-sonnet-5": 16384,
   "claude-fable-5": 16384,
   "claude-mythos-5": 16384,
   "claude-mythos-preview": 16384,

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
@@ -1739,6 +1739,19 @@ describe("Opus 5", () => {
   }, 60000);
 });
 
+describe("Sonnet 5", () => {
+  test("invokes with adaptive thinking enabled by default", async () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      maxTokens: 1024,
+      outputConfig: { effort: "low" },
+    });
+
+    const result = await model.invoke("Reply with the word 'ready'.");
+    expect(result.content).toBeDefined();
+  }, 60000);
+});
+
 describe("Opus 4.6", () => {
   const opus46Model = "claude-opus-4-6";
 

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.test.ts
@@ -2421,6 +2421,81 @@ describe("Fable 5 and Mythos 5", () => {
   );
 });
 
+describe("Sonnet 5", () => {
+  test("default max_tokens for claude-sonnet-5 is 16384", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+    });
+
+    const params = model.invocationParams({});
+    expect(params.max_tokens).toBe(16384);
+  });
+
+  test("rejects thinking.type=enabled for claude-sonnet-5", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      thinking: { type: "enabled", budget_tokens: 2048 } as any,
+    });
+
+    expect(() => model.invocationParams({})).toThrow(
+      `thinking.type="enabled" is not supported for claude-sonnet-5; use thinking.type="adaptive" instead`
+    );
+  });
+
+  test("rejects thinking.budget_tokens for claude-sonnet-5", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      thinking: { type: "adaptive", budget_tokens: 2048 } as any,
+    });
+
+    expect(() => model.invocationParams({})).toThrow(
+      `thinking.budget_tokens is not supported for claude-sonnet-5; use outputConfig.effort instead`
+    );
+  });
+
+  test("rejects non-default sampling params for claude-sonnet-5", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+      temperature: 0.1,
+    });
+
+    expect(() => model.invocationParams({})).toThrow(
+      `temperature is not supported for claude-sonnet-5 when set to non-default values`
+    );
+  });
+
+  test("does not include sampling params for claude-sonnet-5 even if set to defaults", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+      temperature: 1,
+      topP: 1,
+    });
+
+    const params = model.invocationParams({});
+
+    expect(params.temperature).toBeUndefined();
+    expect(params.top_p).toBeUndefined();
+    expect(params.top_k).toBeUndefined();
+  });
+
+  test("allows disabled thinking for claude-sonnet-5", () => {
+    const model = new ChatAnthropic({
+      model: "claude-sonnet-5",
+      apiKey: "testing",
+      thinking: { type: "disabled" },
+    });
+
+    expect(model.invocationParams({}).thinking).toEqual({ type: "disabled" });
+  });
+});
+
 describe("withStructuredOutput - StandardSchema", () => {
   function makeSerializableSchema() {
     return {

--- a/libs/providers/langchain-anthropic/src/utils/params.ts
+++ b/libs/providers/langchain-anthropic/src/utils/params.ts
@@ -19,6 +19,7 @@ const ADAPTIVE_ONLY_MODEL_PREFIXES = [
   "claude-opus-4-7",
   "claude-opus-4-8",
   "claude-opus-5",
+  "claude-sonnet-5",
   "claude-fable-5",
   "claude-mythos-5",
   "claude-mythos-preview",


### PR DESCRIPTION
## Summary

Adds `claude-sonnet-5` support to `@langchain/anthropic`

## Changes

### `@langchain/anthropic`

- Register the Sonnet 5 default `max_tokens` alongside the other Claude 5 family entries (its capability profile already existed in `profiles.ts`).
- Treat Sonnet 5 as adaptive-thinking-only: reject legacy fixed thinking budgets, `thinking.type="enabled"`, and unsupported sampling controls (`temperature`/`top_p`/`top_k` at non-default values), matching the API behavior. `thinking.type="disabled"` remains allowed.
- Add unit coverage for default request behavior and compatibility validation, plus a live low-effort Sonnet 5 invocation test.

`pnpm lint`, `pnpm format:check`, and `pnpm --filter @langchain/anthropic test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
