### PR TITLE
chore: exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,4 +1,4 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc"
 }


### PR DESCRIPTION
## Summary

Runs \`pnpm changeset pre exit\` to signal the end of the current \`rc\` prerelease cycle (\`.changeset/pre.json\` mode flips from \`pre\` to \`exit\`).

Pairs with #11594 (revert of middleware trace policies), which already merged — both were required before a stable release can go out.

Once this merges, the next \`changeset version\` run (via the automated Changesets release PR) will consolidate the pending changesets plus everything preserved under \`.changeset/pre/\` into a normal, stable version bump instead of another \`-rc\`, and clear prerelease state entirely.