### PR TITLE
fix(langchain): keep structured output tool names stable for prompt caching

### DIFF
--- a/.changeset/deterministic-structured-output-tool-naming.md
+++ b/.changeset/deterministic-structured-output-tool-naming.md
@@ -1,0 +1,18 @@
+---
+"langchain": patch
+---
+
+fix(langchain): derive structured output tool names from the schema
+
+An untitled `responseFormat` schema produced a tool named from a module-global
+counter, so the structured output tool was called `extract-1` on one model
+request and `extract-2` on the next. Providers render tool definitions at the
+front of the cached prompt prefix, so the changing name invalidated the prompt
+cache on every request in an agent loop — the system prompt and message history
+included.
+
+The generated name is now a hash of the emitted JSON Schema, so the same schema
+yields the same tool name across every request in a loop, across turns of a
+conversation, and across separate processes. Schemas carrying a title are
+unaffected. Two identical schemas in one `responseFormat` list now collapse to a
+single tool rather than two indistinguishable ones.

--- a/libs/langchain/src/agents/responses.ts
+++ b/libs/langchain/src/agents/responses.ts
@@ -8,6 +8,7 @@ import {
 } from "@langchain/core/utils/types";
 import { type AIMessage } from "@langchain/core/messages";
 import { toJsonSchema, Validator } from "@langchain/core/utils/json_schema";
+import { sha256 } from "@langchain/core/utils/hash";
 import { type FunctionDefinition } from "@langchain/core/language_models/base";
 import {
   type SerializableSchema,
@@ -41,9 +42,20 @@ export type ResponseFormatUndefined = {
 const PROVIDER_STRATEGY_DEFAULT_STRICT = true;
 
 /**
- * This is a global counter for generating unique names for tools.
+ * Derives the name of the tool used to extract structured output.
+ *
+ * Tools must have a name so a tool call can be mapped back to the strategy that
+ * produced it. When the schema carries no title the name is hashed from the
+ * schema the tool definition is built from, so the same schema always yields
+ * the same name - within an agent loop, across conversation turns, and across
+ * processes.
+ *
+ * @param schema - The schema the tool definition is built from
+ * @param title - The schema's title, used verbatim when present
  */
-let bindingIdentifier = 0;
+function getFunctionName(schema: Record<string, unknown>, title?: string) {
+  return title ?? `extract-${sha256(JSON.stringify(schema)).slice(0, 16)}`;
+}
 
 /**
  * Information for tracking structured output tool metadata.
@@ -95,20 +107,12 @@ export class ToolStrategy<_T = unknown> {
     schema: InteropZodObject | SerializableSchema | Record<string, unknown>,
     outputOptions?: ToolStrategyOptions
   ): ToolStrategy<any> {
-    /**
-     * It is required for tools to have a name so we can map the tool call to the correct tool
-     * when parsing the response.
-     */
-    function getFunctionName(name?: string) {
-      return name ?? `extract-${++bindingIdentifier}`;
-    }
-
     if (isSerializableSchema(schema) || isInteropZodSchema(schema)) {
       const asJsonSchema = toJsonSchema(schema);
       const tool = {
         type: "function" as const,
         function: {
-          name: getFunctionName(asJsonSchema.title),
+          name: getFunctionName(asJsonSchema, asJsonSchema.title),
           strict: false,
           description:
             asJsonSchema.description ??
@@ -128,7 +132,7 @@ export class ToolStrategy<_T = unknown> {
       functionDefinition = schema as unknown as FunctionDefinition;
     } else {
       functionDefinition = {
-        name: getFunctionName(schema.title as string),
+        name: getFunctionName(schema, schema.title as string),
         description: (schema.description as string) ?? "",
         parameters: schema.schema || (schema as Record<string, unknown>),
       };

--- a/libs/langchain/src/agents/tests/reactAgent.test.ts
+++ b/libs/langchain/src/agents/tests/reactAgent.test.ts
@@ -199,12 +199,14 @@ describe("createAgent", () => {
 
     type WeatherResponse = z.infer<typeof WeatherResponseSchema>;
 
+    const [structuredTool] = toolStrategy(WeatherResponseSchema);
+
     const toolCalls = [
       [
         {
           args: { temperature: 75 },
           id: "2",
-          name: "extract-1",
+          name: structuredTool.name,
           type: "tool_call" as const,
         },
       ],

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -5,7 +5,7 @@ import { z as z4 } from "zod/v4";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
-import { tool } from "@langchain/core/tools";
+import { tool, type ClientTool } from "@langchain/core/tools";
 import type { SerializableSchema } from "@langchain/core/utils/standard_schema";
 
 import { fakeModel } from "@langchain/core/testing";
@@ -21,7 +21,13 @@ import {
   hasSupportForJsonSchemaOutput,
   ProviderStrategy,
   ToolStrategy,
+  type ResponseFormatInput,
 } from "../responses.js";
+
+/** The tool calls a `FakeToolCallingModel` replays, one entry per request. */
+type FakeToolCalls = NonNullable<
+  ConstructorParameters<typeof FakeToolCallingModel>[0]
+>["toolCalls"];
 
 function makeSerializableSchema(
   jsonSchema: Record<string, unknown> = {
@@ -49,20 +55,29 @@ describe("structured output handling", () => {
   describe("toolStrategy", () => {
     describe("multiple structured output tool calls", () => {
       it("should retry by default when multiple structured outputs are called", async () => {
+        const responseFormat = toolStrategy([
+          z.object({
+            foo: z.string(),
+          }),
+          z.object({
+            bar: z.string(),
+          }),
+        ]);
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
         const model = new FakeToolCallingChatModel({
           responses: [
             new AIMessage({
               content: "",
               tool_calls: [
-                { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
-                { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
+                { name: fooToolName, args: { foo: "foo" }, id: "call_1" },
+                { name: barToolName, args: { bar: "bar" }, id: "call_2" },
               ],
             }),
             new AIMessage({
               content: "",
               tool_calls: [
                 {
-                  name: "extract-1",
+                  name: fooToolName,
                   args: { foo: "valid structured value" },
                   id: "call_1",
                 },
@@ -73,14 +88,7 @@ describe("structured output handling", () => {
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy([
-            z.object({
-              foo: z.string(),
-            }),
-            z.object({
-              bar: z.string(),
-            }),
-          ]),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -101,33 +109,32 @@ describe("structured output handling", () => {
       });
 
       it("should throw if error handler is set to false", async () => {
+        const responseFormat = toolStrategy(
+          [
+            z.object({
+              foo: z.string(),
+            }),
+            z.object({
+              bar: z.string(),
+            }),
+          ],
+          {
+            handleError: false,
+          }
+        );
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
         const model = new FakeToolCallingModel({
           toolCalls: [
             [
-              /**
-               * `extract-3` and `extract-5` are the computed function names for the json schemas
-               */
-              { name: "extract-3", args: { foo: "foo" }, id: "call_1" },
-              { name: "extract-4", args: { bar: "bar" }, id: "call_2" },
+              { name: fooToolName, args: { foo: "foo" }, id: "call_1" },
+              { name: barToolName, args: { bar: "bar" }, id: "call_2" },
             ],
           ],
         });
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            [
-              z.object({
-                foo: z.string(),
-              }),
-              z.object({
-                bar: z.string(),
-              }),
-            ],
-            {
-              handleError: false,
-            }
-          ),
+          responseFormat,
         });
 
         await expect(
@@ -138,13 +145,27 @@ describe("structured output handling", () => {
       });
 
       it("should retry if error handler is set to true", async () => {
+        const responseFormat = toolStrategy(
+          [
+            z.object({
+              foo: z.string(),
+            }),
+            z.object({
+              bar: z.string(),
+            }),
+          ],
+          {
+            handleError: true,
+          }
+        );
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
         const toolCalls = [
-          { name: "extract-5", args: { foo: "foo" }, id: "call_1" },
-          { name: "extract-6", args: { bar: "bar" }, id: "call_2" },
+          { name: fooToolName, args: { foo: "foo" }, id: "call_1" },
+          { name: barToolName, args: { bar: "bar" }, id: "call_2" },
         ];
         const toolCall2 = [
           {
-            name: "extract-5",
+            name: fooToolName,
             args: { foo: "valid structured value" },
             id: "call_3",
           },
@@ -164,19 +185,7 @@ describe("structured output handling", () => {
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            [
-              z.object({
-                foo: z.string(),
-              }),
-              z.object({
-                bar: z.string(),
-              }),
-            ],
-            {
-              handleError: true,
-            }
-          ),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -204,13 +213,27 @@ describe("structured output handling", () => {
       });
 
       it("should retry if the error handler is set to the MultipleStructuredOutputsError", async () => {
+        const responseFormat = toolStrategy(
+          [
+            z.object({
+              foo: z.string(),
+            }),
+            z.object({
+              bar: z.string(),
+            }),
+          ],
+          {
+            handleError: () => "foobar",
+          }
+        );
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
         const toolCalls = [
-          { name: "extract-7", args: { foo: "foo" }, id: "call_1" },
-          { name: "extract-8", args: { bar: "bar" }, id: "call_2" },
+          { name: fooToolName, args: { foo: "foo" }, id: "call_1" },
+          { name: barToolName, args: { bar: "bar" }, id: "call_2" },
         ];
         const toolCall2 = [
           {
-            name: "extract-7",
+            name: fooToolName,
             args: { foo: "fixed structured value" },
             id: "call_3",
           },
@@ -219,39 +242,18 @@ describe("structured output handling", () => {
           responses: [
             new AIMessage({
               content: "",
-              tool_calls: [
-                { name: "extract-7", args: { foo: "foo" }, id: "call_1" },
-                { name: "extract-8", args: { bar: "bar" }, id: "call_2" },
-              ],
+              tool_calls: toolCalls,
             }),
             new AIMessage({
               content: "",
-              tool_calls: [
-                {
-                  name: "extract-7",
-                  args: { foo: "fixed structured value" },
-                  id: "call_3",
-                },
-              ],
+              tool_calls: toolCall2,
             }),
           ],
         });
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            [
-              z.object({
-                foo: z.string(),
-              }),
-              z.object({
-                bar: z.string(),
-              }),
-            ],
-            {
-              handleError: () => "foobar",
-            }
-          ),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -277,13 +279,29 @@ describe("structured output handling", () => {
       });
 
       it("should throw if error handler throws an error", async () => {
+        const responseFormat = toolStrategy(
+          [
+            z.object({
+              foo: z.string(),
+            }),
+            z.object({
+              bar: z.string(),
+            }),
+          ],
+          {
+            handleError: () => {
+              throw new Error("foobar");
+            },
+          }
+        );
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
         const model = new FakeToolCallingChatModel({
           responses: [
             new AIMessage({
               content: "",
               tool_calls: [
-                { name: "extract-9", args: { foo: "foo" }, id: "call_1" },
-                { name: "extract-10", args: { bar: "bar" }, id: "call_2" },
+                { name: fooToolName, args: { foo: "foo" }, id: "call_1" },
+                { name: barToolName, args: { bar: "bar" }, id: "call_2" },
               ],
             }),
           ],
@@ -291,21 +309,7 @@ describe("structured output handling", () => {
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            [
-              z.object({
-                foo: z.string(),
-              }),
-              z.object({
-                bar: z.string(),
-              }),
-            ],
-            {
-              handleError: () => {
-                throw new Error("foobar");
-              },
-            }
-          ),
+          responseFormat,
         });
 
         await expect(
@@ -318,12 +322,21 @@ describe("structured output handling", () => {
 
     describe("single structured output tool call", () => {
       it("should retry if error handler is set to true", async () => {
+        const responseFormat = toolStrategy(
+          z.object({
+            foo: z.string(),
+          }),
+          {
+            handleError: true,
+          }
+        );
+        const [{ name: toolName }] = responseFormat;
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-11", args: { bar: "foo" }, id: "call_1" }],
+            [{ name: toolName, args: { bar: "foo" }, id: "call_1" }],
             [
               {
-                name: "extract-11",
+                name: toolName,
                 args: { foo: "fixed structured value" },
                 id: "call_2",
               },
@@ -333,14 +346,7 @@ describe("structured output handling", () => {
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            z.object({
-              foo: z.string(),
-            }),
-            {
-              handleError: true,
-            }
-          ),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -360,22 +366,24 @@ describe("structured output handling", () => {
       });
 
       it("should return a structured response if it matches the schema", async () => {
+        const responseFormat = toolStrategy(
+          z.object({
+            foo: z.string(),
+          })
+        );
+        const [{ name: toolName }] = responseFormat;
         const model = new FakeToolCallingModel({
           toolCalls: [
             [
               { name: "something", args: { result: 123 }, id: "call_1" },
-              { name: "extract-12", args: { foo: "bar" }, id: "call_2" },
+              { name: toolName, args: { foo: "bar" }, id: "call_2" },
             ],
           ],
         });
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            z.object({
-              foo: z.string(),
-            })
-          ),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -386,23 +394,23 @@ describe("structured output handling", () => {
       });
 
       it("should return a structured response if it matches the schema and toolMessageContent is provided", async () => {
+        const responseFormat = toolStrategy(
+          z.object({
+            foo: z.string(),
+          }),
+          {
+            toolMessageContent: "foobar",
+          }
+        );
+        const [{ name: toolName }] = responseFormat;
         const model = new FakeToolCallingModel({
-          toolCalls: [
-            [{ name: "extract-13", args: { foo: "bar" }, id: "call_1" }],
-          ],
+          toolCalls: [[{ name: toolName, args: { foo: "bar" }, id: "call_1" }]],
         });
 
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy(
-            z.object({
-              foo: z.string(),
-            }),
-            {
-              toolMessageContent: "foobar",
-            }
-          ),
+          responseFormat,
         });
 
         const res = await agent.invoke({
@@ -422,22 +430,24 @@ describe("structured output handling", () => {
       });
 
       it("should return structured response if it matches one of the schemas", async () => {
+        const responseFormat = toolStrategy([
+          z.object({
+            foo: z.string(),
+          }),
+          z.object({
+            bar: z.string(),
+          }),
+        ]);
+        const [, { name: barToolName }] = responseFormat;
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-15", args: { bar: "foo" }, id: "call_1" }],
+            [{ name: barToolName, args: { bar: "foo" }, id: "call_1" }],
           ],
         });
         const agent = createAgent({
           model,
           tools: [],
-          responseFormat: toolStrategy([
-            z.object({
-              foo: z.string(),
-            }),
-            z.object({
-              bar: z.string(),
-            }),
-          ]),
+          responseFormat,
         });
         const res = await agent.invoke({
           messages: [{ role: "user", content: "hi" }],
@@ -473,14 +483,14 @@ describe("structured output handling", () => {
         expect(strategy.name).toBe("my_json_tool");
       });
 
-      it("should fall back to extract-{n} when no title is provided", () => {
+      it("should fall back to a schema-derived name when no title is provided", () => {
         const zodSchema = z4.object({
           status: z4.string(),
         });
 
         const [strategy] = toolStrategy(zodSchema);
 
-        expect(strategy.name).toMatch(/^extract-\d+$/);
+        expect(strategy.name).toMatch(/^extract-[0-9a-f]{16}$/);
       });
 
       it("should use title from ToolStrategy.fromSchema with Zod v4 schema", () => {
@@ -509,6 +519,245 @@ describe("structured output handling", () => {
         expect(strategy.name).toBe("get_data");
       });
     });
+
+    describe("deterministic tool naming", () => {
+      /**
+       * Tools reach `bindTools` in two shapes: user tools as class instances
+       * carrying `name`, structured output tools as OpenAI-style function
+       * definitions carrying it under `function`.
+       */
+      function nameOfBoundTool(boundTool: unknown): string {
+        const { name, function: fn } = boundTool as {
+          name?: string;
+          function?: { name?: string };
+        };
+        const boundName = name ?? fn?.name;
+        if (boundName == null) {
+          throw new Error(
+            `Bound tool has no name: ${JSON.stringify(boundTool)}`
+          );
+        }
+        return boundName;
+      }
+
+      /**
+       * Runs an agent against a fake model, capturing the tool names it
+       * offered the model on each model request.
+       *
+       * The generated name is not public API, so tests read it back from what
+       * was actually bound rather than hardcoding it - except where pinning
+       * the literal is the point.
+       *
+       * @returns the agent, `boundToolNames` (one entry per model request, and
+       *   appended to by any further invocation), and the run's result
+       */
+      async function runAgent({
+        responseFormat,
+        tools = [],
+        toolCalls = [],
+      }: {
+        responseFormat: ResponseFormatInput;
+        tools?: ClientTool[];
+        toolCalls?: FakeToolCalls;
+      }) {
+        const model = new FakeToolCallingModel({ toolCalls });
+
+        const boundToolNames: string[][] = [];
+        const bindTools = model.bindTools.bind(model);
+        vi.spyOn(model, "bindTools").mockImplementation((bound) => {
+          boundToolNames.push(bound.map(nameOfBoundTool));
+          return bindTools(bound);
+        });
+
+        const agent = createAgent({
+          model,
+          tools,
+          /**
+           * Every form under test is valid input, but overload resolution
+           * cannot see that through the union.
+           */
+          responseFormat: responseFormat as ToolStrategy,
+        });
+        const result = await agent.invoke({
+          messages: [{ role: "user", content: "hi" }],
+        });
+
+        return { agent, boundToolNames, result };
+      }
+
+      it("should offer the same name on every model request in a loop", async () => {
+        const responseFormat = z.object({ answer: z.string() });
+        const [{ name: structuredToolName }] = toolStrategy(responseFormat);
+
+        const getWeather = tool(() => "sunny", {
+          name: "get_weather",
+          description: "Get the weather",
+          schema: z.object({}),
+        });
+
+        const { boundToolNames, result } = await runAgent({
+          responseFormat,
+          tools: [getWeather],
+          toolCalls: [
+            [{ name: "get_weather", args: {}, id: "call_1" }],
+            [
+              {
+                name: structuredToolName,
+                args: { answer: "sunny" },
+                id: "call_2",
+              },
+            ],
+          ],
+        });
+
+        expect(boundToolNames).toHaveLength(2);
+        expect(boundToolNames[1]).toEqual(boundToolNames[0]);
+        expect(result.structuredResponse).toEqual({ answer: "sunny" });
+      });
+
+      it("should offer the same name on a later invocation of the same agent", async () => {
+        const { agent, boundToolNames } = await runAgent({
+          responseFormat: z.object({ answer: z.string() }),
+        });
+
+        /** A second conversation turn, served by the same agent. */
+        await agent.invoke({
+          messages: [{ role: "user", content: "hi again" }],
+        });
+
+        expect(boundToolNames).toHaveLength(2);
+        expect(boundToolNames[1]).toEqual(boundToolNames[0]);
+      });
+
+      it("should offer the same name for separately constructed identical schemas", async () => {
+        const first = await runAgent({
+          responseFormat: z.object({ answer: z.string() }),
+        });
+        const second = await runAgent({
+          responseFormat: z.object({ answer: z.string() }),
+        });
+
+        expect(first.boundToolNames).toEqual(second.boundToolNames);
+      });
+
+      it("should offer different names for different schemas", async () => {
+        const answer = await runAgent({
+          responseFormat: z.object({ answer: z.string() }),
+        });
+        const result = await runAgent({
+          responseFormat: z.object({ result: z.string() }),
+        });
+
+        expect(answer.boundToolNames).not.toEqual(result.boundToolNames);
+      });
+
+      it("should offer a different name when a field description changes", async () => {
+        const plain = await runAgent({
+          responseFormat: z.object({ answer: z.string() }),
+        });
+        const described = await runAgent({
+          responseFormat: z.object({
+            answer: z.string().describe("the answer"),
+          }),
+        });
+
+        expect(plain.boundToolNames).not.toEqual(described.boundToolNames);
+      });
+
+      it("should offer a distinctly named tool per entry and parse against the one called", async () => {
+        const responseFormat = toolStrategy([
+          z.object({ foo: z.string() }),
+          z.object({ bar: z.string() }),
+        ]);
+        const [{ name: fooToolName }, { name: barToolName }] = responseFormat;
+
+        const { boundToolNames, result } = await runAgent({
+          responseFormat,
+          toolCalls: [
+            [{ name: barToolName, args: { bar: "foo" }, id: "call_1" }],
+          ],
+        });
+
+        expect(boundToolNames[0]).toEqual([fooToolName, barToolName]);
+        expect(new Set(boundToolNames[0]).size).toBe(2);
+        expect(result.structuredResponse).toEqual({ bar: "foo" });
+      });
+
+      it("should offer one tool when the same schema is passed twice", async () => {
+        const schema = z.object({ foo: z.string() });
+        const responseFormat = toolStrategy([schema, schema]);
+        const [{ name: toolName }] = responseFormat;
+
+        const { boundToolNames, result } = await runAgent({
+          responseFormat,
+          toolCalls: [[{ name: toolName, args: { foo: "bar" }, id: "call_1" }]],
+        });
+
+        /**
+         * Same-named entries collapse in the agent's name-keyed strategy map,
+         * so the model is never offered two indistinguishable tools.
+         */
+        expect(boundToolNames[0]).toEqual([toolName]);
+        expect(result.structuredResponse).toEqual({ foo: "bar" });
+      });
+
+      it("should offer the same names for every composition form", async () => {
+        const schema = z.object({ answer: z.string() });
+
+        const runs = await Promise.all(
+          [
+            schema,
+            [schema],
+            toolStrategy(schema),
+            toolStrategy([schema]),
+            ToolStrategy.fromSchema(schema),
+          ].map((responseFormat) => runAgent({ responseFormat }))
+        );
+
+        for (const run of runs) {
+          expect(run.boundToolNames).toEqual(runs[0].boundToolNames);
+        }
+      });
+
+      it("should offer a titled schema under its title", async () => {
+        const { boundToolNames } = await runAgent({
+          responseFormat: z4
+            .object({ answer: z4.string() })
+            .meta({ title: "my_custom_tool" }),
+        });
+
+        expect(boundToolNames[0]).toEqual(["my_custom_tool"]);
+      });
+
+      /**
+       * Pinning the literal names is the point here: the promise is that the
+       * same schema yields the same name in every process and every release,
+       * so a refactor that changes the derivation must fail loudly rather than
+       * silently rename every user's tool.
+       */
+      describe("generated name", () => {
+        it("should be pinned for a known Standard Schema", async () => {
+          const { boundToolNames } = await runAgent({
+            responseFormat: makeSerializableSchema(),
+          });
+
+          expect(boundToolNames[0]).toEqual(["extract-b24ae6e238353a13"]);
+        });
+
+        it("should be pinned for a known JSON schema", async () => {
+          const { boundToolNames } = await runAgent({
+            responseFormat: {
+              type: "object",
+              properties: {
+                value: { type: "number" },
+              },
+            },
+          });
+
+          expect(boundToolNames[0]).toEqual(["extract-757afc2191c3f222"]);
+        });
+      });
+    });
   });
 
   describe("providerStrategy", () => {
@@ -516,7 +765,7 @@ describe("structured output handling", () => {
       it("should not throw error if use provider strategy directly", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-16", args: { foo: "bar" }, id: "call_2" }],
+            [{ name: "extract-unmatched", args: { foo: "bar" }, id: "call_2" }],
           ],
         });
         const agent = createAgent({

--- a/libs/langchain/src/agents/tests/state_schema.test.ts
+++ b/libs/langchain/src/agents/tests/state_schema.test.ts
@@ -10,7 +10,7 @@ import {
 import { tool } from "@langchain/core/tools";
 import { StateSchema, ReducedValue, Command } from "@langchain/langgraph";
 
-import { createAgent, createMiddleware } from "../index.js";
+import { createAgent, createMiddleware, toolStrategy } from "../index.js";
 import { FakeToolCallingModel } from "./utils.js";
 import type { InferAgentState } from "../types.js";
 import type { NormalizedSchemaInput } from "../middleware/types.js";
@@ -652,12 +652,14 @@ describe("StateSchema support", () => {
         confidence: z.number(),
       });
 
+      const [structuredTool] = toolStrategy(responseFormat);
+
       const agent = createAgent({
         model: new FakeToolCallingModel({
           toolCalls: [
             [
               {
-                name: "extract-1",
+                name: structuredTool.name,
                 args: { answer: "test", confidence: 0.9 },
                 id: "extract",
               },


### PR DESCRIPTION
> **Alternative to #11600 for #11151. Only one of the two should merge.**
> Same bug, same fix, different generated name. This PR derives the name from
> a hash of the schema; #11600 numbers by position. See the comparison table on
> #11600.

Fixes #11151

### Problem

When a `responseFormat` schema has no title and resolves to the tool strategy rather than the provider's native structured output, the structured-output tool is named from a module-global counter — `extract-1` on the first model request, `extract-2` on the second. Providers render tool definitions at the very front of the cached prompt prefix, so a name that changes between requests invalidates the entire cache, system prompt and message history included.

It is also nondeterministic: the counter is global to the process, so concurrent agents interleave their increments and a restart resets the sequence.

### Measurement

Two runs of the same agent against the live Anthropic API — same system prompt, same tool, same middleware, same number of model requests:

```
before   req#1  tools=[get_weather, extract-1]                 cache_write=10790  cache_read=0
         req#2  tools=[get_weather, extract-2]                 cache_write=10863  cache_read=0

after    req#1  tools=[get_weather, extract-b8db57530ae59966]  cache_write=10797  cache_read=0
         req#2  tools=[get_weather, extract-b8db57530ae59966]  cache_write=73     cache_read=10797
```

### Change

The generated name is now `extract-` followed by a truncated hash of the schema the tool definition is built from, so the same schema always produces the same name: within one agent loop, across turns of a conversation, and across separate processes. The counter has been removed.

- Schemas carrying a title are unaffected, so anyone who adopted the title workaround keeps their current names.
- The `extract-` prefix is retained, since `ReactAgent` and the PII redaction middleware both classify structured-output tool calls by it. A custom title produces a name with no such prefix, so I plan to investigate those call sites separately to see whether a titled schema is problematic there.
- The hash reuses `sha256` from `@langchain/core/utils/hash`, already used by the PII middleware. No new dependency, no Node-only APIs, still synchronous.

One behavioural change: two identical schemas in one `responseFormat` list now collapse to a single tool, the last entry winning. The agent already keys its strategy map by name, so this needs no new code. Previously the two were offered to the model as separate tools differing only in name, and whichever the model called decided which entry's options applied.

No user-facing API changes and no migration. The generated name remains an implementation detail; the escape hatch for a specific name is still the schema title.

### Credit

The root cause was correctly diagnosed by @bisma-nawaz in #11161. This PR takes a different approach — deriving the name from schema content rather than memoising the derived strategies — because the agent node rebuilds the model on every request, and for a model passed as an identifier string that produces a fresh instance each time, so a memo keyed on the model never hits. Content-derived naming is also the only variant stable across processes.

