### PR TITLE
fix(core): handle empty args string in finalizeContentBlock

### DIFF
--- a/.changeset/fix-finalize-content-block-empty-args.md
+++ b/.changeset/fix-finalize-content-block-empty-args.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Fix streamed parameterless tool calls becoming invalid_tool_call in finalizeContentBlock

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -508,7 +508,7 @@ export function finalizeContentBlock(block: ContentBlock): ContentBlock {
     const chunk = block as ContentBlock.Tools.ToolCallChunk;
     let parsedArgs: unknown;
     try {
-      parsedArgs = JSON.parse(chunk.args ?? "{}");
+      parsedArgs = JSON.parse(chunk.args || "{}");
     } catch {
       return {
         type: "invalid_tool_call" as const,

--- a/libs/langchain-core/src/language_models/tests/compat.test.ts
+++ b/libs/langchain-core/src/language_models/tests/compat.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect } from "vitest";
+import { finalizeContentBlock, convertChunksToEvents } from "../compat.js";
+import { AIMessageChunk } from "../../messages/ai.js";
+import { ChatGenerationChunk } from "../../outputs.js";
+import type { ContentBlock } from "../../messages/content/index.js";
+
+describe("finalizeContentBlock", () => {
+  test("finalizes tool_call_chunk with empty string args to tool_call with empty object", () => {
+    const chunk: ContentBlock.Tools.ToolCallChunk = {
+      type: "tool_call_chunk",
+      id: "call_empty_string",
+      name: "zero_arg_tool",
+      args: "",
+      index: 0,
+    };
+
+    const finalized = finalizeContentBlock(chunk);
+
+    expect(finalized).toEqual({
+      type: "tool_call",
+      id: "call_empty_string",
+      name: "zero_arg_tool",
+      args: {},
+    });
+  });
+
+  test("finalizes tool_call_chunk with undefined args to tool_call with empty object", () => {
+    const chunk: ContentBlock.Tools.ToolCallChunk = {
+      type: "tool_call_chunk",
+      id: "call_no_args",
+      name: "zero_arg_tool",
+      index: 0,
+    };
+
+    const finalized = finalizeContentBlock(chunk);
+
+    expect(finalized).toEqual({
+      type: "tool_call",
+      id: "call_no_args",
+      name: "zero_arg_tool",
+      args: {},
+    });
+  });
+
+  test("finalizes tool_call_chunk with valid JSON args to tool_call with parsed args", () => {
+    const chunk: ContentBlock.Tools.ToolCallChunk = {
+      type: "tool_call_chunk",
+      id: "call_with_args",
+      name: "query_tool",
+      args: '{"query":"langchain","limit":5}',
+      index: 0,
+    };
+
+    const finalized = finalizeContentBlock(chunk);
+
+    expect(finalized).toEqual({
+      type: "tool_call",
+      id: "call_with_args",
+      name: "query_tool",
+      args: { query: "langchain", limit: 5 },
+    });
+  });
+
+  test("finalizes tool_call_chunk with invalid JSON to invalid_tool_call", () => {
+    const chunk: ContentBlock.Tools.ToolCallChunk = {
+      type: "tool_call_chunk",
+      id: "call_malformed",
+      name: "broken_tool",
+      args: '{"broken":',
+      index: 0,
+    };
+
+    const finalized = finalizeContentBlock(chunk);
+
+    expect(finalized).toEqual({
+      type: "invalid_tool_call",
+      id: "call_malformed",
+      name: "broken_tool",
+      args: '{"broken":',
+      error: "Failed to parse tool call arguments as JSON",
+    });
+  });
+
+  test("returns non-tool blocks unchanged", () => {
+    const textBlock: ContentBlock = {
+      type: "text",
+      text: "hello world",
+    };
+
+    expect(finalizeContentBlock(textBlock)).toBe(textBlock);
+  });
+});
+
+describe("convertChunksToEvents with parameterless tool calls", () => {
+  test("yields tool_call with empty args object when tool_call_chunk has no arguments", async () => {
+    async function* generateChunks() {
+      yield new ChatGenerationChunk({
+        text: "",
+        message: new AIMessageChunk({
+          content: "",
+          tool_call_chunks: [
+            {
+              type: "tool_call_chunk",
+              name: "list_items",
+              id: "tooluse_123",
+              index: 0,
+            },
+          ],
+        }),
+      });
+    }
+
+    const events = [];
+    for await (const event of convertChunksToEvents(generateChunks())) {
+      events.push(event);
+    }
+
+    const finishEvent = events.find(
+      (e) => e.event === "content-block-finish" && e.index === 0
+    );
+    expect(finishEvent).toBeDefined();
+    expect(finishEvent?.event).toBe("content-block-finish");
+    if (finishEvent?.event === "content-block-finish") {
+      expect(finishEvent.content).toEqual({
+        type: "tool_call",
+        id: "tooluse_123",
+        name: "list_items",
+        args: {},
+      });
+    }
+  });
+});


### PR DESCRIPTION
### Description
Fixes an issue in `@langchain/core` where streamed tool calls with parameterless schemas (or empty accumulated arguments) were downgraded to `invalid_tool_call` instead of completing as a valid `tool_call` with `args: {}`.

### Context & Cause
During streaming in `convertChunksToEvents`, a `tool_call_chunk` content block initializes `args: ""` and appends incoming deltas. When a tool has no parameters (or the model emits no argument delta), `chunk.args` remains `""`.

In `finalizeContentBlock` (`compat.ts`), `JSON.parse(chunk.args ?? "{}")` was evaluated. Because `"" ?? "{}"` evaluates to `""`, `JSON.parse("")` threw `SyntaxError: Unexpected end of JSON input`, causing the catch block to return an `invalid_tool_call`.

Changing `chunk.args ?? "{}"` to `chunk.args || "{}"` ensures that both empty strings and undefined/null arguments safely fall back to `"{}"`, producing `args: {}`. This matches the behavior already present in `@langchain/anthropic`'s stream event finalizer.

### Changes
- Updated `finalizeContentBlock` in `libs/langchain-core/src/language_models/compat.ts` to use `chunk.args || "{}"`.
- Added unit tests in `libs/langchain-core/src/language_models/tests/compat.test.ts` covering parameterless tool call finalization, valid JSON parsing, malformed JSON fallback, non-tool block passthrough, and full chunk-to-events streaming conversion.
- Added changeset for `@langchain/core` patch release.

Fixes #11311
