### PR TITLE
fix(google-genai): forward abort signal to non-streaming requests

### DIFF
--- a/.changeset/calm-impalas-learn.md
+++ b/.changeset/calm-impalas-learn.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+Forward abort signals to non-streaming Google Generative AI requests.

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -933,7 +933,8 @@ export class ChatGoogleGenerativeAI
     }
 
     const res = await this.completionWithRetry(
-      this._buildGenerateContentRequest(messages, options)
+      this._buildGenerateContentRequest(messages, options),
+      options
     );
 
     let usageMetadata: UsageMetadata | undefined;

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -1234,3 +1234,29 @@ describe("withStructuredOutput - StandardSchema", () => {
     expect((result as any).parsed).toEqual({ name: "cobalt" });
   });
 });
+
+test("Google AI - abort signal reaches the non-streaming request", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    apiKey: "testing",
+    model: "gemini-2.0-flash",
+  });
+
+  const spy = vi
+    .spyOn(model, "completionWithRetry")
+    .mockImplementation(
+      async () => ({ response: mockGenerateContentResponse("ok") }) as never
+    );
+
+  const controller = new AbortController();
+  await model.invoke([new HumanMessage("Hello")], {
+    signal: controller.signal,
+  });
+
+  // Regression: `_generate` invoked `completionWithRetry(request)` with no
+  // second argument, so `options` — and therefore `signal` — was `undefined`.
+  // `completionWithRetry` passes that signal to both `caller.callWithOptions`
+  // and `client.generateContent`, so an in-flight non-streaming request could
+  // not be aborted. Both streaming paths already forward it.
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.calls[0][1]?.signal).toBe(controller.signal);
+});


### PR DESCRIPTION
Fixes #9667

`ChatGoogleGenerativeAI._generate` called `completionWithRetry` with only the request, dropping the second `options` argument. `completionWithRetry` uses that argument in two places, so both received `undefined`:

```ts
return this.caller.callWithOptions(
  { signal: options?.signal },
  async () => await this.client.generateContent(request, { signal: options?.signal }),
);
```

The result is that `model.invoke(messages, { signal })` cannot abort an in-flight non-streaming request. The `options.signal?.throwIfAborted()` at the top of `_generate` only covers the moment before dispatch.

Both streaming paths already forward the signal — `_streamChatModelEvents` and `_streamResponseChunks` each pass it to `callWithOptions` and to `generateContentStream` — so this was a single missed call site on the non-streaming path. `langchain-anthropic` uses the same idiom at three call sites.

## How I verified it

- Added a regression test asserting the signal reaches `completionWithRetry`. It **fails** before the change and passes after.
- Package suite goes from 93 to 94 passing, no type errors, no existing test affected.
- `oxfmt --check` and `oxlint` clean on both changed files.

The package had no existing abort/signal coverage, so the new test is the first.

**Scope of verification:** the integration tests require live API keys, so I confirmed the signal is plumbed through at the unit level rather than that a real Gemini request cancels end to end.
