### PR TITLE
fix(openai): keep concurrent reasoning items separate when streaming

### DIFF
--- a/.changeset/tame-donkeys-shout.md
+++ b/.changeset/tame-donkeys-shout.md
@@ -1,0 +1,8 @@
+---
+"@langchain/openai": patch
+"@langchain/core": patch
+---
+
+fix(openai): keep concurrent reasoning items separate when streaming
+
+A response can emit more than one reasoning item (e.g. a multi-step tool-calling turn on GPT-5.6). These previously shared one `additional_kwargs.reasoning` object, so concurrent items collided during chunk merging and produced a corrupted `encrypted_content` payload that the Responses API rejected on replay. `additional_kwargs.reasoning` is now an array, one entry per item, keyed by `output_index`.

--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -217,7 +217,7 @@ function convertResponsesAnnotation(
  *   content: [{ type: "text", text: "Hello world", annotations: [] }],
  *   tool_calls: [{ id: "123", name: "calculator", args: { a: 1, b: 2 } }],
  *   additional_kwargs: {
- *     reasoning: { summary: [{ text: "Let me calculate this..." }] },
+ *     reasoning: [{ summary: [{ text: "Let me calculate this..." }] }],
  *     tool_outputs: [
  *       {
  *         type: "code_interpreter_call",
@@ -243,24 +243,26 @@ export function convertToV1FromResponses(
   message: AIMessage
 ): Array<ContentBlock.Standard> {
   function* iterateContent(): Iterable<ContentBlock.Standard> {
-    if (
-      _isObject(message.additional_kwargs?.reasoning) &&
-      _isArray(message.additional_kwargs.reasoning.summary)
-    ) {
-      const summary =
-        message.additional_kwargs.reasoning.summary.reduce<string>(
-          (acc, item) => {
-            if (_isObject(item) && _isString(item.text)) {
-              return `${acc}${item.text}`;
-            }
-            return acc;
-          },
-          ""
-        );
-      yield {
-        type: "reasoning",
-        reasoning: summary,
-      };
+    // One entry per reasoning item; older messages may still have the
+    // legacy single-object shape, so both are supported here.
+    const reasoningItems = _isArray(message.additional_kwargs?.reasoning)
+      ? message.additional_kwargs.reasoning
+      : _isObject(message.additional_kwargs?.reasoning)
+        ? [message.additional_kwargs.reasoning]
+        : [];
+    for (const reasoningItem of reasoningItems) {
+      if (_isObject(reasoningItem) && _isArray(reasoningItem.summary)) {
+        const summary = reasoningItem.summary.reduce<string>((acc, item) => {
+          if (_isObject(item) && _isString(item.text)) {
+            return `${acc}${item.text}`;
+          }
+          return acc;
+        }, "");
+        yield {
+          type: "reasoning",
+          reasoning: summary,
+        };
+      }
     }
     const content =
       typeof message.content === "string"

--- a/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
@@ -252,6 +252,27 @@ describe("openaiTranslator", () => {
       expect(message2.content).toEqual(expected);
     });
 
+    it("should translate multiple concurrent reasoning items to separate reasoning blocks", () => {
+      const message = new AIMessage({
+        content: [{ type: "text", text: "Done." }],
+        additional_kwargs: {
+          reasoning: [
+            { index: 0, summary: [{ text: "First item thinking..." }] },
+            { index: 1, summary: [{ text: "Second item thinking..." }] },
+          ],
+        },
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const expected: Array<ContentBlock.Standard> = [
+        { type: "reasoning", reasoning: "First item thinking..." },
+        { type: "reasoning", reasoning: "Second item thinking..." },
+        { type: "text", text: "Done." },
+      ];
+
+      expect(message.contentBlocks).toEqual(expected);
+    });
+
     it("should translate responses chunk and include tool_call when args parse", () => {
       const chunk1 = new AIMessageChunk({
         content: [{ type: "text", text: "Processing ", index: 0 }],

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
@@ -835,9 +835,11 @@ describe("reasoning summaries", () => {
     expect(aiMessage.id).toBe(aiMessage.response_metadata.id);
 
     // Check the final aggregated message
-    const reasoning = aiMessage?.additional_kwargs
-      .reasoning as ChatOpenAIReasoningSummary;
-    expect(reasoning).toBeDefined();
+    const reasoningItems = aiMessage?.additional_kwargs
+      .reasoning as ChatOpenAIReasoningSummary[];
+    expect(reasoningItems).toBeDefined();
+    expect(reasoningItems.length).toBeGreaterThan(0);
+    const reasoning = reasoningItems[0];
     expect(reasoning.id).toBeDefined();
     expect(typeof reasoning.id).toBe("string");
     expect(reasoning.id).toMatch(/^rs_[a-f0-9]+$/);
@@ -881,8 +883,9 @@ describe("reasoning summaries", () => {
     });
 
     const aiMessage = await concatStream(llm.stream(prompt));
-    const reasoning = aiMessage.additional_kwargs
-      .reasoning as ChatOpenAIReasoningSummary;
+    const reasoningItems = aiMessage.additional_kwargs
+      .reasoning as ChatOpenAIReasoningSummary[];
+    const reasoning = reasoningItems[0];
 
     expect(reasoning.encrypted_content).toEqual(expect.any(String));
     expect(reasoning.encrypted_content).not.toHaveLength(0);

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -379,7 +379,7 @@ export const convertResponsesMessageToAIMessage: Converter<
   const additional_kwargs: {
     [key: string]: unknown;
     refusal?: string;
-    reasoning?: OpenAIClient.Responses.ResponseReasoningItem;
+    reasoning?: OpenAIClient.Responses.ResponseReasoningItem[];
     tool_outputs?: unknown[];
     parsed?: unknown;
     [_FUNCTION_CALL_IDS_MAP_KEY]?: Record<string, string>;
@@ -439,7 +439,8 @@ export const convertResponsesMessageToAIMessage: Converter<
         additional_kwargs[_FUNCTION_CALL_IDS_MAP_KEY][item.call_id] = item.id;
       }
     } else if (item.type === "reasoning") {
-      additional_kwargs.reasoning = item;
+      additional_kwargs.reasoning ??= [];
+      additional_kwargs.reasoning.push(item);
       // Also elevate reasoning to content for UI rendering
       const reasoningText = item.summary
         ?.map((s) => s.text)
@@ -591,8 +592,11 @@ export const convertReasoningSummaryToResponsesReasoningItem: Converter<
     Object.fromEntries(Object.entries(s).filter(([k]) => k !== "index"))
   ) as OpenAIClient.Responses.ResponseReasoningItem.Summary[];
 
+  // `index` is merge bookkeeping, not part of the Responses API schema.
+  const { index: _index, ...rest } = reasoning;
+
   return {
-    ...reasoning,
+    ...rest,
     summary,
   } as OpenAIClient.Responses.ResponseReasoningItem;
 };
@@ -665,7 +669,7 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
   };
   const additional_kwargs: {
     [key: string]: unknown;
-    reasoning?: Partial<ChatOpenAIReasoningSummary>;
+    reasoning?: Array<Partial<ChatOpenAIReasoningSummary>>;
     tool_outputs?: unknown[];
   } = {};
   let id: string | undefined;
@@ -735,11 +739,14 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
     event.item.type === "reasoning" &&
     event.item.encrypted_content
   ) {
-    // Encrypted reasoning content is only complete on the done event. Emit it
-    // separately so it merges with the id and summary from output_item.added.
-    additional_kwargs.reasoning = {
-      encrypted_content: event.item.encrypted_content,
-    };
+    // Encrypted content is only complete on the done event; keyed by
+    // output_index so concurrent reasoning items don't collide when merged.
+    additional_kwargs.reasoning = [
+      {
+        index: event.output_index,
+        encrypted_content: event.item.encrypted_content,
+      },
+    ];
   } else if (
     event.type === "response.output_item.done" &&
     event.item.type === "computer_call"
@@ -874,14 +881,18 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
         }))
       : undefined;
 
-    additional_kwargs.reasoning = {
-      // We only capture ID in the first event or else the concatenated result of all chunks will
-      // have an ID field that is repeated once per event. There is special handling for the `type`
-      // field that prevents this, however.
-      id: event.item.id,
-      type: event.item.type,
-      ...(summary ? { summary } : {}),
-    };
+    additional_kwargs.reasoning = [
+      {
+        // Keyed by output_index to keep concurrent reasoning items separate.
+        index: event.output_index,
+        // We only capture ID in the first event or else the concatenated result of all chunks will
+        // have an ID field that is repeated once per event. There is special handling for the `type`
+        // field that prevents this, however.
+        id: event.item.id,
+        type: event.item.type,
+        ...(summary ? { summary } : {}),
+      },
+    ];
 
     // Also elevate reasoning to content for UI rendering
     const reasoningText = event.item.summary
@@ -892,40 +903,49 @@ export const convertResponsesDeltaToChatGenerationChunk: Converter<
       content.push({
         type: "reasoning",
         reasoning: reasoningText,
+        index: event.output_index,
       });
     }
   } else if (event.type === "response.reasoning_summary_part.added") {
-    additional_kwargs.reasoning = {
-      type: "reasoning",
-      summary: [{ ...event.part, index: event.summary_index }],
-    };
+    additional_kwargs.reasoning = [
+      {
+        index: event.output_index,
+        type: "reasoning",
+        summary: [{ ...event.part, index: event.summary_index }],
+      },
+    ];
 
-    // Also elevate reasoning to content for UI rendering
+    // Also elevate to content, keyed by output_index + summary_index so
+    // concurrent items' summary text doesn't merge into the same block.
     if (event.part.text) {
       content.push({
         type: "reasoning",
         reasoning: event.part.text,
-        index: event.summary_index,
+        index: `${event.output_index}:${event.summary_index}`,
       });
     }
   } else if (event.type === "response.reasoning_summary_text.delta") {
-    additional_kwargs.reasoning = {
-      type: "reasoning",
-      summary: [
-        {
-          text: event.delta,
-          type: "summary_text",
-          index: event.summary_index,
-        },
-      ],
-    };
+    additional_kwargs.reasoning = [
+      {
+        index: event.output_index,
+        type: "reasoning",
+        summary: [
+          {
+            text: event.delta,
+            type: "summary_text",
+            index: event.summary_index,
+          },
+        ],
+      },
+    ];
 
-    // Also elevate reasoning to content for UI rendering
+    // Also elevate to content, keyed by output_index + summary_index so
+    // concurrent items' summary text doesn't merge into the same block.
     if (event.delta) {
       content.push({
         type: "reasoning",
         reasoning: event.delta,
-        index: event.summary_index,
+        index: `${event.output_index}:${event.summary_index}`,
       });
     }
   } else if (event.type === "response.image_generation_call.partial_image") {
@@ -1397,7 +1417,9 @@ export const convertMessagesToResponsesInput: Converter<
       const additional_kwargs =
         lcMsg.additional_kwargs as BaseMessageFields["additional_kwargs"] & {
           [_FUNCTION_CALL_IDS_MAP_KEY]?: Record<string, string>;
-          reasoning?: OpenAIClient.Responses.ResponseReasoningItem;
+          // May still be a bare object on messages persisted before this
+          // became an array (to support multiple reasoning items).
+          reasoning?: ChatOpenAIReasoningSummary | ChatOpenAIReasoningSummary[];
           type?: string;
           refusal?: string;
         };
@@ -1526,19 +1548,25 @@ export const convertMessagesToResponsesInput: Converter<
 
         const input: ResponsesInputItem[] = [];
 
-        // reasoning items
-        const reasoning = additional_kwargs?.reasoning;
-        const hasEncryptedContent = !!reasoning?.encrypted_content;
-        /**
-         * With ZDR enabled, OpenAI returns encrypted reasoning content for stateless
-         * replay, so only send reasoning items when that payload is available.
-         * With ZDR disabled, include reasoning item IDs so OpenAI can reference
-         * the stored items.
-         */
-        if (reasoning && (!zdrEnabled || hasEncryptedContent)) {
-          const reasoningItem =
-            convertReasoningSummaryToResponsesReasoningItem(reasoning);
-          input.push(reasoningItem);
+        // reasoning items (a response can contain more than one)
+        const reasoningItems = Array.isArray(additional_kwargs?.reasoning)
+          ? additional_kwargs.reasoning
+          : additional_kwargs?.reasoning
+            ? [additional_kwargs.reasoning]
+            : [];
+        for (const reasoning of reasoningItems) {
+          const hasEncryptedContent = !!reasoning?.encrypted_content;
+          /**
+           * With ZDR enabled, OpenAI returns encrypted reasoning content for stateless
+           * replay, so only send reasoning items when that payload is available.
+           * With ZDR disabled, include reasoning item IDs so OpenAI can reference
+           * the stored items.
+           */
+          if (reasoning && (!zdrEnabled || hasEncryptedContent)) {
+            input.push(
+              convertReasoningSummaryToResponsesReasoningItem(reasoning)
+            );
+          }
         }
 
         // ai content

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -148,14 +148,16 @@ describe("convertResponsesMessageToAIMessage", () => {
 
     // Verify reasoning is in additional_kwargs
     expect(result.additional_kwargs.reasoning).toBeDefined();
-    expect(result.additional_kwargs.reasoning).toEqual({
-      type: "reasoning",
-      id: "rs_abc123",
-      summary: [
-        { type: "summary_text", text: "First reasoning step" },
-        { type: "summary_text", text: "Second reasoning step" },
-      ],
-    });
+    expect(result.additional_kwargs.reasoning).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_abc123",
+        summary: [
+          { type: "summary_text", text: "First reasoning step" },
+          { type: "summary_text", text: "Second reasoning step" },
+        ],
+      },
+    ]);
 
     // Verify reasoning is elevated to content array
     expect(Array.isArray(result.content)).toBe(true);
@@ -176,6 +178,89 @@ describe("convertResponsesMessageToAIMessage", () => {
     const textBlocks = contentArray.filter((block) => block.type === "text");
     expect(textBlocks.length).toBe(1);
     expect(textBlocks[0]).toMatchObject({ type: "text", text: "Hello!" });
+  });
+
+  it("should keep multiple reasoning items separate (non-streaming)", () => {
+    const response = {
+      id: "resp_123",
+      model: "o3-mini",
+      created_at: 1234567890,
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          type: "reasoning",
+          id: "rs_first",
+          summary: [{ type: "summary_text", text: "First item" }],
+        },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "get_weather",
+          arguments: "{}",
+        },
+        {
+          type: "reasoning",
+          id: "rs_second",
+          summary: [{ type: "summary_text", text: "Second item" }],
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+    };
+
+    const result = convertResponsesMessageToAIMessage(response as any);
+
+    // Both reasoning items are kept, not overwritten by one another.
+    expect(result.additional_kwargs.reasoning).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_first",
+        summary: [{ type: "summary_text", text: "First item" }],
+      },
+      {
+        type: "reasoning",
+        id: "rs_second",
+        summary: [{ type: "summary_text", text: "Second item" }],
+      },
+    ]);
+
+    const contentArray = result.content as Array<{
+      type: string;
+      [key: string]: unknown;
+    }>;
+    const reasoningBlocks = contentArray.filter(
+      (block) => block.type === "reasoning"
+    );
+    expect(reasoningBlocks).toEqual([
+      { type: "reasoning", reasoning: "First item" },
+      { type: "reasoning", reasoning: "Second item" },
+    ]);
+
+    // Force reconstruction instead of the response_metadata.output fast path,
+    // to actually exercise the multi-item reasoning replay logic.
+    delete result.response_metadata.output;
+    const replayInput = convertMessagesToResponsesInput({
+      messages: [result],
+      zdrEnabled: false,
+      model: "o3-mini",
+    });
+    const replayedReasoning = replayInput.filter(
+      (item): item is OpenAIClient.Responses.ResponseReasoningItem =>
+        "type" in item && item.type === "reasoning"
+    );
+    expect(replayedReasoning).toEqual([
+      {
+        id: "rs_first",
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "First item" }],
+      },
+      {
+        id: "rs_second",
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "Second item" }],
+      },
+    ]);
   });
 
   it("should handle reasoning with empty summary", () => {
@@ -683,6 +768,432 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       ]);
     });
 
+    it("keeps two concurrent reasoning items separate when streamed interleaved", () => {
+      // Two reasoning items at different output_index values, interleaved.
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [],
+            encrypted_content: "incomplete_first",
+          },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [],
+            encrypted_content: "incomplete_second",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [],
+            encrypted_content: "canonical_first",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 1,
+          item: {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [],
+            encrypted_content: "canonical_second",
+          },
+        },
+      ];
+
+      const chunks = events.map((event) =>
+        convertResponsesDeltaToChatGenerationChunk(event as any)!
+      );
+      expect(chunks.every((chunk) => chunk !== null)).toBe(true);
+
+      const streamedMessage = chunks
+        .slice(1)
+        .reduce(
+          (acc, chunk) => acc.concat(chunk.message as AIMessageChunk),
+          chunks[0].message as AIMessageChunk
+        );
+
+      expect(streamedMessage.additional_kwargs.reasoning).toEqual([
+        {
+          index: 0,
+          id: "rs_first",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_first",
+        },
+        {
+          index: 1,
+          id: "rs_second",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_second",
+        },
+      ]);
+
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      expect(replayInput).toEqual([
+        {
+          id: "rs_first",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_first",
+        },
+        {
+          id: "rs_second",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_second",
+        },
+      ]);
+    });
+
+    it("keeps summary text separate for two items with interleaved summary deltas", () => {
+      // Closer to real GPT-5.6 tool-loop streaming: summary text for two
+      // reasoning items arrives incrementally and interleaved, not just via
+      // whole added/done payloads.
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_first", summary: [] },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: { type: "reasoning", id: "rs_second", summary: [] },
+        },
+        {
+          type: "response.reasoning_summary_part.added",
+          output_index: 0,
+          summary_index: 0,
+          part: { type: "summary_text", text: "" },
+        },
+        {
+          type: "response.reasoning_summary_part.added",
+          output_index: 1,
+          summary_index: 0,
+          part: { type: "summary_text", text: "" },
+        },
+        {
+          type: "response.reasoning_summary_text.delta",
+          output_index: 0,
+          summary_index: 0,
+          delta: "Thinking about A",
+        },
+        {
+          type: "response.reasoning_summary_text.delta",
+          output_index: 1,
+          summary_index: 0,
+          delta: "Thinking about B",
+        },
+        {
+          type: "response.reasoning_summary_text.delta",
+          output_index: 0,
+          summary_index: 0,
+          delta: " more A",
+        },
+        {
+          type: "response.reasoning_summary_text.delta",
+          output_index: 1,
+          summary_index: 0,
+          delta: " more B",
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [
+              { type: "summary_text", text: "Thinking about A more A" },
+            ],
+            encrypted_content: "canonical_first",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 1,
+          item: {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [
+              { type: "summary_text", text: "Thinking about B more B" },
+            ],
+            encrypted_content: "canonical_second",
+          },
+        },
+      ];
+
+      const chunks = events.map((event) =>
+        convertResponsesDeltaToChatGenerationChunk(event as any)!
+      );
+      expect(chunks.every((chunk) => chunk !== null)).toBe(true);
+
+      const streamedMessage = chunks
+        .slice(1)
+        .reduce(
+          (acc, chunk) => acc.concat(chunk.message as AIMessageChunk),
+          chunks[0].message as AIMessageChunk
+        );
+
+      // Summary text for each item accumulated independently, not mixed.
+      // (The nested summary index is per-summary-part bookkeeping, only
+      // stripped later by convertReasoningSummaryToResponsesReasoningItem.)
+      expect(streamedMessage.additional_kwargs.reasoning).toEqual([
+        {
+          index: 0,
+          id: "rs_first",
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "Thinking about A more A", index: 0 },
+          ],
+          encrypted_content: "canonical_first",
+        },
+        {
+          index: 1,
+          id: "rs_second",
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "Thinking about B more B", index: 0 },
+          ],
+          encrypted_content: "canonical_second",
+        },
+      ]);
+
+      // Elevated content blocks stay separate per item too (composite index).
+      const reasoningBlocks = (
+        streamedMessage.content as Array<{
+          type: string;
+          reasoning?: string;
+          index?: string;
+        }>
+      ).filter((block) => block.type === "reasoning");
+      expect(reasoningBlocks).toEqual([
+        {
+          type: "reasoning",
+          reasoning: "Thinking about A more A",
+          index: "0:0",
+        },
+        {
+          type: "reasoning",
+          reasoning: "Thinking about B more B",
+          index: "1:0",
+        },
+      ]);
+
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      // Trailing empty message item is an unrelated existing quirk: elevated
+      // "reasoning" content blocks make content.length > 0.
+      expect(replayInput).toEqual([
+        {
+          id: "rs_first",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Thinking about A more A" }],
+          encrypted_content: "canonical_first",
+        },
+        {
+          id: "rs_second",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Thinking about B more B" }],
+          encrypted_content: "canonical_second",
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [],
+          phase: undefined,
+        },
+      ]);
+    });
+
+    it("only replays items with encrypted content when ZDR is mixed across items", () => {
+      // One item never gets encrypted_content (e.g. dropped by the provider);
+      // in ZDR mode it must be excluded from replay, the other still included.
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_with_content", summary: [] },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: { type: "reasoning", id: "rs_without_content", summary: [] },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_with_content",
+            summary: [],
+            encrypted_content: "canonical_content",
+          },
+        },
+        // No output_item.done with encrypted_content for output_index 1.
+      ];
+
+      const chunks = events.map((event) =>
+        convertResponsesDeltaToChatGenerationChunk(event as any)!
+      );
+      const streamedMessage = chunks
+        .slice(1)
+        .reduce(
+          (acc, chunk) => acc.concat(chunk.message as AIMessageChunk),
+          chunks[0].message as AIMessageChunk
+        );
+
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      expect(replayInput).toEqual([
+        {
+          id: "rs_with_content",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_content",
+        },
+      ]);
+    });
+
+    it("keeps three items separate with non-sequential output_index values", () => {
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_a", summary: [] },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 2,
+          item: { type: "reasoning", id: "rs_c", summary: [] },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 5,
+          item: { type: "reasoning", id: "rs_f", summary: [] },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 5,
+          item: {
+            type: "reasoning",
+            id: "rs_f",
+            summary: [],
+            encrypted_content: "content_f",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_a",
+            summary: [],
+            encrypted_content: "content_a",
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 2,
+          item: {
+            type: "reasoning",
+            id: "rs_c",
+            summary: [],
+            encrypted_content: "content_c",
+          },
+        },
+      ];
+
+      const chunks = events.map((event) =>
+        convertResponsesDeltaToChatGenerationChunk(event as any)!
+      );
+      const streamedMessage = chunks
+        .slice(1)
+        .reduce(
+          (acc, chunk) => acc.concat(chunk.message as AIMessageChunk),
+          chunks[0].message as AIMessageChunk
+        );
+
+      // Each item keeps its own id/encrypted_content; none collide despite
+      // done-events arriving out of output_index order.
+      expect(streamedMessage.additional_kwargs.reasoning).toEqual([
+        {
+          index: 0,
+          id: "rs_a",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_a",
+        },
+        {
+          index: 2,
+          id: "rs_c",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_c",
+        },
+        {
+          index: 5,
+          id: "rs_f",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_f",
+        },
+      ]);
+
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      expect(replayInput).toEqual([
+        {
+          id: "rs_a",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_a",
+        },
+        {
+          id: "rs_c",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_c",
+        },
+        {
+          id: "rs_f",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "content_f",
+        },
+      ]);
+    });
+
     it("should elevate reasoning to content on response.output_item.added with reasoning", () => {
       const event = {
         type: "response.output_item.added",
@@ -702,10 +1213,13 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
 
       // Verify reasoning is in additional_kwargs
       expect(aiMessageChunk.additional_kwargs.reasoning).toBeDefined();
-      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject({
-        id: "rs_abc123",
-        type: "reasoning",
-      });
+      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject([
+        {
+          index: 0,
+          id: "rs_abc123",
+          type: "reasoning",
+        },
+      ]);
 
       // Verify reasoning is elevated to content
       expect(Array.isArray(aiMessageChunk.content)).toBe(true);
@@ -720,6 +1234,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "Thinking about this...Let me reason through.",
+        index: 0,
       });
     });
 
@@ -740,12 +1255,15 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
 
       // Verify reasoning is in additional_kwargs
       expect(aiMessageChunk.additional_kwargs.reasoning).toBeDefined();
-      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject({
-        type: "reasoning",
-        summary: [
-          { type: "summary_text", text: "Initial reasoning step", index: 0 },
-        ],
-      });
+      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject([
+        {
+          index: 0,
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "Initial reasoning step", index: 0 },
+          ],
+        },
+      ]);
 
       // Verify reasoning is elevated to content
       expect(Array.isArray(aiMessageChunk.content)).toBe(true);
@@ -760,7 +1278,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "Initial reasoning step",
-        index: 0,
+        index: "0:0",
       });
     });
 
@@ -778,12 +1296,15 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
 
       // Verify reasoning is in additional_kwargs
       expect(aiMessageChunk.additional_kwargs.reasoning).toBeDefined();
-      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject({
-        type: "reasoning",
-        summary: [
-          { type: "summary_text", text: "more reasoning text", index: 0 },
-        ],
-      });
+      expect(aiMessageChunk.additional_kwargs.reasoning).toMatchObject([
+        {
+          index: 0,
+          type: "reasoning",
+          summary: [
+            { type: "summary_text", text: "more reasoning text", index: 0 },
+          ],
+        },
+      ]);
 
       // Verify reasoning is elevated to content
       expect(Array.isArray(aiMessageChunk.content)).toBe(true);
@@ -798,7 +1319,7 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       expect(reasoningBlocks[0]).toEqual({
         type: "reasoning",
         reasoning: "more reasoning text",
-        index: 0,
+        index: "0:0",
       });
     });
 

--- a/libs/providers/langchain-openai/src/types.ts
+++ b/libs/providers/langchain-openai/src/types.ts
@@ -319,6 +319,11 @@ export type ChatOpenAIReasoningSummary = Omit<
   "summary"
 > & {
   /**
+   * The item's output_index, when streamed. Keeps concurrent reasoning items
+   * from colliding while their chunks are merged.
+   */
+  index?: number;
+  /**
    * The summary of the reasoning step. The index field will be populated if the response was
    * streamed. This allows LangChain to recompose the reasoning summary output correctly when the
    * AIMessage is used as an input for future generation requests.


### PR DESCRIPTION
## Summary

Follow-up to #11448. That PR fixed a dropped `encrypted_content` field, but breaks when a response has more than one reasoning item. Concurrent items shared one `additional_kwargs.reasoning` object, so their `id` and `encrypted_content` fields got corrupted during merging, and OpenAI rejected the replayed request.

`additional_kwargs.reasoning` is now an array, one entry per item, keyed by `output_index`, so concurrent items stay separate and all replay correctly.

## Test plan

- [x] New unit tests for concurrent reasoning items, interleaved streaming, mixed ZDR, and non-streaming responses
- [x] Existing tests updated for the new shape, backward compatibility preserved
- [x] Tests, lint, and format all pass
- [ ] Integration tests reviewed but not run (no API credentials here)