### PR TITLE
Keep reasoning and tool calls separate while streaming

### DIFF
--- a/.changeset/keep-stream-blocks-separate.md
+++ b/.changeset/keep-stream-blocks-separate.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Keep streamed text, reasoning, and tool calls separate when provider indexes overlap. Preserve tool argument fragments as IDs and indexes become available.

--- a/libs/langchain-core/src/language_models/compat.ts
+++ b/libs/langchain-core/src/language_models/compat.ts
@@ -148,6 +148,26 @@ export async function* convertChunksToEvents(
     number,
     { type: string; accumulated: ContentBlock }
   >();
+  // Provider content and tool indexes are independent input namespaces.
+  // Allocate event indexes together so arrival order cannot create collisions.
+  const blockIndexes = new Map<string, number>();
+  const getBlockIndex = (...keys: (string | undefined)[]): number => {
+    let index: number | undefined;
+    for (const key of keys) {
+      if (key === undefined) continue;
+      const existing = blockIndexes.get(key);
+      if (existing === undefined) continue;
+      if (index !== undefined && index !== existing) {
+        throw new Error("Conflicting provider content block identifiers");
+      }
+      index = existing;
+    }
+    index ??= nextBlockIndex(activeBlocks);
+    for (const key of keys) {
+      if (key !== undefined) blockIndexes.set(key, index);
+    }
+    return index;
+  };
   let messageStarted = false;
   let lastUsage:
     | { input_tokens: number; output_tokens: number; total_tokens: number }
@@ -180,7 +200,9 @@ export async function* convertChunksToEvents(
     const content = msg.content;
     if (typeof content === "string") {
       if (content !== "") {
-        const blockIndex = 0;
+        const blockIndex = getBlockIndex(
+          JSON.stringify(["content", "text", 0])
+        );
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock.Text = { type: "text", text: "" };
           activeBlocks.set(blockIndex, {
@@ -206,8 +228,11 @@ export async function* convertChunksToEvents(
       }
     } else if (Array.isArray(content)) {
       for (const part of content) {
-        const blockIndex =
-          typeof part.index === "number" ? part.index : activeBlocks.size;
+        const blockIndex = getBlockIndex(
+          typeof part.index === "number" || typeof part.index === "string"
+            ? JSON.stringify(["content", part.type, part.index])
+            : undefined
+        );
 
         if (!activeBlocks.has(blockIndex)) {
           activeBlocks.set(blockIndex, {
@@ -239,10 +264,15 @@ export async function* convertChunksToEvents(
       msg.tool_call_chunks.length > 0
     ) {
       for (const toolChunk of msg.tool_call_chunks) {
-        const blockIndex =
-          typeof toolChunk.index === "number"
-            ? toolChunk.index
-            : activeBlocks.size;
+        const blockIndex = getBlockIndex(
+          typeof toolChunk.index === "number" ||
+            typeof toolChunk.index === "string"
+            ? JSON.stringify(["tool", "index", toolChunk.index])
+            : undefined,
+          typeof toolChunk.id === "string" && toolChunk.id.length > 0
+            ? JSON.stringify(["tool", "id", toolChunk.id])
+            : undefined
+        );
 
         if (!activeBlocks.has(blockIndex)) {
           const initial: ContentBlock = {

--- a/libs/langchain-core/src/language_models/tests/compat.test.ts
+++ b/libs/langchain-core/src/language_models/tests/compat.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "vitest";
+import {
+  AIMessageChunk,
+  type AIMessageChunkFields,
+} from "../../messages/ai.js";
+import { ChatGenerationChunk } from "../../outputs.js";
+import { convertChunksToEvents } from "../compat.js";
+import { ChatModelStream } from "../stream.js";
+import type { ChatModelStreamEvent } from "../event.js";
+
+function chunk(
+  content: AIMessageChunkFields["content"],
+  tool_call_chunks: AIMessageChunkFields["tool_call_chunks"] = []
+) {
+  return new ChatGenerationChunk({
+    message: new AIMessageChunk({ content, tool_call_chunks }),
+    text: typeof content === "string" ? content : "",
+  });
+}
+
+async function collect(chunks: ChatGenerationChunk[]) {
+  const before = JSON.stringify(chunks);
+  const events: ChatModelStreamEvent[] = [];
+  async function* source() {
+    yield* chunks;
+  }
+  async function* observed() {
+    for await (const event of convertChunksToEvents(source())) {
+      events.push(event);
+      yield event;
+    }
+  }
+  const message = await new ChatModelStream(observed());
+  const starts = events.filter(
+    (event) => event.event === "content-block-start"
+  );
+  expect(new Set(starts.map((event) => event.index)).size).toBe(starts.length);
+  expect(JSON.stringify(chunks)).toBe(before);
+  return message;
+}
+
+const toolStart = () =>
+  chunk("", [{ index: 0, id: "call_search", name: "search", args: '{"q":' }]);
+const toolEnd = () => chunk("", [{ index: 0, args: '"hello"}' }]);
+const expectedTool = {
+  type: "tool_call",
+  id: "call_search",
+  name: "search",
+  args: { q: "hello" },
+};
+
+describe("convertChunksToEvents block identities", () => {
+  test.each(["text first", "tool first"])(
+    "preserves string text and fragmented tool arguments: %s",
+    async (order) => {
+      const text = chunk("Hello");
+      const start = toolStart();
+      const message = await collect([
+        ...(order === "text first" ? [text, start] : [start, text]),
+        chunk(" world"),
+        toolEnd(),
+      ]);
+      expect(message.text).toBe("Hello world");
+      expect(message.tool_calls).toEqual([expectedTool]);
+    }
+  );
+
+  test("keeps two reasoning summaries separate from a tool with the same index", async () => {
+    const summaries = [
+      { type: "reasoning", index: 0, id: "reasoning_a", reasoning: "First" },
+      { type: "reasoning", index: 1, id: "reasoning_a", reasoning: "Second" },
+    ];
+    const message = await collect([
+      chunk([summaries[0]]),
+      chunk([summaries[1]]),
+      chunk("", [
+        { index: 1, id: "call_search", name: "search", args: '{"q":"hello"}' },
+      ]),
+    ]);
+    expect(message.content.slice(0, 2)).toEqual(summaries);
+    expect(message.tool_calls).toEqual([expectedTool]);
+  });
+
+  test.each(["reasoning first", "text first"])(
+    "allocates late content independently of a prior tool and other content types: %s",
+    async (order) => {
+      const reasoning = chunk([
+        { type: "reasoning", index: 0, reasoning: "Think" },
+      ]);
+      const text = chunk([{ type: "text", index: 0, text: "Answer" }]);
+      const message = await collect([
+        chunk("", [
+          {
+            index: 5,
+            id: "call_search",
+            name: "search",
+            args: '{"q":"hello"}',
+          },
+        ]),
+        ...(order === "reasoning first"
+          ? [reasoning, text]
+          : [text, reasoning]),
+        chunk([{ type: "reasoning", index: 0, reasoning: " again" }]),
+        chunk("!"),
+      ]);
+      expect(message.text).toBe("Answer!");
+      expect(message.content).toContainEqual({
+        type: "reasoning",
+        index: 0,
+        reasoning: "Think again",
+      });
+      expect(message.tool_calls).toEqual([expectedTool]);
+    }
+  );
+
+  test("reuses string content indexes across interleaved tools", async () => {
+    const message = await collect([
+      chunk([{ type: "reasoning", index: "0:0", reasoning: "First" }]),
+      toolStart(),
+      chunk([{ type: "reasoning", index: "0:1", reasoning: "Second" }]),
+      chunk([{ type: "reasoning", index: "0:0", reasoning: " again" }]),
+      toolEnd(),
+    ]);
+    if (!Array.isArray(message.content))
+      throw new Error("Expected content blocks");
+    expect(
+      message.content.filter(
+        (block) => typeof block !== "string" && block.type === "reasoning"
+      )
+    ).toEqual([
+      { type: "reasoning", index: "0:0", reasoning: "First again" },
+      { type: "reasoning", index: "0:1", reasoning: "Second" },
+    ]);
+    expect(message.tool_calls).toEqual([expectedTool]);
+  });
+
+  test.each(["id", "index"])(
+    "links tool aliases when a stream begins with only %s",
+    async (first) => {
+      const message = await collect([
+        chunk("", [
+          {
+            ...(first === "id" ? { id: "call_search" } : { index: 3 }),
+            name: "search",
+            args: '{"q":',
+          },
+        ]),
+        chunk("", [{ index: 3, id: "call_search", args: '"hello"' }]),
+        chunk("", [
+          {
+            ...(first === "id" ? { index: 3 } : { id: "call_search" }),
+            args: "}",
+          },
+        ]),
+      ]);
+      expect(message.tool_calls).toEqual([expectedTool]);
+    }
+  );
+
+  test("does not join parallel tool calls through empty ID placeholders", async () => {
+    const message = await collect([
+      chunk("", [
+        { index: 0, id: "", name: "first", args: '{"value":' },
+        { index: 1, id: "", name: "second", args: '{"value":' },
+      ]),
+      chunk("", [
+        { index: 1, id: "call_second", args: "2}" },
+        { index: 0, id: "call_first", args: "1}" },
+      ]),
+    ]);
+    expect(message.tool_calls).toEqual([
+      {
+        type: "tool_call",
+        id: "call_first",
+        name: "first",
+        args: { value: 1 },
+      },
+      {
+        type: "tool_call",
+        id: "call_second",
+        name: "second",
+        args: { value: 2 },
+      },
+    ]);
+  });
+
+  test("rejects aliases that identify two already-emitted tool blocks", async () => {
+    await expect(
+      collect([
+        chunk("", [
+          { index: 0, id: "call_first", name: "first", args: "{}" },
+          { index: 1, id: "call_second", name: "second", args: "{}" },
+        ]),
+        chunk("", [{ index: 0, id: "call_second", args: "" }]),
+      ])
+    ).rejects.toThrow("Conflicting provider content block identifiers");
+  });
+
+  test("keeps anonymous content distinct with sparse tool indexes and invalid arguments", async () => {
+    const image = { type: "image", mimeType: "image/png", data: "example" };
+    const message = await collect([
+      chunk("", [
+        { index: 1000000, id: "call_invalid", name: "search", args: "{broken" },
+      ]),
+      chunk([image, image]),
+      chunk([{ type: "text", index: 0, text: "Answer" }]),
+    ]);
+    expect(message.text).toBe("Answer");
+    if (!Array.isArray(message.content))
+      throw new Error("Expected content blocks");
+    expect(
+      message.content.filter(
+        (block) => typeof block !== "string" && block.type === "image"
+      )
+    ).toEqual([image, image]);
+    expect(message.tool_calls).toEqual([]);
+    expect(message.content).toContainEqual(
+      expect.objectContaining({
+        type: "invalid_tool_call",
+        id: "call_invalid",
+        args: "{broken",
+      })
+    );
+  });
+});


### PR DESCRIPTION
Fixes #11074.

Legacy content indexes and tool-call indexes can overlap. For example, reasoning summaries at indexes 0 and 1 followed by a tool at index 1 currently attach tool fields to the reasoning block. The assembled message can lose the tool call and carry corrupted content into the next request.

This allocates event indexes together while keeping provider content types/indexes and tool indexes/IDs in separate namespaces. Tool ID and index aliases stay linked as they arrive. Empty ID placeholders do not join parallel calls, and contradictory aliases fail explicitly instead of merging two blocks that were already emitted.

Related proposals #11114 and #11091 remap tool indexes alone. That handles text arriving first, but later content can still claim an allocated tool slot: a tool at provider index 5 followed by text at index 0 is one example. This change remaps both sides and covers reverse arrival order, late reasoning/text, string indexes, fragmented arguments, ID/index transitions, and empty IDs with synthetic core-only tests through `ChatModelStream`.

Validation:

- Full core unit suite: 101 files passed; 1,523 tests passed and 1 skipped.
- Core TypeScript check, touched-file oxlint, and formatting checks passed.
- The new regression file fails 9 of its 11 tests against unmodified upstream main and passes all 11 with this change.

The tests use only core classes and synthetic chunks; they need no provider package or API calls.
