### PR TITLE
fix(openai): correctly handle multiple reasoning items in openAi

### DIFF
--- a/.changeset/tidy-planets-argue.md
+++ b/.changeset/tidy-planets-argue.md
@@ -1,0 +1,6 @@
+---
+"@langchain/core": patch
+"@langchain/openai": patch
+---
+
+Fix `AIMessage.contentBlocks` to correctly represent OpenAI responses with more than one reasoning item (e.g. a reasoning model making multiple tool calls in one turn). Reasoning blocks are now derived from `response_metadata.output` when available, with `id`/`encrypted_content` included, fixing dropped/failed replay under Zero Data Retention. `additional_kwargs.reasoning` is unchanged.

--- a/.changeset/tidy-planets-argue.md
+++ b/.changeset/tidy-planets-argue.md
@@ -3,4 +3,4 @@
 "@langchain/openai": patch
 ---
 
-Fix `AIMessage.contentBlocks` to correctly represent OpenAI responses with more than one reasoning item (e.g. a reasoning model making multiple tool calls in one turn). Reasoning blocks are now derived from `response_metadata.output` when available, with `id`/`encrypted_content` included, fixing dropped/failed replay under Zero Data Retention. `additional_kwargs.reasoning` is unchanged.
+Fix OpenAI Responses API replay under Zero Data Retention when a response contains more than one reasoning item, for both v0 and v1. In v0, the default replay path now reuses `response_metadata.output` directly, preserving every reasoning item's `id`/`encrypted_content` in original order. In v1, `AIMessage.contentBlocks` (`outputVersion: "v1"`) is fixed the same way. `additional_kwargs.reasoning` is unchanged.

--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -200,7 +200,7 @@ function convertResponsesAnnotation(
   return annotation;
 }
 
-// Builds a reasoning content block, including id/encrypted_content when present.
+/** Builds a reasoning content block, including id/encrypted_content when present. */
 function mapReasoningItemToV1(
   item: Record<string, unknown>
 ): ContentBlock.Standard | undefined {
@@ -226,12 +226,6 @@ function* mapToolOutputToV1Blocks(
   toolOutput: unknown
 ): Iterable<ContentBlock.Standard> {
   if (_isContentBlock(toolOutput, "web_search_call")) {
-    /**
-     * Build args from available action data.
-     * The ResponseFunctionWebSearch base type only has id, status, type.
-     * The action field (with query, sources, etc.) may be present at
-     * runtime when the `include` parameter includes "web_search_call.action.sources".
-     */
     const webSearchArgs: Record<string, unknown> = {};
     if (_isObject(toolOutput.action) && _isString(toolOutput.action.query)) {
       webSearchArgs.query = toolOutput.action.query;

--- a/libs/langchain-core/src/messages/block_translators/openai.ts
+++ b/libs/langchain-core/src/messages/block_translators/openai.ts
@@ -200,6 +200,222 @@ function convertResponsesAnnotation(
   return annotation;
 }
 
+// Builds a reasoning content block, including id/encrypted_content when present.
+function mapReasoningItemToV1(
+  item: Record<string, unknown>
+): ContentBlock.Standard | undefined {
+  if (!_isArray(item.summary)) return undefined;
+  const summary = item.summary.reduce<string>((acc, part) => {
+    if (_isObject(part) && _isString(part.text)) {
+      return `${acc}${part.text}`;
+    }
+    return acc;
+  }, "");
+  return {
+    type: "reasoning",
+    reasoning: summary,
+    ...(_isString(item.id) ? { id: item.id } : {}),
+    ...(_isString(item.encrypted_content)
+      ? { encrypted_content: item.encrypted_content }
+      : {}),
+  } as ContentBlock.Standard;
+}
+
+// Converts a single built-in tool call/result entry into v1 content blocks.
+function* mapToolOutputToV1Blocks(
+  toolOutput: unknown
+): Iterable<ContentBlock.Standard> {
+  if (_isContentBlock(toolOutput, "web_search_call")) {
+    /**
+     * Build args from available action data.
+     * The ResponseFunctionWebSearch base type only has id, status, type.
+     * The action field (with query, sources, etc.) may be present at
+     * runtime when the `include` parameter includes "web_search_call.action.sources".
+     */
+    const webSearchArgs: Record<string, unknown> = {};
+    if (_isObject(toolOutput.action) && _isString(toolOutput.action.query)) {
+      webSearchArgs.query = toolOutput.action.query;
+    }
+    yield {
+      id: toolOutput.id,
+      type: "server_tool_call",
+      name: "web_search",
+      args: webSearchArgs,
+    };
+    // Emit a server_tool_call_result when the search has completed or failed
+    if (toolOutput.status === "completed" || toolOutput.status === "failed") {
+      const output: Record<string, unknown> = {};
+      if (_isObject(toolOutput.action)) {
+        output.action = toolOutput.action;
+      }
+      yield {
+        type: "server_tool_call_result",
+        toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
+        status: toolOutput.status === "completed" ? "success" : "error",
+        output,
+      };
+    }
+    return;
+  }
+  if (_isContentBlock(toolOutput, "file_search_call")) {
+    yield {
+      id: toolOutput.id,
+      type: "server_tool_call",
+      name: "file_search",
+      args: {
+        queries: _isArray(toolOutput.queries) ? toolOutput.queries : [],
+      },
+    };
+    // Emit a server_tool_call_result when results are available
+    if (toolOutput.status === "completed" || toolOutput.status === "failed") {
+      yield {
+        type: "server_tool_call_result",
+        toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
+        status: toolOutput.status === "completed" ? "success" : "error",
+        output: _isArray(toolOutput.results)
+          ? { results: toolOutput.results }
+          : {},
+      };
+    }
+    return;
+  }
+  if (_isContentBlock(toolOutput, "computer_call")) {
+    yield { type: "non_standard", value: toolOutput };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "code_interpreter_call")) {
+    if (_isString(toolOutput.code)) {
+      yield {
+        id: toolOutput.id,
+        type: "server_tool_call",
+        name: "code_interpreter",
+        args: { code: toolOutput.code },
+      };
+    }
+    if (_isArray(toolOutput.outputs)) {
+      const returnCode = iife(() => {
+        if (toolOutput.status === "in_progress") return undefined;
+        if (toolOutput.status === "completed") return 0;
+        if (toolOutput.status === "incomplete") return 127;
+        if (toolOutput.status === "interpreting") return undefined;
+        if (toolOutput.status === "failed") return 1;
+        return undefined;
+      });
+      for (const output of toolOutput.outputs) {
+        if (_isContentBlock(output, "logs")) {
+          yield {
+            type: "server_tool_call_result",
+            toolCallId: toolOutput.id ?? "",
+            status: "success",
+            output: {
+              type: "code_interpreter_output",
+              returnCode: returnCode ?? 0,
+              stderr: [0, undefined].includes(returnCode)
+                ? undefined
+                : String(output.logs),
+              stdout: [0, undefined].includes(returnCode)
+                ? String(output.logs)
+                : undefined,
+            },
+          };
+        }
+      }
+    }
+    return;
+  }
+  if (_isContentBlock(toolOutput, "mcp_call")) {
+    yield {
+      id: toolOutput.id,
+      type: "server_tool_call",
+      name: "mcp_call",
+      args: toolOutput.input,
+    };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "mcp_list_tools")) {
+    yield {
+      id: toolOutput.id,
+      type: "server_tool_call",
+      name: "mcp_list_tools",
+      args: toolOutput.input,
+    };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "mcp_approval_request")) {
+    yield { type: "non_standard", value: toolOutput };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "tool_search_call")) {
+    const toolSearchArgs: Record<string, unknown> = {};
+    if (_isObject(toolOutput.arguments)) {
+      Object.assign(toolSearchArgs, toolOutput.arguments);
+    }
+    const toolSearchCallExtras: Record<string, unknown> = {};
+    if (_isString(toolOutput.execution)) {
+      toolSearchCallExtras.execution = toolOutput.execution;
+    }
+    if (_isString(toolOutput.status)) {
+      toolSearchCallExtras.status = toolOutput.status;
+    }
+    if (_isString(toolOutput.call_id)) {
+      toolSearchCallExtras.call_id = toolOutput.call_id;
+    }
+    yield {
+      id: _isString(toolOutput.id) ? toolOutput.id : "",
+      type: "server_tool_call",
+      name: "tool_search",
+      args: toolSearchArgs,
+      ...(Object.keys(toolSearchCallExtras).length > 0
+        ? { extras: toolSearchCallExtras }
+        : {}),
+    };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "tool_search_output")) {
+    const toolSearchOutputExtras: Record<string, unknown> = {
+      name: "tool_search",
+    };
+    if (_isString(toolOutput.execution)) {
+      toolSearchOutputExtras.execution = toolOutput.execution;
+    }
+    yield {
+      type: "server_tool_call_result",
+      toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
+      status:
+        toolOutput.status === "completed"
+          ? "success"
+          : toolOutput.status === "failed"
+            ? "error"
+            : "success",
+      output: {
+        tools: _isArray(toolOutput.tools) ? toolOutput.tools : [],
+      },
+      extras: toolSearchOutputExtras,
+    };
+    return;
+  }
+  if (_isContentBlock(toolOutput, "image_generation_call")) {
+    // Convert image_generation_call to proper image content block if result is available
+    if (_isString(toolOutput.result)) {
+      yield {
+        type: "image",
+        mimeType: "image/png",
+        data: toolOutput.result,
+        id: _isString(toolOutput.id) ? toolOutput.id : undefined,
+        metadata: {
+          status: _isString(toolOutput.status) ? toolOutput.status : undefined,
+        },
+      };
+    }
+    // Also yield as non_standard for backwards compatibility
+    yield { type: "non_standard", value: toolOutput };
+    return;
+  }
+  if (_isObject(toolOutput)) {
+    yield { type: "non_standard", value: toolOutput };
+  }
+}
+
 /**
  * Converts a ChatOpenAIResponses message to an array of v1 standard content blocks.
  *
@@ -207,6 +423,14 @@ function convertResponsesAnnotation(
  * and converts them to the standardized v1 content block format. It handles reasoning summaries,
  * text content with annotations, tool calls, and various tool outputs including code interpreter,
  * web search, file search, computer calls, and MCP-related blocks.
+ *
+ * A response can hold more than one reasoning item (e.g. multiple tool calls
+ * in one turn, common on GPT-5.6-class models). When `response_metadata.output`
+ * is available, each item's own `id`/`encrypted_content` is preserved and
+ * blocks are sorted back into original order, so replay under Zero Data
+ * Retention interleaves reasoning and tool calls correctly. Without it (e.g.
+ * a hand-built message), falls back to a single reasoning block from
+ * `additional_kwargs.reasoning`, as before.
  *
  * @param message - The AI message containing OpenAI Responses-formatted content blocks
  * @returns Array of content blocks in v1 standard format
@@ -234,34 +458,74 @@ function convertResponsesAnnotation(
  * //   { type: "reasoning", reasoning: "Let me calculate this..." },
  * //   { type: "text", text: "Hello world", annotations: [] },
  * //   { type: "tool_call", id: "123", name: "calculator", args: { a: 1, b: 2 } },
- * //   { type: "code_interpreter_call", code: "print('hello')" },
- * //   { type: "code_interpreter_result", output: [{ type: "code_interpreter_output", returnCode: 0, stdout: "hello" }] }
+ * //   { type: "server_tool_call", name: "code_interpreter", args: { code: "print('hello')" } },
+ * //   { type: "server_tool_call_result", toolCallId: "", status: "success", output: { type: "code_interpreter_output", returnCode: 0, stdout: "hello" } }
  * // ]
  * ```
  */
 export function convertToV1FromResponses(
   message: AIMessage
 ): Array<ContentBlock.Standard> {
-  function* iterateContent(): Iterable<ContentBlock.Standard> {
-    if (
+  const rawOutput = message.response_metadata?.output;
+  const hasRawOutput = _isArray(rawOutput) && rawOutput.length > 0;
+
+  // Maps a per-item key (namespaced by type, since ids aren't globally unique) to its original response.output position.
+  const positionByKey = new Map<string, number>();
+  let messageItemCount = 0;
+  let onlyMessageItemIndex: number | undefined;
+  if (hasRawOutput) {
+    (rawOutput as unknown[]).forEach((rawItem, index) => {
+      if (!_isObject(rawItem) || !_isString(rawItem.type)) return;
+      if (rawItem.type === "reasoning" && _isString(rawItem.id)) {
+        positionByKey.set(`reasoning:${rawItem.id}`, index);
+      } else if (
+        // These three types all become tool_call blocks keyed by call_id.
+        (rawItem.type === "function_call" ||
+          rawItem.type === "custom_tool_call" ||
+          rawItem.type === "computer_call") &&
+        _isString(rawItem.call_id)
+      ) {
+        positionByKey.set(`tool_call:${rawItem.call_id}`, index);
+      } else if (rawItem.type === "message") {
+        messageItemCount += 1;
+        onlyMessageItemIndex = index;
+      } else if (_isString(rawItem.id)) {
+        positionByKey.set(`other:${rawItem.type}:${rawItem.id}`, index);
+      }
+    });
+  }
+  // Text isn't keyed to a specific "message" item, so only position it when exactly one exists (an unambiguous match).
+  const textBlockKey =
+    messageItemCount === 1 && onlyMessageItemIndex != null
+      ? `message:${onlyMessageItemIndex}`
+      : undefined;
+  if (textBlockKey != null) {
+    positionByKey.set(textBlockKey, onlyMessageItemIndex as number);
+  }
+
+  function* iterateContent(): Iterable<
+    [block: ContentBlock.Standard, key: string | undefined]
+  > {
+    if (hasRawOutput) {
+      for (const rawItem of rawOutput as unknown[]) {
+        if (_isObject(rawItem) && rawItem.type === "reasoning") {
+          const block = mapReasoningItemToV1(rawItem);
+          if (block) {
+            yield [
+              block,
+              _isString(rawItem.id) ? `reasoning:${rawItem.id}` : undefined,
+            ];
+          }
+        }
+      }
+    } else if (
       _isObject(message.additional_kwargs?.reasoning) &&
       _isArray(message.additional_kwargs.reasoning.summary)
     ) {
-      const summary =
-        message.additional_kwargs.reasoning.summary.reduce<string>(
-          (acc, item) => {
-            if (_isObject(item) && _isString(item.text)) {
-              return `${acc}${item.text}`;
-            }
-            return acc;
-          },
-          ""
-        );
-      yield {
-        type: "reasoning",
-        reasoning: summary,
-      };
+      const block = mapReasoningItemToV1(message.additional_kwargs.reasoning);
+      if (block) yield [block, undefined];
     }
+
     const content =
       typeof message.content === "string"
         ? [{ type: "text", text: message.content }]
@@ -282,233 +546,68 @@ export function convertToV1FromResponses(
           extras.phase = phase;
         }
         const extrasSpread = Object.keys(extras).length > 0 ? { extras } : {};
-        if (Array.isArray(annotations)) {
-          yield {
+        yield [
+          {
             ...rest,
             ...extrasSpread,
             type: "text",
             text: String(text),
-            annotations: annotations.map(convertResponsesAnnotation),
-          };
-        } else {
-          yield {
-            ...rest,
-            ...extrasSpread,
-            type: "text",
-            text: String(text),
-          };
-        }
+            ...(Array.isArray(annotations)
+              ? { annotations: annotations.map(convertResponsesAnnotation) }
+              : {}),
+          },
+          textBlockKey,
+        ];
       }
     }
     for (const toolCall of message.tool_calls ?? []) {
-      yield {
-        type: "tool_call",
-        id: toolCall.id,
-        name: toolCall.name,
-        args: toolCall.args,
-      };
+      yield [
+        {
+          type: "tool_call",
+          id: toolCall.id,
+          name: toolCall.name,
+          args: toolCall.args,
+        },
+        toolCall.id ? `tool_call:${toolCall.id}` : undefined,
+      ];
     }
     if (
       _isObject(message.additional_kwargs) &&
       _isArray(message.additional_kwargs.tool_outputs)
     ) {
       for (const toolOutput of message.additional_kwargs.tool_outputs) {
-        if (_isContentBlock(toolOutput, "web_search_call")) {
-          /**
-           * Build args from available action data.
-           * The ResponseFunctionWebSearch base type only has id, status, type.
-           * The action field (with query, sources, etc.) may be present at
-           * runtime when the `include` parameter includes "web_search_call.action.sources".
-           */
-          const webSearchArgs: Record<string, unknown> = {};
-          if (
-            _isObject(toolOutput.action) &&
-            _isString(toolOutput.action.query)
-          ) {
-            webSearchArgs.query = toolOutput.action.query;
-          }
-          yield {
-            id: toolOutput.id,
-            type: "server_tool_call",
-            name: "web_search",
-            args: webSearchArgs,
-          };
-          // Emit a server_tool_call_result when the search has completed or failed
-          if (
-            toolOutput.status === "completed" ||
-            toolOutput.status === "failed"
-          ) {
-            const output: Record<string, unknown> = {};
-            if (_isObject(toolOutput.action)) {
-              output.action = toolOutput.action;
-            }
-            yield {
-              type: "server_tool_call_result",
-              toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
-              status: toolOutput.status === "completed" ? "success" : "error",
-              output,
-            };
-          }
-          continue;
-        } else if (_isContentBlock(toolOutput, "file_search_call")) {
-          yield {
-            id: toolOutput.id,
-            type: "server_tool_call",
-            name: "file_search",
-            args: {
-              queries: _isArray(toolOutput.queries) ? toolOutput.queries : [],
-            },
-          };
-          // Emit a server_tool_call_result when results are available
-          if (
-            toolOutput.status === "completed" ||
-            toolOutput.status === "failed"
-          ) {
-            yield {
-              type: "server_tool_call_result",
-              toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
-              status: toolOutput.status === "completed" ? "success" : "error",
-              output: _isArray(toolOutput.results)
-                ? { results: toolOutput.results }
-                : {},
-            };
-          }
-          continue;
-        } else if (_isContentBlock(toolOutput, "computer_call")) {
-          yield { type: "non_standard", value: toolOutput };
-          continue;
-        } else if (_isContentBlock(toolOutput, "code_interpreter_call")) {
-          if (_isString(toolOutput.code)) {
-            yield {
-              id: toolOutput.id,
-              type: "server_tool_call",
-              name: "code_interpreter",
-              args: { code: toolOutput.code },
-            };
-          }
-          if (_isArray(toolOutput.outputs)) {
-            const returnCode = iife(() => {
-              if (toolOutput.status === "in_progress") return undefined;
-              if (toolOutput.status === "completed") return 0;
-              if (toolOutput.status === "incomplete") return 127;
-              if (toolOutput.status === "interpreting") return undefined;
-              if (toolOutput.status === "failed") return 1;
-              return undefined;
-            });
-            for (const output of toolOutput.outputs) {
-              if (_isContentBlock(output, "logs")) {
-                yield {
-                  type: "server_tool_call_result",
-                  toolCallId: toolOutput.id ?? "",
-                  status: "success",
-                  output: {
-                    type: "code_interpreter_output",
-                    returnCode: returnCode ?? 0,
-                    stderr: [0, undefined].includes(returnCode)
-                      ? undefined
-                      : String(output.logs),
-                    stdout: [0, undefined].includes(returnCode)
-                      ? String(output.logs)
-                      : undefined,
-                  },
-                };
-                continue;
-              }
-            }
-          }
-          continue;
-        } else if (_isContentBlock(toolOutput, "mcp_call")) {
-          yield {
-            id: toolOutput.id,
-            type: "server_tool_call",
-            name: "mcp_call",
-            args: toolOutput.input,
-          };
-          continue;
-        } else if (_isContentBlock(toolOutput, "mcp_list_tools")) {
-          yield {
-            id: toolOutput.id,
-            type: "server_tool_call",
-            name: "mcp_list_tools",
-            args: toolOutput.input,
-          };
-          continue;
-        } else if (_isContentBlock(toolOutput, "mcp_approval_request")) {
-          yield { type: "non_standard", value: toolOutput };
-          continue;
-        } else if (_isContentBlock(toolOutput, "tool_search_call")) {
-          const toolSearchArgs: Record<string, unknown> = {};
-          if (_isObject(toolOutput.arguments)) {
-            Object.assign(toolSearchArgs, toolOutput.arguments);
-          }
-          const toolSearchCallExtras: Record<string, unknown> = {};
-          if (_isString(toolOutput.execution)) {
-            toolSearchCallExtras.execution = toolOutput.execution;
-          }
-          if (_isString(toolOutput.status)) {
-            toolSearchCallExtras.status = toolOutput.status;
-          }
-          if (_isString(toolOutput.call_id)) {
-            toolSearchCallExtras.call_id = toolOutput.call_id;
-          }
-          yield {
-            id: _isString(toolOutput.id) ? toolOutput.id : "",
-            type: "server_tool_call",
-            name: "tool_search",
-            args: toolSearchArgs,
-            ...(Object.keys(toolSearchCallExtras).length > 0
-              ? { extras: toolSearchCallExtras }
-              : {}),
-          };
-          continue;
-        } else if (_isContentBlock(toolOutput, "tool_search_output")) {
-          const toolSearchOutputExtras: Record<string, unknown> = {
-            name: "tool_search",
-          };
-          if (_isString(toolOutput.execution)) {
-            toolSearchOutputExtras.execution = toolOutput.execution;
-          }
-          yield {
-            type: "server_tool_call_result",
-            toolCallId: _isString(toolOutput.id) ? toolOutput.id : "",
-            status:
-              toolOutput.status === "completed"
-                ? "success"
-                : toolOutput.status === "failed"
-                  ? "error"
-                  : "success",
-            output: {
-              tools: _isArray(toolOutput.tools) ? toolOutput.tools : [],
-            },
-            extras: toolSearchOutputExtras,
-          };
-          continue;
-        } else if (_isContentBlock(toolOutput, "image_generation_call")) {
-          // Convert image_generation_call to proper image content block if result is available
-          if (_isString(toolOutput.result)) {
-            yield {
-              type: "image",
-              mimeType: "image/png",
-              data: toolOutput.result,
-              id: _isString(toolOutput.id) ? toolOutput.id : undefined,
-              metadata: {
-                status: _isString(toolOutput.status)
-                  ? toolOutput.status
-                  : undefined,
-              },
-            };
-          }
-          // Also yield as non_standard for backwards compatibility
-          yield { type: "non_standard", value: toolOutput };
-          continue;
-        }
-        if (_isObject(toolOutput)) {
-          yield { type: "non_standard", value: toolOutput };
+        // All blocks from one tool output share this key -- fine since the API returns a call and its result as one item.
+        const key =
+          _isObject(toolOutput) &&
+          _isString(toolOutput.type) &&
+          _isString(toolOutput.id)
+            ? `other:${toolOutput.type}:${toolOutput.id}`
+            : undefined;
+        for (const block of mapToolOutputToV1Blocks(toolOutput)) {
+          yield [block, key];
         }
       }
     }
   }
-  return Array.from(iterateContent());
+
+  const withKeys = Array.from(iterateContent());
+  if (!hasRawOutput) {
+    return withKeys.map(([block]) => block);
+  }
+  // Stable sort by original position; unkeyed blocks sort last, in push order.
+  return withKeys
+    .map(([block, key], pushIndex) => ({
+      block,
+      pushIndex,
+      position: key != null ? positionByKey.get(key) : undefined,
+    }))
+    .sort((a, b) => {
+      const aPos = a.position ?? Number.POSITIVE_INFINITY;
+      const bPos = b.position ?? Number.POSITIVE_INFINITY;
+      if (aPos !== bPos) return aPos - bPos;
+      return a.pushIndex - b.pushIndex;
+    })
+    .map((entry) => entry.block);
 }
 
 /**

--- a/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
+++ b/libs/langchain-core/src/messages/block_translators/tests/openai.test.ts
@@ -700,6 +700,224 @@ describe("openaiTranslator", () => {
         execution: "server",
       });
     });
+
+    it("should derive multiple, correctly-ordered reasoning blocks from response_metadata.output", () => {
+      // additional_kwargs.reasoning (here, deliberately stale) holds only
+      // one item, so multi-item turns must derive from response.output.
+      const message = new AIMessage({
+        content: [],
+        tool_calls: [
+          { id: "call_1", name: "add", args: { a: 1, b: 2 } },
+          { id: "call_2", name: "multiply", args: { a: 3, b: 4 } },
+        ],
+        additional_kwargs: {
+          reasoning: {
+            type: "reasoning",
+            id: "rs_stale",
+            summary: [{ type: "summary_text", text: "stale" }],
+          },
+        },
+        response_metadata: {
+          model_provider: "openai",
+          output: [
+            {
+              type: "reasoning",
+              id: "rs_first",
+              summary: [{ type: "summary_text", text: "First" }],
+              encrypted_content: "enc_1",
+            },
+            {
+              type: "function_call",
+              call_id: "call_1",
+              name: "add",
+              arguments: '{"a":1,"b":2}',
+            },
+            {
+              type: "reasoning",
+              id: "rs_second",
+              summary: [{ type: "summary_text", text: "Second" }],
+              encrypted_content: "enc_2",
+            },
+            {
+              type: "function_call",
+              call_id: "call_2",
+              name: "multiply",
+              arguments: '{"a":3,"b":4}',
+            },
+          ],
+        },
+      });
+
+      const relevant = message.contentBlocks.filter(
+        (b) => b.type === "reasoning" || b.type === "tool_call"
+      );
+      expect(relevant).toEqual([
+        {
+          type: "reasoning",
+          reasoning: "First",
+          id: "rs_first",
+          encrypted_content: "enc_1",
+        },
+        { type: "tool_call", id: "call_1", name: "add", args: { a: 1, b: 2 } },
+        {
+          type: "reasoning",
+          reasoning: "Second",
+          id: "rs_second",
+          encrypted_content: "enc_2",
+        },
+        {
+          type: "tool_call",
+          id: "call_2",
+          name: "multiply",
+          args: { a: 3, b: 4 },
+        },
+      ]);
+    });
+
+    it("should fall back to additional_kwargs.reasoning when response_metadata.output is absent", () => {
+      const message = new AIMessage({
+        content: [{ type: "text", text: "Done." }],
+        additional_kwargs: {
+          reasoning: {
+            type: "reasoning",
+            id: "rs_only",
+            summary: [{ type: "summary_text", text: "Thinking..." }],
+          },
+        },
+        response_metadata: { model_provider: "openai" },
+      });
+
+      const reasoningBlocks = message.contentBlocks.filter(
+        (b) => b.type === "reasoning"
+      );
+      expect(reasoningBlocks).toEqual([
+        {
+          type: "reasoning",
+          reasoning: "Thinking...",
+          id: "rs_only",
+        },
+      ]);
+    });
+
+    it("should position custom_tool_call and computer_call correctly relative to reasoning", () => {
+      const message = new AIMessage({
+        content: [],
+        tool_calls: [
+          {
+            id: "call_1",
+            name: "computer_use",
+            args: { action: { type: "click" } },
+          },
+          { id: "call_2", name: "my_tool", args: { input: "do it" } },
+        ],
+        response_metadata: {
+          model_provider: "openai",
+          output: [
+            {
+              type: "reasoning",
+              id: "rs_first",
+              summary: [{ type: "summary_text", text: "First" }],
+              encrypted_content: "enc_1",
+            },
+            {
+              type: "computer_call",
+              id: "cc_1",
+              call_id: "call_1",
+              action: { type: "click" },
+            },
+            {
+              type: "reasoning",
+              id: "rs_second",
+              summary: [{ type: "summary_text", text: "Second" }],
+              encrypted_content: "enc_2",
+            },
+            {
+              type: "custom_tool_call",
+              id: "ctc_1",
+              call_id: "call_2",
+              name: "my_tool",
+              input: "do it",
+            },
+          ],
+        },
+      });
+
+      const relevant = message.contentBlocks.filter(
+        (b) => b.type === "reasoning" || b.type === "tool_call"
+      );
+      expect(relevant.map((b) => ("id" in b ? b.id : undefined))).toEqual([
+        "rs_first",
+        "call_1",
+        "rs_second",
+        "call_2",
+      ]);
+    });
+
+    it("should position a single text block correctly when it appears before a tool call", () => {
+      const message = new AIMessage({
+        content: [{ type: "text", text: "Let me check that.", phase: "1" }],
+        tool_calls: [{ id: "call_1", name: "add", args: { a: 1, b: 2 } }],
+        response_metadata: {
+          model_provider: "openai",
+          output: [
+            {
+              type: "message",
+              id: "msg_1",
+              content: [{ type: "output_text", text: "Let me check that." }],
+              phase: "1",
+            },
+            {
+              type: "function_call",
+              call_id: "call_1",
+              name: "add",
+              arguments: '{"a":1,"b":2}',
+            },
+          ],
+        },
+      });
+
+      const relevant = message.contentBlocks.filter(
+        (b) => b.type === "text" || b.type === "tool_call"
+      );
+      expect(relevant.map((b) => b.type)).toEqual(["text", "tool_call"]);
+    });
+
+    it("should not collide positions for different item types that share an id", () => {
+      const message = new AIMessage({
+        content: [],
+        additional_kwargs: {
+          tool_outputs: [
+            { type: "web_search_call", id: "shared_id", status: "completed" },
+            {
+              type: "file_search_call",
+              id: "shared_id",
+              status: "completed",
+              queries: [],
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: "openai",
+          output: [
+            { type: "web_search_call", id: "shared_id", status: "completed" },
+            {
+              type: "file_search_call",
+              id: "shared_id",
+              status: "completed",
+              queries: [],
+            },
+          ],
+        },
+      });
+
+      const serverToolCalls = message.contentBlocks.filter(
+        (b) => b.type === "server_tool_call"
+      ) as Array<{ name?: string }>;
+      expect(serverToolCalls.map((b) => b.name)).toEqual([
+        "web_search",
+        "file_search",
+      ]);
+    });
   });
 
   describe("phase parameter support", () => {

--- a/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/responses.int.test.ts
@@ -965,6 +965,64 @@ describe("reasoning summaries", () => {
     expect(replay.content).toBeTruthy();
   });
 
+  test("replays interleaved reasoning and tool calls under ZDR", async () => {
+    const model = new ChatOpenAI({
+      model: "gpt-5.6",
+      useResponsesApi: true,
+      zdrEnabled: true,
+      reasoning: { effort: "high", summary: "detailed" },
+      maxRetries: 0,
+    }).bindTools([
+      { type: "web_search" },
+      { type: "code_interpreter", container: { type: "auto" } },
+    ]);
+    const prompt = [
+      "Search the web for the current populations of San Francisco and San Jose.",
+      "Then use the code interpreter to calculate the difference between them.",
+      "You must use web_search first and code_interpreter second.",
+    ].join("\n");
+
+    const firstResponse = await model.invoke(prompt);
+    const output = firstResponse.response_metadata.output;
+    expect(Array.isArray(output)).toBe(true);
+    if (!Array.isArray(output)) {
+      throw new Error("Expected response_metadata.output to be an array");
+    }
+
+    const reasoningAndToolCalls = output.filter(
+      (item) =>
+        typeof item === "object" &&
+        item != null &&
+        "type" in item &&
+        (item.type === "reasoning" ||
+          item.type === "web_search_call" ||
+          item.type === "code_interpreter_call")
+    ) as Array<{
+      type: "reasoning" | "web_search_call" | "code_interpreter_call";
+      encrypted_content?: string;
+    }>;
+    expect(reasoningAndToolCalls.map((item) => item.type)).toEqual([
+      "reasoning",
+      "web_search_call",
+      "reasoning",
+      "code_interpreter_call",
+    ]);
+    for (const reasoningItem of reasoningAndToolCalls.filter(
+      (item) => item.type === "reasoning"
+    )) {
+      expect(reasoningItem.encrypted_content).toEqual(expect.any(String));
+      expect(reasoningItem.encrypted_content).not.toHaveLength(0);
+    }
+
+    const followUp = await model.invoke([
+      new HumanMessage(prompt),
+      firstResponse,
+      new HumanMessage("What difference did you calculate?"),
+    ]);
+    expect(followUp).toBeInstanceOf(AIMessage);
+    expect(followUp.content).toBeTruthy();
+  });
+
   test.each(["stream", "invoke"])(
     "normal responses API usage (Zero Data Retention disabled), %s",
     async (requestType) => {

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -23,6 +23,10 @@ import type {
   ToolMessage,
 } from "@langchain/core/messages/tool";
 import { ResponseInputMessageContentList } from "openai/resources/responses/responses.js";
+import {
+  toResponseInputItems,
+  type ResponseInputItemLike,
+} from "openai/lib/responses/ResponseInputItems.js";
 import { ChatOpenAIReasoningSummary } from "../types.js";
 import {
   isComputerToolCall,
@@ -1519,15 +1523,26 @@ export const convertMessagesToResponsesInput: Converter<
       }
 
       if (role === "assistant") {
-        // if we have the original response items, just reuse them
+        // If we have the original response items, reuse their canonical order.
+        // This is especially important under ZDR, where independently rebuilding
+        // reasoning and tool-call items loses multiple reasoning payloads and
+        // their interleaving.
         if (
-          !zdrEnabled &&
           responseMetadata?.output != null &&
-          Array.isArray(responseMetadata?.output) &&
-          responseMetadata?.output.length > 0 &&
-          responseMetadata?.output.every((item) => "type" in item)
+          Array.isArray(responseMetadata.output) &&
+          responseMetadata.output.length > 0 &&
+          responseMetadata.output.every(
+            (item) =>
+              typeof item === "object" &&
+              item != null &&
+              "type" in item &&
+              typeof item.type === "string"
+          )
         ) {
-          return responseMetadata?.output;
+          const output = responseMetadata.output as ResponseInputItemLike[];
+          return zdrEnabled
+            ? toResponseInputItems(output)
+            : (output as ResponsesInputItem[]);
         }
 
         // otherwise, try to reconstruct the response from what we have

--- a/libs/providers/langchain-openai/src/converters/responses.ts
+++ b/libs/providers/langchain-openai/src/converters/responses.ts
@@ -1198,10 +1198,18 @@ export const convertStandardContentMessageToResponsesInput: Converter<
       // a populated `content` array on input (`400 Invalid 'input[n].content':
       // array too long. Expected an array with maximum length 0`). The reasoning
       // text is already represented in `summary`, so we do not forward `content`.
+      //
+      // `encrypted_content` is required to replay this item under Zero Data
+      // Retention, so forward it when the block carries one.
+      const encryptedContent = (block as { encrypted_content?: unknown })
+        .encrypted_content;
       return {
         type: "reasoning",
         ...(block.id ? { id: block.id } : {}),
         summary,
+        ...(typeof encryptedContent === "string"
+          ? { encrypted_content: encryptedContent }
+          : {}),
       } as OpenAIClient.Responses.ResponseReasoningItem;
     };
 

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -683,6 +683,76 @@ describe("convertResponsesDeltaToChatGenerationChunk", () => {
       ]);
     });
 
+    it("v0: additional_kwargs.reasoning stays a single, last-write-wins object with two reasoning items (accepted limitation)", () => {
+      // v0 stays a single object forever (array would break existing
+      // readers/merges); multi-item support is v1's job, tested below.
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [],
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [],
+            encrypted_content: "canonical_payload_1",
+          },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [],
+          },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 1,
+          item: {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [],
+            encrypted_content: "canonical_payload_2",
+          },
+        },
+      ];
+
+      const chunks = events.map((event) => {
+        const chunk = convertResponsesDeltaToChatGenerationChunk(event as any);
+        expect(chunk).not.toBeNull();
+        return chunk!.message as AIMessageChunk;
+      });
+
+      const streamedMessage = chunks.reduce((acc, chunk) => acc.concat(chunk));
+
+      const replayInput = convertMessagesToResponsesInput({
+        messages: [streamedMessage],
+        zdrEnabled: true,
+        model: "o3",
+      });
+
+      // The known existing gap: wrong id, concatenated ciphertext.
+      // Fixed in V1
+      expect(replayInput).toEqual([
+        {
+          id: "rs_second",
+          type: "reasoning",
+          summary: [],
+          encrypted_content: "canonical_payload_1canonical_payload_2",
+        },
+      ]);
+    });
+
     it("should elevate reasoning to content on response.output_item.added with reasoning", () => {
       const event = {
         type: "response.output_item.added",
@@ -1673,6 +1743,106 @@ describe("convertMessagesToResponsesInput", () => {
 
       // Should preserve the full output array including reasoning + function_call pairing
       expect(input).toEqual(response.output);
+    });
+  });
+
+  describe("v1 content-block replay (multi-reasoning-item ordering, ZDR)", () => {
+    it('default (v0) path loses a reasoning item under ZDR; opting into outputVersion "v1" replays both correctly', () => {
+      const response = {
+        id: "resp_123",
+        model: "gpt-5.6",
+        created_at: 0,
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "reasoning",
+            id: "rs_first",
+            summary: [{ type: "summary_text", text: "First" }],
+            encrypted_content: "enc_1",
+          },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "add",
+            arguments: '{"a":1,"b":2}',
+          },
+          {
+            type: "reasoning",
+            id: "rs_second",
+            summary: [{ type: "summary_text", text: "Second" }],
+            encrypted_content: "enc_2",
+          },
+          {
+            type: "function_call",
+            id: "fc_2",
+            call_id: "call_2",
+            name: "multiply",
+            arguments: '{"a":3,"b":4}',
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+      };
+
+      const message = convertResponsesMessageToAIMessage(response as any);
+
+      // --- Default (v0) path: additional_kwargs.reasoning only ever holds
+      // one item, so under ZDR the first reasoning item -- and the call it
+      // informed -- is silently dropped from replay.
+      const defaultReplay = (
+        convertMessagesToResponsesInput({
+          messages: [message],
+          zdrEnabled: true,
+          model: "gpt-5.6",
+        }) as unknown as Array<Record<string, unknown>>
+      )
+        .filter(
+          (item) => item.type === "reasoning" || item.type === "function_call"
+        )
+        .map((item) =>
+          item.type === "reasoning"
+            ? `reasoning:${item.id}:${item.encrypted_content}`
+            : `function_call:${item.call_id}`
+        );
+      expect(defaultReplay).toEqual([
+        "reasoning:rs_second:enc_2",
+        "function_call:call_1",
+        "function_call:call_2",
+      ]);
+
+      // --- Opting into outputVersion: "v1": mirrors @langchain/core's
+      // castStandardMessageContent exactly, using the same message's
+      // response_metadata.output (untouched by the defect above, since it's
+      // the original response, not the reconstructed additional_kwargs.reasoning).
+      const standardizedMessage = new AIMessage({
+        ...message,
+        content: message.contentBlocks,
+        response_metadata: {
+          ...message.response_metadata,
+          output_version: "v1",
+        },
+      });
+
+      const v1Replay = (
+        convertMessagesToResponsesInput({
+          messages: [standardizedMessage],
+          zdrEnabled: true,
+          model: "gpt-5.6",
+        }) as unknown as Array<Record<string, unknown>>
+      ).map((item) =>
+        item.type === "reasoning"
+          ? `reasoning:${item.id}:${item.encrypted_content}`
+          : item.type === "function_call"
+            ? `function_call:${item.call_id}`
+            : item.type
+      );
+      expect(v1Replay).toEqual([
+        "reasoning:rs_first:enc_1",
+        "function_call:call_1",
+        "reasoning:rs_second:enc_2",
+        "function_call:call_2",
+      ]);
     });
   });
 });

--- a/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
+++ b/libs/providers/langchain-openai/src/converters/tests/responses.test.ts
@@ -1707,6 +1707,68 @@ describe("convertMessagesToResponsesInput", () => {
       expect(result).toEqual(output);
     });
 
+    it("preserves multiple ordered reasoning items from response_metadata.output in ZDR mode", () => {
+      const output = [
+        {
+          type: "reasoning",
+          id: "rs_first",
+          summary: [{ type: "summary_text", text: "First" }],
+          encrypted_content: "encrypted_first",
+          created_by: "provider",
+        },
+        {
+          type: "function_call",
+          id: "fc_first",
+          call_id: "call_first",
+          name: "add",
+          arguments: '{"a":1,"b":2}',
+          created_by: "provider",
+        },
+        {
+          type: "reasoning",
+          id: "rs_second",
+          summary: [{ type: "summary_text", text: "Second" }],
+          encrypted_content: "encrypted_second",
+          created_by: "provider",
+        },
+        {
+          type: "function_call",
+          id: "fc_second",
+          call_id: "call_second",
+          name: "multiply",
+          arguments: '{"a":3,"b":4}',
+          created_by: "provider",
+        },
+      ];
+      const message = new AIMessage({
+        content: [],
+        tool_calls: [
+          { name: "add", args: { a: 1, b: 2 }, id: "call_first" },
+          {
+            name: "multiply",
+            args: { a: 3, b: 4 },
+            id: "call_second",
+          },
+        ],
+        additional_kwargs: {
+          // The legacy field can only retain one reasoning item. The original
+          // output must take precedence when it is available.
+          reasoning: output[2],
+        },
+        response_metadata: { output },
+      });
+
+      const result = convertMessagesToResponsesInput({
+        messages: [message],
+        zdrEnabled: true,
+        model: "o3-mini",
+      });
+
+      expect(result).toEqual(
+        output.map(({ created_by: _createdBy, ...item }) => item)
+      );
+    });
+
     it("round-trips reasoning + tool calls through AIMessage", () => {
       const response = {
         id: "resp_123",
@@ -1747,7 +1809,7 @@ describe("convertMessagesToResponsesInput", () => {
   });
 
   describe("v1 content-block replay (multi-reasoning-item ordering, ZDR)", () => {
-    it('default (v0) path loses a reasoning item under ZDR; opting into outputVersion "v1" replays both correctly', () => {
+    it('both the default (v0) path and opting into outputVersion "v1" replay multiple reasoning items correctly under ZDR', () => {
       const response = {
         id: "resp_123",
         model: "gpt-5.6",
@@ -1788,8 +1850,9 @@ describe("convertMessagesToResponsesInput", () => {
       const message = convertResponsesMessageToAIMessage(response as any);
 
       // --- Default (v0) path: additional_kwargs.reasoning only ever holds
-      // one item, so under ZDR the first reasoning item -- and the call it
-      // informed -- is silently dropped from replay.
+      // one item, but replay now reuses response_metadata.output directly
+      // (normalized via the SDK's toResponseInputItems), so every reasoning
+      // item is preserved in its original position.
       const defaultReplay = (
         convertMessagesToResponsesInput({
           messages: [message],
@@ -1806,15 +1869,12 @@ describe("convertMessagesToResponsesInput", () => {
             : `function_call:${item.call_id}`
         );
       expect(defaultReplay).toEqual([
-        "reasoning:rs_second:enc_2",
+        "reasoning:rs_first:enc_1",
         "function_call:call_1",
+        "reasoning:rs_second:enc_2",
         "function_call:call_2",
       ]);
 
-      // --- Opting into outputVersion: "v1": mirrors @langchain/core's
-      // castStandardMessageContent exactly, using the same message's
-      // response_metadata.output (untouched by the defect above, since it's
-      // the original response, not the reconstructed additional_kwargs.reasoning).
       const standardizedMessage = new AIMessage({
         ...message,
         content: message.contentBlocks,


### PR DESCRIPTION
## Summary
- `contentBlocks`/v1 replay only derived one reasoning block (from `additional_kwargs.reasoning`), missing `id`/`encrypted_content`, breaking responses with multiple reasoning items.
- Now derives from `response_metadata.output` when available — one block per item, correctly ordered, replayable under ZDR. Falls back to prior behavior otherwise; `additional_kwargs.reasoning` is untouched.