### PR TITLE
fix(openai): skip kwargs.tool_calls when invalid_tool_calls is set

### DIFF
--- a/.changeset/skip-kwargs-tool-calls-when-invalid.md
+++ b/.changeset/skip-kwargs-tool-calls-when-invalid.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): skip additional_kwargs.tool_calls when invalid_tool_calls is set

--- a/libs/providers/langchain-openai/src/converters/completions.ts
+++ b/libs/providers/langchain-openai/src/converters/completions.ts
@@ -670,7 +670,13 @@ export const convertStandardContentMessageToCompletionsMessage: Converter<
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToOpenAI
       ) as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
-    } else if (message.additional_kwargs.tool_calls != null) {
+    } else if (
+      message.additional_kwargs.tool_calls != null &&
+      !(
+        AIMessage.isInstance(message) &&
+        (message.invalid_tool_calls?.length ?? 0) > 0
+      )
+    ) {
       completionParam.tool_calls = message.additional_kwargs
         .tool_calls as OpenAIClient.Chat.Completions.ChatCompletionMessageToolCall[];
     }
@@ -861,7 +867,13 @@ export const convertMessagesToCompletionsMessageParams: Converter<
         convertLangChainToolCallToOpenAI
       );
     } else {
-      if (message.additional_kwargs.tool_calls != null) {
+      if (
+        message.additional_kwargs.tool_calls != null &&
+        !(
+          AIMessage.isInstance(message) &&
+          (message.invalid_tool_calls?.length ?? 0) > 0
+        )
+      ) {
         completionParam.tool_calls = message.additional_kwargs.tool_calls;
       }
       if (ToolMessage.isInstance(message) && message.tool_call_id != null) {

--- a/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/completions.test.ts
@@ -419,6 +419,99 @@ describe("convertCompletionsMessageToBaseMessage", () => {
         },
       });
     });
+
+    describe("invalid_tool_calls vs additional_kwargs.tool_calls", () => {
+      const rawLegacyToolCalls = [
+        {
+          id: "call_legacy",
+          type: "function" as const,
+          function: {
+            name: "get_weather",
+            arguments: '{"location":"SF"}',
+          },
+        },
+      ];
+
+      const invalidToolCalls = [
+        {
+          id: "call_legacy",
+          name: "get_weather",
+          args: '{"location":"SF"}',
+          error: "Malformed args.",
+        },
+      ];
+
+      function makeLegacyKwargsMessage(options: {
+        invalid: boolean;
+        outputVersion?: "v1";
+      }) {
+        return new AIMessage({
+          content: "",
+          // Explicit empty tool_calls so AIMessage does not parse
+          // additional_kwargs.tool_calls into structured tool_calls.
+          tool_calls: [],
+          invalid_tool_calls: options.invalid ? invalidToolCalls : [],
+          additional_kwargs: { tool_calls: rawLegacyToolCalls },
+          ...(options.outputVersion
+            ? { response_metadata: { output_version: options.outputVersion } }
+            : {}),
+        });
+      }
+
+      it("legacy converter skips kwargs.tool_calls when invalid_tool_calls is set", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const result = convertMessagesToCompletionsMessageParams({
+          messages: [makeLegacyKwargsMessage({ invalid: true })],
+        });
+        warnSpy.mockRestore();
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).not.toHaveProperty("tool_calls");
+      });
+
+      it("legacy converter still serializes kwargs.tool_calls without invalid_tool_calls", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const result = convertMessagesToCompletionsMessageParams({
+          messages: [makeLegacyKwargsMessage({ invalid: false })],
+        });
+        warnSpy.mockRestore();
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          role: "assistant",
+          tool_calls: rawLegacyToolCalls,
+        });
+      });
+
+      it("standard-content converter skips kwargs.tool_calls when invalid_tool_calls is set", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const result = convertMessagesToCompletionsMessageParams({
+          messages: [
+            makeLegacyKwargsMessage({ invalid: true, outputVersion: "v1" }),
+          ],
+        });
+        warnSpy.mockRestore();
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).not.toHaveProperty("tool_calls");
+      });
+
+      it("standard-content converter still serializes kwargs.tool_calls without invalid_tool_calls", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const result = convertMessagesToCompletionsMessageParams({
+          messages: [
+            makeLegacyKwargsMessage({ invalid: false, outputVersion: "v1" }),
+          ],
+        });
+        warnSpy.mockRestore();
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          role: "assistant",
+          tool_calls: rawLegacyToolCalls,
+        });
+      });
+    });
   });
 
   describe("completionsApiContentBlockConverter.fromStandardFileBlock", () => {


### PR DESCRIPTION
## Description

When streaming tool-call arguments fail to parse, `@langchain/core` records `invalid_tool_calls` with `Malformed args.` and leaves `tool_calls` empty. LangGraph `toolsCondition` therefore routes to `END` without a `ToolMessage`.

On the next model call, `@langchain/openai` still serializes `additional_kwargs.tool_calls` (the raw OpenAI payload kept for compatibility) onto the Completions request. The provider then sees an assistant turn with `tool_calls` and no matching `role: tool` results, and returns `400 INVALID_TOOL_RESULTS`.

This change skips the `additional_kwargs.tool_calls` fallback when `invalid_tool_calls` is non-empty. Messages that only have legacy kwargs (no `invalid_tool_calls`) are unchanged.

## Motivation

Same `AIMessage` currently has two semantics:
- Graph routing looks at empty `tool_calls` → no tool execution
- Outbound conversion looks at `additional_kwargs.tool_calls` → request still has `tool_calls`

That mismatch is not implied by the OpenAI tool-calling protocol; it is leftover compatibility behavior.

## Changes

- `convertStandardContentMessageToCompletionsMessage`
- `convertMessagesToCompletionsMessageParams`

## Test plan

- [x] Unit tests for the converter (legacy + v1 / standard-content paths)
- [x] Persist an AIMessage with empty `tool_calls`, non-empty `invalid_tool_calls`, and `additional_kwargs.tool_calls`; next `invoke` must not send `tool_calls`
- [x] Legacy AIMessage with only `additional_kwargs.tool_calls` still serializes them