### PR TITLE
feat(core): add RunnableSequence trace processors

### DIFF
--- a/.changeset/tiny-traces-processors.md
+++ b/.changeset/tiny-traces-processors.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": minor
+---
+
+Add synchronous `RunnableSequence` trace input and output processors, and correct batch sequence end callbacks to record each run's corresponding output.

--- a/.changeset/tiny-traces-processors.md
+++ b/.changeset/tiny-traces-processors.md
@@ -2,4 +2,4 @@
 "@langchain/core": minor
 ---
 
-Add synchronous `RunnableSequence` trace input and output processors, and correct batch sequence end callbacks to record each run's corresponding output.
+Add synchronous `RunnableSequence` input and output trace processors, and correct batch sequence end callbacks to record each run's corresponding output.

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -1910,9 +1910,9 @@ export type RunnableSequenceFields<RunInput, RunOutput> = {
   name?: string;
   omitSequenceTags?: boolean;
   /** Receives the input by reference and must not mutate it. */
-  traceInputs?: (input: RunInput) => unknown;
+  processInputs?: (input: RunInput) => unknown;
   /** Receives the output by reference and must not mutate it. */
-  traceOutputs?: (output: RunOutput) => unknown;
+  processOutputs?: (output: RunOutput) => unknown;
 };
 
 /**
@@ -1945,9 +1945,9 @@ export class RunnableSequence<
 
   omitSequenceTags = false;
 
-  protected traceInputs?: (input: RunInput) => unknown;
+  protected processInputs?: (input: RunInput) => unknown;
 
-  protected traceOutputs?: (output: RunOutput) => unknown;
+  protected processOutputs?: (output: RunOutput) => unknown;
 
   lc_serializable = true;
 
@@ -1960,8 +1960,8 @@ export class RunnableSequence<
     this.last = fields.last;
     this.name = fields.name;
     this.omitSequenceTags = fields.omitSequenceTags ?? this.omitSequenceTags;
-    this.traceInputs = fields.traceInputs;
-    this.traceOutputs = fields.traceOutputs;
+    this.processInputs = fields.processInputs;
+    this.processOutputs = fields.processOutputs;
   }
 
   get lc_serializable_keys(): string[] {
@@ -1969,11 +1969,11 @@ export class RunnableSequence<
   }
 
   protected _processTraceInput(input: RunInput): unknown {
-    return this._processTraceValue(input, this.traceInputs, "input");
+    return this._processTraceValue(input, this.processInputs, "input");
   }
 
   protected _processTraceOutput(output: RunOutput): unknown {
-    return this._processTraceValue(output, this.traceOutputs, "output");
+    return this._processTraceValue(output, this.processOutputs, "output");
   }
 
   private _processTraceValue<T>(
@@ -2071,7 +2071,7 @@ export class RunnableSequence<
     batchOptions?: RunnableBatchOptions
   ): Promise<(RunOutput | Error)[]> {
     const configList = this._getOptionsList(options ?? {}, inputs.length);
-    const traceInputs = inputs.map((input) => this._processTraceInput(input));
+    const processInputs = inputs.map((input) => this._processTraceInput(input));
     const callbackManagers = await Promise.all(
       configList.map(getCallbackManagerForConfig)
     );
@@ -2079,7 +2079,7 @@ export class RunnableSequence<
       callbackManagers.map(async (callbackManager, i) => {
         const handleStartRes = await callbackManager?.handleChainStart(
           this.toJSON(),
-          _coerceToDict(traceInputs[i], "input"),
+          _coerceToDict(processInputs[i], "input"),
           configList[i].runId,
           undefined,
           undefined,
@@ -2242,8 +2242,8 @@ export class RunnableSequence<
         last: coerceable.last,
         name: this.name ?? coerceable.name,
         omitSequenceTags: this.omitSequenceTags,
-        traceInputs: this.traceInputs,
-        traceOutputs: this.traceOutputs,
+        processInputs: this.processInputs,
+        processOutputs: this.processOutputs,
       });
     } else {
       return new RunnableSequence({
@@ -2252,8 +2252,8 @@ export class RunnableSequence<
         last: _coerceToRunnable(coerceable),
         name: this.name,
         omitSequenceTags: this.omitSequenceTags,
-        traceInputs: this.traceInputs,
-        traceOutputs: this.traceOutputs,
+        processInputs: this.processInputs,
+        processOutputs: this.processOutputs,
       });
     }
   }

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -1909,6 +1909,10 @@ export type RunnableSequenceFields<RunInput, RunOutput> = {
   last: Runnable<any, RunOutput>;
   name?: string;
   omitSequenceTags?: boolean;
+  /** Receives the input by reference and must not mutate it. */
+  traceInputs?: (input: RunInput) => unknown;
+  /** Receives the output by reference and must not mutate it. */
+  traceOutputs?: (output: RunOutput) => unknown;
 };
 
 /**
@@ -1941,6 +1945,10 @@ export class RunnableSequence<
 
   omitSequenceTags = false;
 
+  protected traceInputs?: (input: RunInput) => unknown;
+
+  protected traceOutputs?: (output: RunOutput) => unknown;
+
   lc_serializable = true;
 
   lc_namespace = ["langchain_core", "runnables"];
@@ -1952,6 +1960,36 @@ export class RunnableSequence<
     this.last = fields.last;
     this.name = fields.name;
     this.omitSequenceTags = fields.omitSequenceTags ?? this.omitSequenceTags;
+    this.traceInputs = fields.traceInputs;
+    this.traceOutputs = fields.traceOutputs;
+  }
+
+  get lc_serializable_keys(): string[] {
+    return ["first", "middle", "last", "name", "omitSequenceTags"];
+  }
+
+  protected _processTraceInput(input: RunInput): unknown {
+    return this._processTraceValue(input, this.traceInputs, "input");
+  }
+
+  protected _processTraceOutput(output: RunOutput): unknown {
+    return this._processTraceValue(output, this.traceOutputs, "output");
+  }
+
+  private _processTraceValue<T>(
+    value: T,
+    processor: ((value: T) => unknown) | undefined,
+    type: "input" | "output"
+  ): unknown {
+    if (processor === undefined) {
+      return value;
+    }
+    try {
+      return processor(value);
+    } catch (error) {
+      console.warn(`Failed to process RunnableSequence trace ${type}.`, error);
+      return value;
+    }
   }
 
   get steps() {
@@ -1960,10 +1998,11 @@ export class RunnableSequence<
 
   async invoke(input: RunInput, options?: RunnableConfig): Promise<RunOutput> {
     const config = ensureConfig(options);
+    const traceInput = this._processTraceInput(input);
     const callbackManager_ = await getCallbackManagerForConfig(config);
     const runManager = await callbackManager_?.handleChainStart(
       this.toJSON(),
-      _coerceToDict(input, "input"),
+      _coerceToDict(traceInput, "input"),
       config.runId,
       undefined,
       undefined,
@@ -2003,7 +2042,8 @@ export class RunnableSequence<
       await runManager?.handleChainError(e);
       throw e;
     }
-    await runManager?.handleChainEnd(_coerceToDict(finalOutput, "output"));
+    const traceOutput = this._processTraceOutput(finalOutput);
+    await runManager?.handleChainEnd(_coerceToDict(traceOutput, "output"));
     return finalOutput;
   }
 
@@ -2031,6 +2071,7 @@ export class RunnableSequence<
     batchOptions?: RunnableBatchOptions
   ): Promise<(RunOutput | Error)[]> {
     const configList = this._getOptionsList(options ?? {}, inputs.length);
+    const traceInputs = inputs.map((input) => this._processTraceInput(input));
     const callbackManagers = await Promise.all(
       configList.map(getCallbackManagerForConfig)
     );
@@ -2038,7 +2079,7 @@ export class RunnableSequence<
       callbackManagers.map(async (callbackManager, i) => {
         const handleStartRes = await callbackManager?.handleChainStart(
           this.toJSON(),
-          _coerceToDict(inputs[i], "input"),
+          _coerceToDict(traceInputs[i], "input"),
           configList[i].runId,
           undefined,
           undefined,
@@ -2073,8 +2114,10 @@ export class RunnableSequence<
       throw e;
     }
     await Promise.all(
-      runManagers.map((runManager) =>
-        runManager?.handleChainEnd(_coerceToDict(nextStepInputs, "output"))
+      runManagers.map((runManager, i) =>
+        runManager?.handleChainEnd(
+          _coerceToDict(this._processTraceOutput(nextStepInputs[i]), "output")
+        )
       )
     );
     return nextStepInputs;
@@ -2089,11 +2132,12 @@ export class RunnableSequence<
     input: RunInput,
     options?: RunnableConfig
   ): AsyncGenerator<RunOutput> {
+    const traceInput = this._processTraceInput(input);
     const callbackManager_ = await getCallbackManagerForConfig(options);
     const { runId, ...otherOptions } = options ?? {};
     const runManager = await callbackManager_?.handleChainStart(
       this.toJSON(),
-      _coerceToDict(input, "input"),
+      _coerceToDict(traceInput, "input"),
       runId,
       undefined,
       undefined,
@@ -2147,7 +2191,8 @@ export class RunnableSequence<
       await runManager?.handleChainError(e);
       throw e;
     }
-    await runManager?.handleChainEnd(_coerceToDict(finalOutput, "output"));
+    const traceOutput = this._processTraceOutput(finalOutput);
+    await runManager?.handleChainEnd(_coerceToDict(traceOutput, "output"));
   }
 
   getGraph(config?: RunnableConfig): Graph {
@@ -2196,6 +2241,9 @@ export class RunnableSequence<
         ]),
         last: coerceable.last,
         name: this.name ?? coerceable.name,
+        omitSequenceTags: this.omitSequenceTags,
+        traceInputs: this.traceInputs,
+        traceOutputs: this.traceOutputs,
       });
     } else {
       return new RunnableSequence({
@@ -2203,6 +2251,9 @@ export class RunnableSequence<
         middle: [...this.middle, this.last],
         last: _coerceToRunnable(coerceable),
         name: this.name,
+        omitSequenceTags: this.omitSequenceTags,
+        traceInputs: this.traceInputs,
+        traceOutputs: this.traceOutputs,
       });
     }
   }

--- a/libs/langchain-core/src/runnables/base.ts
+++ b/libs/langchain-core/src/runnables/base.ts
@@ -2232,7 +2232,7 @@ export class RunnableSequence<
     coerceable: RunnableLike<RunOutput, NewRunOutput>
   ): RunnableSequence<RunInput, Exclude<NewRunOutput, Error>> {
     if (RunnableSequence.isRunnableSequence(coerceable)) {
-      return new RunnableSequence({
+      return new RunnableSequence<RunInput, Exclude<NewRunOutput, Error>>({
         first: this.first,
         middle: this.middle.concat([
           this.last,
@@ -2243,17 +2243,21 @@ export class RunnableSequence<
         name: this.name ?? coerceable.name,
         omitSequenceTags: this.omitSequenceTags,
         processInputs: this.processInputs,
-        processOutputs: this.processOutputs,
+        processOutputs: this.processOutputs as
+          | ((output: Exclude<NewRunOutput, Error>) => unknown)
+          | undefined,
       });
     } else {
-      return new RunnableSequence({
+      return new RunnableSequence<RunInput, Exclude<NewRunOutput, Error>>({
         first: this.first,
         middle: [...this.middle, this.last],
         last: _coerceToRunnable(coerceable),
         name: this.name,
         omitSequenceTags: this.omitSequenceTags,
         processInputs: this.processInputs,
-        processOutputs: this.processOutputs,
+        processOutputs: this.processOutputs as
+          | ((output: Exclude<NewRunOutput, Error>) => unknown)
+          | undefined,
       });
     }
   }

--- a/libs/langchain-core/src/runnables/index.ts
+++ b/libs/langchain-core/src/runnables/index.ts
@@ -7,6 +7,7 @@ export {
   RunnableBinding,
   RunnableEach,
   RunnableRetry,
+  type RunnableSequenceFields,
   RunnableSequence,
   RunnableMap,
   RunnableParallel,

--- a/libs/langchain-core/src/runnables/tests/runnable.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable.test.ts
@@ -427,8 +427,8 @@ test("RunnableSequence trace processors transform only sequence callbacks", asyn
       (input: { value: string }) => ({ value: `${input.value}!` }),
     ],
     {
-      traceInputs: () => null,
-      traceOutputs: () => undefined,
+      processInputs: () => null,
+      processOutputs: () => undefined,
     }
   );
 
@@ -448,19 +448,19 @@ test("RunnableSequence trace processors transform only sequence callbacks", asyn
 });
 
 test("RunnableSequence trace processors run without callbacks and preserve failures", async () => {
-  const traceInputs = vi.fn(() => {
+  const processInputs = vi.fn(() => {
     throw new Error("processor failure");
   });
-  const traceOutputs = vi.fn((output: string) => output.toUpperCase());
+  const processOutputs = vi.fn((output: string) => output.toUpperCase());
   const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   const sequence = RunnableSequence.from(
     [(input: string) => input, (input: string) => `${input}!`],
-    { traceInputs, traceOutputs }
+    { processInputs, processOutputs }
   );
 
   await expect(sequence.invoke("original")).resolves.toBe("original!");
-  expect(traceInputs).toHaveBeenCalledWith("original");
-  expect(traceOutputs).toHaveBeenCalledWith("original!");
+  expect(processInputs).toHaveBeenCalledWith("original");
+  expect(processOutputs).toHaveBeenCalledWith("original!");
   expect(warn).toHaveBeenCalledWith(
     "Failed to process RunnableSequence trace input.",
     expect.any(Error)
@@ -473,8 +473,8 @@ test("RunnableSequence batch traces each result with its matching run", async ()
   const sequence = RunnableSequence.from(
     [(input: number) => input, (input: number) => input + 1],
     {
-      traceInputs: (input) => ({ traced: input }),
-      traceOutputs: (output) => ({ traced: output }),
+      processInputs: (input) => ({ traced: input }),
+      processOutputs: (output) => ({ traced: output }),
     }
   );
 
@@ -505,7 +505,7 @@ test("RunnableSequence streaming traces processed aggregate output", async () =>
           yield "lo";
         })(),
     ],
-    { traceInputs: () => [], traceOutputs: () => false }
+    { processInputs: () => [], processOutputs: () => false }
   );
 
   const chunks = [];
@@ -527,8 +527,8 @@ test("RunnableSequence retains processors through withConfig and pipe", async ()
   const sequence = RunnableSequence.from(
     [(input: string) => input, (input: string) => `${input}!`],
     {
-      traceInputs: () => ({ input: "traced" }),
-      traceOutputs: () => ({ output: "traced" }),
+      processInputs: () => ({ input: "traced" }),
+      processOutputs: () => ({ output: "traced" }),
     }
   );
 
@@ -540,8 +540,8 @@ test("RunnableSequence retains processors through withConfig and pipe", async ()
 
   expect(tracer.runs[0].inputs).toEqual({ input: "traced" });
   expect(tracer.runs[0].outputs).toEqual({ output: "traced" });
-  expect(sequence.toJSON().kwargs).not.toHaveProperty("traceInputs");
-  expect(sequence.toJSON().kwargs).not.toHaveProperty("traceOutputs");
+  expect(sequence.toJSON().kwargs).not.toHaveProperty("processInputs");
+  expect(sequence.toJSON().kwargs).not.toHaveProperty("processOutputs");
 });
 
 test("RunnableSequence keeps the left sequence trace processors when piping sequences", async () => {
@@ -549,15 +549,15 @@ test("RunnableSequence keeps the left sequence trace processors when piping sequ
   const first = RunnableSequence.from(
     [(input: string) => input, (input: string) => `${input}!`],
     {
-      traceInputs: () => "left input",
-      traceOutputs: () => "left output",
+      processInputs: () => "left input",
+      processOutputs: () => "left output",
     }
   );
   const last = RunnableSequence.from(
     [(input: string) => input, (input: string) => `${input}?`],
     {
-      traceInputs: () => "right input",
-      traceOutputs: () => "right output",
+      processInputs: () => "right input",
+      processOutputs: () => "right output",
     }
   );
 

--- a/libs/langchain-core/src/runnables/tests/runnable.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable.test.ts
@@ -540,8 +540,13 @@ test("RunnableSequence retains processors through withConfig and pipe", async ()
 
   expect(tracer.runs[0].inputs).toEqual({ input: "traced" });
   expect(tracer.runs[0].outputs).toEqual({ output: "traced" });
-  expect(sequence.toJSON().kwargs).not.toHaveProperty("processInputs");
-  expect(sequence.toJSON().kwargs).not.toHaveProperty("processOutputs");
+  const serialized = sequence.toJSON();
+  expect("kwargs" in serialized && serialized.kwargs).not.toHaveProperty(
+    "processInputs"
+  );
+  expect("kwargs" in serialized && serialized.kwargs).not.toHaveProperty(
+    "processOutputs"
+  );
 });
 
 test("RunnableSequence keeps the left sequence trace processors when piping sequences", async () => {

--- a/libs/langchain-core/src/runnables/tests/runnable.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable.test.ts
@@ -24,7 +24,9 @@ import {
   FakeListChatModel,
   SingleRunExtractor,
   FakeStreamingChatModel,
+  FakeTracer,
 } from "../../utils/testing/index.js";
+import { awaitAllCallbacks } from "../../singletons/callbacks.js";
 import { charChunks } from "../../utils/testing/helpers.js";
 import { RunnableSequence, RunnableLambda } from "../base.js";
 import { RouterRunnable } from "../router.js";
@@ -415,6 +417,155 @@ test("Create a runnable sequence with a static method with no tags", async () =>
   for (const event of events) {
     expect(event.tags?.find((tag) => tag.startsWith("seq:"))).toBeUndefined();
   }
+});
+
+test("RunnableSequence trace processors transform only sequence callbacks", async () => {
+  const tracer = new FakeTracer();
+  const sequence = RunnableSequence.from(
+    [
+      (input: { value: string }) => input,
+      (input: { value: string }) => ({ value: `${input.value}!` }),
+    ],
+    {
+      traceInputs: () => null,
+      traceOutputs: () => undefined,
+    }
+  );
+
+  await expect(
+    sequence.invoke({ value: "original" }, { callbacks: [tracer] })
+  ).resolves.toEqual({
+    value: "original!",
+  });
+  await awaitAllCallbacks();
+
+  expect(tracer.runs).toHaveLength(1);
+  expect(tracer.runs[0].inputs).toEqual({ input: null });
+  expect(tracer.runs[0].outputs).toEqual({ output: undefined });
+  expect(tracer.runs[0].child_runs).toHaveLength(2);
+  expect(tracer.runs[0].child_runs[0].inputs).toEqual({ value: "original" });
+  expect(tracer.runs[0].child_runs[1].outputs).toEqual({ value: "original!" });
+});
+
+test("RunnableSequence trace processors run without callbacks and preserve failures", async () => {
+  const traceInputs = vi.fn(() => {
+    throw new Error("processor failure");
+  });
+  const traceOutputs = vi.fn((output: string) => output.toUpperCase());
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const sequence = RunnableSequence.from(
+    [(input: string) => input, (input: string) => `${input}!`],
+    { traceInputs, traceOutputs }
+  );
+
+  await expect(sequence.invoke("original")).resolves.toBe("original!");
+  expect(traceInputs).toHaveBeenCalledWith("original");
+  expect(traceOutputs).toHaveBeenCalledWith("original!");
+  expect(warn).toHaveBeenCalledWith(
+    "Failed to process RunnableSequence trace input.",
+    expect.any(Error)
+  );
+  warn.mockRestore();
+});
+
+test("RunnableSequence batch traces each result with its matching run", async () => {
+  const tracer = new FakeTracer();
+  const sequence = RunnableSequence.from(
+    [(input: number) => input, (input: number) => input + 1],
+    {
+      traceInputs: (input) => ({ traced: input }),
+      traceOutputs: (output) => ({ traced: output }),
+    }
+  );
+
+  await expect(
+    sequence.batch([1, 2], { callbacks: [tracer] })
+  ).resolves.toEqual([2, 3]);
+  await awaitAllCallbacks();
+
+  expect(tracer.runs).toHaveLength(2);
+  expect(tracer.runs.map((run) => run.inputs)).toEqual([
+    { traced: 1 },
+    { traced: 2 },
+  ]);
+  expect(tracer.runs.map((run) => run.outputs)).toEqual([
+    { traced: 2 },
+    { traced: 3 },
+  ]);
+});
+
+test("RunnableSequence streaming traces processed aggregate output", async () => {
+  const tracer = new FakeTracer();
+  const sequence = RunnableSequence.from(
+    [
+      (input: string) => input,
+      () =>
+        (async function* () {
+          yield "hel";
+          yield "lo";
+        })(),
+    ],
+    { traceInputs: () => [], traceOutputs: () => false }
+  );
+
+  const chunks = [];
+  for await (const chunk of await sequence.stream("original", {
+    callbacks: [tracer],
+  })) {
+    chunks.push(chunk);
+  }
+  await awaitAllCallbacks();
+
+  expect(chunks).toEqual(["hel", "lo"]);
+  expect(tracer.runs).toHaveLength(1);
+  expect(tracer.runs[0].inputs).toEqual({ input: [] });
+  expect(tracer.runs[0].outputs).toEqual({ output: false });
+});
+
+test("RunnableSequence retains processors through withConfig and pipe", async () => {
+  const tracer = new FakeTracer();
+  const sequence = RunnableSequence.from(
+    [(input: string) => input, (input: string) => `${input}!`],
+    {
+      traceInputs: () => ({ input: "traced" }),
+      traceOutputs: () => ({ output: "traced" }),
+    }
+  );
+
+  await sequence
+    .withConfig({ callbacks: [tracer] })
+    .pipe((input) => `${input}?`)
+    .invoke("original");
+  await awaitAllCallbacks();
+
+  expect(tracer.runs[0].inputs).toEqual({ input: "traced" });
+  expect(tracer.runs[0].outputs).toEqual({ output: "traced" });
+  expect(sequence.toJSON().kwargs).not.toHaveProperty("traceInputs");
+  expect(sequence.toJSON().kwargs).not.toHaveProperty("traceOutputs");
+});
+
+test("RunnableSequence keeps the left sequence trace processors when piping sequences", async () => {
+  const tracer = new FakeTracer();
+  const first = RunnableSequence.from(
+    [(input: string) => input, (input: string) => `${input}!`],
+    {
+      traceInputs: () => "left input",
+      traceOutputs: () => "left output",
+    }
+  );
+  const last = RunnableSequence.from(
+    [(input: string) => input, (input: string) => `${input}?`],
+    {
+      traceInputs: () => "right input",
+      traceOutputs: () => "right output",
+    }
+  );
+
+  await first.pipe(last).invoke("original", { callbacks: [tracer] });
+  await awaitAllCallbacks();
+
+  expect(tracer.runs[0].inputs).toEqual({ input: "left input" });
+  expect(tracer.runs[0].outputs).toEqual({ output: "left output" });
 });
 
 test("RunnableSequence can pass config to every step in batched request", async () => {


### PR DESCRIPTION
### Summary

- add synchronous `traceInputs` and `traceOutputs` hooks for `RunnableSequence` callback payloads without changing execution values or child span payloads
- apply hooks across invoke, batch, and streaming paths; preserve raw values when a processor throws
- correct the existing batch callback bug so each sequence run records its own output
- preserve left-hand sequence trace processors when composing sequences and omit processors from serialization

### Validation

- `pnpm format`
- `pnpm lint`
- `pnpm --filter @langchain/core exec vitest run src/runnables/tests/runnable.test.ts --no-color`
- `pnpm --filter @langchain/core build`

Made by [Open SWE](https://openswe.vercel.app/agents/7bba1c1a-b3e1-5910-9d8a-a7c9ebed07e9)