### PR TITLE
fix(openrouter): apply retry policy to native event streams

### DIFF
--- a/.changeset/retry-router-events.md
+++ b/.changeset/retry-router-events.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openrouter": patch
+---
+
+Apply configured retry and concurrency limits when opening native event streams.

--- a/libs/providers/langchain-openrouter/src/chat_models/index.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/index.ts
@@ -470,16 +470,21 @@ export class ChatOpenRouter extends BaseChatModel<
       stream: true,
     };
 
-    const response = await fetch(this.buildUrl(), {
-      method: "POST",
-      headers: this.buildHeaders(),
-      body: JSON.stringify(body),
-      signal: options.signal,
-    });
-
-    if (!response.ok) {
-      throw await OpenRouterError.fromResponse(response);
-    }
+    const response = await this.caller.callWithOptions(
+      { signal: options.signal },
+      async () => {
+        const nextResponse = await fetch(this.buildUrl(), {
+          method: "POST",
+          headers: this.buildHeaders(),
+          body: JSON.stringify(body),
+          signal: options.signal,
+        });
+        if (!nextResponse.ok) {
+          throw await OpenRouterError.fromResponse(nextResponse);
+        }
+        return nextResponse;
+      }
+    );
 
     if (!response.body) {
       return;

--- a/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-openrouter/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -81,3 +81,42 @@ describe("ChatOpenRouter.streamEvents", () => {
     });
   });
 });
+
+test("streamEvents retries a transient HTTP failure", async () => {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      Response.json(
+        { error: { message: "Provider unavailable" } },
+        { status: 503 }
+      )
+    )
+    .mockResolvedValueOnce(sseResponseFromOpenAIChunks(openAITextOnlyChunks()));
+  const model = new ChatOpenRouter({
+    apiKey: "fake-key",
+    model: "test",
+    maxRetries: 1,
+  });
+  await expect(model.streamEvents("Hi")).toHaveStreamText("Hello world");
+  expect(fetchSpy).toHaveBeenCalledTimes(2);
+});
+
+test("streamEvents honors maxRetries zero", async () => {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(
+      Response.json(
+        { error: { message: "Provider unavailable" } },
+        { status: 503 }
+      )
+    );
+  const model = new ChatOpenRouter({
+    apiKey: "fake-key",
+    model: "test",
+    maxRetries: 0,
+  });
+  await expect(model.streamEvents("Hi").output).rejects.toThrow(
+    "Provider unavailable"
+  );
+  expect(fetchSpy).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
`ChatOpenRouter.streamEvents()` opens its HTTP request with bare `fetch`, bypassing the `AsyncCaller` used by `.invoke()` and `.stream()`. A transient 503 therefore fails immediately even with `maxRetries: 1`.

Route the initial native-event request through `caller.callWithOptions`, including the existing HTTP error mapping. This applies the configured retry/concurrency policy while retaining the abort signal. Only request establishment is retried; consumed stream content is not replayed.

Add public-API regressions for a 503 followed by success, and for explicit `maxRetries: 0`. The retry case fails before the fix. Validation on Node.js 24.18.0: 89 package tests passed with no type errors; package build, lint, format check, and diff check passed. Lint/format run in a sparse checkout. All requests are mocked; includes a patch changeset.
