### PR TITLE
fix(openrouter): honor per-call stream usage options

### DIFF
--- a/.changeset/tidy-stream-usage.md
+++ b/.changeset/tidy-stream-usage.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Honor per-call streamUsage options over instance defaults in both streaming APIs.

--- a/libs/providers/langchain-openrouter/src/chat_models/index.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/index.ts
@@ -503,7 +503,7 @@ export class ChatOpenRouter extends BaseChatModel<
       }
     }
 
-    const shouldStreamUsage = this.streamUsage ?? options.streamUsage ?? true;
+    const shouldStreamUsage = options.streamUsage ?? this.streamUsage;
     yield* convertOpenRouterStream(readChunks(), {
       streamUsage: shouldStreamUsage,
     });
@@ -573,7 +573,7 @@ export class ChatOpenRouter extends BaseChatModel<
 
         if (
           data.usage &&
-          this.streamUsage &&
+          (options.streamUsage ?? this.streamUsage) &&
           AIMessageChunk.isInstance(chunk)
         ) {
           chunk.usage_metadata = convertUsageMetadata(data.usage);

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -81,3 +81,63 @@ describe("ChatOpenRouter.streamEvents", () => {
     });
   });
 });
+
+describe.each(["stream", "streamEvents"] as const)(
+  "%s usage options",
+  (method) => {
+    test.each([
+      [undefined, undefined, true],
+      [false, undefined, false],
+      [undefined, false, false],
+      [true, false, false],
+      [false, true, true],
+    ])(
+      "instance=%s call=%s includes usage=%s",
+      async (instance, call, expected) => {
+        const model = new ChatOpenRouter({
+          apiKey: "fake-key",
+          model: "test",
+          streamUsage: instance,
+        });
+        const chunks = [
+          {
+            id: "test",
+            model: "test",
+            object: "chat.completion.chunk" as const,
+            created: 0,
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant" as const, content: "Hello" },
+                finish_reason: "stop" as const,
+              },
+            ],
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 2,
+              total_tokens: 12,
+            },
+          },
+        ];
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          sseResponseFromOpenAIChunks(chunks)
+        );
+        let hasUsage = false;
+        if (method === "stream") {
+          for await (const chunk of await model.stream("Hi", {
+            streamUsage: call,
+          })) {
+            hasUsage ||= chunk.usage_metadata !== undefined;
+          }
+        } else {
+          for await (const event of model.streamEvents("Hi", {
+            streamUsage: call,
+          })) {
+            hasUsage ||= "usage" in event && event.usage !== undefined;
+          }
+        }
+        expect(hasUsage).toBe(expected);
+      }
+    );
+  }
+);


### PR DESCRIPTION
Per-call `streamUsage` options are ignored by `ChatOpenRouter`: `.stream()` reads only the instance field, and `.streamEvents()` reads the already-defaulted instance field before the call option. For example, `.stream("Hi", { streamUsage: false })` still emits usage with the default constructor settings.

Give the call option precedence in both streaming paths. Add a shared regression matrix covering the default, instance-only suppression, and overrides in both directions through the public APIs. Six cases fail before the fix; the full package suite passes afterward.

Validation (Node.js 24.18.0): `pnpm --filter @langchain/openrouter test` (97 tests, no type errors), package build, `pnpm lint`, `pnpm format:check`, and `git diff --check`. Lint and format checks run in a sparse checkout. Provider responses are mocked. Includes a patch changeset.
