### PR TITLE
fix(perplexity): preserve chat completion token usage

### DIFF
--- a/.changeset/perplexity-token-usage.md
+++ b/.changeset/perplexity-token-usage.md
@@ -1,0 +1,5 @@
+---
+"@langchain/perplexity": patch
+---
+
+Preserve Chat Completions token usage in message usage metadata, including streaming usage-only chunks.

--- a/libs/providers/langchain-perplexity/src/chat_models.ts
+++ b/libs/providers/langchain-perplexity/src/chat_models.ts
@@ -51,6 +51,17 @@ import {
   ReasoningStructuredOutputParser,
 } from "./utils/output_parsers.js";
 
+function toUsageMetadata(
+  usage: OpenAI.CompletionUsage | null | undefined
+): UsageMetadata | undefined {
+  if (!usage) return undefined;
+  return {
+    input_tokens: usage.prompt_tokens,
+    output_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+  };
+}
+
 /**
  * Type representing the role of a message in the Perplexity chat model.
  */
@@ -705,6 +716,7 @@ export class ChatPerplexity
       text: message.content ?? "",
       message: new AIMessage({
         content: message.content ?? "",
+        usage_metadata: toUsageMetadata(response.usage),
         additional_kwargs: {
           // oxlint-disable-next-line @typescript-eslint/no-explicit-any
           citations: (response as any).citations,
@@ -812,8 +824,11 @@ export class ChatPerplexity
     });
 
     let firstChunk = true;
+    let usageMetadata: UsageMetadata | undefined;
     for await (const chunk of stream) {
+      if (chunk.usage) usageMetadata = toUsageMetadata(chunk.usage);
       const choice = chunk.choices[0];
+      if (!choice) continue;
       const { delta } = choice;
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       const citations = (chunk as any).citations ?? [];
@@ -852,6 +867,17 @@ export class ChatPerplexity
       if (runManager) {
         await runManager.handleLLMNewToken(delta.content);
       }
+    }
+
+    // Usage is cumulative; emit the final totals once for chunk aggregation.
+    if (usageMetadata) {
+      yield new ChatGenerationChunk({
+        text: "",
+        message: new AIMessageChunk({
+          content: "",
+          usage_metadata: usageMetadata,
+        }),
+      });
     }
   }
 

--- a/libs/providers/langchain-perplexity/src/tests/token_usage.test.ts
+++ b/libs/providers/langchain-perplexity/src/tests/token_usage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AIMessageChunk } from "@langchain/core/messages";
+import { asAsyncIterable } from "@langchain/core/testing";
+import type OpenAI from "openai";
+import { ChatPerplexity } from "../chat_models.js";
+
+const usage = { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 };
+const expectedUsage = { input_tokens: 10, output_tokens: 20, total_tokens: 30 };
+const base = { id: "test", created: 0, model: "sonar" };
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ChatPerplexity token usage", () => {
+  test.each([usage, undefined])(
+    "invoke exposes supplied usage: %j",
+    async (tokens) => {
+      const model = new ChatPerplexity({ apiKey: "test-key", model: "sonar" });
+      vi.spyOn(model.client.chat.completions, "create").mockResolvedValue({
+        ...base,
+        object: "chat.completion",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            logprobs: null,
+            message: { role: "assistant", content: "Hello", refusal: null },
+          },
+        ],
+        usage: tokens,
+      });
+      const result = await model.invoke("Hi");
+      expect(result.content).toBe("Hello");
+      expect(result.usage_metadata).toEqual(tokens ? expectedUsage : undefined);
+    }
+  );
+
+  test.each(["empty delta", "empty choices", "text", "cumulative"] as const)(
+    "stream preserves usage from %s chunks without double counting",
+    async (kind) => {
+      const model = new ChatPerplexity({ apiKey: "test-key", model: "sonar" });
+      const chunks: OpenAI.Chat.Completions.ChatCompletionChunk[] = [
+        {
+          ...base,
+          object: "chat.completion.chunk",
+          choices: [
+            {
+              index: 0,
+              finish_reason: null,
+              delta: { role: "assistant", content: "Hello" },
+            },
+          ],
+          usage:
+            kind === "cumulative"
+              ? { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 }
+              : undefined,
+        },
+        {
+          ...base,
+          object: "chat.completion.chunk",
+          choices:
+            kind === "empty choices"
+              ? []
+              : [
+                  {
+                    index: 0,
+                    finish_reason: "stop",
+                    delta: {
+                      role: "assistant",
+                      content: kind === "text" ? " world" : "",
+                    },
+                  },
+                ],
+          usage,
+        },
+      ];
+      vi.spyOn(model.client.chat.completions, "create").mockResolvedValue(
+        asAsyncIterable(chunks) as never
+      );
+      let result = new AIMessageChunk("");
+      for await (const chunk of await model.stream("Hi")) {
+        result = result.concat(chunk);
+      }
+      expect(result.content).toBe(kind === "text" ? "Hello world" : "Hello");
+      expect(result.usage_metadata).toMatchObject(expectedUsage);
+    }
+  );
+});


### PR DESCRIPTION
ChatPerplexity stores non-streaming Chat Completions usage only in llmOutput, leaving the returned AIMessage without standard usage_metadata. Ordinary streaming drops usage on empty-content chunks and throws when a usage-only chunk has no choices.

Map input/output/total token counts into message usage metadata. Streaming remembers the latest totals and emits them once at completion, so concatenating chunks does not double-count cumulative usage. The existing llmOutput fields and Responses API behavior are preserved.

Six mocked public-API cases cover invoke with/without usage and streams with empty deltas, empty choices, text-bearing usage, and cumulative updates. Five regressions fail before the fix. Validation on Node.js 24.18.0: 86 package tests passed (1 existing skip), no type errors; build, lint, format check, and diff check passed. Lint/format run in a sparse checkout; includes a patch changeset.

Provider reference: [Perplexity streaming metadata](https://docs.perplexity.ai/docs/sonar/features).
