### PR TITLE
fix(core): handle zero and negative maxima during normalization

### DIFF
--- a/.changeset/finite-zero-normalization.md
+++ b/.changeset/finite-zero-normalization.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Avoid NaN scores when normalizing an all-zero distance matrix.

--- a/.changeset/finite-zero-normalization.md
+++ b/.changeset/finite-zero-normalization.md
@@ -2,4 +2,4 @@
 "@langchain/core": patch
 ---
 
-Avoid NaN scores when normalizing an all-zero distance matrix.
+Handle zero maxima, all-negative matrices, and empty rows when normalizing matrices.

--- a/libs/langchain-core/src/utils/math.ts
+++ b/libs/langchain-core/src/utils/math.ts
@@ -47,7 +47,7 @@ export function matrixFunc(
 }
 
 export function normalize(M: number[][], similarity = false): number[][] {
-  const max = matrixMaxVal(M);
+  const max = matrixMaxVal(M) || 1;
   return M.map((row) =>
     row.map((val) => (similarity ? 1 - val / max : val / max))
   );

--- a/libs/langchain-core/src/utils/math.ts
+++ b/libs/langchain-core/src/utils/math.ts
@@ -46,10 +46,17 @@ export function matrixFunc(
   );
 }
 
+/**
+ * Divide each value by the matrix maximum, using a divisor of 1 when it is zero.
+ * When similarity is true, return 1 minus each scaled value.
+ * Finite non-negative inputs produce values in [0, 1]; signed inputs can produce
+ * values outside that range. This does not perform min-max scaling or clamping.
+ */
 export function normalize(M: number[][], similarity = false): number[][] {
-  const max = matrixMaxVal(M) || 1;
+  const max = matrixMaxVal(M);
+  const divisor = max === 0 ? 1 : max;
   return M.map((row) =>
-    row.map((val) => (similarity ? 1 - val / max : val / max))
+    row.map((val) => (similarity ? 1 - val / divisor : val / divisor))
   );
 }
 
@@ -172,8 +179,13 @@ function argMax(array: number[]): MaxInfo {
 }
 
 function matrixMaxVal(arrays: number[][]): number {
-  return arrays.reduce(
-    (acc, array) => Math.max(acc, argMax(array).maxValue),
-    0
-  );
+  let max: number | undefined;
+  for (const array of arrays) {
+    if (array.length === 0) {
+      continue;
+    }
+    const { maxValue } = argMax(array);
+    max = max === undefined ? maxValue : Math.max(max, maxValue);
+  }
+  return max ?? 0;
 }

--- a/libs/langchain-core/src/utils/tests/math_utils.test.ts
+++ b/libs/langchain-core/src/utils/tests/math_utils.test.ts
@@ -165,6 +165,45 @@ test("Test normalize", async () => {
   expect(actual).toEqual(expected);
 });
 
+test("normalize returns finite distances for an all-zero matrix", () => {
+  const input = [
+    [0, 0],
+    [0, 0],
+  ];
+  expect(normalize(input)).toEqual([
+    [0, 0],
+    [0, 0],
+  ]);
+  expect(normalize(input, true)).toEqual([
+    [1, 1],
+    [1, 1],
+  ]);
+  expect(input).toEqual([
+    [0, 0],
+    [0, 0],
+  ]);
+});
+
+test("normalize preserves empty matrix shapes", () => {
+  expect(normalize([])).toEqual([]);
+  expect(normalize([[]])).toEqual([[]]);
+});
+
+test("normalize converts nonzero distances to similarities", () => {
+  expect(
+    normalize(
+      [
+        [0, 2],
+        [2, 0],
+      ],
+      true
+    )
+  ).toEqual([
+    [1, 0],
+    [0, 1],
+  ]);
+});
+
 test("Test innerProduct", async () => {
   const x = [
     [1, 2],

--- a/libs/langchain-core/src/utils/tests/math_utils.test.ts
+++ b/libs/langchain-core/src/utils/tests/math_utils.test.ts
@@ -187,6 +187,45 @@ test("normalize returns finite distances for an all-zero matrix", () => {
 test("normalize preserves empty matrix shapes", () => {
   expect(normalize([])).toEqual([]);
   expect(normalize([[]])).toEqual([[]]);
+  expect(normalize([[], []], true)).toEqual([[], []]);
+});
+
+test("normalize uses the actual maximum for all-negative matrices", () => {
+  const input = [[-4, -2], [-6]];
+  expect(normalize(input)).toEqual([[2, 1], [3]]);
+  expect(normalize(input, true)).toEqual([[-1, 0], [-2]]);
+  expect(input).toEqual([[-4, -2], [-6]]);
+});
+
+test("normalize retains maximum-based scaling for mixed-sign matrices", () => {
+  const input = [[-2, 0, 4]];
+  expect(normalize(input)).toEqual([[-0.5, 0, 1]]);
+  expect(normalize(input, true)).toEqual([[1.5, 1, 0]]);
+});
+
+test("normalize ignores empty rows when finding the maximum", () => {
+  expect(normalize([[], [2], [], [4], []])).toEqual([[], [0.5], [], [1], []]);
+  expect(normalize([[], [2], [], [4], []], true)).toEqual([
+    [],
+    [0.5],
+    [],
+    [0],
+    [],
+  ]);
+  expect(normalize([[], [-4, -2], []])).toEqual([[], [2, 1], []]);
+  expect(normalize([[], [0], []])).toEqual([[], [0], []]);
+  expect(normalize([[], [0], []], true)).toEqual([[], [1], []]);
+});
+
+test("normalize uses a unit divisor when signed inputs have a zero maximum", () => {
+  expect(normalize([[-2, 0]])).toEqual([[-2, 0]]);
+  expect(normalize([[-2, 0]], true)).toEqual([[3, 1]]);
+});
+
+test("normalize does not replace a NaN maximum with a unit divisor", () => {
+  const result = normalize([[NaN], [2]]);
+  expect(result[0][0]).toBeNaN();
+  expect(result[1][0]).toBeNaN();
 });
 
 test("normalize converts nonzero distances to similarities", () => {


### PR DESCRIPTION
Fixes #11564.

`normalize` divides all-zero matrices by zero, while its maximum helper treats all-negative matrices as having a maximum of zero and lets empty rows contaminate the result with NaN. Find the maximum from nonempty rows and use a divisor of 1 only when that maximum is exactly zero. A NaN maximum is no longer silently replaced with 1.

Keep the existing maximum-based scaling and `1 - value / divisor` similarity calculation. Document that finite non-negative inputs produce values in `[0, 1]`, while signed inputs can fall outside that range. Positive-input behavior is preserved.

Regression coverage includes zero matrices in both modes, all-negative matrices, mixed signs, empty rows among nonempty rows, entirely empty shapes, signed inputs with a zero maximum, NaN maxima, and unchanged input. Include a patch changeset for `@langchain/core`.

Validation: three added regression tests failed against the preceding PR revision. The updated utility suite passes 286 tests across 15 files with no reported type errors. Repository Oxlint and formatting checks pass. No provider requests or API keys were used. Prepared with OpenAI Codex assistance.
