### PR TITLE
fix(openai): emit a single User-Agent header when the caller supplies one

### DIFF
--- a/.changeset/heavy-donuts-smoke.md
+++ b/.changeset/heavy-donuts-smoke.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Fix a caller-supplied `User-Agent` being emitted as a second header. `getHeadersWithUserAgent` looked the caller's value up under `User-Agent`, but `normalizeHeaders` goes through `Headers`, which lowercases every name — so the lookup never matched, the caller's `user-agent` survived the spread beside the library's `User-Agent`, and the transport comma-joined the two. The caller's token is now appended after the library's, space separated, in a single header.

--- a/libs/providers/langchain-openai/src/utils/azure.ts
+++ b/libs/providers/langchain-openai/src/utils/azure.ts
@@ -178,10 +178,21 @@ export function getHeadersWithUserAgent(
   const normalizedHeaders = normalizeHeaders(headers);
   const env = getFormattedEnv();
   const library = `langchainjs${isAzure ? "-azure" : ""}-openai`;
+  const libraryUserAgent = `${library}/${version} (${env})`;
+
+  // `normalizeHeaders` goes through `Headers`, which lowercases every name, so
+  // the caller's user agent is always keyed `user-agent`. Remove it from the
+  // spread rather than letting it sit beside the `User-Agent` added below:
+  // two entries differing only in case are the same header, and a transport
+  // joins them with a comma, which is not the whitespace-separated list of
+  // product tokens RFC 9110 §10.1.5 defines for `User-Agent`.
+  const { "user-agent": callerUserAgent, ...restHeaders } = normalizedHeaders;
+
   return {
-    ...normalizedHeaders,
-    "User-Agent": normalizedHeaders["User-Agent"]
-      ? `${library}/${version} (${env})${normalizedHeaders["User-Agent"]}`
-      : `${library}/${version} (${env})`,
+    ...restHeaders,
+    "User-Agent":
+      typeof callerUserAgent === "string" && callerUserAgent
+        ? `${libraryUserAgent} ${callerUserAgent}`
+        : libraryUserAgent,
   };
 }

--- a/libs/providers/langchain-openai/src/utils/tests/azure.test.ts
+++ b/libs/providers/langchain-openai/src/utils/tests/azure.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { getHeadersWithUserAgent, getFormattedEnv } from "../azure.js";
+
+const libraryUserAgent = (isAzure = false, version = "1.0.0") =>
+  `langchainjs${isAzure ? "-azure" : ""}-openai/${version} (${getFormattedEnv()})`;
+
+describe("getHeadersWithUserAgent", () => {
+  test("sets the library user agent when the caller supplies none", () => {
+    const headers = getHeadersWithUserAgent({});
+
+    expect(headers["User-Agent"]).toBe(libraryUserAgent());
+  });
+
+  test("uses the azure library name and the given version", () => {
+    const headers = getHeadersWithUserAgent({}, true, "2.3.4");
+
+    expect(headers["User-Agent"]).toBe(libraryUserAgent(true, "2.3.4"));
+  });
+
+  test("appends a caller user agent after the library one, space separated", () => {
+    const headers = getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" });
+
+    expect(headers["User-Agent"]).toBe(`${libraryUserAgent()} my-app/1.2`);
+  });
+
+  test("matches a caller user agent whatever its casing", () => {
+    for (const name of ["User-Agent", "user-agent", "USER-AGENT"]) {
+      const headers = getHeadersWithUserAgent({ [name]: "my-app/1.2" });
+
+      expect(headers["User-Agent"]).toBe(`${libraryUserAgent()} my-app/1.2`);
+    }
+  });
+
+  test("emits exactly one user-agent entry, so a transport does not comma-join two", () => {
+    const headers = getHeadersWithUserAgent({ "User-Agent": "my-app/1.2" });
+
+    const userAgentKeys = Object.keys(headers).filter(
+      (key) => key.toLowerCase() === "user-agent"
+    );
+    expect(userAgentKeys).toEqual(["User-Agent"]);
+
+    expect(new Headers(headers).get("user-agent")).toBe(
+      `${libraryUserAgent()} my-app/1.2`
+    );
+  });
+
+  test("preserves other headers", () => {
+    const headers = getHeadersWithUserAgent({
+      "Content-Type": "application/json",
+      "X-Custom": "value",
+    });
+
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["x-custom"]).toBe("value");
+  });
+
+  test("accepts a Headers instance", () => {
+    const headers = getHeadersWithUserAgent(
+      new Headers({ "User-Agent": "my-app/1.2" })
+    );
+
+    expect(headers["User-Agent"]).toBe(`${libraryUserAgent()} my-app/1.2`);
+  });
+
+  test("accepts an array of header pairs", () => {
+    const headers = getHeadersWithUserAgent([["user-agent", "my-app/1.2"]]);
+
+    expect(headers["User-Agent"]).toBe(`${libraryUserAgent()} my-app/1.2`);
+  });
+
+  test("ignores an empty caller user agent", () => {
+    const headers = getHeadersWithUserAgent({ "User-Agent": "" });
+
+    expect(headers["User-Agent"]).toBe(libraryUserAgent());
+  });
+});


### PR DESCRIPTION
Closes #11438.

## The bug

`getHeadersWithUserAgent` (`libs/providers/langchain-openai/src/utils/azure.ts`) reads the caller's user agent back out of the normalized record using the canonical casing:

```ts
const normalizedHeaders = normalizeHeaders(headers);
return {
  ...normalizedHeaders,
  "User-Agent": normalizedHeaders["User-Agent"]
    ? `${library}/${version} (${env})${normalizedHeaders["User-Agent"]}`
    : `${library}/${version} (${env})`,
};
```

`normalizeHeaders` builds a WHATWG `Headers` instance and returns `Object.fromEntries(output.entries())`. `Headers` lowercases names on construction, so the record is keyed `user-agent` and `normalizedHeaders["User-Agent"]` is always `undefined`. Three consequences, all confirmed against `main`:

1. **The truthy branch is unreachable** — a caller's user agent is never appended, whatever casing they use.
2. **Two user-agent entries are emitted** — the spread keeps `user-agent`, then `User-Agent` is added beside it. HTTP header names are case-insensitive, so a transport joins them: `new Headers(result).get("user-agent")` returns `"my-app/1.2, langchainjs-openai/1.0.0 (…)"`. RFC 9110 §10.1.5 defines `User-Agent` as product tokens separated by whitespace, so the comma-joined form is malformed and breaks user-agent parsing on the provider side.
3. **The dead branch also lacks a separator** — were it reached it would produce `…(env)my-app/1.2`.

All six call sites pass `defaultHeaders` through this function, so it affects `ChatOpenAI`, `AzureChatOpenAI`, `OpenAIEmbeddings`, `AzureOpenAIEmbeddings`, and the `OpenAI` / `AzureOpenAI` LLMs — plain OpenAI usage as much as Azure.

## The fix

Destructure the lowercase `user-agent` out of the spread and build the header from that binding, joined with a space:

```ts
const { "user-agent": callerUserAgent, ...restHeaders } = normalizedHeaders;

return {
  ...restHeaders,
  "User-Agent":
    typeof callerUserAgent === "string" && callerUserAgent
      ? `${libraryUserAgent} ${callerUserAgent}`
      : libraryUserAgent,
};
```

This keeps the evident intent — library token first, caller's after — and guarantees exactly one user-agent entry. The `typeof` guard is because `normalizeHeaders` is typed `Record<string, HeaderValue | readonly HeaderValue[]>`; the empty-string check preserves the old behaviour of falling back to the library agent alone.

Behaviour is unchanged for the overwhelmingly common case of a caller supplying no user agent.

## Tests

New `src/utils/tests/azure.test.ts` covers `getHeadersWithUserAgent`, which had no unit tests:

- library-only user agent when the caller supplies none
- the azure library name and an explicit version
- caller's token appended after the library's, space separated
- matching across `User-Agent` / `user-agent` / `USER-AGENT`
- exactly one user-agent key, asserted through `new Headers(result).get("user-agent")` so the comma-join is what regresses
- other headers preserved
- `Headers` instance and `[key, value][]` array inputs
- an empty caller value ignored

**5 of the 9 fail on `main`** and all pass with the fix.

## Validation

```
pnpm vitest run                 # 29 files, 336 tests passed
pnpm vitest run src/utils/tests/azure.test.ts   # 9 passed
oxlint  <changed files>         # clean
oxfmt --check <changed files>   # clean
```

Patch changeset included.