### PR TITLE
deduplicate callback instances when configuring runs

### DIFF
--- a/.changeset/tidy-callback-configuration.md
+++ b/.changeset/tidy-callback-configuration.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+Deliver callbacks once per handler instance when merged runnable configurations contain duplicate registrations. Preserve handler order and inheritance, including handlers registered both locally and as inheritable.

--- a/libs/langchain-core/src/callbacks/manager.ts
+++ b/libs/langchain-core/src/callbacks/manager.ts
@@ -1520,8 +1520,11 @@ export class CallbackManager
         callbackManager.handlers,
         callbackManager.inheritableHandlers
       );
-      callbackManager.handlers = coalesced.handlers;
-      callbackManager.inheritableHandlers = coalesced.inheritableHandlers;
+      // Merged configs may register the same instance more than once.
+      callbackManager.handlers = [...new Set(coalesced.handlers)];
+      callbackManager.inheritableHandlers = [
+        ...new Set(coalesced.inheritableHandlers),
+      ];
     }
 
     return callbackManager;

--- a/libs/langchain-core/src/callbacks/tests/configuration_identity.test.ts
+++ b/libs/langchain-core/src/callbacks/tests/configuration_identity.test.ts
@@ -1,0 +1,345 @@
+import { EventStreamCallbackHandler } from "../../tracers/event_stream.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { BaseCallbackHandler } from "../base.js";
+import { CallbackManager, ensureHandler } from "../manager.js";
+import { AIMessage, HumanMessage } from "../../messages/index.js";
+import { mergeConfigs } from "../../runnables/config.js";
+import { LangChainTracer } from "../../tracers/tracer_langchain.js";
+
+class RecordingHandler extends BaseCallbackHandler {
+  name = "registration-contract";
+  handleChatModelStart = vi.fn();
+  handleLLMNewToken = vi.fn();
+  handleLLMEnd = vi.fn();
+  handleLLMError = vi.fn();
+  handleChainStart = vi.fn();
+  handleChainEnd = vi.fn();
+  handleToolStart = vi.fn();
+  handleToolEnd = vi.fn();
+  handleRetrieverStart = vi.fn();
+  handleRetrieverEnd = vi.fn();
+
+  constructor() {
+    super({ _awaitHandler: true });
+  }
+}
+
+const serialized = {
+  lc: 1 as const,
+  type: "not_implemented" as const,
+  id: ["contract"],
+};
+const output = {
+  generations: [[{ text: "hello", message: new AIMessage("hello") }]],
+};
+
+function callbacks(handler: BaseCallbackHandler, asManager: boolean) {
+  return asManager
+    ? new CallbackManager(undefined, {
+        handlers: [handler],
+        inheritableHandlers: [handler],
+      })
+    : [handler];
+}
+
+describe("callback configuration identity", () => {
+  const tracingKeys = [
+    "LANGSMITH_TRACING",
+    "LANGCHAIN_TRACING_V2",
+    "LANGCHAIN_TRACING",
+  ] as const;
+  const tracingBefore = tracingKeys.map((key) => process.env[key]);
+
+  beforeAll(() => {
+    for (const key of tracingKeys) process.env[key] = "";
+  });
+
+  afterAll(() => {
+    tracingKeys.forEach((key, index) => {
+      if (tracingBefore[index] === undefined) delete process.env[key];
+      else process.env[key] = tracingBefore[index];
+    });
+  });
+  it.each([
+    { leftManager: false, rightManager: false },
+    { leftManager: false, rightManager: true },
+    { leftManager: true, rightManager: false },
+    { leftManager: true, rightManager: true },
+  ])(
+    "delivers every lifecycle once after merging $leftManager / $rightManager managers",
+    async ({ leftManager, rightManager }) => {
+      const handler = new RecordingHandler();
+      const merged = mergeConfigs(
+        { callbacks: callbacks(handler, leftManager) },
+        { callbacks: callbacks(handler, rightManager) }
+      );
+      const manager = await CallbackManager.configure(merged.callbacks);
+      expect(manager).toBeDefined();
+      if (!manager) return;
+
+      const [model] = await manager.handleChatModelStart(serialized, [
+        [new HumanMessage("hello")],
+      ]);
+      await model.handleLLMNewToken("hello");
+      await model.handleLLMEnd(output);
+      const chain = await manager.handleChainStart(serialized, {});
+      await chain.handleChainEnd({});
+      const tool = await manager.handleToolStart(serialized, "input");
+      await tool.handleToolEnd("output");
+      const retriever = await manager.handleRetrieverStart(serialized, "query");
+      await retriever.handleRetrieverEnd([]);
+
+      for (const callback of [
+        handler.handleChatModelStart,
+        handler.handleLLMNewToken,
+        handler.handleLLMEnd,
+        handler.handleChainStart,
+        handler.handleChainEnd,
+        handler.handleToolStart,
+        handler.handleToolEnd,
+        handler.handleRetrieverStart,
+        handler.handleRetrieverEnd,
+      ])
+        expect(callback).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("preserves constructor array ownership and normalizes configured copies in order", async () => {
+    const first = new RecordingHandler();
+    const second = new RecordingHandler();
+    const handlers = [first, first];
+    const inheritableHandlers = [first, first];
+    const input = new CallbackManager("parent", {
+      handlers,
+      inheritableHandlers,
+    });
+    handlers.push(second);
+    expect(input.handlers).toBe(handlers);
+    expect(input.inheritableHandlers).toBe(inheritableHandlers);
+    const manager = await CallbackManager.configure(input);
+    expect(manager?.handlers).toEqual([first, second]);
+    expect(manager?.inheritableHandlers).toEqual([first]);
+    expect(manager?.getParentRunId()).toBe("parent");
+    expect(handlers).toEqual([first, first, second]);
+    expect(inheritableHandlers).toEqual([first, first]);
+  });
+
+  it("promotes an existing local handler and delivers it once to children", async () => {
+    const handler = new RecordingHandler();
+    const manager = new CallbackManager();
+    manager.addHandler(handler, false);
+    manager.addHandler(handler, true);
+    manager.addHandler(handler, false);
+    const configured = await CallbackManager.configure(manager);
+    const parent = await configured!.handleChainStart(serialized, {});
+    const child = await parent.getChild().handleChainStart(serialized, {});
+    await child.handleChainEnd({});
+    await parent.handleChainEnd({});
+    expect(handler.handleChainStart).toHaveBeenCalledTimes(2);
+    expect(handler.handleChainEnd).toHaveBeenCalledTimes(2);
+    expect(child.parentRunId).toBe(parent.runId);
+  });
+
+  it("keeps local handlers out of child runs", async () => {
+    const local = new RecordingHandler();
+    const inherited = new RecordingHandler();
+    const manager = new CallbackManager();
+    manager.addHandler(local, false);
+    manager.addHandler(inherited, true);
+    const configured = await CallbackManager.configure(manager);
+    const parent = await configured!.handleChainStart(serialized, {});
+    const child = await parent.getChild().handleChainStart(serialized, {});
+    await child.handleChainEnd({});
+    await parent.handleChainEnd({});
+    expect(local.handleChainEnd).toHaveBeenCalledTimes(1);
+    expect(inherited.handleChainEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps separate same-name handlers and independent registrations", async () => {
+    const first = new RecordingHandler();
+    const second = new RecordingHandler();
+    const manager = new CallbackManager(undefined, {
+      handlers: [first, second],
+    });
+    const [model] = await manager.handleChatModelStart(serialized, [
+      [new HumanMessage("hello")],
+    ]);
+    await model.handleLLMEnd(output);
+    expect(first.handleLLMEnd).toHaveBeenCalledTimes(1);
+    expect(second.handleLLMEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates fresh wrappers and observes callback method changes between requests", async () => {
+    const first = vi.fn();
+    const replacement = vi.fn();
+    const methods = { handleChainEnd: first };
+    const firstHandler = ensureHandler(methods);
+    firstHandler.ignoreChain = true;
+    expect(ensureHandler(methods)).not.toBe(firstHandler);
+    expect(ensureHandler(methods).ignoreChain).toBe(false);
+    const manager = await CallbackManager.configure([methods]);
+    await (await manager!.handleChainStart(serialized, {})).handleChainEnd({});
+    methods.handleChainEnd = replacement;
+    const next = await CallbackManager.configure([methods]);
+    await (await next!.handleChainStart(serialized, {})).handleChainEnd({});
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(replacement).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves explicit registrations until configuration", async () => {
+    const handler = new RecordingHandler();
+    const manager = new CallbackManager();
+    manager.setHandlers([handler, handler], true);
+    expect(manager.handlers).toEqual([handler, handler]);
+    const configured = await CallbackManager.configure(manager);
+    expect(configured?.handlers).toEqual([handler]);
+    expect(configured?.inheritableHandlers).toEqual([handler]);
+    manager.removeHandler(handler);
+    manager.addHandler(handler, false);
+    expect(manager.handlers).toEqual([handler]);
+    expect(manager.inheritableHandlers).toEqual([]);
+  });
+
+  it("still coalesces LangSmith tracing copies by run store", async () => {
+    const tracer = new LangChainTracer();
+    const inherited = tracer.copyWithTracingConfig({ tags: ["child"] });
+    const separate = new LangChainTracer();
+    const manager = await CallbackManager.configure(
+      new CallbackManager(undefined, {
+        handlers: [tracer, inherited, separate],
+        inheritableHandlers: [inherited, separate],
+      })
+    );
+    expect(manager?.handlers).toHaveLength(2);
+    expect(manager?.inheritableHandlers).toHaveLength(2);
+    expect(manager?.handlers).toContain(separate);
+    const mergedTracer = manager?.handlers.find(
+      (handler) => handler !== separate
+    ) as LangChainTracer;
+    expect(mergedTracer._getRunStoreKey()).toBe(tracer._getRunStoreKey());
+    expect(manager?.inheritableHandlers).toContain(mergedTracer);
+  });
+
+  it("keeps concurrent runs independent when they share a callback instance", async () => {
+    const handler = new RecordingHandler();
+    await Promise.all(
+      [false, true].map(async (asManager) => {
+        const config = mergeConfigs(
+          { callbacks: callbacks(handler, asManager) },
+          { callbacks: callbacks(handler, !asManager) }
+        );
+        const manager = await CallbackManager.configure(config.callbacks);
+        expect(manager).toBeDefined();
+        if (!manager) return;
+        const [model] = await manager.handleChatModelStart(serialized, [
+          [new HumanMessage("hello")],
+        ]);
+        await model.handleLLMEnd(output);
+      })
+    );
+    expect(handler.handleChatModelStart).toHaveBeenCalledTimes(2);
+    expect(handler.handleLLMEnd).toHaveBeenCalledTimes(2);
+    const starts = handler.handleChatModelStart.mock.calls.map(
+      (call) => call[2]
+    );
+    const ends = handler.handleLLMEnd.mock.calls.map((call) => call[1]);
+    expect(new Set(starts).size).toBe(2);
+    expect(ends.sort()).toEqual(starts.sort());
+  });
+
+  it("delivers errors once and still reports a later successful retry", async () => {
+    const handler = new RecordingHandler();
+    const manager = (await CallbackManager.configure(
+      new CallbackManager(undefined, { handlers: [handler, handler] })
+    ))!;
+    const [failed] = await manager.handleChatModelStart(serialized, [
+      [new HumanMessage("hello")],
+    ]);
+    const failure = new Error("provider failed");
+    await failed.handleLLMError(failure);
+    const [retried] = await manager.handleChatModelStart(serialized, [
+      [new HumanMessage("hello")],
+    ]);
+    await retried.handleLLMEnd(output);
+    expect(handler.handleChatModelStart).toHaveBeenCalledTimes(2);
+    expect(handler.handleLLMError).toHaveBeenCalledTimes(1);
+    expect(handler.handleLLMEnd).toHaveBeenCalledTimes(1);
+    expect(retried.runId).not.toBe(failed.runId);
+  });
+  it.each([false, true])(
+    "preserves inheritance when the local manager is on the left: %s",
+    async (localFirst) => {
+      const shared = new RecordingHandler();
+      const localOnly = new RecordingHandler();
+      const local = new CallbackManager("ancestor", {
+        handlers: [shared, localOnly],
+        tags: ["inherited", "local"],
+        inheritableTags: ["inherited"],
+        metadata: { inherited: 1, local: 2 },
+        inheritableMetadata: { inherited: 1 },
+      });
+      const configs = [{ callbacks: local }, { callbacks: [shared] }];
+      const merged = mergeConfigs(
+        ...(localFirst ? configs : configs.reverse())
+      );
+      const manager = (await CallbackManager.configure(merged.callbacks))!;
+      expect(manager.getParentRunId()).toBe("ancestor");
+      const parent = await manager.handleChainStart(serialized, {});
+      const childManager = parent.getChild();
+      expect(childManager.tags).toEqual(["inherited"]);
+      expect(childManager.metadata).toEqual({ inherited: 1 });
+      const child = await childManager.handleChainStart(serialized, {});
+      await child.handleChainEnd({});
+      await parent.handleChainEnd({});
+      expect(shared.handleChainEnd).toHaveBeenCalledTimes(2);
+      expect(localOnly.handleChainEnd).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("keeps mutable method-object state private to each configured wrapper", async () => {
+    const counts: number[] = [];
+    const methods = {
+      count: 0,
+      handleChainEnd() {
+        counts.push(++this.count);
+      },
+    };
+    for (let i = 0; i < 2; i++) {
+      const manager = (await CallbackManager.configure([methods]))!;
+      await (await manager.handleChainStart(serialized, {})).handleChainEnd({});
+    }
+    expect(counts).toEqual([1, 1]);
+    expect(methods.count).toBe(0);
+  });
+
+  it.each([false, true])(
+    "pairs streamed model events when duplicate callbacks use managers: %s",
+    async (asManager) => {
+      const handler = new EventStreamCallbackHandler({ autoClose: false });
+      const config = mergeConfigs(
+        { callbacks: callbacks(handler, asManager) },
+        { callbacks: callbacks(handler, !asManager) }
+      );
+      const manager = CallbackManager.configure(config.callbacks)!;
+      const events: string[] = [];
+      const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const consume = (async () => {
+        for await (const event of handler) events.push(event.event);
+      })();
+      let warnings: unknown[][] = [];
+      try {
+        const [model] = await manager.handleChatModelStart(serialized, [
+          [new HumanMessage("hello")],
+        ]);
+        await model.handleLLMEnd(output);
+      } finally {
+        await handler.finish();
+        await consume;
+        warnings = [...warning.mock.calls];
+        warning.mockRestore();
+      }
+      expect(events).toEqual(["on_chat_model_start", "on_chat_model_end"]);
+      expect(warnings).toEqual([]);
+    }
+  );
+});


### PR DESCRIPTION
Merged runnable configurations can contain the same callback handler instance more than once. Each lifecycle call then reaches that instance twice: stream consumers see duplicate starts, and the second end delivery can throw `Run ID … not found in run map` after the first has removed the run.

This deduplicates `handlers` and `inheritableHandlers` by object identity at the end of `CallbackManager._configureSync`, after existing LangChainTracer coalescing. The production change is **+5/-2 lines**; the rest is 18 regression/compatibility tests and a core patch changeset.

Related: #11360, #11387, langchain-ai/langgraphjs#2696.

### Why this boundary

Both core's runnable config merging and LangGraph's config propagation feed callback configuration. Normalizing here covers the four array/manager combinations without needing separate fixes for each producer, and prevents duplicate dispatch for custom handlers as well as EventStreamCallbackHandler.

The two collections are deduplicated independently. A handler present locally and also inherited gets one parent delivery and remains available to children. First-occurrence order is preserved, distinct same-name instances remain distinct, and existing tracer copies still coalesce by their shared run store.

This keeps the behavioral change focused on configured runs. Constructor array ownership, explicit `addHandler` registrations, and fresh wrappers for plain callback-method objects retain their existing behavior. In a compatibility experiment, caching those wrappers globally caused later method replacements to be ignored and mutable wrapper state to survive into subsequent requests. This fix needs no such cache.

### Relationship to the other fixes

#11387 makes EventStream end handling tolerate duplicate delivery. This addresses the earlier fan-out that causes duplicate starts, tokens, ends, and custom-handler side effects. Defensive end handling can still be useful for callers that deliver lifecycle events directly; this PR does not make arbitrary repeated end calls idempotent or address the separate chain-error cleanup concern in #11360.

langchain-ai/langgraphjs/pull/2696 addresses merging earlier in graph propagation. Its latest revision includes inheritance promotion, stable wrappers, and internal handler-name equivalence. This PR deliberately uses existing instance identity at core configuration and does not claim to replace those additional semantics. It offers a small common fix for the duplicate-instance delivery reproduced here, including core-only merges.

### Validation

At head `7d9a6492`, based on upstream `a443ab0c`:

- All 18 new tests pass. Running the same file on the unmodified base produces 13 failures and five passing controls.
- All 101 core unit-test files pass: 1,531 tests passed, one skipped.
- Core TypeScript check, build, attw, publint, and focused lint/format checks pass.
- Tests cover all four core merge shapes, model/chain/tool/retriever delivery, errors and retries, concurrent runs, inheritance in both merge directions, parent/tags/metadata, tracer coalescing, wrapper compatibility, and actual EventStream events with no warnings.

For the full unit suite I used:

```sh
env -u LANGCHAIN_TRACING LANGSMITH_TRACING=false LANGCHAIN_TRACING_V2=false LANGCHAIN_CALLBACKS_BACKGROUND=false pnpm --filter @langchain/core test
```

Additional downstream validation of the equivalent compiled patch on core 1.2.9 / LangGraph 1.4.13 passed all eight core/LangGraph merge combinations in both CJS and ESM. A fake-model nested-tool reproduction modeled on #11360, with an explicit traceable parent and stubbed tracing transport, went from 12 duplicate lifecycle events and 12 warnings to zero, with the tool still called once. On those installed versions, the same reproduction without the explicit parent was already clean. These downstream checks are supporting evidence; the self-contained core regressions are included in this PR.
