### PR TITLE
fix(langchain): number structured output tool names by position

### DIFF
--- a/.changeset/positional-structured-output-tool-naming.md
+++ b/.changeset/positional-structured-output-tool-naming.md
@@ -1,0 +1,17 @@
+---
+"langchain": patch
+---
+
+fix(langchain): keep structured output tool names stable for prompt caching
+
+An untitled `responseFormat` schema produced a tool named from a module-global
+counter, so the structured output tool was called `extract-1` on one model
+request and `extract-2` on the next. Providers render tool definitions at the
+front of the cached prompt prefix, so the changing name invalidated the prompt
+cache on every request in an agent loop - the system prompt and message history
+included.
+
+Generated names are now assigned by position in the `responseFormat` list, so a
+given schema keeps the same name across every request in a loop, across turns of
+a conversation, and across separate processes. Schemas carrying a title are
+unaffected and do not consume a position.

--- a/libs/langchain/src/agents/responses.ts
+++ b/libs/langchain/src/agents/responses.ts
@@ -41,17 +41,19 @@ export type ResponseFormatUndefined = {
 const PROVIDER_STRATEGY_DEFAULT_STRICT = true;
 
 /**
- * This is a global counter for generating unique names for tools.
- */
-let bindingIdentifier = 0;
-
-/**
  * Information for tracking structured output tool metadata.
  * This contains all necessary information to handle structured responses generated
  * via tool calls, including the original schema, its type classification, and the
  * corresponding tool implementation used by the tools strategy.
  */
 export class ToolStrategy<_T = unknown> {
+  /**
+   * Whether the tool's name was generated here because the schema carried no
+   * title, rather than chosen by the caller. Only generated names may be
+   * renumbered by {@link ToolStrategy._assignGeneratedNames}.
+   */
+  #hasGeneratedName: boolean;
+
   private constructor(
     /**
      * The original JSON Schema provided for structured output
@@ -69,11 +71,88 @@ export class ToolStrategy<_T = unknown> {
     /**
      * The options to use for the tool output.
      */
-    public readonly options?: ToolStrategyOptions
-  ) {}
+    public readonly options?: ToolStrategyOptions,
+
+    hasGeneratedName: boolean = false
+  ) {
+    this.#hasGeneratedName = hasGeneratedName;
+  }
 
   get name() {
     return this.tool.function.name;
+  }
+
+  /**
+   * Returns a copy of this strategy whose tool carries `name`, or `this` if it
+   * already does.
+   *
+   * Copies rather than mutates: a strategy can be constructed once and reused
+   * across several agents, where it may sit at a different position in each.
+   */
+  #withName(name: string): ToolStrategy<_T> {
+    if (this.tool.function.name === name) {
+      return this;
+    }
+    return new ToolStrategy(
+      this.schema,
+      { ...this.tool, function: { ...this.tool.function, name } },
+      this.options,
+      this.#hasGeneratedName
+    );
+  }
+
+  /**
+   * Numbers the structured output tools that had to generate their own name,
+   * by their position among the other generated names in the assembled list.
+   *
+   * Naming has to happen here rather than at construction because a strategy is
+   * built before it knows what it will sit alongside: `toolStrategy` sees only
+   * its own arguments, so two strategies built separately and composed into one
+   * `responseFormat` would both be `extract-1`, and the agent - which keys its
+   * strategies by tool name - would bind only one of them.
+   *
+   * A titled schema keeps its name and does not consume a number, so a list of
+   * one titled and one anonymous schema yields `extract-1` rather than an
+   * `extract-2` with nothing before it.
+   *
+   * Numbering steps over any name the caller chose, so a schema titled
+   * `extract-1` alongside an anonymous one leaves the anonymous one as
+   * `extract-2` rather than colliding with it - the agent keys its strategies
+   * by name, so a collision would drop one of the two schemas. Only the
+   * response format list is in scope; a regular tool sharing a generated name
+   * is not visible at this layer.
+   *
+   * Entries that are not a `ToolStrategy`, such as a `ProviderStrategy`, pass
+   * through untouched.
+   *
+   * @internal
+   */
+  static _assignGeneratedNames(formats: ResponseFormat[]): ResponseFormat[] {
+    const taken = new Set(
+      formats
+        .filter(
+          (format): format is ToolStrategy<any> =>
+            format instanceof ToolStrategy && !format.#hasGeneratedName
+        )
+        .map((format) => format.name)
+    );
+
+    // Counts generated names, not list positions: titled schemas are skipped,
+    // so this deliberately diverges from the index once one appears.
+    let generatedCount = 0;
+    function nextName() {
+      let name: string;
+      do {
+        name = `extract-${++generatedCount}`;
+      } while (taken.has(name));
+      return name;
+    }
+
+    return formats.map((format) =>
+      format instanceof ToolStrategy && format.#hasGeneratedName
+        ? format.#withName(nextName())
+        : format
+    );
   }
 
   static fromSchema<S extends InteropZodObject>(
@@ -98,9 +177,14 @@ export class ToolStrategy<_T = unknown> {
     /**
      * It is required for tools to have a name so we can map the tool call to the correct tool
      * when parsing the response.
+     *
+     * A schema with no title cannot name itself, and this is the wrong place to
+     * number it: only the assembled `responseFormat` list knows how many other
+     * anonymous schemas it sits alongside. It is numbered by position in
+     * {@link ToolStrategy._assignGeneratedNames}; this is the single-entry case.
      */
     function getFunctionName(name?: string) {
-      return name ?? `extract-${++bindingIdentifier}`;
+      return name ?? "extract-1";
     }
 
     if (isSerializableSchema(schema) || isInteropZodSchema(schema)) {
@@ -116,29 +200,45 @@ export class ToolStrategy<_T = unknown> {
           parameters: asJsonSchema,
         },
       };
-      return new ToolStrategy(asJsonSchema, tool, outputOptions);
+      return new ToolStrategy(
+        asJsonSchema,
+        tool,
+        outputOptions,
+        asJsonSchema.title == null
+      );
     }
 
     let functionDefinition: FunctionDefinition;
+    let hasGeneratedName: boolean;
     if (
       typeof schema.name === "string" &&
       typeof schema.parameters === "object" &&
       schema.parameters != null
     ) {
+      /**
+       * The caller passed a function definition, so the name is theirs.
+       */
       functionDefinition = schema as unknown as FunctionDefinition;
+      hasGeneratedName = false;
     } else {
       functionDefinition = {
         name: getFunctionName(schema.title as string),
         description: (schema.description as string) ?? "",
         parameters: schema.schema || (schema as Record<string, unknown>),
       };
+      hasGeneratedName = schema.title == null;
     }
     const asJsonSchema = toJsonSchema(schema);
     const tool = {
       type: "function" as const,
       function: functionDefinition,
     };
-    return new ToolStrategy(asJsonSchema, tool, outputOptions);
+    return new ToolStrategy(
+      asJsonSchema,
+      tool,
+      outputOptions,
+      hasGeneratedName
+    );
   }
 
   /**
@@ -316,6 +416,16 @@ export type ResponseFormatInput<
  * @returns
  */
 export function transformResponseFormat(
+  responseFormat?: ResponseFormatInput,
+  options?: ToolStrategyOptions,
+  model?: LanguageModelLike
+): ResponseFormat[] {
+  return ToolStrategy._assignGeneratedNames(
+    resolveResponseFormat(responseFormat, options, model)
+  );
+}
+
+function resolveResponseFormat(
   responseFormat?: ResponseFormatInput,
   options?: ToolStrategyOptions,
   model?: LanguageModelLike

--- a/libs/langchain/src/agents/tests/responses.test.ts
+++ b/libs/langchain/src/agents/tests/responses.test.ts
@@ -21,6 +21,7 @@ import {
   hasSupportForJsonSchemaOutput,
   ProviderStrategy,
   ToolStrategy,
+  type ResponseFormatInput,
 } from "../responses.js";
 
 function makeSerializableSchema(
@@ -105,10 +106,10 @@ describe("structured output handling", () => {
           toolCalls: [
             [
               /**
-               * `extract-3` and `extract-5` are the computed function names for the json schemas
+               * Anonymous schemas are named by their position in the list.
                */
-              { name: "extract-3", args: { foo: "foo" }, id: "call_1" },
-              { name: "extract-4", args: { bar: "bar" }, id: "call_2" },
+              { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
+              { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
             ],
           ],
         });
@@ -139,12 +140,12 @@ describe("structured output handling", () => {
 
       it("should retry if error handler is set to true", async () => {
         const toolCalls = [
-          { name: "extract-5", args: { foo: "foo" }, id: "call_1" },
-          { name: "extract-6", args: { bar: "bar" }, id: "call_2" },
+          { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
+          { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
         ];
         const toolCall2 = [
           {
-            name: "extract-5",
+            name: "extract-1",
             args: { foo: "valid structured value" },
             id: "call_3",
           },
@@ -205,12 +206,12 @@ describe("structured output handling", () => {
 
       it("should retry if the error handler is set to the MultipleStructuredOutputsError", async () => {
         const toolCalls = [
-          { name: "extract-7", args: { foo: "foo" }, id: "call_1" },
-          { name: "extract-8", args: { bar: "bar" }, id: "call_2" },
+          { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
+          { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
         ];
         const toolCall2 = [
           {
-            name: "extract-7",
+            name: "extract-1",
             args: { foo: "fixed structured value" },
             id: "call_3",
           },
@@ -220,15 +221,15 @@ describe("structured output handling", () => {
             new AIMessage({
               content: "",
               tool_calls: [
-                { name: "extract-7", args: { foo: "foo" }, id: "call_1" },
-                { name: "extract-8", args: { bar: "bar" }, id: "call_2" },
+                { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
+                { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
               ],
             }),
             new AIMessage({
               content: "",
               tool_calls: [
                 {
-                  name: "extract-7",
+                  name: "extract-1",
                   args: { foo: "fixed structured value" },
                   id: "call_3",
                 },
@@ -282,8 +283,8 @@ describe("structured output handling", () => {
             new AIMessage({
               content: "",
               tool_calls: [
-                { name: "extract-9", args: { foo: "foo" }, id: "call_1" },
-                { name: "extract-10", args: { bar: "bar" }, id: "call_2" },
+                { name: "extract-1", args: { foo: "foo" }, id: "call_1" },
+                { name: "extract-2", args: { bar: "bar" }, id: "call_2" },
               ],
             }),
           ],
@@ -320,10 +321,10 @@ describe("structured output handling", () => {
       it("should retry if error handler is set to true", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-11", args: { bar: "foo" }, id: "call_1" }],
+            [{ name: "extract-1", args: { bar: "foo" }, id: "call_1" }],
             [
               {
-                name: "extract-11",
+                name: "extract-1",
                 args: { foo: "fixed structured value" },
                 id: "call_2",
               },
@@ -364,7 +365,7 @@ describe("structured output handling", () => {
           toolCalls: [
             [
               { name: "something", args: { result: 123 }, id: "call_1" },
-              { name: "extract-12", args: { foo: "bar" }, id: "call_2" },
+              { name: "extract-1", args: { foo: "bar" }, id: "call_2" },
             ],
           ],
         });
@@ -388,7 +389,7 @@ describe("structured output handling", () => {
       it("should return a structured response if it matches the schema and toolMessageContent is provided", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-13", args: { foo: "bar" }, id: "call_1" }],
+            [{ name: "extract-1", args: { foo: "bar" }, id: "call_1" }],
           ],
         });
 
@@ -424,7 +425,7 @@ describe("structured output handling", () => {
       it("should return structured response if it matches one of the schemas", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-15", args: { bar: "foo" }, id: "call_1" }],
+            [{ name: "extract-2", args: { bar: "foo" }, id: "call_1" }],
           ],
         });
         const agent = createAgent({
@@ -473,14 +474,14 @@ describe("structured output handling", () => {
         expect(strategy.name).toBe("my_json_tool");
       });
 
-      it("should fall back to extract-{n} when no title is provided", () => {
+      it("should fall back to a positional name when no title is provided", () => {
         const zodSchema = z4.object({
           status: z4.string(),
         });
 
         const [strategy] = toolStrategy(zodSchema);
 
-        expect(strategy.name).toMatch(/^extract-\d+$/);
+        expect(strategy.name).toBe("extract-1");
       });
 
       it("should use title from ToolStrategy.fromSchema with Zod v4 schema", () => {
@@ -516,7 +517,7 @@ describe("structured output handling", () => {
       it("should not throw error if use provider strategy directly", async () => {
         const model = new FakeToolCallingModel({
           toolCalls: [
-            [{ name: "extract-16", args: { foo: "bar" }, id: "call_2" }],
+            [{ name: "extract-1", args: { foo: "bar" }, id: "call_2" }],
           ],
         });
         const agent = createAgent({
@@ -841,5 +842,126 @@ describe("native structured output does not force strict tools", () => {
   it("keeps tools non-strict for an explicit providerStrategy strict: false", async () => {
     const opts = await bindOptions(ProviderStrategy.fromSchema(schema, false));
     expect(opts.strict).toBeUndefined();
+  });
+});
+
+describe("generated structured output tool names", () => {
+  const echo = tool(async () => "ok", {
+    name: "echo",
+    description: "Echo the text.",
+    schema: z.object({ text: z.string() }),
+  });
+
+  /**
+   * Run an agent and return the tool names bound on each model request, in
+   * order. Structured output tools are plain `{ function: { name } }` objects
+   * where the user's own tools are `StructuredTool` instances, so both shapes
+   * are read here.
+   */
+  async function boundToolNames(
+    responseFormat: ResponseFormatInput,
+    toolCalls: FakeToolCallingModel["toolCalls"] = [[]]
+  ) {
+    const model = new FakeToolCallingModel({ toolCalls });
+    const bindTools = vi.spyOn(model, "bindTools");
+    const agent = createAgent({
+      model,
+      tools: [echo],
+      // These cases deliberately span every accepted `responseFormat` shape,
+      // which no single `createAgent` overload covers.
+      responseFormat: responseFormat as never,
+    });
+    await agent.invoke({ messages: [new HumanMessage("hi")] });
+    return bindTools.mock.calls.map(([tools]) =>
+      (tools as unknown as { name?: string; function?: { name: string } }[])
+        .map((t) => t.name ?? t.function?.name)
+        .filter((name) => name !== echo.name)
+    );
+  }
+
+  it("binds the same generated name on every model request", async () => {
+    const names = await boundToolNames(z.object({ answer: z.string() }), [
+      [{ name: "echo", args: { text: "hi" }, id: "call_1" }],
+      [],
+    ]);
+
+    expect(names).toEqual([["extract-1"], ["extract-1"]]);
+  });
+
+  it("numbers strategies constructed separately and composed into one list", async () => {
+    const names = await boundToolNames([
+      ...toolStrategy(z.object({ a: z.string() })),
+      ...toolStrategy(z.object({ b: z.string() })),
+    ]);
+
+    expect(names).toEqual([["extract-1", "extract-2"]]);
+  });
+
+  it("does not spend a number on a titled schema", async () => {
+    const names = await boundToolNames([
+      {
+        type: "object",
+        title: "titled_schema",
+        properties: { a: { type: "string" } },
+      },
+      { type: "object", properties: { b: { type: "string" } } },
+    ]);
+
+    expect(names).toEqual([["titled_schema", "extract-1"]]);
+  });
+
+  it("names every composition form of the same schemas identically", async () => {
+    const a = z.object({ a: z.string() });
+    const b = z.object({ b: z.string() });
+
+    expect([
+      await boundToolNames(toolStrategy([a, b])),
+      await boundToolNames([...toolStrategy(a), ...toolStrategy(b)]),
+      await boundToolNames([a, b]),
+    ]).toEqual([
+      [["extract-1", "extract-2"]],
+      [["extract-1", "extract-2"]],
+      [["extract-1", "extract-2"]],
+    ]);
+  });
+
+  it("leaves a title alone even when it looks like a generated name", async () => {
+    const names = await boundToolNames([
+      {
+        type: "object",
+        title: "extract-5",
+        properties: { a: { type: "string" } },
+      },
+      { type: "object", properties: { b: { type: "string" } } },
+    ]);
+
+    expect(names).toEqual([["extract-5", "extract-1"]]);
+  });
+
+  it("numbers past a title that collides with the generated sequence", async () => {
+    // The agent keys strategies by tool name, so handing the anonymous schema
+    // `extract-1` here would drop one of the two schemas before it reached the
+    // model.
+    const names = await boundToolNames([
+      {
+        type: "object",
+        title: "extract-1",
+        properties: { a: { type: "string" } },
+      },
+      { type: "object", properties: { b: { type: "string" } } },
+    ]);
+
+    expect(names).toEqual([["extract-1", "extract-2"]]);
+  });
+
+  it("binds two tools for the same schema listed twice", async () => {
+    // Content-derived naming collapsed these to one tool. Positional naming
+    // does not, which is the trade recorded in the spec: the model is offered
+    // two identical options again.
+    const schema = z.object({ answer: z.string() });
+
+    const names = await boundToolNames(toolStrategy([schema, schema]));
+
+    expect(names).toEqual([["extract-1", "extract-2"]]);
   });
 });


### PR DESCRIPTION
> **Alternative to #11589 for #11151. Only one of the two should merge.**
> Same bug, same fix, different generated name. #11589 derives the name from a
> hash of the schema; this one numbers by position. Opened alongside so the
> choice can be made by reading both.

### Problem

When a `responseFormat` schema has no title and resolves to the tool strategy
rather than the provider's native structured output, the structured-output tool
is named from a module-global counter — `extract-1` on the first model request,
`extract-2` on the second. Providers render tool definitions at the very front
of the cached prompt prefix, so a name that changes between requests invalidates
the entire cache, system prompt and message history included.

It is also nondeterministic: the counter is global to the process, so concurrent
agents interleave their increments and a restart resets the sequence.

### Measurement

Two runs of the same agent against the live Anthropic API — same system prompt,
same tool, same middleware, same number of model requests — each starting from a
cold cache:

```
before   req#1  tools=[get_weather, extract-1]  cache_write=10797  cache_read=0
         req#2  tools=[get_weather, extract-2]  cache_write=10870  cache_read=0

after    req#1  tools=[get_weather, extract-1]  cache_write=10798  cache_read=0
         req#2  tools=[get_weather, extract-1]  cache_write=73     cache_read=10798
```

Before, the structured output tool renames between requests and the entire
prefix is rewritten with nothing read back. After, the name holds and the second
request reads 10,798 cached tokens, writing only the 73-token delta.

### Change

Generated names are assigned by position among the other generated names in the
assembled response format list, in a wrapper around `transformResponseFormat` —
the one function every entry point funnels through, including the per-request
middleware override. The counter is deleted.

Naming cannot happen at construction. `toolStrategy` sees only its own
arguments, so `[...toolStrategy(A), ...toolStrategy(B)]` would produce two
`extract-1`s, and the agent keys its strategies by tool name, so it would bind
only one of the two schemas. Renaming copies rather than mutates, so a strategy
held in a variable and reused across agents is never written to.

Whether a name was generated is recorded on the strategy rather than inferred
from its shape. Pattern-matching `/^extract-\d+$/` was tried first and dropped:
it clobbers a caller's title that happens to look generated, and becomes
materially worse if titled schemas are ever routed through an `extract-` prefix
so the prefix checks in `ReactAgent` and the PII middleware cover both kinds —
under that scheme a schema titled `200` arrives as `extract-200` and gets
renumbered, silently, with nothing to fail.

Numbering also steps over any name the caller chose, so a schema titled
`extract-1` alongside an anonymous one leaves the anonymous one as `extract-2`
rather than colliding with it.

### Choosing between this and #11589

|                                          | #11589 (hash)              | this PR (positional)     |
| ---------------------------------------- | -------------------------- | ------------------------ |
| Name a reader sees                       | `extract-b8db57530ae59966` | `extract-1`              |
| Non-comment source lines added           | 6                          | 65                       |
| Stable across requests, turns, processes | yes                        | yes                      |
| Same schema always gets the same name    | yes                        | no — depends on position |
| Same schema twice in one list            | binds one tool             | binds two                |
| New members on the public `ToolStrategy` | none                       | one `@internal` static   |

The two share every property in the caching core. They differ on legibility
against two things the hash gives and this does not:

- A strategy reused across agents at different positions is named differently in
  each.
- Two identical schemas in one list bind two indistinguishable tools again, so
  which entry's `options` apply is decided by the model's arbitrary choice
  between them rather than deterministically.

### Credit

The root cause was correctly diagnosed by @bisma-nawaz in #11161.
