### PR TITLE
fix(openai): preserve audio in Responses input

### DIFF
--- a/.changeset/preserve-responses-audio.md
+++ b/.changeset/preserve-responses-audio.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Preserve supported audio blocks when converting messages to Responses API input.

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1163,6 +1163,30 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       return undefined;
     };
 
+    const resolveAudioItem = (
+      block: ContentBlock.Multimodal.Audio
+    ): OpenAIClient.Responses.ResponseInputAudio | undefined => {
+      if (!block.data) {
+        return undefined;
+      }
+      const format = block.mimeType?.split("/")[1];
+      if (format !== "mp3" && format !== "wav") {
+        throw new Error(
+          "Audio content blocks must have mime type of audio/wav or audio/mp3 for the Responses API"
+        );
+      }
+      return {
+        type: "input_audio",
+        input_audio: {
+          data:
+            typeof block.data === "string"
+              ? block.data
+              : Buffer.from(block.data).toString("base64"),
+          format,
+        },
+      };
+    };
+
     const convertReasoningBlock = (
       block: ContentBlock.Reasoning
     ): OpenAIClient.Responses.ResponseReasoningItem => {
@@ -1297,7 +1321,10 @@ export const convertStandardContentMessageToResponsesInput: Converter<
         yield* flushMessage();
         yield convertFunctionCallOutput(block);
       } else if (block.type === "audio") {
-        // no-op
+        const audioItem = resolveAudioItem(block);
+        if (audioItem) {
+          pushMessageContent([audioItem]);
+        }
       } else if (block.type === "file") {
         const fileItem = resolveFileItem(block);
         if (fileItem) {

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1052,6 +1052,37 @@ describe("convertStandardContentMessageToResponsesInput", () => {
     ]);
   });
 
+  it("converts v1 audio blocks to Responses API input_audio", () => {
+    const message = new HumanMessage({
+      content: [
+        { type: "text", text: "Transcribe this clip" },
+        {
+          type: "audio",
+          source_type: "base64",
+          mime_type: "audio/wav",
+          data: "UklGRg==",
+        },
+      ],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const result = convertStandardContentMessageToResponsesInput(message);
+
+    expect(result).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Transcribe this clip" },
+          {
+            type: "input_audio",
+            input_audio: { data: "UklGRg==", format: "wav" },
+          },
+        ],
+      },
+    ]);
+  });
+
   it("preserves OpenAI-only non_standard content when present", () => {
     const message = new AIMessage({
       contentBlocks: [


### PR DESCRIPTION
## Summary
- convert v1 `audio/wav` and `audio/mp3` blocks to Responses API `input_audio` items
- preserve `Uint8Array` audio by encoding it as base64
- reject unsupported audio MIME types explicitly rather than silently dropping the attachment
- add regression coverage for a legacy HumanMessage audio block

## Validation
- `git diff --check`

The focused Vitest suite could not start in this environment because the concurrent pnpm workspace install did not create the required internal package links; the failure was module resolution for `@langchain/tsconfig`, before the test file executed.

Fixes #11460