### PR TITLE
fix(mcp-adapters): preserve type info for `anyOf: [T, {type: "null"}]` optional schemas

### DIFF
--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -768,6 +768,45 @@ describe("Simplified Tool Adapter Tests", () => {
       expect(result).toBe("Configured");
     });
 
+    test("should resolve Optional[T] anyOf (T | null) to the non-null variant", async () => {
+      const schemaWithOptionalArray = {
+        type: "object" as const,
+        properties: {
+          name: {
+            anyOf: [
+              { type: "array", items: { type: "string" } },
+              { type: "null" },
+            ],
+            default: null,
+            description: "List of name",
+          },
+        },
+      };
+
+      mockClient.listTools.mockReturnValueOnce(
+        Promise.resolve({
+          tools: [
+            {
+              name: "search",
+              description: "Search something",
+              inputSchema: schemaWithOptionalArray,
+            },
+          ],
+        })
+      );
+
+      const tools = await loadMcpTools(
+        "mockServer(optional anyOf)",
+        mockClient as Client
+      );
+
+      const nameSchema = (tools[0].schema as { properties: Record<string, unknown> })
+        .properties.name as { type?: string; items?: { type?: string } };
+
+      expect(nameSchema.type).toBe("array");
+      expect(nameSchema.items).toEqual({ type: "string" });
+    });
+
     test("should simplify schemas with oneOf at top level by merging object schemas", async () => {
       // Test oneOf at the TOP level (where OpenAI restriction applies)
       const schemaWithOneOf = {

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -365,6 +365,27 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   // because the union semantics mean any ONE of the schemas should match, not all.
   const unionSchemas = anyOf || oneOf;
   if (Array.isArray(unionSchemas) && unionSchemas.length > 0) {
+    // Common "Optional[T]" pattern from Pydantic/JSON Schema: anyOf: [T, {type: "null"}].
+    // Use the single non-null variant directly instead of running it through the
+    // object-merge logic below, which only knows how to combine object-like schemas
+    // and would otherwise drop T's type/items entirely.
+    const nonNullSchemas = unionSchemas.filter(
+      (s) => !(typeof s === "object" && s !== null && s.type === "null")
+    );
+    if (
+      nonNullSchemas.length === 1 &&
+      nonNullSchemas.length < unionSchemas.length
+    ) {
+      result = deepMergeSchemas(
+        result,
+        simplifyJsonSchemaForLLM(nonNullSchemas[0])
+      );
+      debugLog(
+        `INFO: Resolved optional (T | null) ${anyOf ? "anyOf" : "oneOf"} to its non-null variant`
+      );
+      return result;
+    }
+
     // Check if all schemas in the union are object-like (have type: object or have properties)
     const allAreObjects = unionSchemas.every(
       (s) =>


### PR DESCRIPTION
### Problem

MCP servers built with Pydantic v2 (and other JSON Schema generators) commonly represent an optional field `Optional[T]` as:

```json
{
  "name": {
    "anyOf": [
      { "type": "array", "items": { "type": "string" } },
      { "type": "null" }
    ],
    "default": null,
    "description": "List of name"
  }
}
```

`simplifyJsonSchemaForLLM` in `libs/langchain-mcp-adapters/src/tools.ts` handles `anyOf`/`oneOf` by merging variants that are "object-like" (`type ==="object"` or has `properties`). For the pattern above, neither the array variant nor the `null` variant is object-like, so both get filtered out of `schemasToMerge`. The merge loop then runs over an empty array and produces nothing — the property's `type`, `items`, etc. are silently dropped.

Net effect: the resulting tool schema exposes `name` as an unconstrained field (just `description`/`default`, no `type`), so the LLM has no idea it should be an array of strings.

### Root cause

The `anyOf`/`oneOf` handling only knows how to merge object schemas. It has no special case for the extremely common "nullable type" union pattern (`T | null`), which isn't an object union at all — it's just `T` with an optional/nullable annotation.

### Fix

In `simplifyJsonSchemaForLLM`, before running the object-merge logic, check whether the union has exactly one non-`null` variant. If so, simplify and use that variant directly (merged into the base schema) instead of feeding it through the object-only merge path.

```ts
const nonNullSchemas = unionSchemas.filter(
  (s) => !(typeof s === "object" && s !== null && s.type === "null")
);
if (nonNullSchemas.length === 1 && nonNullSchemas.length < unionSchemas.length) {
  result = deepMergeSchemas(result, simplifyJsonSchemaForLLM(nonNullSchemas[0]));
  return result;
}
```

This only changes behavior for unions where exactly one variant is non-`null`; the existing object-merge behavior for multi-variant `anyOf`/`oneOf` (e.g. `anyOf` of several object shapes) is untouched.

### Testing

Added a unit test in `libs/langchain-mcp-adapters/src/tests/tools.test.ts` covering the reported case: a tool input property with `anyOf: [{type: "array", items: {type: "string"}}, {type: "null"}]` now correctly simplifies to `{type: "array", items: {type: "string"}}`.

Existing `anyOf`/`oneOf` object-merge tests still pass unchanged.

```
pnpm --filter @langchain/mcp-adapters test
```

### Checklist

- [x] `pnpm lint`
- [x] `pnpm format`
- [x] Added unit test (`*.test.ts`)
- [ ] No public API changes — internal schema simplification only
- [x] Focused change, single file (+ test)
