### PR TITLE
fix(core): use functionCall.id for contentBlocks tool_call id in Google translators

### DIFF
--- a/libs/langchain-core/src/messages/block_translators/google.ts
+++ b/libs/langchain-core/src/messages/block_translators/google.ts
@@ -71,7 +71,7 @@ function convertToV1FromChatGoogleMessage(
         ) {
           return {
             type: "tool_call",
-            id: message.id,
+            id: block.functionCall.id,
             name: block.functionCall.name,
             args: block.functionCall.args,
           };

--- a/libs/langchain-core/src/messages/block_translators/google_genai.ts
+++ b/libs/langchain-core/src/messages/block_translators/google_genai.ts
@@ -47,7 +47,7 @@ function convertToV1FromChatGoogleMessage(
       ) {
         yield {
           type: "tool_call",
-          id: message.id,
+          id: block.functionCall.id,
           name: block.functionCall.name,
           args: block.functionCall.args,
         };

--- a/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/google.test.ts
@@ -101,6 +101,34 @@ describe("ChatGoogleTranslator", () => {
     ]);
   });
 
+  it("should set contentBlocks tool_call id from functionCall.id, not message.id", () => {
+    const message = new AIMessage({
+      content: [
+        {
+          type: "functionCall",
+          functionCall: {
+            id: "fn-abc123",
+            name: "calculator",
+            args: { expression: "1 + 1" },
+          },
+        },
+      ],
+      tool_calls: [
+        { type: "tool_call", id: "fn-abc123", name: "calculator", args: { expression: "1 + 1" } },
+      ],
+      response_metadata: { model_provider: "google" },
+    });
+
+    expect(message.contentBlocks).toEqual([
+      {
+        type: "tool_call",
+        id: "fn-abc123",
+        name: "calculator",
+        args: { expression: "1 + 1" },
+      },
+    ]);
+  });
+
   it("should pass through array content when no thoughtSignature exists", () => {
     const message = new AIMessage({
       content: [


### PR DESCRIPTION
## What Problem This Solves

Fixes #11110

`AIMessage.contentBlocks` returns Gemini tool_call blocks with `id: undefined` while `AIMessage.tool_calls` has the correct id. This happens because both Google block translators (`google_genai.ts` and `google.ts`) set the tool_call id from `message.id` (the AIMessage's auto-generated UUID) instead of `block.functionCall.id` (the actual tool call id from the Gemini API).

## Why This Change Was Made

Downstream code expecting `contentBlock.id` to match the tool call id breaks — for example, matching tool results back to their calls via contentBlocks fails silently.

## User Impact

Any code that uses `message.contentBlocks` to access tool call ids on Google/Gemini responses will now get the correct id instead of `undefined`.

## Evidence

- Regression test added to `google.test.ts` confirming `contentBlocks` returns `id: "fn-abc123"` from `functionCall.id`
- All existing block_translator tests pass (83/83, 1 pre-existing skip in bedrock_converse.test.ts unrelated to this change)
