### PR TITLE
fix(aws): skip tool_call/tool_use content blocks in convertAIMessageToConverseMessage

### DIFF
--- a/.changeset/fix-bedrock-skip-tool-call-blocks.md
+++ b/.changeset/fix-bedrock-skip-tool-call-blocks.md
@@ -1,0 +1,11 @@
+---
+"@langchain/aws": patch
+---
+
+fix(aws): skip `tool_call`/`tool_use` content blocks in `convertAIMessageToConverseMessage`
+
+`ChatBedrockConverse` threw `Unsupported content block type: tool_call` when an
+assistant message carried a `tool_call` (or `tool_use`) content block in its
+`content` array — e.g. when replaying history from another provider or an agent
+loop. Tool calls are already serialized from `msg.tool_calls`, so such blocks
+are duplicates and are now skipped instead of rejected.

--- a/libs/providers/langchain-aws/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-aws/src/tests/chat_models.test.ts
@@ -766,6 +766,47 @@ describe("reasoning content replay", () => {
     ]);
   });
 
+  it("skips tool_call content blocks when no output version is set", () => {
+    const result = convertToConverseMessages([
+      new AIMessage({
+        content: [
+          { type: "text", text: "Let me check the weather for you." },
+          {
+            type: "tool_call",
+            id: "call_123",
+            name: "get_weather",
+            args: { location: "San Francisco" },
+          },
+        ],
+        tool_calls: [
+          {
+            name: "get_weather",
+            args: { location: "San Francisco" },
+            id: "call_123",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: "call_123",
+        content: "72°F and sunny",
+      }),
+    ]);
+
+    expect(result.converseMessages[0].content).toEqual([
+      {
+        text: "Let me check the weather for you.",
+      },
+      {
+        toolUse: {
+          toolUseId: "call_123",
+          name: "get_weather",
+          input: { location: "San Francisco" },
+        },
+      },
+    ]);
+  });
+
   it("replays standard reasoning without an output version", () => {
     const result = convertToConverseMessages([
       new AIMessage({

--- a/libs/providers/langchain-aws/src/utils/message_inputs.ts
+++ b/libs/providers/langchain-aws/src/utils/message_inputs.ts
@@ -620,6 +620,10 @@ function convertAIMessageToConverseMessage(msg: AIMessage): Bedrock.Message {
         }
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push(convertCachePointBlock(block));
+      } else if (block.type === "tool_call" || block.type === "tool_use") {
+        // Tool calls are already serialized from msg.tool_calls below; a
+        // tool_call/tool_use content block is a duplicate that must be
+        // skipped rather than rejected.
       } else {
         const blockValues = Object.fromEntries(
           Object.entries(block).filter(([key]) => key !== "type")


### PR DESCRIPTION
Fixes #11476

## Problem

`ChatBedrockConverse` throws `Unsupported content block type: tool_call` when an assistant message's `content` array contains a `tool_call` (or `tool_use`) block. `convertAIMessageToConverseMessage` iterates content blocks and throws on any unrecognized `type` — but tool calls are already serialized from the separate `msg.tool_calls` field a few lines later. So a `tool_call` content block is a duplicate that should be skipped, not thrown on: the converter rejects a message shape the same class produces (e.g. when replaying history from an agent loop).

## Fix

Skip `tool_call` / `tool_use` content blocks in the `content` loop (they are already emitted from `msg.tool_calls` below), rather than throwing. Exactly the one-branch skip from the issue's suggested fix.

## Tests

Added a regression test in `chat_models.test.ts` asserting that an assistant message with a `tool_call` content block (and matching `tool_calls`) converts without throwing and produces the expected `toolUse` block, deduplicated from `msg.tool_calls`.