### PR TITLE
fix(perplexity): forward request cancellation and client limits

### DIFF
--- a/.changeset/perplexity-request-controls.md
+++ b/.changeset/perplexity-request-controls.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Forward cancellation signals for Chat Completions and Responses requests, and honor configured HTTP timeouts and retry limits.

--- a/libs/providers/langchain-perplexity/src/chat_models.ts
+++ b/libs/providers/langchain-perplexity/src/chat_models.ts
@@ -502,6 +502,8 @@ export class ChatPerplexity
     this.client = new OpenAI({
       apiKey: this.apiKey,
       baseURL: "https://api.perplexity.ai",
+      timeout: this.timeout,
+      maxRetries: fields.maxRetries,
     });
   }
 
@@ -686,16 +688,20 @@ export class ChatPerplexity
       });
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       const response = await (this.client as any).responses.create(
-        responsesPayload
+        responsesPayload,
+        { signal: options.signal }
       );
       return convertResponsesToChatResult(response);
     }
 
-    const response = await this.client.chat.completions.create({
-      messages: messagesList,
-      ...this.invocationParams(options),
-      stream: false,
-    });
+    const response = await this.client.chat.completions.create(
+      {
+        messages: messagesList,
+        ...this.invocationParams(options),
+        stream: false,
+      },
+      { signal: options.signal }
+    );
 
     const { message } = response.choices[0];
 
@@ -745,11 +751,14 @@ export class ChatPerplexity
       return;
     }
 
-    const stream = await this.client.chat.completions.create({
-      messages: messagesList,
-      ...this.invocationParams(options),
-      stream: true,
-    });
+    const stream = await this.client.chat.completions.create(
+      {
+        messages: messagesList,
+        ...this.invocationParams(options),
+        stream: true,
+      },
+      { signal: options.signal }
+    );
     const abortableStream = async function* (
       source: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
       signal?: AbortSignal
@@ -789,7 +798,8 @@ export class ChatPerplexity
       });
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       const responsesStream = await (this.client as any).responses.create(
-        responsesPayload
+        responsesPayload,
+        { signal: options.signal }
       );
       for await (const event of responsesStream as AsyncIterable<
         // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -805,11 +815,14 @@ export class ChatPerplexity
       return;
     }
 
-    const stream = await this.client.chat.completions.create({
-      messages: messagesList,
-      ...this.invocationParams(options),
-      stream: true,
-    });
+    const stream = await this.client.chat.completions.create(
+      {
+        messages: messagesList,
+        ...this.invocationParams(options),
+        stream: true,
+      },
+      { signal: options.signal }
+    );
 
     let firstChunk = true;
     for await (const chunk of stream) {

--- a/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
@@ -285,7 +285,8 @@ describe("ChatPerplexity", () => {
             { role: "user", content: "Hello!" },
           ],
           stream: false,
-        })
+        }),
+        { signal: undefined }
       );
     });
 
@@ -812,7 +813,8 @@ describe("ChatPerplexity", () => {
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: [{ role: "user", content: "Hello" }],
-        })
+        }),
+        { signal: undefined }
       );
     });
 
@@ -821,7 +823,8 @@ describe("ChatPerplexity", () => {
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: [{ role: "assistant", content: "I am an AI" }],
-        })
+        }),
+        { signal: undefined }
       );
     });
 
@@ -830,7 +833,8 @@ describe("ChatPerplexity", () => {
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: [{ role: "system", content: "Be helpful" }],
-        })
+        }),
+        { signal: undefined }
       );
     });
 
@@ -852,7 +856,8 @@ describe("ChatPerplexity", () => {
             { role: "assistant", content: "Hello!" },
             { role: "user", content: "How are you?" },
           ],
-        })
+        }),
+        { signal: undefined }
       );
     });
   });

--- a/libs/providers/langchain-perplexity/src/tests/request_controls.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/request_controls.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ChatPerplexity } from "../chat_models.js";
+
+const response = () =>
+  Response.json({
+    choices: [{ message: { role: "assistant", content: "Done" } }],
+  });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe.each([false, true])(
+  "request controls with responses API=%s",
+  (useResponsesApi) => {
+    test.each(["invoke", "stream", "streamEvents"] as const)(
+      "%s forwards cancellation to the HTTP request",
+      async (method) => {
+        const controller = new AbortController();
+        let networkAborted = false;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+          controller.abort();
+          networkAborted = init?.signal?.aborted === true;
+          return response();
+        });
+        const model = new ChatPerplexity({
+          apiKey: "fake-key",
+          model: "sonar",
+          useResponsesApi,
+        });
+        try {
+          if (method === "invoke") {
+            await model.invoke("Hi", { signal: controller.signal });
+          } else {
+            const stream =
+              method === "stream"
+                ? await model.stream("Hi", { signal: controller.signal })
+                : model.streamEvents("Hi", { signal: controller.signal });
+            for await (const _chunk of stream) {
+              /* consume */
+            }
+          }
+        } catch {
+          // Both the Runnable and the SDK may surface cancellation. The HTTP
+          // signal must also be aborted so the network request does not continue.
+        }
+        expect(networkAborted).toBe(true);
+      }
+    );
+  }
+);
+
+test("applies the configured HTTP timeout", async () => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (_url, init) =>
+      new Promise((resolve, reject) => {
+        const timer = setTimeout(() => resolve(response()), 100);
+        init?.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new DOMException("Aborted", "AbortError"));
+          },
+          { once: true }
+        );
+      })
+  );
+  const model = new ChatPerplexity({
+    apiKey: "fake-key",
+    model: "sonar",
+    timeout: 10,
+    maxRetries: 0,
+  });
+  await expect(model.invoke("Hi")).rejects.toThrow(/timed out/i);
+});
+
+test("honors disabling SDK retries", async () => {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      Response.json({ error: { message: "Unavailable" } }, { status: 503 })
+    )
+    .mockImplementation(async () => response());
+  const model = new ChatPerplexity({
+    apiKey: "fake-key",
+    model: "sonar",
+    maxRetries: 0,
+  });
+  await expect(model.invoke("Hi")).rejects.toThrow("Unavailable");
+  expect(fetchSpy).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
`ChatPerplexity` accepts timeout/retry configuration and per-call cancellation signals, but the SDK client and requests never receive them. Cancelling a Runnable can therefore leave its HTTP request active; configured timeouts and disabled retries also have no effect on the SDK.

Forward constructor timeout/maxRetries to the SDK and the per-call signal to Chat Completions and Responses requests, including streaming/event-stream paths. Existing payload assertions now also check the request-options argument.

Eight regressions use the real SDK with mocked HTTP: six cancellation paths, a stalled request timing out, and a 503 with retries disabled. All eight fail before the fix. Validation on Node.js 24.18.0: 88 package tests passed (1 existing skip), no type errors; build, lint, format check, and diff check passed. Lint/format run in a sparse checkout; includes a patch changeset.
