### PR TITLE
fix(google-genai): forward abort signal to non-streaming generateContent

### DIFF
--- a/.changeset/google-genai-abort-signal.md
+++ b/.changeset/google-genai-abort-signal.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): forward abort signals to non-streaming generateContent calls

--- a/libs/providers/langchain-google-genai/src/chat_models.ts
+++ b/libs/providers/langchain-google-genai/src/chat_models.ts
@@ -933,7 +933,8 @@ export class ChatGoogleGenerativeAI
     }
 
     const res = await this.completionWithRetry(
-      this._buildGenerateContentRequest(messages, options)
+      this._buildGenerateContentRequest(messages, options),
+      options
     );
 
     let usageMetadata: UsageMetadata | undefined;

--- a/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
+++ b/libs/providers/langchain-google-genai/src/tests/chat_models.test.ts
@@ -139,10 +139,12 @@ test("Google AI - passes system instruction and response schema per request", as
     },
   } as unknown as Schema;
   const requests: GenerateContentRequest[] = [];
-  vi.spyOn(model, "completionWithRetry").mockImplementation(async (request) => {
-    requests.push(request as GenerateContentRequest);
-    return { response: mockGenerateContentResponse("ok") } as never;
-  });
+  vi.spyOn(model, "completionWithRetry").mockImplementation(
+    async (request, _options) => {
+      requests.push(request as GenerateContentRequest);
+      return { response: mockGenerateContentResponse("ok") } as never;
+    }
+  );
 
   await model.invoke(
     [new SystemMessage("First system instruction"), new HumanMessage("Hello")],
@@ -167,6 +169,26 @@ test("Google AI - passes system instruction and response schema per request", as
   expect(client.systemInstruction).toBeUndefined();
   expect(client.generationConfig.responseSchema).toBeUndefined();
   expect(client.generationConfig.responseMimeType).toBeUndefined();
+});
+
+test("Google AI - forwards call options to non-streaming completion", async () => {
+  const model = new ChatGoogleGenerativeAI({
+    apiKey: "testing",
+    model: "gemini-2.0-flash",
+  });
+  const signal = new AbortController().signal;
+  const completionWithRetry = vi
+    .spyOn(model, "completionWithRetry")
+    .mockResolvedValue({
+      response: mockGenerateContentResponse("ok"),
+    } as never);
+
+  await model.invoke([new HumanMessage("Hello")], { signal });
+
+  expect(completionWithRetry).toHaveBeenCalledWith(
+    expect.any(Object),
+    expect.objectContaining({ signal })
+  );
 });
 
 test("Google AI - `safetySettings` category array must be unique", async () => {


### PR DESCRIPTION
Non-streaming `ChatGoogleGenerativeAI._generate` now passes `options` as the second argument to `completionWithRetry`, so the caller's `AbortSignal` reaches `generateContent`, matching the streaming path and what `completionWithRetry` already implements (`callWithOptions` plus SDK `{ signal }`). `_generate` previously called `completionWithRetry` with only the request. Pre-flight `options.signal?.throwIfAborted()` still ran, but a timeout or abort after the request started was ignored and the fetch ran (and billed) to completion.

Related: #10501 (open, conflicts with main, same one-line fix) and closed unmerged #11401. Same class of bug as #10470 / #10471 in `@langchain/google`.

Streaming `_streamChatModelEvents` / `_streamResponseChunks` are unchanged.

Fixes #11388

## Decision

The unit test spies `completionWithRetry` and asserts it receives `{ signal }` (same as #11401 / #10501). The alternative is to mock `client.generateContent`, abort after the call starts, and assert the same `AbortSignal` object reached the SDK (what #10471 does for `ChatGoogle`, and what was offered on this issue). `completionWithRetry` already forwards `options?.signal` to both the retry caller and `generateContent`, so the spy is the smallest reversible check. Can switch to the generateContent test.

## Test plan

- [x] Unit test: `invoke` with `{ signal }` forwards that signal to `completionWithRetry` (fake API key, no Gemini network)
- [x] Test fails without the one-line pass-through and passes with it
- [x] Existing `chat_models.test.ts` suite (45 tests) passes
- [ ] Optional live check: `invoke(..., { signal: AbortSignal.timeout(1) })` against Gemini
