### PR TITLE
fix(google): explicit googleAuthOptions must take precedence over ambient GOOGLE_API_KEY

### DIFF
--- a/.changeset/google-auth-precedence.md
+++ b/.changeset/google-auth-precedence.md
@@ -1,0 +1,9 @@
+---
+"@langchain/google": patch
+---
+
+When `googleAuthOptions` is provided, `NodeApiClient` no longer falls back to the
+ambient `GOOGLE_API_KEY` environment variable. Explicitly configured OAuth (e.g.
+Vertex AI with Application Default Credentials) previously lost header priority
+to whatever key happened to be set in the environment, causing Vertex requests
+to fail with "API keys are not supported by this API".

--- a/libs/providers/langchain-google/src/clients/node.ts
+++ b/libs/providers/langchain-google/src/clients/node.ts
@@ -240,9 +240,6 @@ export class NodeApiClient extends ApiClient {
   constructor(protected params: NodeApiClientParams = {}) {
     super();
 
-    // An explicitly provided googleAuthOptions is a deliberate choice of
-    // OAuth (e.g. Vertex ADC): it must take precedence over an ambient
-    // GOOGLE_API_KEY env var, which may belong to an unrelated service.
     this.apiKey =
       params.apiKey ??
       (params.googleAuthOptions

--- a/libs/providers/langchain-google/src/clients/node.ts
+++ b/libs/providers/langchain-google/src/clients/node.ts
@@ -240,11 +240,7 @@ export class NodeApiClient extends ApiClient {
   constructor(protected params: NodeApiClientParams = {}) {
     super();
 
-    this.apiKey =
-      params.apiKey ??
-      (params.googleAuthOptions
-        ? undefined
-        : getEnvironmentVariable("GOOGLE_API_KEY"));
+    this.apiKey = this.resolveApiKey(params);
     this.credentials = iife(() => {
       if (params.credentials) {
         return normalizeGCPCredentials(params.credentials);
@@ -264,6 +260,25 @@ export class NodeApiClient extends ApiClient {
       }
       return undefined;
     });
+  }
+
+  /**
+   * Resolves which API key applies, in priority order:
+   *
+   * 1. An explicit `apiKey` param.
+   * 2. Nothing, when the caller chose OAuth via `googleAuthOptions` — an
+   *    ambient `GOOGLE_API_KEY` (possibly belonging to an unrelated service)
+   *    must never override that choice.
+   * 3. The ambient `GOOGLE_API_KEY` environment variable.
+   */
+  private resolveApiKey(params: NodeApiClientParams): string | undefined {
+    if (params.apiKey !== undefined) {
+      return params.apiKey;
+    }
+    if (params.googleAuthOptions) {
+      return undefined;
+    }
+    return getEnvironmentVariable("GOOGLE_API_KEY");
   }
 
   /**

--- a/libs/providers/langchain-google/src/clients/node.ts
+++ b/libs/providers/langchain-google/src/clients/node.ts
@@ -240,7 +240,14 @@ export class NodeApiClient extends ApiClient {
   constructor(protected params: NodeApiClientParams = {}) {
     super();
 
-    this.apiKey = params.apiKey ?? getEnvironmentVariable("GOOGLE_API_KEY");
+    // An explicitly provided googleAuthOptions is a deliberate choice of
+    // OAuth (e.g. Vertex ADC): it must take precedence over an ambient
+    // GOOGLE_API_KEY env var, which may belong to an unrelated service.
+    this.apiKey =
+      params.apiKey ??
+      (params.googleAuthOptions
+        ? undefined
+        : getEnvironmentVariable("GOOGLE_API_KEY"));
     this.credentials = iife(() => {
       if (params.credentials) {
         return normalizeGCPCredentials(params.credentials);

--- a/libs/providers/langchain-google/src/clients/tests/node.test.ts
+++ b/libs/providers/langchain-google/src/clients/tests/node.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from "vitest";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import { NodeApiClient } from "../node.js";
+
+describe("NodeApiClient auth precedence", () => {
+  test("explicit googleAuthOptions suppress the ambient GOOGLE_API_KEY", () => {
+    vi.stubEnv("GOOGLE_API_KEY", "ambient-key-that-should-be-ignored");
+
+    const client = new NodeApiClient({
+      googleAuthOptions: {
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      },
+    });
+
+    // The ambient key must not leak into the client: if it did, fetch()
+    // would attach it as `X-Goog-Api-Key` and override OAuth on Vertex AI.
+    expect((client as unknown as { apiKey?: string }).apiKey).toBeUndefined();
+    expect(getEnvironmentVariable("GOOGLE_API_KEY")).toBe(
+      "ambient-key-that-should-be-ignored"
+    );
+
+    vi.unstubAllEnvs();
+  });
+
+  test("without googleAuthOptions, the ambient GOOGLE_API_KEY env fallback still applies", () => {
+    vi.stubEnv("GOOGLE_API_KEY", "ambient-key");
+
+    const client = new NodeApiClient({});
+
+    expect((client as unknown as { apiKey?: string }).apiKey).toBe(
+      "ambient-key"
+    );
+
+    vi.unstubAllEnvs();
+  });
+});


### PR DESCRIPTION
## Summary

`NodeApiClient` unconditionally fell back to the `GOOGLE_API_KEY` environment variable when constructing the client, so on any machine where that variable is set — possibly for an entirely unrelated service — an explicit `googleAuthOptions` configuration silently lost header priority: requests carried `X-Goog-Api-Key: <ambient>` instead of the OAuth bearer token, and Vertex AI failed with:

> API keys are not supported by this API. Expected OAuth2 access token...

The class's own documented precedence (explicit config → credentials → GoogleAuth) and `ChatGoogleNode`'s existing behavior of skipping the same env fallback when `googleAuthOptions` is present both indicate the env var should only apply when no explicit auth choice was made.

### Changes
- Skip the `GOOGLE_API_KEY` env fallback in `NodeApiClient` when `params.googleAuthOptions` is provided
- New `clients/tests/node.test.ts`: asserts ambient keys are ignored under `googleAuthOptions`, and still applied otherwise
- Changeset

### Context
Surfaced while adding live Vertex integration tests for #11444 — see #11477 (independent scope; either PR can land first).