### PR TITLE
fix(openrouter): surface top-level provider field in response_metadata

### DIFF
--- a/.changeset/openrouter-surface-provider-metadata.md
+++ b/.changeset/openrouter-surface-provider-metadata.md
@@ -1,0 +1,13 @@
+---
+"@langchain/openrouter": patch
+---
+
+fix(openrouter): surface OpenRouter's top-level `provider` field in `response_metadata`
+
+OpenRouter's non-streaming chat completions response includes a top-level
+`provider` field naming the upstream that actually served the request (e.g.
+`"DigitalOcean"`). `convertOpenRouterResponseToBaseMessage` never read it, so
+`response_metadata` exposed only the hardcoded `model_provider: "openrouter"`
+and callers had no per-call way to tell which upstream answered. The field is
+now copied through when present, matching the Python `langchain-openrouter`
+package which sets `response_metadata["provider"]` in `_create_chat_result`.

--- a/libs/providers/langchain-openrouter/src/api-types.ts
+++ b/libs/providers/langchain-openrouter/src/api-types.ts
@@ -544,6 +544,12 @@ export namespace OpenRouter {
     choices: ChatResponseChoice[];
     created: number;
     model: string;
+    /**
+     * The upstream inference provider that actually served the request
+     * (e.g. `"DigitalOcean"`, `"Together"`). OpenRouter routes each call to
+     * one of several upstreams, and this names the one that answered.
+     */
+    provider?: string;
     object: "chat.completion";
     system_fingerprint?: string | null;
     usage?: ChatGenerationTokenUsage;

--- a/libs/providers/langchain-openrouter/src/converters/messages.ts
+++ b/libs/providers/langchain-openrouter/src/converters/messages.ts
@@ -90,6 +90,16 @@ export function convertOpenRouterResponseToBaseMessage(
     finish_reason: choice.finish_reason,
   };
 
+  // Surface the upstream inference provider that actually served the call
+  // (e.g. "DigitalOcean"). OpenRouter routes each request to one of several
+  // upstreams, and the OpenAI completions converter doesn't know about this
+  // OpenRouter-specific top-level field, so copy it through when present.
+  // Mirrors the Python `langchain-openrouter` package, which sets
+  // `response_metadata["provider"]` in `_create_chat_result`.
+  if (typeof rawResponse.provider === "string") {
+    message.response_metadata.provider = rawResponse.provider;
+  }
+
   return message;
 }
 

--- a/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
@@ -109,6 +109,7 @@ describe("convertOpenRouterResponseToBaseMessage metadata", () => {
       choices: [choice],
       created: 0,
       model: "anthropic/claude-4-sonnet",
+      provider: "Anthropic",
       object: "chat.completion",
     };
 
@@ -119,6 +120,28 @@ describe("convertOpenRouterResponseToBaseMessage metadata", () => {
     expect(meta.model_provider).toBe("openrouter");
     expect(meta.model_name).toBe("anthropic/claude-4-sonnet");
     expect(meta.finish_reason).toBe("stop");
+    expect(meta.provider).toBe("Anthropic");
+  });
+
+  it("omits provider from response_metadata when absent", () => {
+    const choice: OpenRouter.ChatResponseChoice = {
+      index: 0,
+      finish_reason: "stop",
+      message: { role: "assistant", content: "hello" },
+    };
+    const rawResponse: OpenRouter.ChatResponse = {
+      id: "gen-124",
+      choices: [choice],
+      created: 0,
+      model: "anthropic/claude-4-sonnet",
+      object: "chat.completion",
+    };
+
+    const msg = convertOpenRouterResponseToBaseMessage(choice, rawResponse);
+
+    const meta = msg.response_metadata as Record<string, unknown>;
+    expect(meta.model_provider).toBe("openrouter");
+    expect("provider" in meta).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #11509

## What

OpenRouter's non-streaming chat completions response includes a top-level `provider` field naming the upstream that actually served the request (e.g. `"DigitalOcean"`, `"Anthropic"`). `convertOpenRouterResponseToBaseMessage` never read it, so `response_metadata` exposed only the hardcoded `model_provider: "openrouter"` — callers had no per-call way to tell which upstream answered, which matters for cost attribution and per-provider quality debugging.

## Fix

- Add the optional `provider` field to the `OpenRouter.ChatResponse` type in `api-types.ts`.
- In `convertOpenRouterResponseToBaseMessage`, copy `rawResponse.provider` into `response_metadata.provider` when it's a string (absent → not added, so existing responses are unchanged).

This mirrors the Python `langchain-openrouter` package, which sets `response_metadata["provider"]` in `_create_chat_result`.

Scope note: this handles the non-streaming `invoke()` path from the issue. The streaming path is intentionally left for a follow-up — `provider` isn't in core's keep-incoming `_mergeDicts` list, so naively setting it on every chunk would concatenate the value across chunks (`"DigitalOceanDigitalOcean..."`); doing it correctly needs set-once handling I didn't want to fold into this small fix.

## Tests

Updated the existing `convertOpenRouterResponseToBaseMessage metadata` test to assert `provider` is surfaced, and added a case asserting it's omitted when the API doesn't return it.

## Validation (real results on this branch)

Toolchain: Node 22, pnpm 10.14.0. `@langchain/core`/`@langchain/openai` were resolved from source via a temp vitest config (`resolve.conditions: ["input"]` + inlining `@langchain/*`) since their `dist/` wasn't built locally; that temp config is not part of this PR.

- Package unit suite (int tests excluded, as the repo's default config does): `7 files, 88 tests passed`.
- Converters test with typecheck enabled: `21 passed`, `Type Errors: no errors`.
- RED→GREEN: reverting only the source copy-through → `patches response_metadata with openrouter fields` fails with `expected undefined to be 'Anthropic'`; restoring → green.
- `oxlint libs/providers/langchain-openrouter/src/` and `oxfmt --check` on the changed files: clean.

The `*.int.test.ts` suites require a live `OPENROUTER_API_KEY` and were not run (no network credentials).

Happy to adjust the approach or add the streaming case in this PR if you'd prefer it here.
