### PR TITLE
fix(openai): route GPT-5.6 family to Responses API

### DIFF
--- a/.changeset/tidy-rivers-route.md
+++ b/.changeset/tidy-rivers-route.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Route the full GPT-5.6 model family to the Responses API for function tools with reasoning.

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -936,8 +936,11 @@ describe("ChatOpenAI", () => {
       expect(_modelPrefersResponsesAPI("gpt-5.5-pro")).toBe(true);
     });
 
-    it("should return true for gpt-5.6-sol", () => {
+    it("should return true for gpt-5.6 models", () => {
+      expect(_modelPrefersResponsesAPI("gpt-5.6")).toBe(true);
       expect(_modelPrefersResponsesAPI("gpt-5.6-sol")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.6-terra")).toBe(true);
+      expect(_modelPrefersResponsesAPI("gpt-5.6-luna")).toBe(true);
     });
 
     it("should return true for codex models", () => {

--- a/libs/providers/langchain-openai/src/utils/misc.ts
+++ b/libs/providers/langchain-openai/src/utils/misc.ts
@@ -94,7 +94,7 @@ export function _modelPrefersResponsesAPI(model: string): boolean {
   if (model.includes("gpt-5.2-pro")) return true;
   if (model.includes("gpt-5.4-pro")) return true;
   if (model.includes("gpt-5.5-pro")) return true;
-  if (model.includes("gpt-5.6-sol")) return true;
+  if (model.includes("gpt-5.6")) return true;
   // Codex models are Responses API only
   if (model.includes("codex")) return true;
   return false;


### PR DESCRIPTION
OpenAI's GPT-5.6 guidance states that function tools with reasoning should use the Responses API across the model family. The earlier fix covered only Sol, leaving the `gpt-5.6` alias, Terra, and Luna susceptible to Chat Completions errors at their default reasoning effort.

This broadens model inference to the GPT-5.6 family, adds focused coverage for every variant, and includes a patch changeset.

Made by [Open SWE](https://openswe.vercel.app/agents/2eaa47e3-35c8-5a06-b3af-ad8671c0b584)