### PR TITLE
fix(google): preserve thought and thoughtSignature on resent text/reasoning/functionCall parts

### DIFF
--- a/.changeset/preserve-thought-on-text-parts.md
+++ b/.changeset/preserve-thought-on-text-parts.md
@@ -1,0 +1,8 @@
+---
+"@langchain/google": patch
+---
+
+Preserve `thought` and `thoughtSignature` when converting `AIMessage` history back to Gemini API parts. Previously, resending a prior turn's thinking text stripped these markers, so a thinking model's own chain-of-thought was replayed to Gemini as an ordinary, unflagged assistant utterance on the next turn — contradicting Gemini's documented requirement (https://ai.google.dev/gemini-api/docs/thinking) that thought blocks be resent verbatim including their flag/signature. Fixes both content-block shapes a Gemini `AIMessage` can present as:
+
+- The legacy/default `AIMessage.content` array (`{ type: "text", thought: true, ... }`), read directly by `convertLegacyContentMessageToGeminiContent`.
+- The standardized `AIMessage.contentBlocks` getter, which `ChatGoogleTranslator` (`@langchain/core`) normalizes into `{ type: "reasoning", reasoning, thought, ... }` — read by `convertStandardContentMessageToGeminiContent` whenever `response_metadata.model_provider === "google"` (i.e. on every real response this package produces) and `output_version` isn't explicitly `"v1"`.

--- a/.changeset/preserve-thought-on-text-parts.md
+++ b/.changeset/preserve-thought-on-text-parts.md
@@ -6,3 +6,4 @@ Preserve `thought` and `thoughtSignature` when converting `AIMessage` history ba
 
 - The legacy/default `AIMessage.content` array (`{ type: "text", thought: true, ... }`), read directly by `convertLegacyContentMessageToGeminiContent`.
 - The standardized `AIMessage.contentBlocks` getter, which `ChatGoogleTranslator` (`@langchain/core`) normalizes into `{ type: "reasoning", reasoning, thought, ... }` — read by `convertStandardContentMessageToGeminiContent` whenever `response_metadata.model_provider === "google"` (i.e. on every real response this package produces) and `output_version` isn't explicitly `"v1"`.
+- `AIMessage.tool_calls`: `convertStandardContentMessageToGeminiContent` rebuilds `functionCall` parts directly from `tool_calls` rather than from a content-block item, which was dropping `thoughtSignature` on a thinking model's tool calls.

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1816,6 +1816,12 @@ describe.each(thinkingModelInfo)(
         .thoughtSignature;
       expect(toolCallSignature).toBeDefined();
 
+      // Force v1 - the default (legacy) route already preserves this signature
+      firstResult.response_metadata = {
+        ...firstResult.response_metadata,
+        output_version: "v1",
+      };
+
       await llm.invoke([
         new HumanMessage("What is the weather in New York?"),
         firstResult,

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1743,6 +1743,62 @@ describe.each(thinkingModelInfo)(
       );
       expect(hasThoughtSignature).toBe(true);
     });
+
+    test("thought/thoughtSignature survive a multi-turn round trip (regression for #10461)", async () => {
+      // Reproduces the production bug: resending a prior thinking AIMessage
+      // as history silently stripped its thought marker/signature before
+      // this fix, either losing the flag (legacy content array) or dropping
+      // the block outright (contentBlocks -> ChatGoogleTranslator ->
+      // "reasoning" -> default: return null in the standard converter).
+      const llm = newChatGoogle({ reasoningEffort: "low" });
+
+      const firstResult = await llm.invoke("Why is the sky blue?");
+      const firstReasoningBlocks = firstResult.contentBlocks.filter(
+        (b) => b.type === "reasoning"
+      );
+      expect(firstReasoningBlocks.length).toBeGreaterThan(0);
+      const firstSignatures = firstResult.contentBlocks
+        .filter((b) => "thoughtSignature" in b)
+        .map((b) => b.thoughtSignature);
+      expect(firstSignatures.length).toBeGreaterThan(0);
+
+      // Feed the thinking AIMessage back in as history and ask a follow-up.
+      // recorder.request captures the actual outbound HTTP body for the
+      // second call — assert the resent turn's `contents` entry still
+      // carries `thought`/`thoughtSignature` on the wire, not just that the
+      // call succeeds (a successful call alone wouldn't catch a silently
+      // dropped/unflagged thought block, since Gemini doesn't require the
+      // resent history to include one).
+      await llm.invoke([
+        new HumanMessage("Why is the sky blue?"),
+        firstResult,
+        new HumanMessage("Now explain it to a 5 year old."),
+      ]);
+
+      const sentContents = recorder.request?.body?.contents ?? [];
+      const modelTurn = sentContents.find(
+        (c: { role?: string }) => c.role === "model"
+      );
+      expect(modelTurn).toBeDefined();
+
+      const sentThoughtParts = (modelTurn?.parts ?? []).filter(
+        (p: { thought?: boolean }) => p.thought === true
+      );
+      expect(sentThoughtParts.length).toBeGreaterThan(0);
+
+      const sentSignatures = (modelTurn?.parts ?? [])
+        .filter((p: { thoughtSignature?: string }) => "thoughtSignature" in p)
+        .map((p: { thoughtSignature?: string }) => p.thoughtSignature);
+      expect(sentSignatures.length).toBeGreaterThan(0);
+      // At least one signature from the first response must round-trip
+      // verbatim — Gemini validates these, so a regenerated/blank value
+      // would defeat the point of preserving the field at all.
+      expect(
+        sentSignatures.some((sig: string | undefined) =>
+          firstSignatures.includes(sig)
+        )
+      ).toBe(true);
+    });
   }
 );
 

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1801,11 +1801,7 @@ describe.each(thinkingModelInfo)(
     });
 
     test("functionCall thoughtSignature survives a multi-turn round trip after a real tool call (root cause: tool_calls-rebuild path)", async () => {
-      // convertStandardContentMessageToGeminiContent rebuilds functionCall
-      // parts from AIMessage.tool_calls directly, not from a content-block
-      // item - it's the one outgoing path that doesn't get thoughtSignature
-      // "for free" via an object spread, so it's the one that can silently
-      // drop it. Verifies that against a real tool-calling thinking response.
+      // tool_calls-rebuilt functionCall parts don't get thoughtSignature "for free" like content-block items do.
       const tools = [weatherTool];
       const llm: Runnable = newChatGoogle({
         reasoningEffort: "low",

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1799,6 +1799,45 @@ describe.each(thinkingModelInfo)(
         )
       ).toBe(true);
     });
+
+    test("functionCall thoughtSignature survives a multi-turn round trip after a real tool call (root cause: tool_calls-rebuild path)", async () => {
+      // convertStandardContentMessageToGeminiContent rebuilds functionCall
+      // parts from AIMessage.tool_calls directly, not from a content-block
+      // item - it's the one outgoing path that doesn't get thoughtSignature
+      // "for free" via an object spread, so it's the one that can silently
+      // drop it. Verifies that against a real tool-calling thinking response.
+      const tools = [weatherTool];
+      const llm: Runnable = newChatGoogle({
+        reasoningEffort: "low",
+      }).bindTools(tools);
+
+      const firstResult = (await llm.invoke(
+        "What is the weather in New York?"
+      )) as AIMessage;
+      expect(firstResult.tool_calls?.length).toBeGreaterThan(0);
+      const toolCall = firstResult.tool_calls![0];
+      const toolCallSignature = (toolCall as { thoughtSignature?: string })
+        .thoughtSignature;
+      expect(toolCallSignature).toBeDefined();
+
+      await llm.invoke([
+        new HumanMessage("What is the weather in New York?"),
+        firstResult,
+        new ToolMessage(JSON.stringify({ temp: 21 }), toolCall.id as string),
+      ]);
+
+      const sentContents = recorder.request?.body?.contents ?? [];
+      const modelTurn = sentContents.find(
+        (c: { role?: string }) => c.role === "model"
+      );
+      expect(modelTurn).toBeDefined();
+
+      const sentFunctionCallPart = (modelTurn?.parts ?? []).find(
+        (p: { functionCall?: unknown }) => "functionCall" in p
+      ) as { thoughtSignature?: string } | undefined;
+      expect(sentFunctionCallPart).toBeDefined();
+      expect(sentFunctionCallPart?.thoughtSignature).toBe(toolCallSignature);
+    });
   }
 );
 

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -400,16 +400,12 @@ function convertStandardContentBlockToGeminiPart(
           : {}),
       };
     case "reasoning":
-      // ChatGoogleTranslator (block_translators/google.ts) normalizes a
-      // Gemini thinking part into `{ type: "reasoning", reasoning, thought,
-      // thoughtSignature, reasoningContentBlock }` for the standard
-      // `contentBlocks` getter. Round-trip it back into the shape Gemini
-      // expects — without this, a thinking model's own chain-of-thought is
-      // silently dropped (hits the `default` branch below) when history
-      // that went through `.contentBlocks` is replayed on the next turn.
+      if (block.thought !== true) {
+        return null;
+      }
       return {
         text: block.reasoning,
-        ...("thought" in block ? { thought: block.thought as boolean } : {}),
+        thought: true,
         ...("thoughtSignature" in block
           ? { thoughtSignature: block.thoughtSignature as string }
           : {}),

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -394,7 +394,6 @@ function convertStandardContentBlockToGeminiPart(
     case "text":
       return {
         text: block.text,
-        ...("thought" in block ? { thought: block.thought as boolean } : {}),
         ...("thoughtSignature" in block
           ? { thoughtSignature: block.thoughtSignature as string }
           : {}),
@@ -1099,10 +1098,21 @@ export const convertGeminiPartToContentBlock: Converter<
 > = (part: Gemini.Part): ContentBlock => {
   const block: ContentBlock = iife(() => {
     if ("text" in part && typeof part.text === "string") {
-      return {
-        type: "text",
-        text: part.text,
-      };
+      if (
+        "thought" in part &&
+        typeof part.thought === "boolean" &&
+        part.thought
+      ) {
+        return {
+          type: "reasoning",
+          reasoning: part.text,
+        };
+      } else {
+        return {
+          type: "text",
+          text: part.text,
+        };
+      }
     } else if ("inlineData" in part && part.inlineData) {
       return {
         type: "inlineData",

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -491,11 +491,15 @@ function convertStandardContentMessageToGeminiContent(
   // Convert AIMessage tool_calls to functionCall parts
   if (AIMessage.isInstance(message) && message.tool_calls?.length) {
     for (const toolCall of message.tool_calls) {
+      const toolCallSignature = (toolCall as { thoughtSignature?: string })
+        .thoughtSignature;
       parts.push({
         functionCall: {
           name: toolCall.name,
           args: toolCall.args ?? {},
         },
+        // thoughtSignature also rides on functionCall parts, not just text
+        ...(toolCallSignature ? { thoughtSignature: toolCallSignature } : {}),
       } as Gemini.Part.FunctionCall);
     }
   }

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -392,7 +392,28 @@ function convertStandardContentBlockToGeminiPart(
 ): Gemini.Part | null {
   switch (block.type) {
     case "text":
-      return { text: block.text };
+      return {
+        text: block.text,
+        ...("thought" in block ? { thought: block.thought as boolean } : {}),
+        ...("thoughtSignature" in block
+          ? { thoughtSignature: block.thoughtSignature as string }
+          : {}),
+      };
+    case "reasoning":
+      // ChatGoogleTranslator (block_translators/google.ts) normalizes a
+      // Gemini thinking part into `{ type: "reasoning", reasoning, thought,
+      // thoughtSignature, reasoningContentBlock }` for the standard
+      // `contentBlocks` getter. Round-trip it back into the shape Gemini
+      // expects — without this, a thinking model's own chain-of-thought is
+      // silently dropped (hits the `default` branch below) when history
+      // that went through `.contentBlocks` is replayed on the next turn.
+      return {
+        text: block.reasoning,
+        ...("thought" in block ? { thought: block.thought as boolean } : {}),
+        ...("thoughtSignature" in block
+          ? { thoughtSignature: block.thoughtSignature as string }
+          : {}),
+      };
     case "image":
     case "audio":
     case "text-plain":
@@ -748,7 +769,16 @@ function convertLegacyContentMessageToGeminiContent(
         parts.push({ text: item });
       } else if (typeof item === "object" && item !== null) {
         if (isMessageContentText(item)) {
-          parts.push({ text: item.text });
+          const itemRecord = item as Record<string, unknown>;
+          parts.push({
+            text: item.text,
+            ...("thought" in itemRecord
+              ? { thought: itemRecord.thought as boolean }
+              : {}),
+            ...("thoughtSignature" in itemRecord
+              ? { thoughtSignature: itemRecord.thoughtSignature as string }
+              : {}),
+          });
         } else if (isDataContentBlock(item)) {
           parts.push(
             convertToProviderContentBlock(item, geminiContentBlockConverter)

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -1169,6 +1169,121 @@ describe("convertMessagesToGeminiContents", () => {
       },
     ]);
   });
+
+  test("legacy path: preserves thought and thoughtSignature on a resent text block", () => {
+    // Shape returned by convertGeminiCandidateToAIMessage for a thinking-model
+    // response — a text part with `thought: true` immediately followed by a
+    // functionCall part carrying `thoughtSignature`. When this AIMessage is
+    // fed back in as history on the next turn, the thought text must keep
+    // its `thought`/`thoughtSignature` markers so Gemini can tell it apart
+    // from a real committed utterance (see
+    // https://ai.google.dev/gemini-api/docs/thinking).
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text", text: "internal reasoning", thought: true },
+        {
+          type: "functionCall",
+          functionCall: { name: "get_weather", args: { city: "London" } },
+          thoughtSignature: "sig-abc",
+        },
+      ],
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "call-1",
+          type: "tool_call",
+        },
+      ],
+    });
+
+    const messages = [new HumanMessage("what's the weather?"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("legacy path: a plain text block with no thought key is unaffected", () => {
+    const message = new AIMessage({
+      content: [{ type: "text", text: "Here are your results." }],
+    });
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hi"),
+      message,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toEqual([{ text: "Here are your results." }]);
+  });
+
+  test("v1 contentBlocks (explicit output_version): preserves thought and thoughtSignature on a resent text block", () => {
+    // response_metadata.output_version === "v1" makes AIMessage.contentBlocks
+    // return `content` verbatim (ai.ts:196-202), bypassing ChatGoogleTranslator
+    // entirely — exercises convertStandardContentBlockToGeminiPart's "text" case.
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text" as const, text: "internal reasoning", thought: true },
+      ],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("v1 contentBlocks (via ChatGoogleTranslator): preserves thought on a resent reasoning block", () => {
+    // The real-world shape: every AIMessage this package produces carries
+    // response_metadata.model_provider = "google" (see
+    // convertGeminiCandidateToAIMessage). With no output_version override,
+    // AIMessage.contentBlocks (ai.ts:204-213) routes through
+    // ChatGoogleTranslator, which normalizes a `{ type: "text", thought:
+    // true }` part into `{ type: "reasoning", reasoning, thought,
+    // reasoningContentBlock }` (block_translators/google.ts).
+    // convertStandardContentBlockToGeminiPart must handle that "reasoning"
+    // shape too, or this history is silently dropped on the next turn.
+    const priorAiMessage = new AIMessage({
+      content: [{ text: "internal reasoning", thought: true, type: "text" }],
+      response_metadata: { model_provider: "google" },
+    });
+
+    // Sanity check the premise: this AIMessage's own .contentBlocks getter
+    // really does normalize to "reasoning" via ChatGoogleTranslator.
+    const blocks = priorAiMessage.contentBlocks;
+    expect(blocks.some((b) => b.type === "reasoning")).toBe(true);
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
 });
 
 test("coalesces consecutive plain HumanMessages into one user content", () => {

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -1339,6 +1339,20 @@ describe("convertMessagesToGeminiContents", () => {
     expect(textPart!.text).toBe("internal reasoning");
     expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
   });
+
+  test("a non-Google reasoning block with no thought flag is dropped, not sent as visible text", () => {
+    const message = new AIMessage({
+      content: [{ type: "reasoning", reasoning: "private reasoning" }],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hi"),
+      message,
+    ]);
+
+    expect(contents.find((c) => c.role === "model")).toBeUndefined();
+  });
 });
 
 test("coalesces consecutive plain HumanMessages into one user content", () => {

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -500,6 +500,61 @@ describe("convertMessagesToGeminiContents", () => {
     expect(functionCallPart.functionCall!.args).toEqual({ city: "London" });
   });
 
+  test("AIMessage tool_calls carrying a thoughtSignature reattach it to the rebuilt functionCall part (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "call-1",
+          type: "tool_call",
+          thoughtSignature: "sig-abc",
+        } as {
+          name: string;
+          args: object;
+          id: string;
+          thoughtSignature: string;
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hello"),
+      aiMsg,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    const functionCallPart = modelContent!.parts.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(functionCallPart).toBeDefined();
+    expect(functionCallPart.thoughtSignature).toBe("sig-abc");
+  });
+
+  test("AIMessage tool_calls with no thoughtSignature produce a functionCall part with no thoughtSignature key (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        { name: "get_weather", args: { city: "London" }, id: "call-1" },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hello"),
+      aiMsg,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    const functionCallPart = modelContent!.parts.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(functionCallPart).toBeDefined();
+    expect("thoughtSignature" in functionCallPart).toBe(false);
+  });
+
   test("ToolMessage name resolved from tool_calls (v1 path)", () => {
     const aiMsg = new AIMessage({
       content: "",


### PR DESCRIPTION
## Summary

Fixes #10461 — resending a prior thinking turn's history to Gemini stripped
`thought`/`thoughtSignature` markers, contradicting Gemini's documented
requirement to echo thought blocks back verbatim

This picks up and extends #11198.

## What's included

- The original fix from #11198: `convertStandardContentBlockToGeminiPart`
  now preserves `thought`/`thoughtSignature` on both the `"text"` and
  `"reasoning"` content-block cases, and the legacy-path text branch does
  the same.
- **New**: `convertStandardContentMessageToGeminiContent` rebuilds
  `functionCall` parts directly from `AIMessage.tool_calls` (not from a
  content-block item), which was a separate path that silently dropped
  `thoughtSignature` on tool calls made by a thinking model. Addresses
  @afirstenberg's review comment that thought signatures "can be on any
  `Gemini.Part`, not just text"

## Deliberately out of scope

@afirstenberg's review also raised a deeper architectural point: a Gemini
part with `thought: true` arguably should already be normalized to a
`ContentBlock.Reasoning` at the producer (`convertGeminiPartToContentBlock`),
rather than the converters having to tolerate the raw `{ type: "text",
thought: true }` shape on the way back out.

That is a  **breaking change**, not a bugfix — the
raw shape is what `AIMessage.content` has always contained for thinking
responses, and `BaseMessage.text` in core currently concatenates it in. 
Changing the producer's output shape would change `.text`'s output for every existing
thinking-model caller.

Hence this will be done in a separate PR., explicitly-scoped
follow-up rather than bundling a breaking change into this fix.

Credit to @saarRozenbaum for the original diagnosis and fix in #11198.