### PR TITLE
fix(core): preserve tool calls after blank streamed text blocks

### DIFF
--- a/.changeset/tidy-tools-stream.md
+++ b/.changeset/tidy-tools-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): preserve tool calls that follow blank streamed text blocks

--- a/libs/langchain-core/src/language_models/stream.ts
+++ b/libs/langchain-core/src/language_models/stream.ts
@@ -121,6 +121,14 @@ function applyDelta(
         data: (block.data ?? "") + delta.data,
       };
     case "block-delta":
+      if (
+        block.type === "text" &&
+        typeof block.text === "string" &&
+        block.text.trim() === "" &&
+        delta.fields.type === "tool_call_chunk"
+      ) {
+        return { ...delta.fields } as ContentBlock;
+      }
       return { ...block, ...delta.fields } as ContentBlock;
     default:
       throw new Error(`Unknown delta type: ${JSON.stringify(delta)}`);
@@ -230,10 +238,17 @@ function parseToolArgs(value: unknown): Record<string, unknown> {
 function standardizeToolBlock(block: ContentBlock): ContentBlock {
   const record = block as Record<string, unknown>;
   if (block.type === "tool_call") return block;
+  const isToolCallInBlankTextBlock =
+    block.type === "text" &&
+    typeof block.text === "string" &&
+    block.text.trim() === "" &&
+    typeof record.name === "string" &&
+    ("args" in record || "input" in record);
   if (
     block.type !== "tool_call_chunk" &&
     block.type !== "tool_use" &&
-    block.type !== "input_json_delta"
+    block.type !== "input_json_delta" &&
+    !isToolCallInBlankTextBlock
   ) {
     return block;
   }
@@ -242,8 +257,10 @@ function standardizeToolBlock(block: ContentBlock): ContentBlock {
   if (name == null) return block;
 
   const args = record.args ?? record.input;
+  const normalizedRecord = { ...record };
+  if (isToolCallInBlankTextBlock) delete normalizedRecord.text;
   return {
-    ...record,
+    ...normalizedRecord,
     type: "tool_call",
     name,
     args: parseToolArgs(args),

--- a/libs/langchain-core/src/language_models/tests/stream.test.ts
+++ b/libs/langchain-core/src/language_models/tests/stream.test.ts
@@ -554,6 +554,94 @@ describe("ChatModelStream", () => {
       ]);
     });
 
+    test("replaces a blank text block with a tool call delta", async () => {
+      const stream = new ChatModelStream(
+        iterEvents([
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "text", text: "\n\n" },
+          },
+          {
+            event: "content-block-delta",
+            index: 0,
+            delta: {
+              type: "block-delta",
+              fields: {
+                type: "tool_call_chunk",
+                id: "call_1",
+                name: "ls",
+                args: '{"path":"/"}',
+              },
+            },
+          },
+          { event: "message-finish", reason: "tool_use" },
+        ])
+      );
+
+      const message = await stream.output;
+
+      expect(message.tool_calls).toEqual([
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "ls",
+          args: { path: "/" },
+        },
+      ]);
+      expect(message.content).toEqual([
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "ls",
+          args: { path: "/" },
+        },
+      ]);
+    });
+
+    test("normalizes a finalized tool call mislabeled as blank text", async () => {
+      const stream = new ChatModelStream(
+        iterEvents([
+          {
+            event: "content-block-start",
+            index: 0,
+            content: { type: "text", text: "\n\n" },
+          },
+          {
+            event: "content-block-finish",
+            index: 0,
+            content: {
+              type: "text",
+              text: "\n\n",
+              id: "call_1",
+              name: "ls",
+              args: '{"path":"/"}',
+            } as unknown as ContentBlock,
+          },
+          { event: "message-finish", reason: "tool_use" },
+        ])
+      );
+
+      const message = await stream.output;
+
+      expect(message.tool_calls).toEqual([
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "ls",
+          args: { path: "/" },
+        },
+      ]);
+      expect(message.content).toEqual([
+        {
+          type: "tool_call",
+          id: "call_1",
+          name: "ls",
+          args: { path: "/" },
+        },
+      ]);
+    });
+
     test("assembles multimodal data chunks", async () => {
       const stream = new ChatModelStream(
         iterEvents([


### PR DESCRIPTION
## Description

Fixes ChatModelStream assembly when a provider emits a blank text block
followed by a tool-call delta at the same content-block index.

Previously, the delta was shallow-merged into the text block, producing a
malformed text block and leaving `AIMessage.tool_calls` empty. This change:

- replaces blank text blocks when they receive a `tool_call_chunk` delta;
- normalizes finalized tool calls that are still mislabeled as blank text;
- leaves non-blank text blocks unchanged.

Regression tests cover both delta-only and finalized-block event sequences.

Fixes #10937

## Tests

- `pnpm --filter @langchain/core test`
- `pnpm --filter @langchain/core build`
- `pnpm lint`
- `pnpm format:check`