### PR TITLE
fix(openai): pass full message to parser in jsonSchema fallback (fixe…

### DIFF
--- a/.changeset/tall-places-pump.md
+++ b/.changeset/tall-places-pump.md
@@ -1,0 +1,6 @@
+---
+"@langchain/openai": patch
+---
+
+fix(openai): pass full message to parser in jsonSchema fallback (fixe…
+)

--- a/libs/providers/langchain-openai/src/chat_models/base.ts
+++ b/libs/providers/langchain-openai/src/chat_models/base.ts
@@ -1159,7 +1159,7 @@ export abstract class BaseChatOpenAI<
             if ("parsed" in aiMessage.additional_kwargs) {
               return aiMessage.additional_kwargs.parsed as RunOutput;
             }
-            return altParser.invoke(aiMessage.content as string);
+            return altParser.invoke(aiMessage);
           }
         );
       } else {

--- a/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/completions.test.ts
@@ -4,6 +4,8 @@ import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import { HumanMessage, AIMessageChunk } from "@langchain/core/messages";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { ChatOpenAICompletions } from "../completions.js";
+import { AIMessage } from "@langchain/core/messages";
+import { ChatOpenAI } from "../index.js";
 
 describe("ChatOpenAICompletions constructor", () => {
   it("supports string model shorthand", () => {
@@ -373,5 +375,36 @@ describe("ChatOpenAICompletions strict tools for structured output", () => {
     expect(
       toolStrict({ response_format: { type: "json_object" } })
     ).toBeUndefined();
+  });
+
+  it("should parse structured output when content is an array of content blocks", async () => {
+    const schema = z.object({ answer: z.string() });
+
+    const message = new AIMessage({
+      content: [{ type: "text", text: '{"answer":"ok"}' }],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const mockCompletions = {
+      getLsParams: () => ({}),
+      invocationParams: () => ({}),
+      async _generate() {
+        return {
+          generations: [{ text: message.text, message }],
+        };
+      },
+    };
+
+    const model = new ChatOpenAI({
+      apiKey: "test",
+      model: "gpt-5",
+      completions: mockCompletions as any,
+    });
+
+    const res = await model
+      .withStructuredOutput(schema, { method: "jsonSchema" })
+      .invoke("Return JSON");
+
+    expect(res).toEqual({ answer: "ok" });
   });
 });


### PR DESCRIPTION
Fixes #11535

### Description
In `@langchain/openai`, `ChatOpenAI.withStructuredOutput` (using the `jsonSchema` method) has a fallback path when `additional_kwargs.parsed` is missing. Previously, it passed `aiMessage.content as string` to the alternative parser (`altParser.invoke(...)`). 

When `aiMessage.content` is returned as an array of content blocks (`ContentBlock[]`), the cast to `string` is invalid at runtime. The parser then treated it incorrectly, attempting to access `.trim()` on `undefined` and throwing an `OutputParserException`.

This PR updates the call to pass the full `aiMessage` object directly (`altParser.invoke(aiMessage)`). This allows the parser to properly extract the text via the standard `BaseMessage.text` accessor, resolving the runtime error.

### Tests
- Added a regression unit test in `completions.test.ts` verifying that `withStructuredOutput` successfully parses output when the model returns an array of content blocks.
- Verified all tests pass via `pnpm vitest run src/chat_models/tests/completions.test.ts`.