### PR TITLE
fix(perplexity): serialize text content blocks

### DIFF
--- a/.changeset/perplexity-text-content.md
+++ b/.changeset/perplexity-text-content.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Serialize text content blocks correctly when sending chat messages to Perplexity.

--- a/libs/providers/langchain-perplexity/src/chat_models.ts
+++ b/libs/providers/langchain-perplexity/src/chat_models.ts
@@ -549,17 +549,17 @@ export class ChatPerplexity
     if (message._getType() === "human") {
       return {
         role: "user",
-        content: message.content.toString(),
+        content: message.text,
       };
     } else if (message._getType() === "ai") {
       return {
         role: "assistant",
-        content: message.content.toString(),
+        content: message.text,
       };
     } else if (message._getType() === "system") {
       return {
         role: "system",
-        content: message.content.toString(),
+        content: message.text,
       };
     }
     throw new Error(`Unknown message type: ${message}`);

--- a/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/chat_models.test.ts
@@ -857,3 +857,44 @@ describe("ChatPerplexity", () => {
     });
   });
 });
+
+describe("text content blocks", () => {
+  test.each([
+    ["user", HumanMessage],
+    ["assistant", AIMessage],
+    ["system", SystemMessage],
+  ] as const)("serializes %s text blocks", async (role, Message) => {
+    const model = new ChatPerplexity({ model: "sonar", apiKey: "test-key" });
+    const createSpy = vi
+      .spyOn(model.client.chat.completions, "create")
+      .mockResolvedValue({
+        id: "test",
+        object: "chat.completion",
+        created: 0,
+        model: "sonar",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            logprobs: null,
+            message: { role: "assistant", content: "Done", refusal: null },
+          },
+        ],
+      });
+    try {
+      await model.invoke([
+        new Message({
+          contentBlocks: [
+            { type: "text", text: "Hello, " },
+            { type: "text", text: "世界!" },
+          ],
+        }),
+      ]);
+      expect(createSpy.mock.calls[0][0].messages).toEqual([
+        { role, content: "Hello, 世界!" },
+      ]);
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #9913.

ChatPerplexity currently sends text content blocks as `[object Object]`. Use the standard message text accessor so user, assistant, and system messages concatenate their text blocks correctly while preserving string content.

Adds three public invoke regressions covering both multiple blocks and Unicode text. All three fail before the fix. Validation on Node.js 24.18.0: 83 package tests passed (1 existing skip), no type errors; build, lint, format check, and diff check passed. Lint/format run in a sparse checkout; includes a patch changeset.

The earlier attempt in #11122 was closed by its author; this is a fresh fix against current main.
