### PR TITLE
docs: fix typo and standardize Deep Agents link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 LangChain is a framework for building LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development — all while future-proofing decisions as the underlying technology evolves.
 
 > [!TIP]
-> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/javascript/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilites for common usage patterns such as planning, subagents, file system usage, and more.
+> Just getting started? Check out **[Deep Agents](https://docs.langchain.com/oss/javascript/deepagents/overview)** — a higher-level package built on LangChain for agents that have built-in capabilities for common usage patterns such as planning, subagents, file system usage, and more.
 
 **Documentation**: To learn more about LangChain, check out [the docs](https://docs.langchain.com/oss/javascript/langchain/overview).
 


### PR DESCRIPTION
## Summary
Fix a typo and standardize the Deep Agents link in the README's getting-started tip.

## Changes
- `capabilites` → `capabilities`
- Use the canonical `https://docs.langchain.com/oss/javascript/deepagents/overview` URL (was plain-`http` and missing the `/overview` path segment), matching how the same page is linked elsewhere in the README.

## Validation
- `curl -sIL https://docs.langchain.com/oss/javascript/deepagents/overview` → HTTP 200
- `git diff --check` clean; single-line, docs-only change, no tests required.

## Issue
n/a (trivial docs fix)