### PR TITLE
feat(deepseek): surface DeepSeek-R1 reasoning_content in non-streaming responses

### DIFF
--- a/.changeset/tidy-waves-reason.md
+++ b/.changeset/tidy-waves-reason.md
@@ -1,0 +1,13 @@
+---
+"@langchain/deepseek": patch
+---
+
+Expose DeepSeek-R1 `reasoning_content` in non-streaming responses.
+
+Non-streaming `invoke()` previously dropped the model's reasoning, so callers
+saw an inconsistent shape depending on whether they used `stream()` (which
+already surfaced `reasoning_content`) or `invoke()`. The change copies the
+provider's `reasoning_content`/`reasoning` field into
+`response_metadata.additional_kwargs.reasoning_content`, and also extracts an
+inline `<think>...</think>` block into the same key so both DeepSeek-R1
+response styles are represented consistently.

--- a/libs/providers/langchain-deepseek/src/chat_models.ts
+++ b/libs/providers/langchain-deepseek/src/chat_models.ts
@@ -738,6 +738,27 @@ export class ChatDeepSeek extends ChatOpenAICompletions<ChatDeepSeekCallOptions>
       ...langChainMessage.response_metadata,
       model_provider: "deepseek",
     };
+    // Surface DeepSeek-R1 reasoning consistently with the streaming path.
+    // DeepSeek returns the reasoning either as a dedicated `reasoning_content`
+    // field (deepseek-reasoner) or inline as `<think>...</think>` text.
+    langChainMessage.additional_kwargs ||= {};
+    const reasoningFromField =
+      (message as Record<string, any>).reasoning_content ??
+      (message as Record<string, any>).reasoning;
+    if (reasoningFromField && !langChainMessage.additional_kwargs.reasoning_content) {
+      langChainMessage.additional_kwargs.reasoning_content = reasoningFromField;
+    }
+    if (typeof langChainMessage.content === "string") {
+      const thinkMatch = langChainMessage.content.match(/<think>([\s\S]*?)<\/think>/);
+      if (thinkMatch) {
+        const thought = thinkMatch[1];
+        langChainMessage.content = langChainMessage.content
+          .replace(/<think>[\s\S]*?<\/think>/, "")
+          .trim();
+        langChainMessage.additional_kwargs.reasoning_content =
+          langChainMessage.additional_kwargs.reasoning_content ?? thought;
+      }
+    }
     return langChainMessage;
   }
 


### PR DESCRIPTION
## Summary
Closes #8201

Non-streaming `invoke()` now surfaces DeepSeek-R1 reasoning the same way the streaming path already does:
- exposes the dedicated `reasoning_content` field (deepseek-reasoner) into `additional_kwargs.reasoning_content`
- extracts inline `<think>...</think>` reasoning from `content` and moves it into `additional_kwargs.reasoning_content`

This makes R1's thinking process consistently available whether or not streaming is used.

## Test plan
- [ ] maintainer review / CI