### PR TITLE
fix(openrouter): preserve reasoning in conversation history

### DIFF
--- a/.changeset/quiet-routers-reason.md
+++ b/.changeset/quiet-routers-reason.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Preserve assistant reasoning text and reasoning details when sending OpenRouter conversation history, including tool-call continuations.

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/index.test.ts
@@ -8,7 +8,7 @@ import {
   vi,
   test,
 } from "vitest";
-import { AIMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { OutputParserException } from "@langchain/core/output_parsers";
 import { ChatOpenRouter } from "../index.js";
 import type { ChatOpenRouterCallOptions } from "../types.js";
@@ -761,4 +761,82 @@ describe("withStructuredOutput with SerializableSchema", () => {
       await structured.invoke("What is your name?");
     }).rejects.toThrow(OutputParserException);
   });
+});
+
+it("replays reasoning details when continuing a tool call", async () => {
+  const reasoningDetails = [
+    { type: "reasoning.text", text: "Check the weather", index: 0 },
+    {
+      type: "reasoning.encrypted",
+      data: "opaque",
+      id: "reasoning_1",
+      index: 1,
+    },
+  ];
+  const toolCalls = [
+    {
+      id: "call_1",
+      type: "function",
+      function: {
+        name: "weather",
+        arguments: "{}",
+      },
+    },
+  ];
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      Response.json({
+        id: "response_1",
+        model: "test-model",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "tool_calls",
+            message: {
+              role: "assistant",
+              content: "",
+              reasoning: "Check the weather",
+              reasoning_details: reasoningDetails,
+              tool_calls: toolCalls,
+            },
+          },
+        ],
+      })
+    )
+    .mockResolvedValueOnce(
+      Response.json({
+        id: "response_2",
+        model: "test-model",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "Sunny" },
+          },
+        ],
+      })
+    );
+  try {
+    const model = new ChatOpenRouter({ model: "test-model", maxRetries: 0 });
+    const user = new HumanMessage("Get the weather");
+    const first = await model.invoke([user]);
+    const snapshot = JSON.stringify(first);
+    await model.invoke([
+      user,
+      first,
+      new ToolMessage({ content: "Sunny", tool_call_id: "call_1" }),
+    ]);
+    const body = JSON.parse(fetchSpy.mock.calls[1][1]?.body as string);
+    expect(body.messages[1]).toEqual({
+      role: "assistant",
+      content: "",
+      tool_calls: toolCalls,
+      reasoning: "Check the weather",
+      reasoning_details: reasoningDetails,
+    });
+    expect(JSON.stringify(first)).toBe(snapshot);
+  } finally {
+    fetchSpy.mockRestore();
+  }
 });

--- a/libs/providers/langchain-openrouter/src/converters/messages.ts
+++ b/libs/providers/langchain-openrouter/src/converters/messages.ts
@@ -25,15 +25,32 @@ export type StreamingChunkData = OpenRouter.ChatStreamingResponseChunk["data"];
  * Delegates to the OpenAI completions converter since OpenRouter's chat
  * API is wire-compatible with OpenAI's. This gives us full support for
  * standard content blocks, reasoning-model developer role mapping,
- * multi-modal inputs, and all edge cases handled upstream.
+ * multi-modal inputs, and all edge cases handled upstream. Assistant reasoning
+ * is restored afterward so tool-call continuations retain OpenRouter context.
  */
 export function convertMessagesToOpenRouterParams(
   messages: BaseMessage[],
   model?: string
 ): OpenAIClient.Chat.Completions.ChatCompletionMessageParam[] {
-  return convertMessagesToCompletionsMessageParams({
-    messages,
-    model,
+  return messages.flatMap((message) => {
+    // Convert each source message separately: audio can expand a single message
+    // into multiple API messages, so input and output indices need not match.
+    const params = convertMessagesToCompletionsMessageParams({
+      messages: [message],
+      model,
+    });
+    const assistant = params[0];
+    if (assistant?.role === "assistant") {
+      const { reasoning_content, reasoning_details } =
+        message.additional_kwargs;
+      if (typeof reasoning_content === "string") {
+        Object.assign(assistant, { reasoning: reasoning_content });
+      }
+      if (Array.isArray(reasoning_details)) {
+        Object.assign(assistant, { reasoning_details });
+      }
+    }
+    return params;
   });
 }
 

--- a/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
+++ b/libs/providers/langchain-openrouter/src/converters/tests/index.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from "@langchain/core/messages";
 import { formatToolChoice } from "../tools.js";
 import {
+  convertMessagesToOpenRouterParams,
   convertUsageMetadata,
   convertOpenRouterResponseToBaseMessage,
   convertOpenRouterDeltaToBaseMessageChunk,
@@ -370,12 +375,66 @@ describe("convertOpenRouterDeltaToBaseMessageChunk reasoning", () => {
 
     const merged = c1.concat(c2).concat(c3);
 
+    expect(convertMessagesToOpenRouterParams([merged])[0]).toHaveProperty(
+      "reasoning_details",
+      merged.additional_kwargs.reasoning_details
+    );
+
     expect(merged.additional_kwargs.reasoning_details).toEqual([
       {
         type: "reasoning.text",
         text: "Let me think.",
         index: 0,
       },
+    ]);
+  });
+});
+
+describe("convertMessagesToOpenRouterParams reasoning", () => {
+  it("preserves reasoning on the correct message after audio expansion", () => {
+    const details = [{ type: "reasoning.encrypted", data: "opaque", index: 0 }];
+    const messages = [
+      new AIMessage({
+        content: "Audio",
+        additional_kwargs: { audio: { id: "audio_1" } },
+      }),
+      new AIMessage({
+        content: "Answer",
+        additional_kwargs: {
+          reasoning_content: "Think first",
+          reasoning_details: details,
+        },
+      }),
+    ];
+    const before = JSON.stringify(messages);
+    expect(convertMessagesToOpenRouterParams(messages)).toEqual([
+      { role: "assistant", content: "Audio" },
+      { role: "assistant", audio: { id: "audio_1" } },
+      {
+        role: "assistant",
+        content: "Answer",
+        reasoning: "Think first",
+        reasoning_details: details,
+      },
+    ]);
+    expect(JSON.stringify(messages)).toBe(before);
+  });
+
+  it("omits reasoning on non-assistant messages and messages without reasoning", () => {
+    expect(
+      convertMessagesToOpenRouterParams([
+        new HumanMessage({
+          content: "Hello",
+          additional_kwargs: {
+            reasoning_content: "Not assistant reasoning",
+            reasoning_details: [],
+          },
+        }),
+        new AIMessage("Hi"),
+      ])
+    ).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
     ]);
   });
 });


### PR DESCRIPTION
When a reasoning model returns a tool call through `ChatOpenRouter`, the response converter retains `reasoning_details` and plaintext reasoning on the `AIMessage`. Sending that message back with the tool result currently drops both fields because the outbound converter delegates entirely to the OpenAI Chat Completions serializer.

Restore OpenRouter reasoning fields on outbound assistant messages. Convert each source message separately before restoring its fields so audio expansion cannot attach reasoning to the wrong message. Reasoning detail objects and their order are preserved without modifying the input messages.

This follows [OpenRouter's reasoning preservation contract](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#preserving-reasoning). The issue reproduces with `@langchain/openrouter` 0.4.11 and on current main. A two-turn `invoke()` regression captures the actual HTTP request body; additional coverage checks streaming chunk aggregation, audio expansion, and messages without assistant reasoning. Three regression assertions fail before the fix and pass afterward.

Validation on Node.js 24.18.0:
- `pnpm --filter @langchain/openrouter test` — 90 tests passed, no type errors
- `pnpm --filter @langchain/openrouter build` — passed, including package checks
- `pnpm lint` — passed in the sparse checkout
- `pnpm format:check` — passed in the sparse checkout
- `git diff --check` — passed
- Original two-turn reproduction rerun against the built package — passed

All model responses were mocked; no live provider inference was run. Includes a patch changeset for `@langchain/openrouter`.
