### PR TITLE
revert: restore middleware trace policies (un-revert #11568)

### DIFF
--- a/.changeset/trace-policy.md
+++ b/.changeset/trace-policy.md
@@ -1,0 +1,5 @@
+---
+"langchain": patch
+---
+
+Add opt-in middleware `tracePolicy` support for transforming hook span input and output payloads, plus re-exports of LangGraph's `TracePolicy` and `omitPayload`.

--- a/libs/langchain/package.json
+++ b/libs/langchain/package.json
@@ -74,7 +74,7 @@
     "@langchain/core": "workspace:^"
   },
   "dependencies": {
-    "@langchain/langgraph": "^1.4.13",
+    "@langchain/langgraph": "1.4.15-rc.0",
     "@langchain/langgraph-checkpoint": "^1.1.5",
     "langsmith": ">=0.5.0 <1.0.0",
     "zod": "^3.25.76 || ^4"

--- a/libs/langchain/src/agents/index.ts
+++ b/libs/langchain/src/agents/index.ts
@@ -717,6 +717,7 @@ export {
   type ResponseFormatUndefined,
 } from "./responses.js";
 export { createMiddleware } from "./middleware.js";
+export { omitPayload, type TracePolicy } from "@langchain/langgraph";
 export { MIDDLEWARE_BRAND } from "./middleware/types.js";
 export type * from "./middleware/types.js";
 export { FakeToolCallingModel } from "./tests/utils.js";

--- a/libs/langchain/src/agents/middleware.ts
+++ b/libs/langchain/src/agents/middleware.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   StateDefinitionInit,
   StreamTransformer,
+  TracePolicy,
 } from "@langchain/langgraph";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
@@ -114,6 +115,13 @@ export function createMiddleware<
    * Merged with `createAgent({ streamTransformers })` when the agent compiles.
    */
   streamTransformers?: TStreamTransformers;
+  /**
+   * Controls the payloads recorded by this middleware's lifecycle hook spans.
+   * Processors affect chain callback payloads, including `streamEvents`; output
+   * omission can suppress messages directly returned by a lifecycle hook, Processors
+   * must not mutate payloads, which are shared with agent execution.
+   */
+  tracePolicy?: TracePolicy;
   /**
    * Wraps tool execution with custom logic. This allows you to:
    * - Modify tool call parameters before execution
@@ -272,6 +280,7 @@ export function createMiddleware<
     afterAgent: config.afterAgent,
     tools: config.tools,
     streamTransformers: config.streamTransformers,
+    tracePolicy: config.tracePolicy,
   };
 
   return middleware;

--- a/libs/langchain/src/agents/middleware/types.ts
+++ b/libs/langchain/src/agents/middleware/types.ts
@@ -20,7 +20,11 @@ import type {
   ToolMessage,
 } from "@langchain/core/messages";
 import type { ToolCall } from "@langchain/core/messages/tool";
-import type { Command, StreamTransformer } from "@langchain/langgraph";
+import type {
+  Command,
+  StreamTransformer,
+  TracePolicy,
+} from "@langchain/langgraph";
 import type { ClientTool, ServerTool } from "@langchain/core/tools";
 
 import type { JumpToTarget } from "../constants.js";
@@ -468,6 +472,25 @@ export interface AgentMiddleware<
    * is compiled.
    */
   streamTransformers?: TStreamTransformers;
+
+  /**
+   * Controls the payloads recorded by this middleware's lifecycle hook spans.
+   * Processors affect chain callback payloads, including `streamEvents`; output
+   * omission can suppress messages directly returned by a lifecycle hook, and
+   * input omission can affect message deduplication. They do not affect execution.
+   *
+   * @example
+   * ```ts
+   * import { createMiddleware, omitPayload } from "langchain";
+   *
+   * const middleware = createMiddleware({
+   *   name: "PrivateMiddleware",
+   *   tracePolicy: { processInputs: omitPayload },
+   *   beforeModel: () => undefined,
+   * });
+   * ```
+   */
+  tracePolicy?: TracePolicy;
 
   /**
    * Wraps tool execution with custom logic. This allows you to:

--- a/libs/langchain/src/agents/nodes/middleware.ts
+++ b/libs/langchain/src/agents/nodes/middleware.ts
@@ -187,6 +187,7 @@ export abstract class MiddlewareNode<
   get nodeOptions() {
     return {
       input: derivePrivateState(this.middleware.stateSchema),
+      tracePolicy: this.middleware.tracePolicy,
     };
   }
 }

--- a/libs/langchain/src/agents/tests/tracePolicy.test-d.ts
+++ b/libs/langchain/src/agents/tests/tracePolicy.test-d.ts
@@ -1,0 +1,23 @@
+import { expectTypeOf, it } from "vitest";
+
+import {
+  createMiddleware,
+  omitPayload,
+  type AgentMiddleware,
+  type TracePolicy,
+} from "../index.js";
+
+it("supports trace policies on middleware", () => {
+  const policy: TracePolicy = {
+    processInputs: omitPayload,
+    processOutputs: (value) => ({ value }),
+  };
+  const middleware = createMiddleware({
+    name: "TracePolicy",
+    tracePolicy: policy,
+    beforeModel: () => undefined,
+  });
+
+  expectTypeOf(middleware).toMatchTypeOf<AgentMiddleware>();
+  expectTypeOf(middleware.tracePolicy).toEqualTypeOf<TracePolicy | undefined>();
+});

--- a/libs/langchain/src/agents/tests/tracePolicy.test.ts
+++ b/libs/langchain/src/agents/tests/tracePolicy.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from "vitest";
+import { HumanMessage, ToolMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { FakeTracer } from "@langchain/core/utils/testing";
+import { z } from "zod/v3";
+
+import { createAgent, createMiddleware, omitPayload } from "../index.js";
+import { FakeToolCallingModel } from "./utils.js";
+
+function runsFor(tracer: FakeTracer, name: string) {
+  const flatten = (runs: typeof tracer.runs): typeof tracer.runs =>
+    runs.flatMap((run) => [run, ...flatten(run.child_runs)]);
+  return flatten(tracer.runs).filter((run) => run.name === name);
+}
+
+describe("middleware tracePolicy", () => {
+  it("preserves default hook payloads and agent results", async () => {
+    const middleware = createMiddleware({
+      name: "Default",
+      beforeModel: () => undefined,
+    });
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [middleware],
+      tools: [],
+    });
+    const tracer = new FakeTracer();
+
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("hello")] },
+      { callbacks: [tracer] }
+    );
+
+    expect(result.messages.at(-1)?.content).toBe("hello");
+    expect(runsFor(tracer, "Default.before_model")[0].inputs).toMatchObject({
+      messages: [expect.objectContaining({ content: "hello" })],
+    });
+  });
+
+  it("applies policies independently for each middleware", async () => {
+    const inputOnly = createMiddleware({
+      name: "InputOnly",
+      tracePolicy: { processInputs: omitPayload },
+      beforeModel: () => undefined,
+    });
+    const outputOnly = createMiddleware({
+      name: "OutputOnly",
+      tracePolicy: { processOutputs: omitPayload },
+      beforeModel: () => undefined,
+    });
+    const unfiltered = createMiddleware({
+      name: "Unfiltered",
+      beforeModel: () => undefined,
+    });
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [inputOnly, outputOnly, unfiltered],
+      tools: [],
+    });
+    const tracer = new FakeTracer();
+
+    await agent.invoke(
+      { messages: [new HumanMessage("hello")] },
+      { callbacks: [tracer] }
+    );
+
+    expect(runsFor(tracer, "InputOnly.before_model")[0].inputs).toEqual({});
+    expect(runsFor(tracer, "InputOnly.before_model")[0].outputs).toHaveProperty(
+      "jumpTo"
+    );
+    expect(runsFor(tracer, "OutputOnly.before_model")[0].inputs).toMatchObject({
+      messages: [expect.anything()],
+    });
+    expect(runsFor(tracer, "OutputOnly.before_model")[0].outputs).toEqual({});
+    expect(runsFor(tracer, "Unfiltered.before_model")[0].inputs).toMatchObject({
+      messages: [expect.anything()],
+    });
+    expect(
+      runsFor(tracer, "Unfiltered.before_model")[0].outputs
+    ).toHaveProperty("jumpTo");
+  });
+
+  it("filters all lifecycle hook spans while preserving child model traces", async () => {
+    const middleware = createMiddleware({
+      name: "Filtered",
+      tracePolicy: {
+        processInputs: omitPayload,
+        processOutputs: omitPayload,
+      },
+      beforeAgent: () => undefined,
+      beforeModel: () => undefined,
+      afterModel: () => undefined,
+      afterAgent: () => undefined,
+    });
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [middleware],
+      tools: [],
+    });
+    const tracer = new FakeTracer();
+
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("x".repeat(10_000))] },
+      { callbacks: [tracer] }
+    );
+
+    expect(result.messages.at(-1)?.content).toBe("x".repeat(10_000));
+    for (const hook of [
+      "before_agent",
+      "before_model",
+      "after_model",
+      "after_agent",
+    ]) {
+      const [run] = runsFor(tracer, `Filtered.${hook}`);
+      expect(run.inputs).toEqual({});
+      expect(run.outputs).toEqual({});
+    }
+    const [modelRun] = runsFor(tracer, "FakeToolCallingModel");
+    expect(JSON.stringify(modelRun.inputs)).toContain("x".repeat(10_000));
+  });
+
+  it("transforms hook outputs independently", async () => {
+    const middleware = createMiddleware({
+      name: "OutputOnly",
+      tracePolicy: { processOutputs: () => undefined },
+      beforeModel: () => ({}),
+    });
+    const tracer = new FakeTracer();
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [middleware],
+      tools: [],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("hello")] },
+      { callbacks: [tracer] }
+    );
+
+    const [run] = runsFor(tracer, "OutputOnly.before_model");
+    expect(run.inputs.messages[0].content).toBe("hello");
+    expect(run.outputs).toEqual({ output: undefined });
+  });
+
+  it("preserves null processor results", async () => {
+    const middleware = createMiddleware({
+      name: "NullOutput",
+      tracePolicy: { processOutputs: () => null },
+      beforeModel: () => ({}),
+    });
+    const tracer = new FakeTracer();
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [middleware],
+      tools: [],
+    });
+
+    await agent.invoke(
+      { messages: [new HumanMessage("hello")] },
+      { callbacks: [tracer] }
+    );
+
+    expect(runsFor(tracer, "NullOutput.before_model")[0].outputs).toEqual({
+      output: null,
+    });
+  });
+
+  it("fails open when a processor throws", async () => {
+    const failure = new Error("processor failed");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const middleware = createMiddleware({
+      name: "Failure",
+      tracePolicy: {
+        processInputs: () => {
+          throw failure;
+        },
+      },
+      beforeModel: () => undefined,
+    });
+    const tracer = new FakeTracer();
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [middleware],
+      tools: [],
+    });
+
+    await expect(
+      agent.invoke(
+        { messages: [new HumanMessage("hello")] },
+        { callbacks: [tracer] }
+      )
+    ).resolves.toMatchObject({ messages: expect.any(Array) });
+    expect(runsFor(tracer, "Failure.before_model")[0].inputs).toMatchObject({
+      messages: [expect.anything()],
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("untransformed payload"),
+      failure
+    );
+  });
+
+  it("transforms middleware chain events while unfiltered streams retain payloads", async () => {
+    const filtered = createMiddleware({
+      name: "FilteredStreaming",
+      tracePolicy: { processInputs: omitPayload, processOutputs: omitPayload },
+      beforeModel: () => undefined,
+    });
+    const unfiltered = createMiddleware({
+      name: "UnfilteredStreaming",
+      beforeModel: () => undefined,
+    });
+    const agent = createAgent({
+      model: new FakeToolCallingModel(),
+      middleware: [filtered, unfiltered],
+      tools: [],
+    });
+    const events = [];
+    for await (const event of agent.streamEvents(
+      { messages: [new HumanMessage("hello")] },
+      { version: "v2" }
+    )) {
+      events.push(event);
+    }
+
+    expect(
+      events.find(
+        (event) =>
+          event.name === "FilteredStreaming.before_model" &&
+          event.event === "on_chain_start"
+      )?.data.input
+    ).toEqual({});
+    expect(
+      events.find(
+        (event) =>
+          event.name === "FilteredStreaming.before_model" &&
+          event.event === "on_chain_end"
+      )?.data.output
+    ).toEqual({});
+    expect(
+      events.find(
+        (event) =>
+          event.name === "UnfilteredStreaming.before_model" &&
+          event.event === "on_chain_start"
+      )?.data.input
+    ).toMatchObject({ messages: [expect.anything()] });
+  });
+
+  it("preserves tool child trace payloads and hierarchy", async () => {
+    const model = new FakeToolCallingModel({
+      toolCalls: [
+        [{ id: "call_1", name: "weather", args: { city: "Tokyo" } }],
+        [],
+      ],
+    });
+    const getWeather = tool(async () => "sunny", {
+      name: "weather",
+      description: "Gets the weather",
+      schema: z.object({ city: z.string() }),
+    });
+    const middleware = createMiddleware({
+      name: "Filtered",
+      tracePolicy: { processInputs: omitPayload, processOutputs: omitPayload },
+      afterModel: () => undefined,
+    });
+    const tracer = new FakeTracer();
+    const agent = createAgent({
+      model,
+      tools: [getWeather],
+      middleware: [middleware],
+    });
+
+    const result = await agent.invoke(
+      { messages: [new HumanMessage("weather in Tokyo")] },
+      { callbacks: [tracer] }
+    );
+
+    expect(result.messages.some(ToolMessage.isInstance)).toBe(true);
+    expect(runsFor(tracer, "Filtered.after_model")[0]).toMatchObject({
+      inputs: {},
+      outputs: {},
+    });
+    const [toolRun] = runsFor(tracer, "weather");
+    expect(toolRun.inputs).toEqual({ input: '{"city":"Tokyo"}' });
+    expect(JSON.stringify(toolRun.outputs)).toContain("sunny");
+    expect(toolRun.parent_run_id).toBeDefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,8 +618,8 @@ importers:
   libs/langchain:
     dependencies:
       '@langchain/langgraph':
-        specifier: ^1.4.13
-        version: 1.4.13(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+        specifier: 1.4.15-rc.0
+        version: 1.4.15-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.5
         version: 1.1.5(@langchain/core@libs+langchain-core)
@@ -647,7 +647,7 @@ importers:
         version: link:../providers/langchain-fireworks
       '@langchain/langgraph-api':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@libs+langchain-core)(@langchain/langgraph-checkpoint@1.1.5(@langchain/core@libs+langchain-core))(@langchain/langgraph-sdk@1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@langchain/langgraph@1.4.13(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.82)(@smithy/hash-node@4.5.2)(@smithy/signature-v4@5.7.3)(undici@8.10.1)(ws@8.21.3(bufferutil@4.1.0))(zod@4.3.6))(ts-node@10.9.2(@swc/core@1.16.1(@swc/helpers@0.5.21))(@types/node@26.4.1)(typescript@7.0.2))(typescript@7.0.2)(ws@8.21.3(bufferutil@4.1.0))
+        version: 1.4.5(@langchain/core@libs+langchain-core)(@langchain/langgraph-checkpoint@1.1.5(@langchain/core@libs+langchain-core))(@langchain/langgraph-sdk@1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@langchain/langgraph@1.4.15-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.82)(@smithy/hash-node@4.5.2)(@smithy/signature-v4@5.7.3)(undici@8.10.1)(ws@8.21.3(bufferutil@4.1.0))(zod@4.3.6))(ts-node@10.9.2(@swc/core@1.16.1(@swc/helpers@0.5.21))(@types/node@26.4.1)(typescript@7.0.2))(typescript@7.0.2)(ws@8.21.3(bufferutil@4.1.0))
       '@langchain/langgraph-sdk':
         specifier: ^1.10.0
         version: 1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3897,6 +3897,18 @@ packages:
       react-dom:
         optional: true
 
+  '@langchain/langgraph-sdk@1.10.3-rc.0':
+    resolution: {integrity: sha512-rC88vymdJYb8oAf4M96bxOPtB52GU6o40UuNzA62A+92wzgS4Z728WGPITNeIBUtjxyNUXmyJcRbgNsFll/R/g==}
+    peerDependencies:
+      '@langchain/core': workspace:^
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@langchain/langgraph-ui@1.4.5':
     resolution: {integrity: sha512-Jy2muKnulO5A2KZJIwr4aji5t23xcmaUYa0xjBgQpLsL4VUTovSy5jfEwtaHZw+V4lxN7mI9MYXd4sHuEZrR9Q==}
     engines: {node: ^18.19.0 || >=20.16.0}
@@ -3904,6 +3916,13 @@ packages:
 
   '@langchain/langgraph@1.4.13':
     resolution: {integrity: sha512-LO1ak6jNQ9jR13tm7Ay4Yh2/otrH7LNVUwWTAI7WJigVdW5Fb6LuYSZUzVn4S7sVSiyVFfnrUcDTd8c7eAzPrQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': workspace:^
+      zod: ^3.25.32 || ^4.2.0
+
+  '@langchain/langgraph@1.4.15-rc.0':
+    resolution: {integrity: sha512-S6kcrItAlhDtovmxO4fU48tdABk74OBjwvbyLl9tzTw0hM1x0BnY6W21AFJJwUEpCwcPUOsm0cYZJclIGPkgtA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': workspace:^
@@ -12830,10 +12849,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@hono/zod-validator@0.7.6(hono@4.13.5)(zod@4.3.6)':
+  '@hono/zod-validator@0.7.6(hono@4.13.5)(zod@4.4.3)':
     dependencies:
       hono: 4.13.5
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@huggingface/jinja@0.3.4':
     optional: true
@@ -13409,14 +13428,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@langchain/langgraph-api@1.4.5(@langchain/core@libs+langchain-core)(@langchain/langgraph-checkpoint@1.1.5(@langchain/core@libs+langchain-core))(@langchain/langgraph-sdk@1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@langchain/langgraph@1.4.13(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.82)(@smithy/hash-node@4.5.2)(@smithy/signature-v4@5.7.3)(undici@8.10.1)(ws@8.21.3(bufferutil@4.1.0))(zod@4.3.6))(ts-node@10.9.2(@swc/core@1.16.1(@swc/helpers@0.5.21))(@types/node@26.4.1)(typescript@7.0.2))(typescript@7.0.2)(ws@8.21.3(bufferutil@4.1.0))':
+  '@langchain/langgraph-api@1.4.5(@langchain/core@libs+langchain-core)(@langchain/langgraph-checkpoint@1.1.5(@langchain/core@libs+langchain-core))(@langchain/langgraph-sdk@1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@langchain/langgraph@1.4.15-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.82)(@smithy/hash-node@4.5.2)(@smithy/signature-v4@5.7.3)(undici@8.10.1)(ws@8.21.3(bufferutil@4.1.0))(zod@4.3.6))(ts-node@10.9.2(@swc/core@1.16.1(@swc/helpers@0.5.21))(@types/node@26.4.1)(typescript@7.0.2))(typescript@7.0.2)(ws@8.21.3(bufferutil@4.1.0))':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@hono/node-server': 2.1.1(hono@4.13.5)
       '@hono/node-ws': 1.3.1(@hono/node-server@2.1.1(hono@4.13.5))(bufferutil@4.1.0)(hono@4.13.5)
-      '@hono/zod-validator': 0.7.6(hono@4.13.5)(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.13.5)(zod@4.4.3)
       '@langchain/core': link:libs/langchain-core
-      '@langchain/langgraph': 1.4.13(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      '@langchain/langgraph': 1.4.15-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       '@langchain/langgraph-checkpoint': 1.1.5(@langchain/core@libs+langchain-core)
       '@langchain/langgraph-ui': 1.4.5
       '@langchain/protocol': 0.0.18
@@ -13435,7 +13454,7 @@ snapshots:
       typescript: 7.0.2
       winston: 3.19.0
       winston-console-format: 1.0.8
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       '@langchain/langgraph-sdk': 1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-node: 10.9.2(@swc/core@1.16.1(@swc/helpers@0.5.21))(@types/node@26.4.1)(typescript@7.0.2)
@@ -13465,6 +13484,17 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@langchain/langgraph-sdk@1.10.3-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@langchain/core': link:libs/langchain-core
+      '@langchain/protocol': 0.0.19
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.3
+      p-retry: 7.1.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@langchain/langgraph-ui@1.4.5':
     dependencies:
       '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
@@ -13479,6 +13509,18 @@ snapshots:
       '@langchain/langgraph-checkpoint': 1.1.5(@langchain/core@libs+langchain-core)
       '@langchain/langgraph-sdk': 1.10.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@langchain/protocol': 0.0.18
+      '@standard-schema/spec': 1.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/langgraph@1.4.15-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': link:libs/langchain-core
+      '@langchain/langgraph-checkpoint': 1.1.5(@langchain/core@libs+langchain-core)
+      '@langchain/langgraph-sdk': 1.10.3-rc.0(@langchain/core@libs+langchain-core)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@langchain/protocol': 0.0.19
       '@standard-schema/spec': 1.1.0
       zod: 4.3.6
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Restores #11568 (`feat(langchain): add middleware trace policies`), which was reverted in #11594 solely to allow the 1.5.11 stable release to go out without a dependency on prerelease `@langchain/langgraph@1.4.15-rc.0`. That release has now shipped (`langchain@1.5.11` on npm).

This puts the `tracePolicy`/`omitPayload` feature and its `@langchain/langgraph@1.4.15-rc.0` dependency back on `main`. Per instruction, this does **not** re-enter Changesets prerelease mode — `main` stays out of "pre" mode, so this will version as a normal patch whenever the next release goes out (which will again require `@langchain/langgraph` to have a matching stable release before that patch can ship).

The changeset is restored as a normal pending changeset (`.changeset/trace-policy.md`), not under `.changeset/pre/`, since `main` isn't currently in prerelease mode.

## Test plan

- `pnpm --filter langchain build` — passes
- `pnpm --filter langchain test` — 880/880 passed, no type errors
- `oxfmt --check` / `oxlint` on all touched files — clean