### PR TITLE
fix(openrouter): cancel responses when stream consumers exit

### DIFF
--- a/.changeset/closed-router-stream.md
+++ b/.changeset/closed-router-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Cancel the HTTP response body when a consumer stops reading a streamed response early.

--- a/libs/providers/langchain-openrouter/src/chat_models/index.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/index.ts
@@ -602,6 +602,9 @@ export class ChatOpenRouter extends BaseChatModel<
         );
       }
     } finally {
+      // Releasing the lock alone leaves the HTTP body (and generation) running
+      // when a consumer stops early. Preserve any error from reading the stream.
+      await reader.cancel().catch(() => {});
       reader.releaseLock();
     }
   }

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -81,3 +81,31 @@ describe("ChatOpenRouter.streamEvents", () => {
     });
   });
 });
+
+describe("ChatOpenRouter.stream cancellation", () => {
+  test("cancels the response body when the consumer stops early", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            `data: ${JSON.stringify({
+              id: "test",
+              choices: [
+                { index: 0, delta: { role: "assistant", content: "Hello" } },
+              ],
+            })}\n\n`
+          )
+        );
+      },
+      cancel,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body));
+    const model = new ChatOpenRouter({ apiKey: "fake-key", model: "test" });
+    const stream = await model.stream("Hi");
+    for await (const _chunk of stream) {
+      break;
+    }
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+});


### PR DESCRIPTION
Breaking out of `ChatOpenRouter.stream()` releases the reader lock but leaves the HTTP response body open. A consumer that already has enough output can therefore leave the upstream generation running.

Cancel the reader in the streaming generator's cleanup before releasing its lock. Ignore cleanup rejection so an existing read error is preserved. Add a public `.stream()` regression backed by an open `ReadableStream`, asserting that an early consumer exit reaches the body's cancellation callback. It fails before the fix and passes afterward. The replayable `.streamEvents()` buffer is outside this change.

Validation on Node.js 24.18.0: 88 package tests passed with no type errors; package build, lint, format check, and diff check passed. Lint/format run in a sparse checkout. No live provider calls. Includes a patch changeset.
