### PR TITLE
fix(google): thought and thoughtSignature on round trip

### DIFF
--- a/.changeset/soft-olives-rhyme.md
+++ b/.changeset/soft-olives-rhyme.md
@@ -1,0 +1,19 @@
+---
+"@langchain/google": patch
+---
+
+This addresses four specific issues:
+
+- "thought" and "thoughtSignature" not being present in the conversation
+  history sent to Gemini when using v0 messages
+- "thought" and "thoughtSignature" not being present in the conversation history sent to Gemini when using v1 messages
+- "thoughtSignature" not being present in v1 tool calls specifically
+- ContentBlock.Reasoning not being handled in v1 at all
+
+It does so by, largely, keeping the existing logic converting from LangChain representation to a Google.Part in both the v0 (legacy) and v1 (standard) paths intact. (This is done in both in the messages.ts file.)
+
+- In convertLegacyContentMessageToGeminiContent(), the conversion is moved to a new function: convertLegacyPartToGeminiPart() for consistency with the standard path and to standardize where and how the thought/thoughtSignature fields are added
+- Both convertLegacyPartToGeminiPart() and convertStandardContentBlockToGeminiPart() get a baseGeminiPart() function that returns the Gemini.Part without the thought or thoughtSignature fields
+- Both then add the additional fields, if necessary, independent of what the underlying Gemini.Part is.
+
+The last point is done because Gemini can attach "thought" or "thoughtSignature" to any block type. Not just text.

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -134,6 +134,7 @@ const allModelInfo: ModelInfo[] = [
     model: "gemini-3.7-flash",
     testConfig: {
       isThinking: true,
+      only: true,
     },
   },
   {
@@ -1743,6 +1744,105 @@ describe.each(thinkingModelInfo)(
       );
       expect(hasThoughtSignature).toBe(true);
     });
+    test.only("thought/thoughtSignature survive a multi-turn round trip (regression for #10461)", async () => {
+      // Reproduces the production bug: resending a prior thinking AIMessage
+      // as history silently stripped its thought marker/signature before
+      // this fix, either losing the flag (legacy content array) or dropping
+      // the block outright (contentBlocks -> ChatGoogleTranslator ->
+      // "reasoning" -> default: return null in the standard converter).
+
+      // Make sure reasoning effort is high to force thinking blocks
+      const llm = newChatGoogle({ reasoningEffort: "high" });
+
+      const firstResult = await llm.invoke("Why is the sky blue?");
+      const firstReasoningBlocks = firstResult.contentBlocks.filter(
+        (b) => b.type === "reasoning"
+      );
+      expect(firstReasoningBlocks.length).toBeGreaterThan(0);
+      const firstSignatures = firstResult.contentBlocks
+        .filter((b) => "thoughtSignature" in b)
+        .map((b) => b.thoughtSignature);
+      expect(firstSignatures.length).toBeGreaterThan(0);
+
+      // Feed the thinking AIMessage back in as history and ask a follow-up.
+      // recorder.request captures the actual outbound HTTP body for the
+      // second call — assert the resent turn's `contents` entry still
+      // carries `thought`/`thoughtSignature` on the wire, not just that the
+      // call succeeds (a successful call alone wouldn't catch a silently
+      // dropped/unflagged thought block, since Gemini doesn't require the
+      // resent history to include one).
+      await llm.invoke([
+        new HumanMessage("Why is the sky blue?"),
+        firstResult,
+        new HumanMessage("Now explain it to a 5 year old."),
+      ]);
+
+      const sentContents = recorder.request?.body?.contents ?? [];
+      const modelTurn = sentContents.find(
+        (c: { role?: string }) => c.role === "model"
+      );
+      expect(modelTurn).toBeDefined();
+
+      const sentThoughtParts = (modelTurn?.parts ?? []).filter(
+        (p: { thought?: boolean }) => p.thought === true
+      );
+      expect(sentThoughtParts.length).toBeGreaterThan(0);
+
+      const sentSignatures = (modelTurn?.parts ?? [])
+        .filter((p: { thoughtSignature?: string }) => "thoughtSignature" in p)
+        .map((p: { thoughtSignature?: string }) => p.thoughtSignature);
+      expect(sentSignatures.length).toBeGreaterThan(0);
+      // At least one signature from the first response must round-trip
+      // verbatim — Gemini validates these, so a regenerated/blank value
+      // would defeat the point of preserving the field at all.
+      expect(
+        sentSignatures.some((sig: string | undefined) =>
+          firstSignatures.includes(sig)
+        )
+      ).toBe(true);
+    });
+
+    test.only("functionCall thoughtSignature survives a multi-turn round trip after a real tool call (root cause: tool_calls-rebuild path)", async () => {
+      // tool_calls-rebuilt functionCall parts don't get thoughtSignature "for free" like content-block items do.
+      const tools = [weatherTool];
+      const llm: Runnable = newChatGoogle({
+        reasoningEffort: "high",
+      }).bindTools(tools);
+
+      const firstResult = (await llm.invoke(
+        "What is the weather in New York?"
+      )) as AIMessage;
+      expect(firstResult.tool_calls?.length).toBeGreaterThan(0);
+      const toolCall = firstResult.tool_calls![0];
+      const toolCallSignature = (toolCall as { thoughtSignature?: string })
+        .thoughtSignature;
+      expect(toolCallSignature).toBeDefined();
+
+      // Force v1 - the default (legacy) route already preserves this signature
+      firstResult.response_metadata = {
+        ...firstResult.response_metadata,
+        output_version: "v1",
+      };
+
+      await llm.invoke([
+        new HumanMessage("What is the weather in New York?"),
+        firstResult,
+        new ToolMessage(JSON.stringify({ temp: 21 }), toolCall.id as string),
+      ]);
+
+      const sentContents = recorder.request?.body?.contents ?? [];
+      const modelTurn = sentContents.find(
+        (c: { role?: string }) => c.role === "model"
+      );
+      expect(modelTurn).toBeDefined();
+
+      const sentFunctionCallPart = (modelTurn?.parts ?? []).find(
+        (p: { functionCall?: unknown }) => "functionCall" in p
+      ) as { thoughtSignature?: string } | undefined;
+      expect(sentFunctionCallPart).toBeDefined();
+      expect(sentFunctionCallPart?.thoughtSignature).toBe(toolCallSignature);
+    });
+
   }
 );
 

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1847,7 +1847,6 @@ describe.each(thinkingModelInfo)(
       expect(sentFunctionCallPart).toBeDefined();
       expect(sentFunctionCallPart?.thoughtSignature).toBe(toolCallSignature);
     });
-
   }
 );
 

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -134,7 +134,12 @@ const allModelInfo: ModelInfo[] = [
     model: "gemini-3.7-flash",
     testConfig: {
       isThinking: true,
-      only: true,
+    },
+  },
+  {
+    model: "gemini-3.8-flash",
+    testConfig: {
+      isThinking: true,
     },
   },
   {
@@ -1744,7 +1749,7 @@ describe.each(thinkingModelInfo)(
       );
       expect(hasThoughtSignature).toBe(true);
     });
-    test.only("thought/thoughtSignature survive a multi-turn round trip (regression for #10461)", async () => {
+    test("thought/thoughtSignature survive a multi-turn round trip (regression for #10461)", async () => {
       // Reproduces the production bug: resending a prior thinking AIMessage
       // as history silently stripped its thought marker/signature before
       // this fix, either losing the flag (legacy content array) or dropping
@@ -1802,7 +1807,7 @@ describe.each(thinkingModelInfo)(
       ).toBe(true);
     });
 
-    test.only("functionCall thoughtSignature survives a multi-turn round trip after a real tool call (root cause: tool_calls-rebuild path)", async () => {
+    test("functionCall thoughtSignature survives a multi-turn round trip after a real tool call (root cause: tool_calls-rebuild path)", async () => {
       // tool_calls-rebuilt functionCall parts don't get thoughtSignature "for free" like content-block items do.
       const tools = [weatherTool];
       const llm: Runnable = newChatGoogle({

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -381,6 +381,25 @@ function convertStandardVideoContentBlockToGeminiPart(
   return ret;
 }
 
+function convertStandardReasoningBlockToGeminiPart(
+  block: ContentBlock.Reasoning
+): Gemini.Part | null {
+  // Reasoning blocks created from Gemini should contain the base
+  // standard block they would be if "thought" wasn't set to true.
+  // If it exists, we'll use that. Otherwise, we'll assume it was
+  // originally a text block.
+  const ret = "reasoningContentBlock" in block && block.reasoningContentBlock
+    ? convertStandardContentBlockToGeminiPart(block.reasoningContentBlock as ContentBlock.Standard)
+    : {text: block.reasoning}
+
+  // Then add that this came from the thinking process
+  if (ret) {
+    ret.thought = true;
+  }
+
+  return ret;
+}
+
 /**
  * Converts a single LangChain standard content block (v1 format)
  * into a Gemini.Part.
@@ -390,19 +409,32 @@ function convertStandardVideoContentBlockToGeminiPart(
 function convertStandardContentBlockToGeminiPart(
   block: ContentBlock.Standard
 ): Gemini.Part | null {
-  switch (block.type) {
-    case "text":
-      return { text: block.text };
-    case "image":
-    case "audio":
-    case "text-plain":
-    case "file":
-      return convertStandardDataContentBlockToGeminiPart(block);
-    case "video":
-      return convertStandardVideoContentBlockToGeminiPart(block);
-    default:
-      return null;
+
+  function baseGeminiPart(): Gemini.Part | null {
+    switch (block.type) {
+      case "text":
+        return { text: block.text };
+      case "reasoning":
+        return convertStandardReasoningBlockToGeminiPart(block);
+      case "image":
+      case "audio":
+      case "text-plain":
+      case "file":
+        return convertStandardDataContentBlockToGeminiPart(block);
+      case "video":
+        return convertStandardVideoContentBlockToGeminiPart(block);
+      default:
+        return null;
+    }
   }
+
+  const ret: Gemini.Part | null = baseGeminiPart();
+  if (ret) {
+    if ("thoughtSignature" in ret) {
+      ret.thoughtSignature = ret.thoughtSignature!;
+    }
+  }
+  return ret;
 }
 
 /**

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -727,6 +727,13 @@ function convertLegacyPartToGeminiPart(
   }
 
   const ret = baseGeminiPart();
+  const itemRecord = item as Record<string,unknown>;
+  if ("thought" in itemRecord) {
+    ret.thought = itemRecord.thought as boolean;
+  }
+  if ("thoughtSignature" in itemRecord) {
+    ret.thoughtSignature = itemRecord.thoughtSignature as string;
+  }
   return ret;
 }
 

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -430,8 +430,8 @@ function convertStandardContentBlockToGeminiPart(
 
   const ret: Gemini.Part | null = baseGeminiPart();
   if (ret) {
-    if ("thoughtSignature" in ret) {
-      ret.thoughtSignature = ret.thoughtSignature!;
+    if ("thoughtSignature" in block) {
+      ret.thoughtSignature = block.thoughtSignature! as string;
     }
   }
   return ret;
@@ -502,12 +502,16 @@ function convertStandardContentMessageToGeminiContent(
   // Convert AIMessage tool_calls to functionCall parts
   if (AIMessage.isInstance(message) && message.tool_calls?.length) {
     for (const toolCall of message.tool_calls) {
-      parts.push({
+      const part = {
         functionCall: {
           name: toolCall.name,
           args: toolCall.args ?? {},
         },
-      } as Gemini.Part.FunctionCall);
+      } as Gemini.Part.FunctionCall;
+      if ("thoughtSignature" in toolCall) {
+        part.thoughtSignature = toolCall.thoughtSignature as string;
+      }
+      parts.push(part);
     }
   }
 

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -388,9 +388,12 @@ function convertStandardReasoningBlockToGeminiPart(
   // standard block they would be if "thought" wasn't set to true.
   // If it exists, we'll use that. Otherwise, we'll assume it was
   // originally a text block.
-  const ret = "reasoningContentBlock" in block && block.reasoningContentBlock
-    ? convertStandardContentBlockToGeminiPart(block.reasoningContentBlock as ContentBlock.Standard)
-    : {text: block.reasoning}
+  const ret =
+    "reasoningContentBlock" in block && block.reasoningContentBlock
+      ? convertStandardContentBlockToGeminiPart(
+          block.reasoningContentBlock as ContentBlock.Standard
+        )
+      : { text: block.reasoning };
 
   // Then add that this came from the thinking process
   if (ret) {
@@ -409,7 +412,6 @@ function convertStandardReasoningBlockToGeminiPart(
 function convertStandardContentBlockToGeminiPart(
   block: ContentBlock.Standard
 ): Gemini.Part | null {
-
   function baseGeminiPart(): Gemini.Part | null {
     switch (block.type) {
       case "text":
@@ -556,7 +558,6 @@ function convertStandardContentMessageToGeminiContent(
 function convertLegacyPartToGeminiPart(
   item: string | ContentBlock | Text
 ): Gemini.Part {
-
   /**
    * @deprecated - This is for use by `convertLegacyContentMessageToGeminiContent` only
    */
@@ -728,42 +729,42 @@ function convertLegacyPartToGeminiPart(
   }
 
   function baseGeminiPart(): Gemini.Part {
-    if( typeof item === "string" ){
-      return {text: item};
-    } else if( typeof item === "object" && item !== null ){
-      if( isMessageContentText( item ) ){
-        return {text: item.text};
-      } else if( isDataContentBlock( item ) ){
-        return convertToProviderContentBlock( item, geminiContentBlockConverter )
-      } else if( "type" in item && item?.type === "functionCall" ){
-        const {type, functionCall, ...etc} = item;
+    if (typeof item === "string") {
+      return { text: item };
+    } else if (typeof item === "object" && item !== null) {
+      if (isMessageContentText(item)) {
+        return { text: item.text };
+      } else if (isDataContentBlock(item)) {
+        return convertToProviderContentBlock(item, geminiContentBlockConverter);
+      } else if ("type" in item && item?.type === "functionCall") {
+        const { type, functionCall, ...etc } = item;
         return {
           ...etc,
           functionCall,
         } as Gemini.Part.FunctionCall;
-      } else if( "type" in item && item?.type === "executableCode" ){
-        const {type, executableCode, ...etc} = item;
+      } else if ("type" in item && item?.type === "executableCode") {
+        const { type, executableCode, ...etc } = item;
         return {
           ...etc,
           executableCode,
         } as Gemini.Part.ExecutableCode;
-      } else if( "type" in item && item?.type === "codeExecutionResult" ){
-        const {type, codeExecutionResult, ...etc} = item;
+      } else if ("type" in item && item?.type === "codeExecutionResult") {
+        const { type, codeExecutionResult, ...etc } = item;
         return {
           ...etc,
           codeExecutionResult,
         } as Gemini.Part.CodeExecutionResult;
-      } else if( isMessageContentImageUrl( item ) ){
-        return messageContentImageUrl( item );
-      } else if( isMessageContentMedia( item ) ){
-        return messageContentMedia( item );
+      } else if (isMessageContentImageUrl(item)) {
+        return messageContentImageUrl(item);
+      } else if (isMessageContentMedia(item)) {
+        return messageContentMedia(item);
       }
     }
     return item as Gemini.Part;
   }
 
   const ret = baseGeminiPart();
-  const itemRecord = item as Record<string,unknown>;
+  const itemRecord = item as Record<string, unknown>;
   if ("thought" in itemRecord) {
     ret.thought = itemRecord.thought as boolean;
   }

--- a/libs/providers/langchain-google/src/converters/messages.ts
+++ b/libs/providers/langchain-google/src/converters/messages.ts
@@ -517,20 +517,9 @@ function convertStandardContentMessageToGeminiContent(
   return { role, parts };
 }
 
-/**
- * Converts a single LangChain message with legacy content blocks (v0 format) to Gemini Content.
- * This handles messages that have `response_metadata.output_version === "v0"`.
- *
- * This is intended to be called from `convertMessagesToGeminiContent`
- */
-function convertLegacyContentMessageToGeminiContent(
-  message: BaseMessage,
-  messages: BaseMessage[]
-): Gemini.Content | null {
-  // Skip system messages - they're handled separately
-  if (SystemMessage.isInstance(message)) {
-    return null;
-  }
+function convertLegacyPartToGeminiPart(
+  item: string | ContentBlock | Text
+): Gemini.Part {
 
   /**
    * @deprecated - This is for use by `convertLegacyContentMessageToGeminiContent` only
@@ -702,6 +691,60 @@ function convertLegacyContentMessageToGeminiContent(
     return ret;
   }
 
+  function baseGeminiPart(): Gemini.Part {
+    if( typeof item === "string" ){
+      return {text: item};
+    } else if( typeof item === "object" && item !== null ){
+      if( isMessageContentText( item ) ){
+        return {text: item.text};
+      } else if( isDataContentBlock( item ) ){
+        return convertToProviderContentBlock( item, geminiContentBlockConverter )
+      } else if( "type" in item && item?.type === "functionCall" ){
+        const {type, functionCall, ...etc} = item;
+        return {
+          ...etc,
+          functionCall,
+        } as Gemini.Part.FunctionCall;
+      } else if( "type" in item && item?.type === "executableCode" ){
+        const {type, executableCode, ...etc} = item;
+        return {
+          ...etc,
+          executableCode,
+        } as Gemini.Part.ExecutableCode;
+      } else if( "type" in item && item?.type === "codeExecutionResult" ){
+        const {type, codeExecutionResult, ...etc} = item;
+        return {
+          ...etc,
+          codeExecutionResult,
+        } as Gemini.Part.CodeExecutionResult;
+      } else if( isMessageContentImageUrl( item ) ){
+        return messageContentImageUrl( item );
+      } else if( isMessageContentMedia( item ) ){
+        return messageContentMedia( item );
+      }
+    }
+    return item as Gemini.Part;
+  }
+
+  const ret = baseGeminiPart();
+  return ret;
+}
+
+/**
+ * Converts a single LangChain message with legacy content blocks (v0 format) to Gemini Content.
+ * This handles messages that have `response_metadata.output_version === "v0"`.
+ *
+ * This is intended to be called from `convertMessagesToGeminiContent`
+ */
+function convertLegacyContentMessageToGeminiContent(
+  message: BaseMessage,
+  messages: BaseMessage[]
+): Gemini.Content | null {
+  // Skip system messages - they're handled separately
+  if (SystemMessage.isInstance(message)) {
+    return null;
+  }
+
   const role: Gemini.Role = iife(() => {
     if (HumanMessage.isInstance(message)) {
       return "user";
@@ -744,41 +787,8 @@ function convertLegacyContentMessageToGeminiContent(
   } else if (Array.isArray(message.content)) {
     // Array of content blocks (legacy format)
     for (const item of message.content) {
-      if (typeof item === "string") {
-        parts.push({ text: item });
-      } else if (typeof item === "object" && item !== null) {
-        if (isMessageContentText(item)) {
-          parts.push({ text: item.text });
-        } else if (isDataContentBlock(item)) {
-          parts.push(
-            convertToProviderContentBlock(item, geminiContentBlockConverter)
-          );
-        } else if (item?.type === "functionCall") {
-          const { type, functionCall, ...etc } = item;
-          parts.push({
-            ...etc,
-            functionCall,
-          } as Gemini.Part.FunctionCall);
-        } else if (item?.type === "executableCode") {
-          const { type, executableCode, ...etc } = item;
-          parts.push({
-            ...etc,
-            executableCode,
-          } as Gemini.Part.ExecutableCode);
-        } else if (item?.type === "codeExecutionResult") {
-          const { type, codeExecutionResult, ...etc } = item;
-          parts.push({
-            ...etc,
-            codeExecutionResult,
-          } as Gemini.Part.CodeExecutionResult);
-        } else if (isMessageContentImageUrl(item)) {
-          parts.push(messageContentImageUrl(item));
-        } else if (isMessageContentMedia(item)) {
-          parts.push(messageContentMedia(item));
-        } else {
-          parts.push(item as Gemini.Part);
-        }
-      }
+      const part = convertLegacyPartToGeminiPart(item);
+      parts.push(part);
     }
   }
 

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -500,6 +500,61 @@ describe("convertMessagesToGeminiContents", () => {
     expect(functionCallPart.functionCall!.args).toEqual({ city: "London" });
   });
 
+  test("AIMessage tool_calls carrying a thoughtSignature reattach it to the rebuilt functionCall part (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "call-1",
+          type: "tool_call",
+          thoughtSignature: "sig-abc",
+        } as {
+          name: string;
+          args: object;
+          id: string;
+          thoughtSignature: string;
+        },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hello"),
+      aiMsg,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    const functionCallPart = modelContent!.parts.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(functionCallPart).toBeDefined();
+    expect(functionCallPart.thoughtSignature).toBe("sig-abc");
+  });
+
+  test("AIMessage tool_calls with no thoughtSignature produce a functionCall part with no thoughtSignature key (v1 path)", () => {
+    const aiMsg = new AIMessage({
+      content: "",
+      tool_calls: [
+        { name: "get_weather", args: { city: "London" }, id: "call-1" },
+      ],
+    });
+    aiMsg.response_metadata = { output_version: "v1" };
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hello"),
+      aiMsg,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    const functionCallPart = modelContent!.parts.find(
+      (p) => "functionCall" in p && p.functionCall
+    ) as Gemini.Part.FunctionCall;
+    expect(functionCallPart).toBeDefined();
+    expect("thoughtSignature" in functionCallPart).toBe(false);
+  });
+
   test("ToolMessage name resolved from tool_calls (v1 path)", () => {
     const aiMsg = new AIMessage({
       content: "",

--- a/libs/providers/langchain-google/src/converters/tests/messages.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/messages.test.ts
@@ -1224,6 +1224,135 @@ describe("convertMessagesToGeminiContents", () => {
       },
     ]);
   });
+
+  test("legacy path: preserves thought and thoughtSignature on a resent text block", () => {
+    // Shape returned by convertGeminiCandidateToAIMessage for a thinking-model
+    // response — a text part with `thought: true` immediately followed by a
+    // functionCall part carrying `thoughtSignature`. When this AIMessage is
+    // fed back in as history on the next turn, the thought text must keep
+    // its `thought`/`thoughtSignature` markers so Gemini can tell it apart
+    // from a real committed utterance (see
+    // https://ai.google.dev/gemini-api/docs/thinking).
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text", text: "internal reasoning", thought: true },
+        {
+          type: "functionCall",
+          functionCall: { name: "get_weather", args: { city: "London" } },
+          thoughtSignature: "sig-abc",
+        },
+      ],
+      tool_calls: [
+        {
+          name: "get_weather",
+          args: { city: "London" },
+          id: "call-1",
+          type: "tool_call",
+        },
+      ],
+    });
+
+    const messages = [new HumanMessage("what's the weather?"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("legacy path: a plain text block with no thought key is unaffected", () => {
+    const message = new AIMessage({
+      content: [{ type: "text", text: "Here are your results." }],
+    });
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hi"),
+      message,
+    ]);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    expect(modelContent!.parts).toEqual([{ text: "Here are your results." }]);
+  });
+
+  test("v1 contentBlocks (explicit output_version): preserves thought and thoughtSignature on a resent text block", () => {
+    // response_metadata.output_version === "v1" makes AIMessage.contentBlocks
+    // return `content` verbatim (ai.ts:196-202), bypassing ChatGoogleTranslator
+    // entirely — exercises convertStandardContentBlockToGeminiPart's "text" case.
+    const priorAiMessage = new AIMessage({
+      content: [
+        { type: "text" as const, text: "internal reasoning", thought: true },
+      ],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("v1 contentBlocks (via ChatGoogleTranslator): preserves thought on a resent reasoning block", () => {
+    // The real-world shape: every AIMessage this package produces carries
+    // response_metadata.model_provider = "google" (see
+    // convertGeminiCandidateToAIMessage). With no output_version override,
+    // AIMessage.contentBlocks (ai.ts:204-213) routes through
+    // ChatGoogleTranslator, which normalizes a `{ type: "text", thought:
+    // true }` part into `{ type: "reasoning", reasoning, thought,
+    // reasoningContentBlock }` (block_translators/google.ts).
+    // convertStandardContentBlockToGeminiPart must handle that "reasoning"
+    // shape too, or this history is silently dropped on the next turn.
+    const priorAiMessage = new AIMessage({
+      content: [{ text: "internal reasoning", thought: true, type: "text" }],
+      response_metadata: { model_provider: "google" },
+    });
+
+    // Sanity check the premise: this AIMessage's own .contentBlocks getter
+    // really does normalize to "reasoning" via ChatGoogleTranslator.
+    const blocks = priorAiMessage.contentBlocks;
+    expect(blocks.some((b) => b.type === "reasoning")).toBe(true);
+
+    const messages = [new HumanMessage("hi"), priorAiMessage];
+    const contents = convertMessagesToGeminiContents(messages);
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const textPart = modelContent!.parts.find((p) => "text" in p) as
+      | Gemini.Part.Text
+      | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("internal reasoning");
+    expect((textPart as unknown as { thought?: boolean }).thought).toBe(true);
+  });
+
+  test("a non-Google reasoning block with no thought flag is dropped, not sent as visible text", () => {
+    const message = new AIMessage({
+      content: [{ type: "reasoning", reasoning: "private reasoning" }],
+      response_metadata: { output_version: "v1" },
+    });
+
+    const contents = convertMessagesToGeminiContents([
+      new HumanMessage("hi"),
+      message,
+    ]);
+
+    expect(contents.find((c) => c.role === "model")).toBeUndefined();
+  });
 });
 
 test("coalesces consecutive plain HumanMessages into one user content", () => {


### PR DESCRIPTION
Fixes #10461 
Supersedes: #11198 #11553

### Background

This addresses four specific issues:
* "thought" and "thoughtSignature" not being present in the conversation history sent to Gemini when using v0 messages
* "thought" and "thoughtSignature" not being present in the conversation history sent to Gemini when using v1 messages
* "thoughtSignature" not being present in v1 tool calls specifically
* `ContentBlock.Reasoning` not being handled in v1 at all

It does so by, largely, keeping the existing logic converting from LangChain representation to a `Google.Part` in both the v0 (legacy) and v1 (standard) paths intact. (This is done in both in the messages.ts file.)
* In `convertLegacyContentMessageToGeminiContent()`, the conversion is moved to a new function: `convertLegacyPartToGeminiPart()` for consistency with the standard path and to standardize where and how the thought/thoughtSignature fields are added
* Both `convertLegacyPartToGeminiPart()` and `convertStandardContentBlockToGeminiPart()` get a `baseGeminiPart()` function that returns the `Gemini.Part` _without_ the thought or thoughtSignature fields
* Both then add the additional fields, if necessary, independent of what the underlying `Gemini.Part` is.

The last point is done because Gemini can attach "thought" or "thoughtSignature" to _any_ block type. Not just text.

### What about the question @afirstenberg kept raising about why this wasn't in a "reasoning" block?

Well, there were two reasons:
* In v0, there is no reasoning block. And there shouldn't be.
* We were missing the "reasoning" handling in the v1 path.

So it was correct that we make sure that text blocks get this additional metadata added back to it.

The v0 content blocks are mostly, but not completely, like the format that is sent by Gemini. It is almost arguable we should just send it back after removing the "type" field. But I wasn't going to dig into that.

I am satisfied, at this point, that we store the v0 in the message `content`, that we should keep doing so, and that we are handling things correctly.

### Why this and not #11553?

This adds the fields back in a slightly different way than #11553 that I think is more correct.

* Issue 11553 adds it back to specific block types. Gemini can take this field on any block type.
* In the v1 path, issue 11553 handles a "reasoning" block by assuming text reasoning, which is an invalid assumption.

### Why wasn't this caught by previous tests?

In some cases, Gemini is tolerant. In other cases... I'm not actually sure why it wasn't.

### Tests

I have added all the tests in chat_models/tests/index.int.test.ts and converters/tests/messages.test.ts from #11553. (But see note about a change to the integration tests.) I have done integration testing against all current models and platforms that we are testing against.

Changes to integration tests:
* Both added tests originally set the reasoningLevel to "low". This didn't guarantee that Gemini would do any thinking at all.
* Changed the reasoning level for both to "high". Which still doesn't guarantee it, but there is a much much higher chance.

Results:
* All "Google Core" and "Google Thinking" tests pass in the integration tests, including the new tests.
* Except as noted below, all the messages tests pass.

Failing tests:
* Four previous tests in messages.test.ts fail. However, these four _also_ failed in issue 11553 and in the current main branch. Several of them _do_ involve tool calls, so they should be investigated more closely.
  * merges consecutive ToolMessages into a single function turn for parallel tool calls (legacy path)
  * AIMessage with tool_calls produces model turn with functionCall parts (legacy path)
  * ToolMessage v1 standard image content block is excluded from functionResponse.result (v1 path)
  * strips type field from executableCode content blocks
* v1 contentBlocks (explicit output_version): preserves thought and thoughtSignature on a resent text block
  * I'm not sure this is a valid test. 
  * It is, essentially, saying that if you add the "thought" field to a text block, which is not a valid v1 attribute, it should "do the right thing".
* a non-Google reasoning block with no thought flag is dropped, not sent as visible text
  * I think this is an invalid test, or at least doesn't match the description.
  * This doesn't test anything about "visible text", and it is explicitly a v1 block, so it is expected to be converted to a Gemini.Part with text and thinking set to true.

### Thanks

My thanks to @jackjin1997 @saarRozenbaum @thushanth-bengre-langchain and @hntrl for helping dig into this.