### PR TITLE
fix(core): respect falsy RunnableBranch output

### DIFF
--- a/.changeset/brave-pandas-fix.md
+++ b/.changeset/brave-pandas-fix.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): respect falsy RunnableBranch output

--- a/libs/langchain-core/src/runnables/branch.ts
+++ b/libs/langchain-core/src/runnables/branch.ts
@@ -149,6 +149,7 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
     runManager?: CallbackManagerForChainRun
   ): Promise<RunOutput> {
     let result;
+    let matched = false;
     for (let i = 0; i < this.branches.length; i += 1) {
       const [condition, branchRunnable] = this.branches[i];
       const conditionValue = await condition.invoke(
@@ -164,10 +165,11 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
             callbacks: runManager?.getChild(`branch:${i + 1}`),
           })
         );
+        matched = true;
         break;
       }
     }
-    if (!result) {
+    if (!matched) {
       result = await this.default.invoke(
         input,
         patchConfig(config, {

--- a/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
@@ -31,6 +31,29 @@ test("RunnableBranch batch", async () => {
   expect(batchResult).toEqual([2, 100, -1]);
 });
 
+test("RunnableBranch respects falsy branch output", async () => {
+  const zeroBranch = RunnableBranch.from([
+    [(x: number) => x > 0, (_x: number) => 0],
+    (_x: number) => -1,
+  ]);
+  expect(await zeroBranch.invoke(5)).toBe(0);
+  expect(await zeroBranch.invoke(-1)).toBe(-1);
+
+  const emptyStringBranch = RunnableBranch.from([
+    [(x: string) => x === "a", (_x: string) => ""],
+    (_x: string) => "default",
+  ]);
+  expect(await emptyStringBranch.invoke("a")).toBe("");
+  expect(await emptyStringBranch.invoke("b")).toBe("default");
+
+  const falseBranch = RunnableBranch.from([
+    [(x: boolean) => x, (_x: boolean) => false],
+    (_x: boolean) => true,
+  ]);
+  expect(await falseBranch.invoke(true)).toBe(false);
+  expect(await falseBranch.invoke(false)).toBe(true);
+});
+
 test("RunnableBranch handles error", async () => {
   let error;
   const branch = RunnableBranch.from([


### PR DESCRIPTION
`RunnableBranch._invoke` in `libs/langchain-core/src/runnables/branch.ts:170` used `if (!result)` to decide if a branch matched. A matched branch returning `0` / `""` / `false` was discarded and `default` ran instead.

Fix: track `matched` flag instead of output truthiness, matching `_streamIterator` logic at `:236` (`stream === undefined`).

Tests:
- Added `RunnableBranch respects falsy branch output` in `libs/langchain-core/src/runnables/tests/runnable_branch.test.ts` covering `0`, `""`, `false` + default fallback still works.
- Verified: `pnpm --filter @langchain/core test src/runnables/tests/runnable_branch.test.ts` (5 passed), `pnpm lint` clean, `pnpm format:check` clean, `pnpm --filter @langchain/core build` pass on Node v24.6.0.

Fixes #11583