### PR TITLE
fix(perplexity): preserve literal think tags in JSON strings

### DIFF
--- a/.changeset/literal-reasoning-strings.md
+++ b/.changeset/literal-reasoning-strings.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Preserve literal think tags inside JSON strings and keys when parsing reasoning-model structured output.

--- a/libs/providers/langchain-perplexity/src/utils/output_parsers.ts
+++ b/libs/providers/langchain-perplexity/src/utils/output_parsers.ts
@@ -15,30 +15,41 @@ const isWhitespace = (char: string): boolean =>
 
 const stripThinkTags = (text: string): string => {
   let cleanedText = "";
-  let searchStart = 0;
+  let inString = false;
+  let escaped = false;
 
-  while (searchStart < text.length) {
-    const openTagIndex = text.indexOf(THINK_OPEN_TAG, searchStart);
-    if (openTagIndex === -1) {
-      cleanedText += text.slice(searchStart);
-      break;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      cleanedText += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
     }
 
-    cleanedText += text.slice(searchStart, openTagIndex);
-
-    const closeTagIndex = text.indexOf(
-      THINK_CLOSE_TAG,
-      openTagIndex + THINK_OPEN_TAG.length
-    );
-    if (closeTagIndex === -1) {
-      cleanedText += text.slice(openTagIndex);
-      break;
+    if (text.startsWith(THINK_OPEN_TAG, index)) {
+      const closeTagIndex = text.indexOf(
+        THINK_CLOSE_TAG,
+        index + THINK_OPEN_TAG.length
+      );
+      if (closeTagIndex === -1) {
+        cleanedText += text.slice(index);
+        break;
+      }
+      index = closeTagIndex + THINK_CLOSE_TAG.length - 1;
+      while (index + 1 < text.length && isWhitespace(text[index + 1])) {
+        index += 1;
+      }
+      continue;
     }
 
-    searchStart = closeTagIndex + THINK_CLOSE_TAG.length;
-    while (searchStart < text.length && isWhitespace(text[searchStart])) {
-      searchStart += 1;
-    }
+    cleanedText += char;
+    inString = char === '"';
   }
 
   return cleanedText.trim();

--- a/libs/providers/langchain-perplexity/src/utils/tests/output_parsers.test.ts
+++ b/libs/providers/langchain-perplexity/src/utils/tests/output_parsers.test.ts
@@ -341,3 +341,33 @@ describe("ReasoningJsonOutputParser", () => {
     });
   });
 });
+
+describe.each(["json", "structured"])("%s literal think tags", (kind) => {
+  test.each([false, true])(
+    "preserves JSON strings with a reasoning prefix=%s",
+    async (prefix) => {
+      const expected = {
+        answer: 'A "quoted" <think>literal value</think> and a backslash: \\',
+        nested: { "<think>key</think>": "<think>value</think>" },
+      };
+      const parser =
+        kind === "json"
+          ? new ReasoningJsonOutputParser()
+          : new ReasoningStructuredOutputParser(
+              z.object({
+                answer: z.string(),
+                nested: z.record(z.string()),
+              })
+            );
+      const input = prefix
+        ? [
+            '<think>Actual reasoning with "quotes"</think>',
+            "```json",
+            JSON.stringify(expected),
+            "```",
+          ].join("\n")
+        : JSON.stringify(expected);
+      await expect(parser.parse(input)).resolves.toEqual(expected);
+    }
+  );
+});


### PR DESCRIPTION
The Perplexity reasoning output parsers remove every `<think>...</think>` segment before parsing JSON, including literal text inside JSON string values and object keys. A valid answer such as `{"answer":"<think>literal</think>"}` is silently changed to `{"answer":""}`.

Track quoted strings and escapes while removing reasoning blocks, preserving tags within JSON data. Existing support for multiple external reasoning blocks, fenced JSON, and trailing reasoning is retained. Four regressions exercise the JSON and schema parsers with and without a reasoning prefix, including nested keys, escaped quotes, and backslashes.

Validation on Node.js 24.18.0: 84 package tests passed (1 existing skip), no type errors; package build, lint, format check, and diff check passed. Lint/format run in a sparse checkout. The four regressions fail before the fix. Includes a patch changeset.
