### PR TITLE
fix(openai): route gpt-5.6-sol to Responses API

### DIFF
--- a/.changeset/olive-melons-route.md
+++ b/.changeset/olive-melons-route.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Route gpt-5.6-sol to the Responses API so function tools work with reasoning.

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -936,6 +936,10 @@ describe("ChatOpenAI", () => {
       expect(_modelPrefersResponsesAPI("gpt-5.5-pro")).toBe(true);
     });
 
+    it("should return true for gpt-5.6-sol", () => {
+      expect(_modelPrefersResponsesAPI("gpt-5.6-sol")).toBe(true);
+    });
+
     it("should return true for codex models", () => {
       expect(_modelPrefersResponsesAPI("codex-mini-latest")).toBe(true);
       expect(_modelPrefersResponsesAPI("gpt-5-codex")).toBe(true);

--- a/libs/providers/langchain-openai/src/utils/misc.ts
+++ b/libs/providers/langchain-openai/src/utils/misc.ts
@@ -94,6 +94,7 @@ export function _modelPrefersResponsesAPI(model: string): boolean {
   if (model.includes("gpt-5.2-pro")) return true;
   if (model.includes("gpt-5.4-pro")) return true;
   if (model.includes("gpt-5.5-pro")) return true;
+  if (model.includes("gpt-5.6-sol")) return true;
   // Codex models are Responses API only
   if (model.includes("codex")) return true;
   return false;


### PR DESCRIPTION
Fixes #11533

## What

`ChatOpenAI` recognizes `gpt-5.6-sol` as a reasoning model, but `_modelPrefersResponsesAPI()` didn't include it, so a request with function tools + `reasoning_effort` was sent to `/v1/chat/completions`, which OpenAI rejects:

> Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to `none`.

## Fix

Add `gpt-5.6-sol` to the Responses-API allowlist in `libs/providers/langchain-openai/src/utils/misc.ts`, matching the existing `gpt-5.x-pro` / `codex` entries.

## Tests

Added a case to the `_modelPrefersResponsesAPI` suite in `index.test.ts` mirroring the sibling `gpt-5.5-pro` test.

## Validation

```
$ npx vitest run src/chat_models/tests/index.test.ts
 Test Files  1 passed (1)
      Tests  52 passed (52)
```

RED→GREEN verified: with the source change reverted (test kept), the new case fails (`_modelPrefersResponsesAPI("gpt-5.6-sol")` → false); restoring the one-line fix turns it green.

Happy to adjust.
