### PR TITLE
fix(mistralai): preserve streamed tool call IDs

### DIFF
--- a/libs/providers/langchain-mistralai/src/chat_models.ts
+++ b/libs/providers/langchain-mistralai/src/chat_models.ts
@@ -449,13 +449,14 @@ function mistralAIResponseToChatMessage(
   }
 }
 
-function _convertDeltaToMessageChunk(
+export function _convertDeltaToMessageChunk(
   delta: {
     role?: string | null | undefined;
     content?: string | MistralAIContentChunk[] | null | undefined;
     toolCalls?: MistralAIToolCall[] | null | undefined;
   },
-  usage?: MistralAITokenUsage | null
+  usage?: MistralAITokenUsage | null,
+  toolCallIds?: Map<number, string>
 ) {
   if (!delta.content && !delta.toolCalls) {
     if (usage) {
@@ -477,12 +478,16 @@ function _convertDeltaToMessageChunk(
   // need to insert it here.
   const rawToolCallChunksWithIndex = delta.toolCalls?.length
     ? delta.toolCalls?.map(
-        (toolCall, index): MistralAIToolCall & { index: number } => ({
-          ...toolCall,
-          index,
-          id: toolCall.id ?? uuidv4().replace(/-/g, ""),
-          type: "function",
-        })
+        (toolCall, index): MistralAIToolCall & { index: number } => {
+          const id =
+            toolCall.id && toolCall.id !== "null"
+              ? toolCall.id
+              : toolCallIds?.get(index) ?? uuidv4().replace(/-/g, "");
+          if (toolCall.function?.name) {
+            toolCallIds?.set(index, id);
+          }
+          return { ...toolCall, index, id, type: "function" };
+        }
       )
     : undefined;
 
@@ -1278,6 +1283,7 @@ export class ChatMistralAI<
     };
 
     const streamIterable = await this.completionWithRetry(input, true);
+    const toolCallIds = new Map<number, string>();
     for await (const { data } of streamIterable) {
       if (options.signal?.aborted) {
         return;
@@ -1298,7 +1304,8 @@ export class ChatMistralAI<
       const shouldStreamUsage = this.streamUsage || options.streamUsage;
       const message = _convertDeltaToMessageChunk(
         delta,
-        shouldStreamUsage ? data.usage : null
+        shouldStreamUsage ? data.usage : null,
+        toolCallIds
       );
       if (message === null) {
         // Do not yield a chunk if the message is empty

--- a/libs/providers/langchain-mistralai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-mistralai/src/tests/chat_models.test.ts
@@ -9,6 +9,7 @@ import { OutputParserException } from "@langchain/core/output_parsers";
 import {
   ChatMistralAI,
   convertMessagesToMistralMessages,
+  _convertDeltaToMessageChunk,
 } from "../chat_models.js";
 import {
   _isValidMistralToolCallId,
@@ -64,6 +65,43 @@ test("Constructor supports string model shorthand", () => {
 
   expect(shorthand.model).toBe(explicit.model);
   expect(shorthand.temperature).toBe(explicit.temperature);
+});
+
+test("preserves the tool call ID for a null-ID continuation chunk", () => {
+  const toolCallIds = new Map<number, string>();
+  const firstChunk = _convertDeltaToMessageChunk(
+    {
+      toolCalls: [
+        {
+          id: "chatcmpl-tool-123",
+          function: { name: "write_file", arguments: "" },
+        },
+      ],
+    } as never,
+    undefined,
+    toolCallIds
+  );
+  const continuationChunk = _convertDeltaToMessageChunk(
+    {
+      toolCalls: [
+        {
+          id: "null",
+          function: {
+            name: "",
+            arguments: '{"file_path":"/one.txt","content":"one"}',
+          },
+        },
+      ],
+    } as never,
+    undefined,
+    toolCallIds
+  );
+
+  expect(firstChunk).toBeInstanceOf(AIMessageChunk);
+  expect(continuationChunk).toBeInstanceOf(AIMessageChunk);
+  expect((continuationChunk as AIMessageChunk).tool_call_chunks?.[0]?.id).toBe(
+    "chatcmpl-tool-123"
+  );
 });
 
 /**


### PR DESCRIPTION
(This PR is AI-authored and human-supervised. )

## Summary
- preserve the prior tool-call ID when Mistral streams an unnamed continuation with `id: "null"`
- add a regression test for the observed named-call / null-ID continuation sequence

## Problem
Mistral-hosted `glm-5-2` can stream a tool call in two chunks: the first has the function name and a normal ID, while the continuation has arguments but `name: ""` and `id: "null"`. The adapter assigned a new UUID to that continuation, preventing LangChain from merging its arguments with the original tool call.

## Validation
- `pnpm --filter @langchain/mistralai exec vitest run src/tests/chat_models.test.ts -t null`

The package-wide TypeScript check remains blocked by two unrelated existing errors in `internal/standard-tests/src/integration_tests/chat_models.ts` and `src/utils/stream_events.ts`.

This fixes the sequential continuation shape. Parallel responses that omit distinct IDs/indexes for multiple continuations remain ambiguous at the provider boundary.