### PR TITLE
feat(langchain): support HITL respond decisions

### DIFF
--- a/.changeset/hitl-respond-decision.md
+++ b/.changeset/hitl-respond-decision.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+feat(langchain): support HITL respond decisions

--- a/libs/langchain/src/agents/middleware/hitl.ts
+++ b/libs/langchain/src/agents/middleware/hitl.ts
@@ -73,9 +73,10 @@ export type DescriptionFactory = z.infer<typeof DescriptionFunctionSchema>;
 /**
  * The type of decision a human can make.
  */
-const ALLOWED_DECISIONS = ["approve", "edit", "reject"] as const;
+const ALLOWED_DECISIONS = ["approve", "edit", "reject", "respond"] as const;
 const DecisionType = z.enum(ALLOWED_DECISIONS);
 export type DecisionType = z.infer<typeof DecisionType>;
+const DEFAULT_ALLOWED_DECISIONS: DecisionType[] = ["approve", "edit", "reject"];
 
 const InterruptOnConfigSchema = z.object({
   /**
@@ -267,9 +268,24 @@ export interface RejectDecision {
 }
 
 /**
+ * Response when a human answers on behalf of the tool.
+ */
+export interface RespondDecision {
+  type: "respond";
+  /**
+   * The message sent to the model as the tool result.
+   */
+  message: string;
+}
+
+/**
  * Union of all possible decision types.
  */
-export type Decision = ApproveDecision | EditDecision | RejectDecision;
+export type Decision =
+  | ApproveDecision
+  | EditDecision
+  | RejectDecision
+  | RespondDecision;
 
 /**
  * Response payload for a HITLRequest.
@@ -661,6 +677,25 @@ export function humanInTheLoopMiddleware(
       return { revisedToolCall: toolCall, toolMessage };
     }
 
+    if (decision.type === "respond" && allowedDecisions.includes("respond")) {
+      if (typeof decision.message !== "string") {
+        throw new Error(
+          `Tool call response for "${
+            toolCall.name
+          }" must be a string, got ${typeof decision.message}`
+        );
+      }
+
+      const toolMessage = new ToolMessage({
+        content: decision.message,
+        name: toolCall.name,
+        tool_call_id: toolCall.id!,
+        status: "success",
+      });
+
+      return { revisedToolCall: toolCall, toolMessage };
+    }
+
     const msg = `Unexpected human decision: ${JSON.stringify(
       decision
     )}. Decision type '${decision.type}' is not allowed for tool '${
@@ -717,7 +752,7 @@ export function humanInTheLoopMiddleware(
           if (typeof toolConfig === "boolean") {
             if (toolConfig === true) {
               resolvedConfigs[toolName] = {
-                allowedDecisions: [...ALLOWED_DECISIONS],
+                allowedDecisions: [...DEFAULT_ALLOWED_DECISIONS],
               };
             }
           } else if (toolConfig.allowedDecisions) {
@@ -811,6 +846,9 @@ export function humanInTheLoopMiddleware(
         const hasRejectedToolCalls = decisions.some(
           (decision) => decision.type === "reject"
         );
+        const hasRespondedToolCalls = decisions.some(
+          (decision) => decision.type === "respond"
+        );
 
         /**
          * Process each decision using helper method
@@ -833,7 +871,9 @@ export function humanInTheLoopMiddleware(
              * with only the tool calls that were rejected as we don't know
              * the results of the approved/updated tool calls at this point.
              */
-            (!hasRejectedToolCalls || decision.type === "reject")
+            (!hasRejectedToolCalls ||
+              decision.type === "reject" ||
+              decision.type === "respond")
           ) {
             revisedToolCalls.push(revisedToolCall);
           }
@@ -849,9 +889,17 @@ export function humanInTheLoopMiddleware(
           lastMessage.tool_calls = revisedToolCalls;
         }
 
-        const jumpTo: JumpToTarget | undefined = hasRejectedToolCalls
-          ? "model"
-          : undefined;
+        const hasPendingToolCalls = revisedToolCalls.some(
+          (toolCall) =>
+            !artificialToolMessages.some(
+              (message) => message.tool_call_id === toolCall.id
+            )
+        );
+        const jumpTo: JumpToTarget | undefined =
+          hasRejectedToolCalls ||
+          (hasRespondedToolCalls && !hasPendingToolCalls)
+            ? "model"
+            : undefined;
         return {
           messages: [lastMessage, ...artificialToolMessages],
           jumpTo,

--- a/libs/langchain/src/agents/middleware/tests/hitl.test.ts
+++ b/libs/langchain/src/agents/middleware/tests/hitl.test.ts
@@ -491,6 +491,176 @@ describe("humanInTheLoopMiddleware", () => {
     );
   });
 
+  it("should handle respond decision type", async () => {
+    const hitlMiddleware = humanInTheLoopMiddleware({
+      interruptOn: {
+        write_file: {
+          allowedDecisions: ["respond"],
+        },
+      },
+    });
+
+    const model = new FakeToolCallingModel({
+      toolCalls: [
+        [
+          {
+            id: "call_1",
+            name: "write_file",
+            args: { filename: "manual.txt", content: "Manual content" },
+          },
+        ],
+        [],
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createAgent({
+      model,
+      checkpointer,
+      tools: [writeFileTool],
+      middleware: [hitlMiddleware],
+    });
+
+    const config = {
+      configurable: {
+        thread_id: "test-respond",
+      },
+    };
+
+    const initialResult = await agent.invoke(
+      {
+        messages: [new HumanMessage("Ask the human before writing")],
+      },
+      config
+    );
+
+    const interruptRequest = initialResult
+      .__interrupt__?.[0] as Interrupt<HITLRequest>;
+    expect(interruptRequest.value.reviewConfigs[0].allowedDecisions).toEqual([
+      "respond",
+    ]);
+
+    const resumedResult = await agent.invoke(
+      new Command({
+        resume: {
+          decisions: [
+            {
+              type: "respond",
+              message: "Use ap-south-1 instead.",
+            },
+          ],
+        } as HITLResponse,
+      }),
+      config
+    );
+
+    expect(writeFileFn).not.toHaveBeenCalled();
+
+    const toolMessage = resumedResult.messages.find((msg: BaseMessage) =>
+      ToolMessage.isInstance(msg)
+    ) as ToolMessage;
+
+    expect(toolMessage).toBeDefined();
+    expect(toolMessage.content).toBe("Use ap-south-1 instead.");
+    expect(toolMessage.tool_call_id).toBe("call_1");
+    expect(toolMessage.status).toBe("success");
+  });
+
+  it("should execute approved tools when another tool is answered with respond", async () => {
+    const hitlMiddleware = humanInTheLoopMiddleware({
+      interruptOn: {
+        calculator: {
+          allowedDecisions: ["respond"],
+        },
+        write_file: {
+          allowedDecisions: ["approve"],
+        },
+      },
+    });
+
+    const model = new FakeToolCallingModel({
+      toolCalls: [
+        [
+          {
+            id: "call_1",
+            name: "calculator",
+            args: { a: 3, b: 4, operation: "add" },
+          },
+          {
+            id: "call_2",
+            name: "write_file",
+            args: { filename: "approved.txt", content: "approved" },
+          },
+        ],
+        [],
+      ],
+    });
+
+    const checkpointer = new MemorySaver();
+    const agent = createAgent({
+      model,
+      checkpointer,
+      tools: [calculateTool, writeFileTool],
+      middleware: [hitlMiddleware],
+    });
+
+    const config = {
+      configurable: {
+        thread_id: "test-respond-with-approved",
+      },
+    };
+
+    await agent.invoke(
+      {
+        messages: [new HumanMessage("Calculate and write the result")],
+      },
+      config
+    );
+
+    const resumedResult = await agent.invoke(
+      new Command({
+        resume: {
+          decisions: [
+            { type: "respond", message: "3 + 4 = 7" },
+            { type: "approve" },
+          ],
+        } as HITLResponse,
+      }),
+      config
+    );
+
+    expect(calculatorFn).not.toHaveBeenCalled();
+    expect(writeFileFn).toHaveBeenCalledTimes(1);
+    expect(writeFileFn).toHaveBeenCalledWith(
+      {
+        filename: "approved.txt",
+        content: "approved",
+      },
+      expect.anything()
+    );
+
+    const toolMessages = resumedResult.messages.filter((msg: BaseMessage) =>
+      ToolMessage.isInstance(msg)
+    ) as ToolMessage[];
+
+    expect(
+      toolMessages.some(
+        (msg) =>
+          msg.tool_call_id === "call_1" &&
+          msg.content === "3 + 4 = 7" &&
+          msg.status === "success"
+      )
+    ).toBe(true);
+    expect(
+      toolMessages.some(
+        (msg) =>
+          msg.tool_call_id === "call_2" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Successfully wrote")
+      )
+    ).toBe(true);
+  });
+
   it("should generate default rejection message when message is not provided", async () => {
     const hitlMiddleware = humanInTheLoopMiddleware({
       interruptOn: {


### PR DESCRIPTION
Adds support for a `respond` human-in-the-loop decision so reviewers can answer on behalf of a tool without executing it.

This creates a successful `ToolMessage` from the reviewer-provided response, keeps responded tool calls in the revised assistant message, and routes back to the model when there are no remaining approved/edited tool calls to execute. The default `interruptOn: true` behavior remains unchanged and still expands to approve/edit/reject only; `respond` must be explicitly allowed.

Fixes #11356

Validation:
- `corepack pnpm --filter langchain build`
- `corepack pnpm --dir libs/langchain exec vitest run src/agents/middleware/tests/hitl.test.ts`
- `corepack pnpm exec oxfmt --check libs/langchain/src/agents/middleware/hitl.ts libs/langchain/src/agents/middleware/tests/hitl.test.ts`
- `git diff --check`