### PR TITLE
fix(core): build streaming llmOutput.tokenUsage from accumulated usage

### DIFF
--- a/.changeset/fix-streaming-llmoutput-token-usage.md
+++ b/.changeset/fix-streaming-llmoutput-token-usage.md
@@ -1,0 +1,12 @@
+---
+"@langchain/core": patch
+"@langchain/google": patch
+---
+
+fix(core): build streaming `llmOutput.tokenUsage` from the fully-accumulated chunk instead of whichever individual chunk's `usage_metadata` arrived last
+
+Affects both core streaming paths — `.stream()`/`.streamEvents()` (`_streamIterator`) and `.invoke()`/`.generate()` when a streaming-preferring callback is attached (`_generateWithCache`'s `hasStreamingHandler` branch). Previously, `llmOutput.tokenUsage` was overwritten by each chunk in turn, so only the last chunk carrying `usage_metadata` won — correct for providers that emit one cumulative total on a final chunk, but wrong for providers (e.g. `@langchain/google`, `@langchain/anthropic`) that emit `usage_metadata` as a per-chunk delta across multiple chunks, where the values must be summed.
+
+Note for provider authors: this assumes each streamed chunk's `usage_metadata` is either a per-chunk delta or appears only on a single final chunk. A provider that instead repeats a cumulative total on every chunk will now see it summed (and inflated) in `llmOutput.tokenUsage`, matching the existing behavior of the correctly-working `message.usage_metadata` field.
+
+Also fixes `@langchain/google`'s `invoke({streaming: true})` path (no streaming-preferring callback attached), where `llmOutput` was never populated at all.

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -6,7 +6,6 @@ import {
   type BaseMessageLike,
   coerceMessageLikeToMessage,
   AIMessageChunk,
-  isAIMessageChunk,
   isBaseMessage,
   isAIMessage,
   MessageOutputVersion,
@@ -554,8 +553,6 @@ export abstract class BaseChatModel<
         runnableConfig.runName
       );
       let generationChunk: ChatGenerationChunk | undefined;
-      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-      let llmOutput: Record<string, any> | undefined;
       try {
         for await (const chunk of this._streamResponseChunks(
           messages,
@@ -583,18 +580,6 @@ export abstract class BaseChatModel<
           } else {
             generationChunk = generationChunk.concat(chunk);
           }
-          if (
-            isAIMessageChunk(chunk.message) &&
-            chunk.message.usage_metadata !== undefined
-          ) {
-            llmOutput = {
-              tokenUsage: {
-                promptTokens: chunk.message.usage_metadata.input_tokens,
-                completionTokens: chunk.message.usage_metadata.output_tokens,
-                totalTokens: chunk.message.usage_metadata.total_tokens,
-              },
-            };
-          }
         }
         // Throw error if stream ended due to abort (provider returned early)
         callOptions.signal?.throwIfAborted();
@@ -605,6 +590,22 @@ export abstract class BaseChatModel<
           )
         );
         throw err;
+      }
+      // Built from the fully-accumulated chunk, not any single chunk's delta.
+      let llmOutput: LLMResult["llmOutput"];
+      if (
+        generationChunk &&
+        AIMessageChunk.isInstance(generationChunk.message) &&
+        generationChunk.message.usage_metadata !== undefined
+      ) {
+        llmOutput = {
+          tokenUsage: {
+            promptTokens: generationChunk.message.usage_metadata.input_tokens,
+            completionTokens:
+              generationChunk.message.usage_metadata.output_tokens,
+            totalTokens: generationChunk.message.usage_metadata.total_tokens,
+          },
+        };
       }
       await Promise.all(
         (runManagers ?? []).map((runManager) =>
@@ -789,8 +790,6 @@ export abstract class BaseChatModel<
           runManagers?.[0]
         );
         let aggregated: ChatGenerationChunk | undefined;
-        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-        let llmOutput: Record<string, any> | undefined;
         for await (const chunk of stream) {
           // Check for abort signal - throw ModelAbortError with partial output
           if (parsedOptions.signal?.aborted) {
@@ -810,18 +809,6 @@ export abstract class BaseChatModel<
             aggregated = chunk;
           } else {
             aggregated = concat(aggregated, chunk);
-          }
-          if (
-            isAIMessageChunk(chunk.message) &&
-            chunk.message.usage_metadata !== undefined
-          ) {
-            llmOutput = {
-              tokenUsage: {
-                promptTokens: chunk.message.usage_metadata.input_tokens,
-                completionTokens: chunk.message.usage_metadata.output_tokens,
-                totalTokens: chunk.message.usage_metadata.total_tokens,
-              },
-            };
           }
         }
         // Check if stream ended due to abort (provider returned early)
@@ -843,6 +830,20 @@ export abstract class BaseChatModel<
           ) as AIMessageChunk;
         }
         generations.push([aggregated]);
+        // Built from the fully-accumulated chunk, same as _streamIterator above.
+        let llmOutput: LLMResult["llmOutput"];
+        if (
+          AIMessageChunk.isInstance(aggregated.message) &&
+          aggregated.message.usage_metadata !== undefined
+        ) {
+          llmOutput = {
+            tokenUsage: {
+              promptTokens: aggregated.message.usage_metadata.input_tokens,
+              completionTokens: aggregated.message.usage_metadata.output_tokens,
+              totalTokens: aggregated.message.usage_metadata.total_tokens,
+            },
+          };
+        }
         await runManagers?.[0].handleLLMEnd({
           generations,
           llmOutput,

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -5,9 +5,14 @@ import { zodToJsonSchema } from "../../utils/zod-to-json-schema/index.js";
 import { FakeChatModel, FakeListChatModel } from "../../utils/testing/index.js";
 import { HumanMessage } from "../../messages/human.js";
 import { getBufferString } from "../../messages/utils.js";
-import { AIMessage } from "../../messages/ai.js";
+import { AIMessage, AIMessageChunk } from "../../messages/ai.js";
+import type { BaseMessage } from "../../messages/base.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
 import { BaseCallbackHandler } from "../../callbacks/base.js";
+import { ChatGenerationChunk } from "../../outputs.js";
+import type { LLMResult, ChatResult } from "../../outputs.js";
+import { BaseChatModel } from "../chat_models.js";
+import type { CallbackManagerForLLMRun } from "../../callbacks/manager.js";
 import { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
 import { LangChainTracer } from "../../tracers/tracer_langchain.js";
 import { awaitAllCallbacks } from "../../callbacks/promises.js";
@@ -615,4 +620,105 @@ test("Test ChatModel applies v1 outputVersion after implicit streaming aggregati
       text: "Hello world!",
     },
   ]);
+});
+
+class DeltaUsageChatModel extends BaseChatModel {
+  _llmType() {
+    return "delta-usage-fake";
+  }
+
+  async _generate(
+    _messages: BaseMessage[],
+    _options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    throw new Error("DeltaUsageChatModel only supports streaming");
+  }
+
+  async *_streamResponseChunks(): AsyncGenerator<ChatGenerationChunk> {
+    const deltas = [
+      {
+        content: "Hello",
+        usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 },
+      },
+      {
+        content: " world",
+        usage: { input_tokens: 0, output_tokens: 4, total_tokens: 4 },
+      },
+      {
+        content: "!",
+        usage: { input_tokens: 0, output_tokens: 7, total_tokens: 7 },
+      },
+    ];
+    for (const d of deltas) {
+      yield new ChatGenerationChunk({
+        text: d.content,
+        message: new AIMessageChunk({
+          content: d.content,
+          usage_metadata: d.usage,
+        }),
+      });
+    }
+  }
+}
+
+test("Test ChatModel .stream() builds llmOutput.tokenUsage from accumulated usage, not the last chunk's delta", async () => {
+  const model = new DeltaUsageChatModel({});
+  let callbackResult: LLMResult | undefined;
+
+  const stream = await model.stream("hi", {
+    callbacks: [
+      {
+        handleLLMEnd: async (output: LLMResult) => {
+          callbackResult = output;
+        },
+      },
+    ],
+  });
+
+  let full: AIMessageChunk | undefined;
+  for await (const chunk of stream) {
+    full = full ? full.concat(chunk) : chunk;
+  }
+
+  expect(full?.usage_metadata).toMatchObject({
+    input_tokens: 10,
+    output_tokens: 12,
+    total_tokens: 22,
+  });
+  expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+    promptTokens: 10,
+    completionTokens: 12,
+    totalTokens: 22,
+  });
+});
+
+test("Test ChatModel .invoke() with a streaming-preferring callback builds llmOutput.tokenUsage from accumulated usage", async () => {
+  class PreferStreamingCallbackHandler extends BaseCallbackHandler {
+    name = "prefer-streaming";
+
+    lc_prefer_streaming = true;
+
+    handleLLMNewToken() {}
+  }
+
+  const model = new DeltaUsageChatModel({});
+  let callbackResult: LLMResult | undefined;
+
+  await model.invoke("hi", {
+    callbacks: [
+      new PreferStreamingCallbackHandler(),
+      {
+        handleLLMEnd: async (output: LLMResult) => {
+          callbackResult = output;
+        },
+      },
+    ],
+  });
+
+  expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+    promptTokens: 10,
+    completionTokens: 12,
+    totalTokens: 22,
+  });
 });

--- a/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
+++ b/libs/providers/langchain-anthropic/src/tests/chat_models.int.test.ts
@@ -19,6 +19,8 @@ import {
   SystemMessagePromptTemplate,
 } from "@langchain/core/prompts";
 import { CallbackManager } from "@langchain/core/callbacks/manager";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import type { LLMResult } from "@langchain/core/outputs";
 import { concat } from "@langchain/core/utils/stream";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { BaseLanguageModelInput } from "@langchain/core/language_models/base";
@@ -1952,5 +1954,62 @@ describe("Opus 4.6", () => {
       expect(typeof compactionBlock.content).toBe("string");
       expect(compactionBlock.content.length).toBeGreaterThan(0);
     }, 120000);
+  });
+});
+
+describe("llmOutput.tokenUsage matches usage_metadata on streaming paths (#11424 regression)", () => {
+  test(".stream()", async () => {
+    let callbackResult: LLMResult | undefined;
+    const model = new ChatAnthropic({
+      model: modelName,
+      callbacks: [
+        {
+          async handleLLMEnd(output: LLMResult) {
+            callbackResult = output;
+          },
+        },
+      ],
+    });
+
+    let res: AIMessageChunk | undefined;
+    for await (const chunk of await model.stream("Say OK.")) {
+      res = res ? concat(res, chunk) : chunk;
+    }
+
+    expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+      promptTokens: res?.usage_metadata?.input_tokens,
+      completionTokens: res?.usage_metadata?.output_tokens,
+      totalTokens: res?.usage_metadata?.total_tokens,
+    });
+  });
+
+  test("invoke() with a streaming-preferring callback", async () => {
+    class PreferStreamingCallbackHandler extends BaseCallbackHandler {
+      name = "prefer-streaming";
+
+      lc_prefer_streaming = true;
+
+      handleLLMNewToken() {}
+    }
+
+    let callbackResult: LLMResult | undefined;
+    const model = new ChatAnthropic({ model: modelName });
+
+    const res: AIMessage = await model.invoke("Say OK.", {
+      callbacks: [
+        new PreferStreamingCallbackHandler(),
+        {
+          async handleLLMEnd(output: LLMResult) {
+            callbackResult = output;
+          },
+        },
+      ],
+    });
+
+    expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+      promptTokens: res.usage_metadata?.input_tokens,
+      completionTokens: res.usage_metadata?.output_tokens,
+      totalTokens: res.usage_metadata?.total_tokens,
+    });
   });
 });

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -568,8 +568,17 @@ export abstract class BaseChatGoogle<
             .originalTextContentBlock as Record<string, unknown>
         ).text = finalChunk.message.content;
       }
+      const usageMetadata = finalChunk?.message?.usage_metadata;
       return {
         generations: finalChunk ? [finalChunk] : [],
+        ...(usageMetadata
+          ? {
+              llmOutput: {
+                tokenUsage: usageMetadataToTokenUsage(usageMetadata),
+                usageMetadata,
+              },
+            }
+          : {}),
       };
     }
 

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -47,6 +47,7 @@ import {
   ChatPromptTemplate,
   MessagesPlaceholder,
 } from "@langchain/core/prompts";
+import type { LLMResult } from "@langchain/core/outputs";
 
 /**
  * Builds the callback handler list for integration tests.
@@ -2481,6 +2482,63 @@ describe
       expect(contents[3]).toEqual({
         role: "user",
         parts: [{ text: "continue" }],
+      });
+    });
+  }
+);
+
+describe.skipIf(!getEnvironmentVariable("TEST_API_KEY"))(
+  "Google token usage & cost accounting root-cause checks (live API)",
+  () => {
+    test("llmOutput.tokenUsage vs usage_metadata across call styles (#11424)", async () => {
+      async function run(streamingCtor: boolean, useStreamMethod: boolean) {
+        let callbackResult: LLMResult | undefined;
+        const llm = new ChatGoogle({
+          model: "gemini-3.8-flash",
+          apiKey: getEnvironmentVariable("TEST_API_KEY"),
+          streaming: streamingCtor,
+          callbacks: [
+            {
+              async handleLLMEnd(output: LLMResult) {
+                callbackResult = output;
+              },
+            },
+          ],
+        });
+
+        const prompt =
+          "Write a 300 word essay about why the sky is blue, covering Rayleigh scattering, wavelength, and atmospheric composition.";
+        let res: AIMessageChunk | AIMessage | null = null;
+        if (useStreamMethod) {
+          for await (const chunk of await llm.stream(prompt)) {
+            res = res ? (res as AIMessageChunk).concat(chunk) : chunk;
+          }
+        } else {
+          res = await llm.invoke(prompt);
+        }
+        return { res, callbackResult };
+      }
+
+      const nonStreaming = await run(false, false);
+      const invokeStreaming = await run(true, false);
+      const dotStream = await run(false, true);
+
+      expect(nonStreaming.callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: nonStreaming.res?.usage_metadata?.input_tokens,
+        completionTokens: nonStreaming.res?.usage_metadata?.output_tokens,
+        totalTokens: nonStreaming.res?.usage_metadata?.total_tokens,
+      });
+
+      expect(invokeStreaming.callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: invokeStreaming.res?.usage_metadata?.input_tokens,
+        completionTokens: invokeStreaming.res?.usage_metadata?.output_tokens,
+        totalTokens: invokeStreaming.res?.usage_metadata?.total_tokens,
+      });
+
+      expect(dotStream.callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: dotStream.res?.usage_metadata?.input_tokens,
+        completionTokens: dotStream.res?.usage_metadata?.output_tokens,
+        totalTokens: dotStream.res?.usage_metadata?.total_tokens,
       });
     });
   }

--- a/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.test.ts
@@ -1178,6 +1178,101 @@ describe("Google Mock", () => {
     });
   });
 
+  describe("llmOutput.tokenUsage across call styles (#11424)", () => {
+    test("invoke(), streaming off", async () => {
+      let callbackResult: LLMResult | undefined;
+      const llm = new ChatGoogle({
+        model: "gemini-3.8-flash",
+        apiClient: new MockApiClient({ fileName: "gemini-chat-001.json" }),
+        callbacks: [
+          {
+            async handleLLMEnd(output: LLMResult) {
+              callbackResult = output;
+            },
+          },
+        ],
+      });
+
+      const result = await llm.invoke("What is 1+1?");
+
+      expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: result.usage_metadata!.input_tokens,
+        completionTokens: result.usage_metadata!.output_tokens,
+        totalTokens: result.usage_metadata!.total_tokens,
+      });
+    });
+
+    test("invoke({streaming: true})", async () => {
+      let callbackResult: LLMResult | undefined;
+      const llm = new ChatGoogle({
+        model: "gemini-3.8-flash",
+        streaming: true,
+        apiClient: new MockApiClient({
+          fileName: "gemini-stream-001.txt",
+          streaming: true,
+        }),
+        callbacks: [
+          {
+            async handleLLMEnd(output: LLMResult) {
+              callbackResult = output;
+            },
+          },
+        ],
+      });
+
+      const result = await llm.invoke("Why is the sky blue?");
+
+      // Message-level usage_metadata is the concatenated, correct total.
+      expect(result.usage_metadata).toMatchObject({
+        input_tokens: 10,
+        output_tokens: 12,
+        total_tokens: 22,
+      });
+
+      // llmOutput.tokenUsage should agree with it.
+      expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: 10,
+        completionTokens: 12,
+        totalTokens: 22,
+      });
+    });
+
+    test(".stream()", async () => {
+      let callbackResult: LLMResult | undefined;
+      const llm = new ChatGoogle({
+        model: "gemini-3.8-flash",
+        apiClient: new MockApiClient({
+          fileName: "gemini-stream-001.txt",
+          streaming: true,
+        }),
+        callbacks: [
+          {
+            async handleLLMEnd(output: LLMResult) {
+              callbackResult = output;
+            },
+          },
+        ],
+      });
+
+      let res: AIMessageChunk | null = null;
+      for await (const chunk of await llm.stream("Why is the sky blue?")) {
+        res = res ? res.concat(chunk) : chunk;
+      }
+
+      expect(res?.usage_metadata).toMatchObject({
+        input_tokens: 10,
+        output_tokens: 12,
+        total_tokens: 22,
+      });
+
+      expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+        promptTokens: 10,
+        completionTokens: 12,
+        totalTokens: 22,
+      });
+    });
+  });
+
   test("handleLLMNewToken is called for non-text streaming chunks", async () => {
     const execCodeChunk = {
       candidates: [

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.int.test.ts
@@ -2,6 +2,7 @@
 import * as z4 from "zod/v4";
 import { describe, test, expect, vi } from "vitest";
 import {
+  AIMessage,
   AIMessageChunk,
   BaseMessage,
   ChatMessage,
@@ -17,6 +18,7 @@ import {
   SystemMessagePromptTemplate,
 } from "@langchain/core/prompts";
 import { CallbackManager } from "@langchain/core/callbacks/manager";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { NewTokenIndices } from "@langchain/core/callbacks/base";
 import { InMemoryCache } from "@langchain/core/caches";
 import { concat } from "@langchain/core/utils/stream";
@@ -1284,4 +1286,61 @@ test("will call responses api for gpt-5.2-pro", async () => {
 
   expect(response).toBeDefined();
   expect(generateSpy).toHaveBeenCalled();
+});
+
+describe("llmOutput.tokenUsage matches usage_metadata on streaming paths (#11424 regression)", () => {
+  test(".stream()", async () => {
+    let callbackResult: LLMResult | undefined;
+    const model = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      callbacks: [
+        {
+          async handleLLMEnd(output: LLMResult) {
+            callbackResult = output;
+          },
+        },
+      ],
+    });
+
+    let res: AIMessageChunk | undefined;
+    for await (const chunk of await model.stream("Say OK.")) {
+      res = res ? res.concat(chunk) : chunk;
+    }
+
+    expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+      promptTokens: res?.usage_metadata?.input_tokens,
+      completionTokens: res?.usage_metadata?.output_tokens,
+      totalTokens: res?.usage_metadata?.total_tokens,
+    });
+  });
+
+  test("invoke() with a streaming-preferring callback", async () => {
+    class PreferStreamingCallbackHandler extends BaseCallbackHandler {
+      name = "prefer-streaming";
+
+      lc_prefer_streaming = true;
+
+      handleLLMNewToken() {}
+    }
+
+    let callbackResult: LLMResult | undefined;
+    const model = new ChatOpenAI({ model: "gpt-4o-mini" });
+
+    const res: AIMessage = await model.invoke("Say OK.", {
+      callbacks: [
+        new PreferStreamingCallbackHandler(),
+        {
+          async handleLLMEnd(output: LLMResult) {
+            callbackResult = output;
+          },
+        },
+      ],
+    });
+
+    expect(callbackResult?.llmOutput?.tokenUsage).toEqual({
+      promptTokens: res.usage_metadata?.input_tokens,
+      completionTokens: res.usage_metadata?.output_tokens,
+      totalTokens: res.usage_metadata?.total_tokens,
+    });
+  });
 });


### PR DESCRIPTION
`_streamIterator` and `_generateWithCache` in `@langchain/core` built `llmOutput.tokenUsage` from whichever streamed chunk arrived last, instead of summing all chunks — wrong for providers (`@langchain/google`, `@langchain/anthropic`) that emit usage as per-chunk deltas.

Fixes:

[#11424](https://github.com/langchain-ai/langchainjs/issues/11424)

Also populates `llmOutput` in `@langchain/google`'s `invoke({streaming: true})` path, which didn't set it at all.