### PR TITLE
fix(openrouter): propagate in-stream provider errors

### DIFF
--- a/.changeset/honest-stream-errors.md
+++ b/.changeset/honest-stream-errors.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Raise OpenRouterError for provider errors delivered inside successful HTTP streaming responses, preserving the API error code and metadata.

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -81,3 +81,61 @@ describe("ChatOpenRouter.streamEvents", () => {
     });
   });
 });
+
+describe.each(["stream", "streamEvents"] as const)(
+  "%s provider errors",
+  (method) => {
+    test.each([false, true])(
+      "throws an SSE error after partial output=%s",
+      async (partial) => {
+        const model = new ChatOpenRouter({
+          apiKey: "fake-key",
+          model: "test",
+          maxRetries: 0,
+        });
+        const events: unknown[] = partial
+          ? [
+              {
+                id: "test",
+                choices: [
+                  { index: 0, delta: { role: "assistant", content: "Hello" } },
+                ],
+              },
+            ]
+          : [];
+        events.push({
+          id: "test",
+          error: {
+            code: "server_error",
+            message: "Provider disconnected",
+            metadata: { provider_name: "test-provider" },
+          },
+          choices: [
+            { index: 0, delta: { content: "" }, finish_reason: "error" },
+          ],
+        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+            { headers: { "Content-Type": "text/event-stream" } }
+          )
+        );
+        async function consume() {
+          const stream =
+            method === "stream"
+              ? await model.stream("Hello")
+              : model.streamEvents("Hello");
+          for await (const _chunk of stream) {
+            /* consume the complete stream */
+          }
+        }
+        await expect(consume()).rejects.toMatchObject({
+          name: "OpenRouterError",
+          message: "Provider disconnected",
+          code: "server_error",
+          metadata: { provider_name: "test-provider" },
+        });
+      }
+    );
+  }
+);

--- a/libs/providers/langchain-openrouter/src/utils/errors.ts
+++ b/libs/providers/langchain-openrouter/src/utils/errors.ts
@@ -20,7 +20,7 @@ export class OpenRouterError extends ns.brand(LangChainError) {
   statusCode?: number;
 
   /** HTTP or API error code, if available. */
-  code?: number;
+  code?: number | string;
 
   /** Additional error metadata returned by the API, if available. */
   metadata?: Record<string, unknown>;
@@ -31,7 +31,7 @@ export class OpenRouterError extends ns.brand(LangChainError) {
   constructor(
     message: string,
     statusCode?: number,
-    code?: number,
+    code?: number | string,
     metadata?: Record<string, unknown>,
     headers?: Record<string, string>
   ) {
@@ -63,7 +63,11 @@ export class OpenRouterError extends ns.brand(LangChainError) {
     }
 
     const error = body?.error as
-      | { message?: string; code?: number; metadata?: Record<string, unknown> }
+      | {
+          message?: string;
+          code?: number | string;
+          metadata?: Record<string, unknown>;
+        }
       | undefined;
 
     const baseMessage =
@@ -122,7 +126,7 @@ export class OpenRouterAuthError extends ns.brand(OpenRouterError, "auth") {
   constructor(
     message: string,
     statusCode?: number,
-    code?: number,
+    code?: number | string,
     metadata?: Record<string, unknown>,
     headers?: Record<string, string>
   ) {
@@ -145,7 +149,7 @@ export class OpenRouterRateLimitError extends ns.brand(
   constructor(
     message: string,
     statusCode?: number,
-    code?: number,
+    code?: number | string,
     metadata?: Record<string, unknown>,
     headers?: Record<string, string>
   ) {

--- a/libs/providers/langchain-openrouter/src/utils/stream.ts
+++ b/libs/providers/langchain-openrouter/src/utils/stream.ts
@@ -1,5 +1,6 @@
 import type { EventSourceMessage } from "eventsource-parser/stream";
 import type { StreamingChunkData } from "../converters/messages.js";
+import { OpenRouterError } from "./errors.js";
 
 /**
  * Web Streams `TransformStream` that sits between an `EventSourceParserStream`
@@ -7,7 +8,8 @@ import type { StreamingChunkData } from "../converters/messages.js";
  * field JSON-parsed into a typed {@link StreamingChunkData} object.
  *
  * Malformed or empty events are forwarded as `undefined` so the downstream
- * reader can skip them without the stream erroring out.
+ * reader can skip them without the stream erroring out. Provider error events
+ * fail the stream even when the HTTP response status was successful.
  */
 export class OpenRouterJsonParseStream extends TransformStream<
   EventSourceMessage,
@@ -19,6 +21,17 @@ export class OpenRouterJsonParseStream extends TransformStream<
         try {
           if (chunk.data) {
             const parsed = JSON.parse(chunk.data);
+            if (parsed?.error) {
+              controller.error(
+                new OpenRouterError(
+                  parsed.error.message ?? "OpenRouter streaming error",
+                  undefined,
+                  parsed.error.code,
+                  parsed.error.metadata
+                )
+              );
+              return;
+            }
             controller.enqueue(parsed);
           } else {
             controller.enqueue(undefined);


### PR DESCRIPTION
OpenRouter reports failures after HTTP headers have been sent as SSE events carrying a top-level `error`, while the HTTP status remains 200. Both streaming APIs currently ignore that field and can finish successfully with an empty or partial answer.

Fail the shared JSON stream with `OpenRouterError` when a provider error arrives, retaining the message, code, and metadata. Allow string API error codes such as `server_error`, as documented by [OpenRouter](https://openrouter.ai/docs/api/reference/streaming#errors-after-the-response-is-committed-mid-stream). Malformed JSON and the `[DONE]` sentinel retain their existing handling.

Four public-API regressions cover `.stream()` and `.streamEvents()`, with an error as the first frame or after partial content. All four fail before the fix and pass afterward.

Validation on Node.js 24.18.0: 91 package tests passed with no type errors; package build, lint, format check, and diff check passed. Lint/format run in a sparse checkout; all HTTP responses are mocked. Includes a patch changeset.
