### PR TITLE
fix(langchain): let wrapModelCall return a structured response

### DIFF
--- a/.changeset/wrap-model-call-structured-response.md
+++ b/.changeset/wrap-model-call-structured-response.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Type `wrapModelCall` hooks so they can return `{ structuredResponse, messages }`, the shape the agent already accepts at runtime. Exports `WrapModelCallStructuredResponse`.

--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -18,6 +18,7 @@ import type {
   AIMessage,
   SystemMessage,
   ToolMessage,
+  BaseMessage,
 } from "@langchain/core/messages";
 import type { ToolCall } from "@langchain/core/messages/tool";
 import type { Command, StreamTransformer } from "@langchain/langgraph";
@@ -225,6 +226,20 @@ export type WrapModelCallHandler<
 ) => PromiseOrValue<AIMessage>;
 
 /**
+ * A final structured response a `wrapModelCall` hook can return instead of an
+ * `AIMessage`. The agent writes `structuredResponse` and appends `messages` to
+ * the state, so the run ends with a structured response without another model
+ * call. The base handler returns this shape when a `providerStrategy` response
+ * format parses the model output.
+ */
+export interface WrapModelCallStructuredResponse<
+  TStructuredResponse = Record<string, unknown>,
+> {
+  structuredResponse: TStructuredResponse;
+  messages: BaseMessage[];
+}
+
+/**
  * Wrapper function type for the wrapModelCall hook.
  * Allows middleware to intercept and modify model execution.
  * This enables you to:
@@ -235,7 +250,9 @@ export type WrapModelCallHandler<
  *
  * @param request - The model request containing all parameters needed for the model call
  * @param handler - The function that invokes the model. Call this with a ModelRequest to get the response
- * @returns The AI message response from the model (or a modified version)
+ * @returns The AI message response from the model (or a modified version), a
+ *   `Command`, or a {@link WrapModelCallStructuredResponse} that ends the run
+ *   with a structured response
  */
 export type WrapModelCallHook<
   TSchema extends StateDefinitionInit | undefined = undefined,
@@ -243,7 +260,7 @@ export type WrapModelCallHook<
 > = (
   request: ModelRequest<NormalizedSchemaInput<TSchema>, TContext>,
   handler: WrapModelCallHandler<TSchema, TContext>
-) => PromiseOrValue<AIMessage | Command>;
+) => PromiseOrValue<AIMessage | Command | WrapModelCallStructuredResponse>;
 
 /**
  * Handler function type for the beforeAgent hook.

--- a/libs/langchain/src/agents/nodes/AgentNode.ts
+++ b/libs/langchain/src/agents/nodes/AgentNode.ts
@@ -43,6 +43,7 @@ import type {
   AgentMiddleware,
   AnyAnnotationRoot,
   WrapModelCallHandler,
+  WrapModelCallStructuredResponse,
 } from "../middleware/types.js";
 import type { ModelRequest } from "./types.js";
 import { withAgentName } from "../withAgentName.js";
@@ -55,10 +56,7 @@ import {
 } from "../responses.js";
 
 type ResponseHandlerResult<StructuredResponseFormat> =
-  | {
-      structuredResponse: StructuredResponseFormat;
-      messages: BaseMessage[];
-    }
+  | WrapModelCallStructuredResponse<StructuredResponseFormat>
   | Promise<Command>;
 
 /**
@@ -686,7 +684,7 @@ export class AgentNode<
               throw new Error(
                 `Invalid response from "wrapModelCall" in middleware "${
                   currentMiddleware.name
-                }": expected AIMessage or Command, got ${typeof middlewareResponse}`
+                }": expected AIMessage, Command, or { structuredResponse, messages }, got ${typeof middlewareResponse}`
               );
             }
 
@@ -696,7 +694,11 @@ export class AgentNode<
               collectedCommands.push(middlewareResponse);
             }
 
-            return middlewareResponse;
+            /**
+             * A middleware does not know the agent's response format, so its
+             * structured response is typed as `Record<string, unknown>`.
+             */
+            return middlewareResponse as InternalModelResponse<StructuredResponseFormat>;
           } catch (error) {
             throw MiddlewareError.wrap(error, currentMiddleware.name);
           }

--- a/libs/langchain/src/agents/tests/middleware.test-d.ts
+++ b/libs/langchain/src/agents/tests/middleware.test-d.ts
@@ -14,7 +14,10 @@ import {
 } from "../index.js";
 import type { AgentBuiltInState } from "../runtime.js";
 import type { InferAgentState } from "../types.js";
-import type { InferMiddlewareType } from "../middleware/types.js";
+import type {
+  InferMiddlewareType,
+  WrapModelCallStructuredResponse,
+} from "../middleware/types.js";
 import type { InferAgentStreamTransformers } from "../types.js";
 import type { JsonSchemaFormat } from "../responses.js";
 
@@ -299,6 +302,32 @@ describe("middleware types", () => {
           },
         }
       );
+    });
+
+    it("allows wrapModelCall to end the run with a structured response", async () => {
+      const middleware = createMiddleware({
+        name: "Middleware",
+        wrapModelCall: async (request, handler) => {
+          if (request.messages.length > 10) {
+            const stop: WrapModelCallStructuredResponse = {
+              structuredResponse: { stopped: true },
+              messages: [new AIMessage("Stopped.")],
+            };
+            return stop;
+          }
+          return handler(request);
+        },
+      });
+
+      const agent = createAgent({
+        middleware: [middleware],
+        tools: [],
+        model: "gpt-4",
+      });
+
+      await agent.invoke({
+        messages: [new HumanMessage("Hello, world!")],
+      });
     });
 
     it("doesn't require users to pass in a context if a middleware has context schema as optional", async () => {

--- a/libs/langchain/src/agents/tests/middleware.test.ts
+++ b/libs/langchain/src/agents/tests/middleware.test.ts
@@ -754,7 +754,9 @@ describe("middleware", () => {
         agent.invoke({
           messages: [{ role: "user", content: "Hi" }],
         })
-      ).rejects.toThrow("expected AIMessage or Command, got undefined");
+      ).rejects.toThrow(
+        "expected AIMessage, Command, or { structuredResponse, messages }, got undefined"
+      );
     });
 
     it("should propagate the middleware name in the error", async () => {
@@ -3034,7 +3036,7 @@ describe("middleware", () => {
         })
       ).rejects.toThrow(
         'Invalid response from "wrapModelCall" in middleware "InvalidMiddleware": ' +
-          "expected AIMessage or Command, got string"
+          "expected AIMessage, Command, or { structuredResponse, messages }, got string"
       );
     });
 


### PR DESCRIPTION
> Claude Fable 5.1: On behalf of @kasperp

`wrapModelCall` is typed to return `AIMessage | Command`, but `AgentNode` accepts a third shape at runtime: `{ structuredResponse, messages }`. The base handler returns it when a `providerStrategy` response format parses the model output, and `AgentNode` checks for it before the `AIMessage` and `Command` branches. A middleware that wants to stop the run with a structured response, for example a call budget or a guardrail decline, has to return this shape, and today that needs a cast to `AIMessage`.

This PR adds the shape to the hook's return type as an exported `WrapModelCallStructuredResponse`, reuses it in `AgentNode`, and names it in the validation error. A type test covers the new return, and the two runtime tests that assert the error text are updated.

Not changed: `WrapModelCallHandler` still says it returns `AIMessage`, although the base handler returns this shape under `providerStrategy`. Widening it would break middleware that reads `tool_calls` off the handler result, so I left it out of this PR.
