### PR TITLE
fix(aws): skip duplicate tool_call content blocks

### DIFF
--- a/.changeset/quiet-tools-repeat.md
+++ b/.changeset/quiet-tools-repeat.md
@@ -1,0 +1,5 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): skip duplicate tool_call content blocks (#11476)

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -566,6 +566,52 @@ describe("convertToConverseMessages", () => {
       },
     },
     {
+      name: "tool_call content blocks are skipped when tool_calls is present",
+      input: [
+        new HumanMessage("What's the weather in SF?"),
+        new AIMessage({
+          content: [
+            { type: "text", text: "Let me check the weather for you." },
+            {
+              type: "tool_call",
+              id: "call_123",
+              name: "get_weather",
+              args: { location: "San Francisco" },
+            },
+          ],
+          tool_calls: [
+            {
+              id: "call_123",
+              name: "get_weather",
+              args: { location: "San Francisco" },
+            },
+          ],
+        }),
+      ],
+      output: {
+        converseSystem: [],
+        converseMessages: [
+          {
+            role: BedrockConversationRole.USER,
+            content: [{ text: "What's the weather in SF?" }],
+          },
+          {
+            role: BedrockConversationRole.ASSISTANT,
+            content: [
+              { text: "Let me check the weather for you." },
+              {
+                toolUse: {
+                  toolUseId: "call_123",
+                  name: "get_weather",
+                  input: { location: "San Francisco" },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       name: "standard v1 format with tool_call blocks (e.g., from Anthropic provider)",
       input: [
         new SystemMessage("You're an advanced AI assistant."),

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -620,6 +620,10 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         }
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push(convertCachePointBlock(block));
+      } else if (block.type === "tool_call") {
+        // Tool calls are serialized from msg.tool_calls below. The content
+        // block is a duplicate representation used by some providers.
+        return;
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")


### PR DESCRIPTION
Fixes #11476

`ChatBedrockConverse` already serializes `AIMessage.tool_calls` into Bedrock `toolUse` blocks. This skips the duplicate `tool_call` content block emitted by some providers instead of rejecting an otherwise valid assistant message.

Added a focused conversion regression covering text plus duplicate `tool_call` content and the canonical `tool_calls` field. `git diff --check` passes; local Vitest execution is pending isolated workspace dependency linking.