### PR TITLE
fix(core): stop queued calls and retries after cancellation

### DIFF
--- a/.changeset/calm-callers-cancel.md
+++ b/.changeset/calm-callers-cancel.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Prevent AsyncCaller from starting queued calls or further retries after cancellation. Abort retry delays promptly, including when cancellation occurs during a failure handler, while keeping running calls in their concurrency slot until they settle.

--- a/libs/langchain-core/src/utils/async_caller.ts
+++ b/libs/langchain-core/src/utils/async_caller.ts
@@ -1,7 +1,7 @@
 import PQueueMod from "p-queue";
 
 import { getRetryable, stampRetryable } from "../errors/index.js";
-import { getAbortSignalError } from "./signal.js";
+import { getAbortSignalError, raceWithSignal } from "./signal.js";
 import pRetry from "./p-retry/index.js";
 
 const STATUS_NO_RETRY = [
@@ -352,6 +352,10 @@ export interface AsyncCallerParams {
 }
 
 export interface AsyncCallerCallOptions {
+  /**
+   * Abort queued calls and retry delays. Running calls must handle cancellation
+   * themselves and keep their concurrency slot until they settle.
+   */
   signal?: AbortSignal;
   maxRetries?: number;
 }
@@ -406,7 +410,8 @@ export class AsyncCaller {
   >(
     retries: AsyncCallerParams["maxRetries"],
     callable: T,
-    args: Parameters<T>
+    args: Parameters<T>,
+    signal?: AbortSignal
   ): Promise<Awaited<ReturnType<T>>> {
     return this.queue.add(
       () =>
@@ -423,6 +428,7 @@ export class AsyncCaller {
           {
             onFailedAttempt: ({ error }) => this.onFailedAttempt?.(error),
             retries,
+            signal,
             randomize: true,
             // If needed we can change some of the defaults here,
             // but they're quite sensible.
@@ -439,23 +445,16 @@ export class AsyncCaller {
     ...args: Parameters<T>
   ): Promise<Awaited<ReturnType<T>>> {
     const retries = options.maxRetries ?? this.maxRetries;
+    if (options.signal?.aborted) {
+      return Promise.reject(getAbortSignalError(options.signal));
+    }
     // Note this doesn't cancel the underlying request,
     // when available prefer to use the signal option of the underlying call
     if (options.signal) {
-      let listener: (() => void) | undefined;
-      return Promise.race([
-        this.callWithRetries<A, T>(retries, callable, args),
-        new Promise<never>((_, reject) => {
-          listener = () => {
-            reject(getAbortSignalError(options.signal));
-          };
-          options.signal?.addEventListener("abort", listener, { once: true });
-        }),
-      ]).finally(() => {
-        if (options.signal && listener) {
-          options.signal.removeEventListener("abort", listener);
-        }
-      });
+      return raceWithSignal(
+        this.callWithRetries<A, T>(retries, callable, args, options.signal),
+        options.signal
+      );
     }
     return this.callWithRetries<A, T>(retries, callable, args);
   }

--- a/libs/langchain-core/src/utils/p-retry/index.js
+++ b/libs/langchain-core/src/utils/p-retry/index.js
@@ -159,6 +159,8 @@ async function onAttemptFailure({
 
   const finalDelay = Math.min(delayTime, remainingTime);
 
+  options.signal?.throwIfAborted();
+
   if (finalDelay > 0) {
     await new Promise((resolve, reject) => {
       const onAbort = () => {
@@ -249,6 +251,7 @@ export default async function pRetry(input, options = {}) {
 
       return result;
     } catch (error) {
+      options.signal?.throwIfAborted();
       if (
         await onAttemptFailure({
           error,

--- a/libs/langchain-core/src/utils/tests/async_caller_abort.test.ts
+++ b/libs/langchain-core/src/utils/tests/async_caller_abort.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AsyncCaller } from "../async_caller.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("AsyncCaller cancellation", () => {
+  test.each([new Error("cancelled"), "cancelled"])(
+    "does not invoke a callable with an already aborted signal (%s)",
+    async (reason) => {
+      const controller = new AbortController();
+      controller.abort(reason);
+      const callable = vi.fn(async () => "unexpected");
+      const caller = new AsyncCaller({ maxRetries: 0 });
+      await expect(
+        caller.callWithOptions({ signal: controller.signal }, callable)
+      ).rejects.toThrow("cancelled");
+      expect(callable).not.toHaveBeenCalled();
+    }
+  );
+
+  test("skips cancelled queued calls and continues processing the queue", async () => {
+    const caller = new AsyncCaller({ maxConcurrency: 1, maxRetries: 0 });
+    const running = deferred<string>();
+    const first = caller.call(() => running.promise);
+    const controller = new AbortController();
+    const reason = new Error("cancel queued call");
+    const callable = vi.fn(async () => "unexpected");
+    const cancelled = caller.callWithOptions(
+      { signal: controller.signal },
+      callable
+    );
+    const rejected = expect(cancelled).rejects.toBe(reason);
+    controller.abort(reason);
+    await rejected;
+    const following = caller.call(async () => "following");
+    running.resolve("first");
+    await expect(first).resolves.toBe("first");
+    await expect(following).resolves.toBe("following");
+    expect(callable).not.toHaveBeenCalled();
+  });
+
+  test("cancels backoff without delaying the next queued call", async () => {
+    vi.useFakeTimers();
+    const caller = new AsyncCaller({ maxConcurrency: 1, maxRetries: 2 });
+    const controller = new AbortController();
+    const callable = vi.fn(async () => {
+      throw new Error("temporary failure");
+    });
+    const cancelled = caller.callWithOptions(
+      { signal: controller.signal },
+      callable
+    );
+    const rejected = expect(cancelled).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+    const following = vi.fn(async () => "following");
+    const next = caller.call(following);
+    controller.abort();
+    await rejected;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(following).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(next).resolves.toBe("following");
+    await vi.runAllTimersAsync();
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not schedule backoff when cancelled during a failure handler", async () => {
+    vi.useFakeTimers();
+    const hook = deferred<void>();
+    const handler = vi.fn(() => hook.promise);
+    const caller = new AsyncCaller({
+      maxConcurrency: 1,
+      maxRetries: 2,
+      onFailedAttempt: handler,
+    });
+    const controller = new AbortController();
+    const callable = vi.fn(async () => {
+      throw new Error("temporary failure");
+    });
+    const cancelled = caller.callWithOptions(
+      { signal: controller.signal },
+      callable
+    );
+    const rejected = expect(cancelled).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handler).toHaveBeenCalledTimes(1);
+    controller.abort();
+    await rejected;
+    hook.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(0);
+    await expect(caller.call(async () => "following")).resolves.toBe(
+      "following"
+    );
+    expect(callable).toHaveBeenCalledTimes(1);
+  });
+
+  test("observes cancellation triggered synchronously by the callable", async () => {
+    const controller = new AbortController();
+    const reason = new Error("synchronous cancellation");
+    const caller = new AsyncCaller({ maxRetries: 0 });
+    await expect(
+      caller.callWithOptions({ signal: controller.signal }, async () => {
+        controller.abort(reason);
+        return "unexpected";
+      })
+    ).rejects.toBe(reason);
+  });
+
+  test("keeps the concurrency slot until a cancelled running call settles", async () => {
+    const onFailedAttempt = vi.fn();
+    const caller = new AsyncCaller({
+      maxConcurrency: 1,
+      maxRetries: 2,
+      onFailedAttempt,
+    });
+    const controller = new AbortController();
+    const running = deferred<string>();
+    const callable = vi.fn(() => running.promise);
+    const cancelled = caller.callWithOptions(
+      { signal: controller.signal },
+      callable
+    );
+    const rejected = expect(cancelled).rejects.toThrow();
+    controller.abort();
+    await rejected;
+    const following = vi.fn(async () => "following");
+    const next = caller.call(following);
+    expect(following).not.toHaveBeenCalled();
+    running.reject(new Error("late failure"));
+    await expect(next).resolves.toBe("following");
+    expect(callable).toHaveBeenCalledTimes(1);
+    expect(onFailedAttempt).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])(
+    "removes the abort listener after settlement (failure: %s)",
+    async (failure) => {
+      const caller = new AsyncCaller({ maxRetries: 0 });
+      const controller = new AbortController();
+      const add = vi.spyOn(controller.signal, "addEventListener");
+      const remove = vi.spyOn(controller.signal, "removeEventListener");
+      const error = new Error("failure");
+      const result = caller.callWithOptions(
+        { signal: controller.signal },
+        async () => {
+          if (failure) throw error;
+          return "success";
+        }
+      );
+      if (failure) await expect(result).rejects.toBe(error);
+      else await expect(result).resolves.toBe("success");
+      const listener = add.mock.calls.find(([event]) => event === "abort")?.[1];
+      expect(listener).toBeDefined();
+      expect(remove).toHaveBeenCalledWith("abort", listener);
+    }
+  );
+});


### PR DESCRIPTION
`AsyncCaller.callWithOptions()` previously rejected only the outer promise on cancellation. Already-aborted signals could still start a call, cancelled queued work could execute later, and retry delays continued to hold a concurrency slot and trigger new attempts after the caller received an abort error.

Pass the signal into the retry loop and reuse `raceWithSignal()` to preserve prompt rejection, including cancellation triggered synchronously by the callable. Check for cancellation before scheduling backoff and before handling a failed attempt, covering cancellation during an asynchronous failure handler and late failures from cancelled calls.

Running callables still occupy their concurrency slot until they settle; cancellation does not forcibly stop work that ignores the signal. Queued cancelled entries are skipped when dequeued. Existing no-signal behavior and retry configuration are retained.

Add regression tests for pre-aborted signals, queued cancellation, backoff cleanup and queue progress, cancellation during failure handlers, synchronous cancellation, concurrency-slot ownership, error reasons, and listener cleanup. Include a patch changeset and document the signal semantics.

## Validation

- Before the fix: 7 new regression cases failed, 2 existing-behavior checks passed.
- After the fix: the cancellation and existing AsyncCaller suites passed all 63 tests.
- Full core suite: 101 test files passed; 1521 tests passed, 1 skipped; no type errors.
- Core build, attw, publint, repository lint, format checks, and git diff --check passed.
- Built ESM smoke test confirmed pre-aborted and cancelled queued tasks never execute.
