### PR TITLE
feat(mcp-adapters): add MCPAdapter API and consolidate Zod4 boundaries

### DIFF
--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -11,3 +11,7 @@ Hook `state` is now typed as `unknown` rather than an object record. Its runtime
 Remove `useStandardContentBlocks`; tool content always uses standard LangChain blocks. Update image/audio consumers to use `data` and `mimeType`. Artifact-routed blocks keep their MCP format, including when passed through `afterToolCall`; resource reads remain explicit.
 
 Resource types now derive from the MCP SDK. `readResource()` preserves SDK content metadata; narrow with `"text" in content` or `"blob" in content` before accessing those fields.
+
+Prefer `listTools()`; `getTools()` remains a compatibility alias. Connections now default to modern protocol mode. Add `mode: "legacy"` to legacy stdio, Streamable HTTP, and SSE server definitions. Modern connections never negotiate legacy or fall back to SSE. Unknown and incompatible configuration fields fail with Zod errors, including empty server maps.
+
+Move notification and progress callbacks into each server configuration. `onInitialized` and SSE fallback are legacy-only. Remove `onRootsListChanged`: roots notifications originate from clients, so this server observer did not implement roots support. Supply workspace paths through tool parameters, resource URIs, or server configuration instead. Global LangChain hooks, naming, output policies, and load-error handling remain adapter options.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -6,6 +6,6 @@ Use `MCPAdapter({ servers })` as the canonical client API. `MultiServerMCPClient
 
 Upgrade to Zod 4. Configuration now rejects conflicting options and unknown output-handling keys. Hook argument overrides must be objects. Configuration snapshots preserve callbacks and OAuth provider identity.
 
-Hook `state` is now `unknown` because LangGraph task inputs can be objects, arrays, or primitives. The value is unchanged; narrow it before accessing application-specific fields. Outside a graph, hooks still receive `{}`.
+Hook `state` is now typed as `unknown` rather than an object record. Its runtime value is unchanged. Applications must narrow it before accessing properties.
 
 Remove `useStandardContentBlocks`; tool content always uses standard LangChain blocks. Update image/audio consumers to use `data` and `mimeType`. Artifact-routed blocks keep their MCP format, including when passed through `afterToolCall`; resource reads remain explicit.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -2,14 +2,10 @@
 "@langchain/mcp-adapters": major
 ---
 
-Add the canonical `MCPAdapter({ servers })` API, retaining `MultiServerMCPClient` as a deprecated alias. Require Zod4, replace duplicated notification schemas with SDK types, and validate hook modifications after awaiting sync or async callbacks. Reject conflicting configuration spellings and unknown output-handling keys. Preserve callbacks and OAuth providers in configuration snapshots.
+Use `MCPAdapter({ servers })` as the canonical client API. `MultiServerMCPClient` and existing server-map configurations remain supported; the old class name is deprecated.
 
-Notification options are isolated per event. Legacy servers named `servers` and explicitly undefined output destinations remain supported.
+Upgrade to Zod 4. Configuration now rejects conflicting options and unknown output-handling keys. Hook argument overrides must be objects. Configuration snapshots preserve callbacks and OAuth provider identity.
 
-Parse configuration into connections with a required transport discriminator. Infer adapter-owned configuration and hook types from Zod schemas, and merge object-shaped argument overrides without mutating the original request.
+Hook `state` is now `unknown` because LangGraph task inputs can be objects, arrays, or primitives. The value is unchanged; narrow it before accessing application-specific fields. Outside a graph, hooks still receive `{}`.
 
-Parse error formatting data without asserting a Zod error version, check hook content/artifact elements, and validate required OAuth methods without replacing the provider. Remove type assertions from tool invocation and schema traversal.
-
-Hook callbacks receive the current LangGraph task input unchanged, or `{}` outside a graph. The `state` parameter is now `unknown` because a task can receive an object, array, or primitive; applications must narrow it before accessing properties.
-
-Remove `useStandardContentBlocks`: always emit standard LangChain content blocks, keep artifact-routed blocks in MCP format, and require explicit resource reads. Migrate image/audio consumers to `data` and `mimeType`.
+Remove `useStandardContentBlocks`; tool content always uses standard LangChain blocks. Update image/audio consumers to use `data` and `mimeType`. Artifact-routed blocks keep their MCP format, including when passed through `afterToolCall`; resource reads remain explicit.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -5,3 +5,5 @@
 Add the canonical `MCPAdapter({ servers })` API, retaining `MultiServerMCPClient` as a deprecated alias. Require Zod4, replace duplicated notification schemas with SDK types, and validate hook modifications after awaiting sync or async callbacks. Reject conflicting configuration spellings and unknown output-handling keys. Preserve callbacks and OAuth providers in configuration snapshots.
 
 Notification options are isolated per event. Legacy servers named `servers` and explicitly undefined output destinations remain supported.
+
+Parse configuration into connections with a required transport discriminator. Infer adapter-owned configuration and hook types from Zod schemas, and merge object-shaped argument overrides without mutating the original request.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -10,4 +10,4 @@ Parse configuration into connections with a required transport discriminator. In
 
 Parse error formatting data without asserting a Zod error version, check hook content/artifact elements, and validate required OAuth methods without replacing the provider. Remove type assertions from tool invocation and schema traversal.
 
-Preserve arbitrary LangGraph task inputs in hooks; type hook state as `unknown` so applications narrow their own state without assuming a record.
+Hook callbacks receive the current LangGraph task input unchanged, or `{}` outside a graph. The `state` parameter is now `unknown` because a task can receive an object, array, or primitive; applications must narrow it before accessing properties.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -9,3 +9,5 @@ Notification options are isolated per event. Legacy servers named `servers` and 
 Parse configuration into connections with a required transport discriminator. Infer adapter-owned configuration and hook types from Zod schemas, and merge object-shaped argument overrides without mutating the original request.
 
 Parse error formatting data without asserting a Zod error version, check hook content/artifact elements, and validate required OAuth methods without replacing the provider. Remove type assertions from tool invocation and schema traversal.
+
+Preserve arbitrary LangGraph task inputs in hooks; type hook state as `unknown` so applications narrow their own state without assuming a record.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -3,3 +3,5 @@
 ---
 
 Add the canonical `MCPAdapter({ servers })` API, retaining `MultiServerMCPClient` as a deprecated alias. Require Zod4, replace duplicated notification schemas with SDK types, and validate hook modifications after awaiting sync or async callbacks. Reject conflicting configuration spellings and unknown output-handling keys. Preserve callbacks and OAuth providers in configuration snapshots.
+
+Notification options are isolated per event. Legacy servers named `servers` and explicitly undefined output destinations remain supported.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -9,3 +9,5 @@ Upgrade to Zod 4. Configuration now rejects conflicting options and unknown outp
 Hook `state` is now typed as `unknown` rather than an object record. Its runtime value is unchanged. Applications must narrow it before accessing properties.
 
 Remove `useStandardContentBlocks`; tool content always uses standard LangChain blocks. Update image/audio consumers to use `data` and `mimeType`. Artifact-routed blocks keep their MCP format, including when passed through `afterToolCall`; resource reads remain explicit.
+
+Resource types now derive from the MCP SDK. `readResource()` preserves SDK content metadata; narrow with `"text" in content` or `"blob" in content` before accessing those fields.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -1,0 +1,5 @@
+---
+"@langchain/mcp-adapters": major
+---
+
+Add the canonical `MCPAdapter({ servers })` API, retaining `MultiServerMCPClient` as a deprecated alias. Require Zod4, replace duplicated notification schemas with SDK types, and validate hook modifications after awaiting sync or async callbacks. Reject conflicting configuration spellings and unknown output-handling keys. Preserve callbacks and OAuth providers in configuration snapshots.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -11,3 +11,5 @@ Parse configuration into connections with a required transport discriminator. In
 Parse error formatting data without asserting a Zod error version, check hook content/artifact elements, and validate required OAuth methods without replacing the provider. Remove type assertions from tool invocation and schema traversal.
 
 Hook callbacks receive the current LangGraph task input unchanged, or `{}` outside a graph. The `state` parameter is now `unknown` because a task can receive an object, array, or primitive; applications must narrow it before accessing properties.
+
+Remove `useStandardContentBlocks`: always emit standard LangChain content blocks, keep artifact-routed blocks in MCP format, and require explicit resource reads. Migrate image/audio consumers to `data` and `mimeType`.

--- a/.changeset/mcp-adapter-config-zod4.md
+++ b/.changeset/mcp-adapter-config-zod4.md
@@ -7,3 +7,5 @@ Add the canonical `MCPAdapter({ servers })` API, retaining `MultiServerMCPClient
 Notification options are isolated per event. Legacy servers named `servers` and explicitly undefined output destinations remain supported.
 
 Parse configuration into connections with a required transport discriminator. Infer adapter-owned configuration and hook types from Zod schemas, and merge object-shaped argument overrides without mutating the original request.
+
+Parse error formatting data without asserting a Zod error version, check hook content/artifact elements, and validate required OAuth methods without replacing the provider. Remove type assertions from tool invocation and schema traversal.

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -642,8 +642,12 @@ The library provides different error types to help with debugging:
 Example error handling:
 
 ```ts
+import { MCPAdapter } from "@langchain/mcp-adapters";
+import { isInteropZodError } from "@langchain/core/utils/types";
+
+let client: MCPAdapter | undefined;
 try {
-  const client = new MCPAdapter({
+  client = new MCPAdapter({
     servers: {
       math: {
         mode: "legacy",
@@ -654,26 +658,18 @@ try {
     },
   });
 
-  const tools = await client.listTools();
-  const result = await tools[0].invoke({ expression: "1 + 2" });
+  const [tool] = await client.listTools();
+  if (!tool) throw new Error("No tools available");
+  console.log(await tool.invoke({ expression: "1 + 2" }));
 } catch (error) {
-  if (error.name === "MCPClientError") {
-    // Handle connection issues
-    console.error(`Connection error (${error.serverName}):`, error.message);
-  } else if (error.name === "ToolException") {
-    // Handle tool execution errors
-    console.error("Tool execution failed:", error.message);
-  } else if (error.name === "ZodError") {
-    // Handle configuration validation errors
-    console.error("Configuration error:", error.issues);
-    // Zod errors contain detailed information about what went wrong
-    error.issues.forEach((issue) => {
-      console.error(`- Path: ${issue.path.join(".")}, Error: ${issue.message}`);
-    });
+  if (isInteropZodError(error)) {
+    console.error("Configuration error:", error);
   } else {
-    // Handle other errors
-    console.error("Unexpected error:", error);
+    // Connection and tool errors retain their original cause for inspection.
+    console.error("MCP operation failed:", error);
   }
+} finally {
+  await client?.close();
 }
 ```
 

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -67,6 +67,7 @@ const client = new MCPAdapter({
   servers: {
     // adds a STDIO connection to a server named "math"
     math: {
+      mode: "legacy",
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-math"],
@@ -80,18 +81,18 @@ const client = new MCPAdapter({
 
     // here's a filesystem server
     filesystem: {
+      mode: "legacy",
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-filesystem"],
     },
 
-    // Streamable HTTP transport example, with auth headers and automatic SSE fallback disabled (defaults to enabled)
+    // Modern Streamable HTTP transport with authentication headers
     weather: {
       url: "https://example.com/weather/mcp",
       headers: {
         Authorization: "Bearer token123",
       },
-      automaticSSEFallback: false,
     },
 
     // OAuth 2.0 authentication (recommended for secure servers)
@@ -104,8 +105,9 @@ const client = new MCPAdapter({
       },
     },
 
-    // how to force SSE, for old servers that are known to only support SSE (streamable HTTP falls back automatically if unsure)
+    // Explicit legacy SSE endpoint
     github: {
+      mode: "legacy",
       transport: "sse", // also works with "type" field instead of "transport"
       url: "https://example.com/mcp",
       reconnect: {
@@ -117,7 +119,7 @@ const client = new MCPAdapter({
   },
 });
 
-const tools = await client.getTools();
+const tools = await client.listTools();
 
 // Create an OpenAI model
 const model = new ChatOpenAI({
@@ -143,13 +145,14 @@ try {
 ```
 
 Construction validates configuration; discovery and invocation open connections.
-No MCP SDK import is needed for this workflow. Use `transport: "sse"` for a
-known legacy SSE endpoint. The current default still uses legacy negotiation;
-modern request rounds and elicitation are separate work in this release stack.
+No MCP SDK import is needed for this workflow. Connections default to `mode: "modern"`
+and require the current modern protocol. Set `mode: "legacy"` for a legacy
+stdio, Streamable HTTP, or SSE server. Modern connections never fall back to SSE.
 
 `MultiServerMCPClient` is a deprecated alias of `MCPAdapter`. Existing
 `mcpServers` and direct server-map configurations remain accepted; new code
-should use `servers`. Do not combine `servers` with `mcpServers`, or conflicting
+should use `servers` and `listTools()`. `getTools()` remains a compatibility alias.
+The old constructor names use the same mode validation. Do not combine `servers` with `mcpServers`, or conflicting
 `transport` and legacy `type` values. See the [migration guide](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md)
 for Zod4, callback and configuration changes.
 
@@ -223,7 +226,7 @@ For more detailed examples, see the [examples](./examples) directory.
 
 ## Notifications and Progress
 
-You can subscribe to server notifications and tool progress events directly on the `MCPAdapter` via top‑level callbacks.
+You can subscribe to server notifications and tool progress events on the server configuration that owns them. Callbacks are not top-level adapter options.
 
 ```ts
 import { MCPAdapter } from "@langchain/mcp-adapters";
@@ -231,37 +234,39 @@ import { MCPAdapter } from "@langchain/mcp-adapters";
 const client = new MCPAdapter({
   servers: {
     everything: {
+      mode: "legacy",
       transport: "stdio",
+      // Receive log/notification messages from the server
+      onMessage: (log, source) => {
+        console.log(`[${source.server}] ${log.data}`);
+      },
+
+      // Receive progress updates (e.g. from long‑running tool calls)
+      onProgress: (progress, source) => {
+        const pct =
+          progress.progress != null && progress.total
+            ? Math.round((progress.progress / progress.total) * 100)
+            : undefined;
+        if (pct != null) {
+          const origin =
+            source.type === "tool"
+              ? `${source.server}/${source.name}`
+              : "unknown";
+          console.log(`[progress:${origin}] ${pct}%`);
+        }
+      },
+
+      // Optional: react to server-side list changes
+      onToolsListChanged: (source) => {
+        console.log(`[${source.server}] tools changed`);
+      },
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-everything"],
     },
   },
-
-  // Receive log/notification messages from the server
-  onMessage: (log, source) => {
-    console.log(`[${source.server}] ${log.data}`);
-  },
-
-  // Receive progress updates (e.g. from long‑running tool calls)
-  onProgress: (progress, source) => {
-    const pct =
-      progress.progress != null && progress.total
-        ? Math.round((progress.progress / progress.total) * 100)
-        : undefined;
-    if (pct != null) {
-      const origin =
-        source.type === "tool" ? `${source.server}/${source.name}` : "unknown";
-      console.log(`[progress:${origin}] ${pct}%`);
-    }
-  },
-
-  // Optional: react to server-side list changes
-  onToolsListChanged: (source) => {
-    console.log(`[${source.server}] tools changed`);
-  },
 });
 
-const tools = await client.getTools();
+const tools = await client.listTools();
 // ... invoke tools as usual ...
 await client.close();
 ```
@@ -270,8 +275,13 @@ Available notification callbacks you can register:
 
 - **onMessage**: server log/diagnostic messages
 - **onProgress**: progress events (`progress` and optional `total`) with `source` describing origin (e.g., tool name/server)
-- **onInitialized**, **onCancelled**
-- **onPromptsListChanged**, **onResourcesListChanged**, **onResourcesUpdated**, **onRootsListChanged**, **onToolsListChanged**
+- **onInitialized**: legacy only; **onCancelled**: cancellation notifications not consumed by the SDK
+- **onPromptsListChanged**, **onResourcesListChanged**, **onResourcesUpdated**, **onToolsListChanged**
+
+`onRootsListChanged` was removed: roots changes are sent by clients, not observed
+from servers. Pass workspace paths through tool arguments, resource URIs, or
+server configuration. Modern subscription cancellation is handled by the SDK;
+`onCancelled` observes notifications the SDK does not consume.
 
 ## Tool Hooks (modify args/results)
 
@@ -283,6 +293,7 @@ import { MCPAdapter } from "@langchain/mcp-adapters";
 const client = new MCPAdapter({
   servers: {
     math: {
+      mode: "legacy",
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-math"],
@@ -315,7 +326,7 @@ const client = new MCPAdapter({
   },
 });
 
-const tools = await client.getTools();
+const tools = await client.listTools();
 const t = tools.find((tool) => tool.name.includes("add"));
 const out = await t?.invoke({ a: 1, b: 2 });
 ```
@@ -451,7 +462,7 @@ const client = new MCPAdapter({
   defaultToolTimeout: 10000, // 10 seconds
 });
 
-const tools = await client.getTools();
+const tools = await client.listTools();
 const slowTool = tools.find((t) => t.name.includes("process_large_dataset"));
 
 // Will timeout after 30 seconds (defaultToolTimeout)
@@ -472,7 +483,7 @@ const client = new MCPAdapter({
   },
 });
 
-const tools = await client.getTools();
+const tools = await client.listTools();
 const slowTool = tools.find((t) => t.name.includes("process_large_dataset"));
 
 // You can use withConfig to set tool-specific timeouts before handing
@@ -608,6 +619,7 @@ Both transport types support automatic reconnection:
 
 ```ts
 {
+  mode: "legacy",
   transport: "sse",
   url: "https://example.com/mcp-server",
   headers: { "Authorization": "Bearer token123" },
@@ -634,6 +646,7 @@ try {
   const client = new MCPAdapter({
     servers: {
       math: {
+        mode: "legacy",
         transport: "stdio",
         command: "npx",
         args: ["-y", "@modelcontextprotocol/server-math"],
@@ -641,7 +654,7 @@ try {
     },
   });
 
-  const tools = await client.getTools();
+  const tools = await client.listTools();
   const result = await tools[0].invoke({ expression: "1 + 2" });
 } catch (error) {
   if (error.name === "MCPClientError") {
@@ -720,7 +733,7 @@ const client = new MCPAdapter({
 });
 
 // This won't throw even though "broken-server" fails to connect
-const tools = await client.getTools(); // Only tools from "working-server"
+const tools = await client.listTools(); // Only tools from "working-server"
 
 // You can check which servers are actually connected
 const workingClient = await client.getClient("working-server"); // Returns client

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -103,8 +103,8 @@ const client = new MCPAdapter({
       authProvider,
       // Can still include custom headers for non-auth purposes
       headers: {
-        "User-Agent": "My-MCP-Client/1.0"
-      }
+        "User-Agent": "My-MCP-Client/1.0",
+      },
     },
 
     // how to force SSE, for old servers that are known to only support SSE (streamable HTTP falls back automatically if unsure)
@@ -250,9 +250,9 @@ const client = new MCPAdapter({
   // Receive progress updates (e.g. from long‑running tool calls)
   onProgress: (progress, source) => {
     const pct =
-      (progress.progress != null && progress.total
+      progress.progress != null && progress.total
         ? Math.round((progress.progress / progress.total) * 100)
-        : undefined);
+        : undefined;
     if (pct != null) {
       const origin =
         source.type === "tool" ? `${source.server}/${source.name}` : "unknown";

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -442,7 +442,9 @@ Similarly, when calling tools on the `microphone` MCP server, the following `out
 
 You can configure a global timeout for all tools by setting the `defaultToolTimeout` field in the client params. You can include a `defaultToolTimeout` field in the server config to set the timeout for all tools for that server, or globally for the entire client by setting it in the top-level config.
 
-This timeout will be used as the default timeout for all tools unless overridden by a tool-specific timeout.
+A top-level `defaultToolTimeout` takes precedence over server-level defaults.
+When the top-level setting is omitted, each server uses its own default. A
+tool-specific timeout can override the resulting default.
 
 ```typescript
 const client = new MCPAdapter({
@@ -450,7 +452,7 @@ const client = new MCPAdapter({
     "data-processor": {
       command: "python",
       args: ["data_server.py"],
-      defaultToolTimeout: 30000, // timeout will be 30 seconds
+      defaultToolTimeout: 30000, // used when no top-level default is set
     },
     "image-processor": {
       transport: "stdio",
@@ -465,7 +467,7 @@ const client = new MCPAdapter({
 const tools = await client.listTools();
 const slowTool = tools.find((t) => t.name.includes("process_large_dataset"));
 
-// Will timeout after 30 seconds (defaultToolTimeout)
+// Will timeout after 10 seconds (the top-level defaultToolTimeout)
 const result = await slowTool.invoke({ dataset: "huge_file.csv" });
 ```
 

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -38,123 +38,42 @@ This library provides a lightweight wrapper that makes [Anthropic Model Context 
 npm install @langchain/mcp-adapters
 ```
 
-# Example: Connect to one or more servers via `MultiServerMCPClient`
-
-The library allows you to connect to one or more MCP servers and load tools from them, without needing to manage your own MCP client instances.
+## Connect servers and use their tools
 
 ```ts
+import { MCPAdapter } from "@langchain/mcp-adapters";
 import { createAgent } from "langchain";
-import { ChatOpenAI } from "@langchain/openai";
-import { MultiServerMCPClient } from "@langchain/mcp-adapters";
 
-// Create client and connect to server
-const client = new MultiServerMCPClient({
-  // Global tool configuration options
-  // Whether to throw on errors if a tool fails to load (optional, default: true)
-  throwOnLoadError: true,
-  // Whether to prefix tool names with the server name (optional, default: false)
-  prefixToolNameWithServerName: false,
-  // Optional additional prefix for tool names (optional, default: "")
-  additionalToolNamePrefix: "",
-
-  // Use standardized content block format in tool outputs
-  useStandardContentBlocks: true,
-
-  // Behavior when a server fails to connect: "throw" (default) or "ignore"
-  onConnectionError: "ignore",
-
-  // Server configuration
-  mcpServers: {
-    // adds a STDIO connection to a server named "math"
-    math: {
-      transport: "stdio",
-      command: "npx",
-      args: ["-y", "@modelcontextprotocol/server-math"],
-      // Restart configuration for stdio transport
-      restart: {
-        enabled: true,
-        maxAttempts: 3,
-        delayMs: 1000,
-      },
-    },
-
-    // here's a filesystem server
-    filesystem: {
-      transport: "stdio",
-      command: "npx",
-      args: ["-y", "@modelcontextprotocol/server-filesystem"],
-    },
-
-    // Sreamable HTTP transport example, with auth headers and automatic SSE fallback disabled (defaults to enabled)
-    weather: {
-      url: "https://example.com/weather/mcp",
-      headers: {
-        Authorization: "Bearer token123",
-      }
-      automaticSSEFallback: false
-    },
-
-    // OAuth 2.0 authentication (recommended for secure servers)
-    "oauth-protected-server": {
-      url: "https://protected.example.com/mcp",
-      authProvider: new MyOAuthProvider({
-        // Your OAuth provider implementation
-        redirectUrl: "https://myapp.com/oauth/callback",
-        clientMetadata: {
-          redirect_uris: ["https://myapp.com/oauth/callback"],
-          client_name: "My MCP Client",
-          scope: "mcp:read mcp:write"
-        }
-      }),
-      // Can still include custom headers for non-auth purposes
-      headers: {
-        "User-Agent": "My-MCP-Client/1.0"
-      }
-    },
-
-    // how to force SSE, for old servers that are known to only support SSE (streamable HTTP falls back automatically if unsure)
-    github: {
-      transport: "sse", // also works with "type" field instead of "transport"
-      url: "https://example.com/mcp",
-      reconnect: {
-        enabled: true,
-        maxAttempts: 5,
-        delayMs: 2000,
-      },
-    },
+const adapter = new MCPAdapter({
+  servers: {
+    weather: { transport: "http", url: "https://example.com/weather/mcp" },
+    local: { transport: "stdio", command: "node", args: ["./server.js"] },
   },
+  prefixToolNameWithServerName: true,
 });
 
-const tools = await client.getTools();
-
-// Create an OpenAI model
-const model = new ChatOpenAI({
-  model: "gpt-4o-mini",
-  temperature: 0,
-});
-
-// Create the React agent
-const agent = createAgent({
-  llm: model,
-  tools,
-});
-
-// Run the agent
 try {
-  const mathResponse = await agent.invoke({
-    messages: [{ role: "user", content: "what's (3 + 5) x 12?" }],
+  const tools = await adapter.getTools();
+  const agent = createAgent({ model: "openai:gpt-4.1-mini", tools });
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "What is the weather in Paris?" }],
   });
-  console.log(mathResponse);
-} catch (error) {
-  console.error("Error during agent execution:", error);
-  // Tools throw ToolException for tool-specific errors
-  if (error.name === "ToolException") {
-    console.error("Tool execution failed:", error.message);
-  }
+  console.log(result.messages);
+} finally {
+  await adapter.close();
 }
-
-await client.close();
 ```
+
+Construction validates configuration; discovery and invocation open connections.
+No MCP SDK import is needed for this workflow. Use `transport: "sse"` for a
+known legacy SSE endpoint. The current default still uses legacy negotiation;
+modern request rounds and elicitation are separate work in this release stack.
+
+`MultiServerMCPClient` is a deprecated alias of `MCPAdapter`. Existing
+`mcpServers` and direct server-map configurations remain accepted; new code
+should use `servers`. Do not combine `servers` with `mcpServers`, or conflicting
+`transport` and legacy `type` values. See the [migration guide](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md)
+for Zod4, callback and configuration changes.
 
 # Example: Manage the MCP Client yourself
 

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -60,9 +60,6 @@ const client = new MCPAdapter({
   // Optional additional prefix for tool names (optional, default: "")
   additionalToolNamePrefix: "",
 
-  // Use standardized content block format in tool outputs
-  useStandardContentBlocks: true,
-
   // Behavior when a server fails to connect: "throw" (default) or "ignore"
   onConnectionError: "ignore",
 
@@ -206,8 +203,6 @@ try {
     prefixToolNameWithServerName: false,
     // Optional additional prefix for tool names (optional, default: "")
     additionalToolNamePrefix: "",
-    // Use standardized content block format in tool outputs (default: false)
-    useStandardContentBlocks: false,
   });
 
   // Create and run the agent
@@ -333,7 +328,7 @@ Notes:
 ## Tool Configuration Options
 
 > [!TIP]
-> The `useStandardContentBlocks` defaults to `false` for backward compatibility, however we recommend setting it to `true` for new applications, as this will likely become the default in a future release.
+> Tool content always uses standard LangChain blocks. Use `outputHandling` to choose which outputs reach the model.
 
 When loading MCP tools either directly through `loadMcpTools` or via `MCPAdapter`, you can configure the following options:
 
@@ -342,7 +337,6 @@ When loading MCP tools either directly through `loadMcpTools` or via `MCPAdapter
 | `throwOnLoadError`             | `boolean`                              | `true`                                                | Whether to throw an error if a tool fails to load                                                    |
 | `prefixToolNameWithServerName` | `boolean`                              | `false`                                               | If true, prefixes all tool names with the server name (e.g., `serverName__toolName`)                 |
 | `additionalToolNamePrefix`     | `string`                               | `""`                                                  | Additional prefix to add to tool names (e.g., `prefix__serverName__toolName`)                        |
-| `useStandardContentBlocks`     | `boolean`                              | `false`                                               | See [Tool Output Mapping](#tool-output-mapping); set true for new applications                       |
 | `outputHandling`               | `"content"`, `"artifact"`, or `object` | `resource` -> `"artifact"`, all others -> `"content"` | See [Tool Output Mapping](#tool-output-mapping)                                                      |
 | `defaultToolTimeout`           | `number`                               | `0`                                                   | Default timeout for all tools (overridable on a per-tool basis)                                      |
 | `onConnectionError`            | `"throw"` \| `"ignore"` \| `Function`  | `"throw"`                                             | Behavior when a server fails to connect. See [Connection Error Handling](#connection-error-handling) |
@@ -350,41 +344,32 @@ When loading MCP tools either directly through `loadMcpTools` or via `MCPAdapter
 ## Tool Output Mapping
 
 > [!TIP]
-> This section is important if you are working with multimodal tools, tools that produce embedded resources, or tools that produce large outputs that you may not want to be included in LLM input context. If you are writing a new application that only works with tools that produce simple text or JSON output, we recommend setting `useStandardContentBlocks` to `true` and leaving `outputHandling` undefined (will use defaults).
+> This section is important if you are working with multimodal tools, tools that produce embedded resources, or tools that produce large outputs that you may not want to be included in LLM input context. If you are writing a new application that only works with tools that produce simple text or JSON output, leave `outputHandling` undefined to use the defaults.
 
-MCP tools return arrays of content blocks. A content block can contain text, an image, audio, or an embedded resource. The right way to map these outputs into LangChain `ToolMessage` objects can differ based on the needs of your application, which is why we introduced the `useStandardContentBlocks` and `outputHandling` configuration options.
+MCP tools return arrays of content blocks. A content block can contain text, an image, audio, or an embedded resource. The right way to map these outputs into LangChain `ToolMessage` objects can differ based on the needs of your application, which is why the adapter provides the `outputHandling` option.
 
-The `useStandardContentBlocks` field determines how individual MCP content blocks are transformed into a structure recognized by LangChain ChatModel providers (e.g. `ChatOpenAI`, `ChatAnthropic`, etc). The `outputHandling` field allows you to specify whether a given type of content should be sent to the LLM, or set aside for some other part of your application to use in some future processing step (e.g. to use a dataframe from a database query in a code execution environment).
+The `outputHandling` field allows you to specify whether a given type of content should be sent to the LLM, or set aside for some other part of your application to use in some future processing step (e.g. to use a dataframe from a database query in a code execution environment).
 
 ### Standardizing the Format of Tool Outputs
 
-In `@langchain/core` version 0.3.48 we created a new set of content block types that offer a standardized structure for multimodal inputs. As you might guess from the name, the `useStandardContentBlocks` setting determines whether `@langchain/mcp-adapters` converts tool outputs to this format. For backward compatibility with older versions of `@langchain/mcp-adapters`, it also determines whether tool message artifacts are converted. See the conversion rules below for more info.
+LangChain core introduced standard multimodal blocks in version 0.3.48. Earlier
+adapter releases offered `useStandardContentBlocks` to opt into those formats
+while retaining older provider-specific shapes. This major release removes that
+toggle: images and audio now use `{ type, data, mimeType }` blocks. Update code
+that reads `image_url`, `source_type`, or `mime_type` to the standard fields.
 
-> [!IMPORTANT] > `ToolMessage.content` and `ToolMessage.artifact` will always be arrays of content block objects as described by the rules below, except in one special case. When the `outputHandling` option routes `text` output to the `ToolMessage.content` field and the only content block produced by a tool call is a `text` block, `ToolMessage.content` will be a `string` containing the text content produced by the tool.
+Text stays text, and embedded resources are converted according to their MIME
+type. Artifact-routed blocks retain their original MCP format. Conversion does
+not fetch resource links; call `readResource` explicitly when needed.
 
-**When `useStandardContentBlocks` is `true` (recommended for new applications):**
-
-- **Text**: Returned as [`StandardTextBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardTextBlock.html) objects.
-- **Images**: Returned as base64 [`StandardImageBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardImageBlock.html) objects.
-- **Audio**: Returned as base64 [`StandardAudioBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardAudioBlock.html) objects.
-- **Embedded Resources**: Returned as [`StandardFileBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardFileBlock.html), with a `source_type` of `text` or `base64` depending on whether the resource was binary or text. URI resources are fetched eagerly from the server and the results of the fetch are returned following these same rules. We treat all embedded resource URIs as resolvable by the server, and we do not attempt to fetch external URIs.
-
-**When `useStandardContentBlocks` is `false` (default for backward compatibility):**
-
-- Tool outputs routed to `ToolMessage.artifact` (controlled by the `outputHandling` option):
-  - **Embedded Resources**: Embedded resources containing only a URI are fetched eagerly from the server and the results of the fetch operation are stored in the artifact array without transformation. Otherwise embedded resources are stored in the `artifact` array in their original MCP content block structure without modification.
-  - **All other content types**: Stored in the `artifact` array in their original MCP content block structure without modification.
-- Tool outputs routed to the `ToolMessage.content` array (controlled by the `outputHandling` option):
-  - **Text**: Returned as [`MessageContentText`](https://v03.api.js.langchain.com/types/_langchain_core.messages.MessageContentText.html) objects, unless it is the only content block in the output, in which case it's assigned directly to `ToolMessage.content` as a `string`.
-  - **Images**: Returned as [`MessageContentImageUrl`](https://v03.api.js.langchain.com/types/_langchain_core.messages.MessageContentImageUrl.html) objects with base64 data URLs (`data:image/png;base64,<data>`)
-  - **Audio**: Returned as [`StandardAudioBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardAudioBlock.html) objects.
-  - **Embedded Resources**: Returned as [`StandardFileBlock`](https://v03.api.js.langchain.com/types/_langchain_core.messages.StandardFileBlock.html), with a `source_type` of `text` or `base64` depending on whether the resource was binary or text. URI resources are fetched eagerly from the server and the results of the fetch are returned following these same rules. We treat all embedded resource URIs as resolvable by the server, and we do not attempt to fetch external URIs.
+A single plain-text result is returned as a string. Other content is returned as
+an array of blocks; `ToolMessage.artifact` holds outputs routed away from the model.
 
 ### Determining Which Tool Outputs will be Visible to the LLM
 
 The `outputHandling` option allows you to determine which tool output types are assigned to `ToolMessage.content`, and which are assigned to `ToolMessage.artifact`. Data in [`ToolMessage.content`](https://v03.api.js.langchain.com/classes/_langchain_core.messages_tool.ToolMessage.html#content) is used as input context when the LLM is invoked, while [`ToolMessage.artifact`](https://v03.api.js.langchain.com/classes/_langchain_core.messages_tool.ToolMessage.html#artifact) is not.
 
-**By default** `@langchain/mcp-adapters` maps MCP `resource` content blocks to `ToolMessage.artifact`, and maps all other MCP content block types to `ToolMessage.content`. The value of [`useStandardContentBlocks`](#standardizing-the-format-of-tool-outputs) determines how the structure of each content block is transformed during this process.
+**By default** `@langchain/mcp-adapters` maps MCP `resource` content blocks to `ToolMessage.artifact`, and maps all other MCP content block types to `ToolMessage.content`. See [Standardizing the Format of Tool Outputs](#standardizing-the-format-of-tool-outputs) for the resulting shapes.
 
 > [!TIP]
 > Examples where `ToolMessage.artifact` can be useful include cases when you need to send multimodal tool outputs via `HumanMessage` or `SystemMessage` because the LLM provider API doesn't accept multimodal tool outputs, or cases where one tool might produce a large output to be indirectly manipulated by some other tool (e.g. a query tool that loads dataframes into a Python code execution environment).
@@ -397,7 +382,6 @@ For example, consider the following configuration:
 
 ```typescript
 const clientConfig = {
-  useStandardContentBlocks: true,
   outputHandling: {
     image: "artifact",
     audio: "artifact",
@@ -486,7 +470,6 @@ const client = new MCPAdapter({
       args: ["data_server.py"],
     },
   },
-  useStandardContentBlocks: true,
 });
 
 const tools = await client.getTools();
@@ -577,7 +560,6 @@ const client = new MCPAdapter({
       }),
     },
   },
-  useStandardContentBlocks: true,
 });
 ```
 
@@ -657,7 +639,6 @@ try {
         args: ["-y", "@modelcontextprotocol/server-math"],
       },
     },
-    useStandardContentBlocks: true,
   });
 
   const tools = await client.getTools();
@@ -736,7 +717,6 @@ const client = new MCPAdapter({
     },
   },
   onConnectionError: "ignore", // Skip failed connections
-  useStandardContentBlocks: true,
 });
 
 // This won't throw even though "broken-server" fails to connect
@@ -769,7 +749,6 @@ const client = new MCPAdapter({
     // For optional servers, just log and continue
     console.warn(`Optional server ${serverName} failed, continuing...`);
   },
-  useStandardContentBlocks: true,
 });
 ```
 

--- a/libs/langchain-mcp-adapters/README.md
+++ b/libs/langchain-mcp-adapters/README.md
@@ -38,29 +38,110 @@ This library provides a lightweight wrapper that makes [Anthropic Model Context 
 npm install @langchain/mcp-adapters
 ```
 
-## Connect servers and use their tools
+## Connect to one or more servers
+
+The library allows you to connect to one or more MCP servers and load tools from them, without needing to manage your own MCP client instances.
 
 ```ts
-import { MCPAdapter } from "@langchain/mcp-adapters";
 import { createAgent } from "langchain";
+import { ChatOpenAI } from "@langchain/openai";
+import { MCPAdapter, type OAuthClientProvider } from "@langchain/mcp-adapters";
 
-const adapter = new MCPAdapter({
-  servers: {
-    weather: { transport: "http", url: "https://example.com/weather/mcp" },
-    local: { transport: "stdio", command: "node", args: ["./server.js"] },
-  },
+// Supply your application-owned OAuth provider; see OAuth setup below.
+declare const authProvider: OAuthClientProvider;
+
+// Create client and connect to server
+const client = new MCPAdapter({
+  // Global tool configuration options
+  // Whether to throw on errors if a tool fails to load (optional, default: true)
+  throwOnLoadError: true,
+  // Avoid tool-name collisions when servers expose tools with the same name
   prefixToolNameWithServerName: true,
+  // Optional additional prefix for tool names (optional, default: "")
+  additionalToolNamePrefix: "",
+
+  // Use standardized content block format in tool outputs
+  useStandardContentBlocks: true,
+
+  // Behavior when a server fails to connect: "throw" (default) or "ignore"
+  onConnectionError: "ignore",
+
+  // Server configuration
+  servers: {
+    // adds a STDIO connection to a server named "math"
+    math: {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-math"],
+      // Restart configuration for stdio transport
+      restart: {
+        enabled: true,
+        maxAttempts: 3,
+        delayMs: 1000,
+      },
+    },
+
+    // here's a filesystem server
+    filesystem: {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem"],
+    },
+
+    // Streamable HTTP transport example, with auth headers and automatic SSE fallback disabled (defaults to enabled)
+    weather: {
+      url: "https://example.com/weather/mcp",
+      headers: {
+        Authorization: "Bearer token123",
+      },
+      automaticSSEFallback: false,
+    },
+
+    // OAuth 2.0 authentication (recommended for secure servers)
+    "oauth-protected-server": {
+      url: "https://protected.example.com/mcp",
+      authProvider,
+      // Can still include custom headers for non-auth purposes
+      headers: {
+        "User-Agent": "My-MCP-Client/1.0"
+      }
+    },
+
+    // how to force SSE, for old servers that are known to only support SSE (streamable HTTP falls back automatically if unsure)
+    github: {
+      transport: "sse", // also works with "type" field instead of "transport"
+      url: "https://example.com/mcp",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 5,
+        delayMs: 2000,
+      },
+    },
+  },
 });
 
+const tools = await client.getTools();
+
+// Create an OpenAI model
+const model = new ChatOpenAI({
+  model: "gpt-4o-mini",
+  temperature: 0,
+});
+
+// Create the React agent
+const agent = createAgent({
+  model,
+  tools,
+});
+
+// Run the agent
 try {
-  const tools = await adapter.getTools();
-  const agent = createAgent({ model: "openai:gpt-4.1-mini", tools });
-  const result = await agent.invoke({
-    messages: [{ role: "user", content: "What is the weather in Paris?" }],
+  const mathResponse = await agent.invoke({
+    messages: [{ role: "user", content: "what's (3 + 5) x 12?" }],
   });
-  console.log(result.messages);
+  console.log(mathResponse);
 } finally {
-  await adapter.close();
+  await client.close();
 }
 ```
 
@@ -79,7 +160,7 @@ for Zod4, callback and configuration changes.
 
 This example shows how you can manage your own MCP client and use it to get LangChain tools. These tools can be used anywhere LangChain tools are used, including with LangGraph prebuilt agents, as shown below.
 
-This is an optional advanced API. `MultiServerMCPClient` manages the SDK client
+This is an optional advanced API. `MCPAdapter` manages the SDK client
 for you and does not require a separate SDK installation. Install
 `@modelcontextprotocol/client` directly only when your application imports and
 constructs its own SDK client, as this example does.
@@ -130,7 +211,7 @@ try {
   });
 
   // Create and run the agent
-  const agent = createAgent({ llm: model, tools });
+  const agent = createAgent({ model, tools });
   const agentResponse = await agent.invoke({
     messages: [{ role: "user", content: "what's (3 + 5) x 12?" }],
   });
@@ -147,13 +228,13 @@ For more detailed examples, see the [examples](./examples) directory.
 
 ## Notifications and Progress
 
-You can subscribe to server notifications and tool progress events directly on the `MultiServerMCPClient` via top‑level callbacks.
+You can subscribe to server notifications and tool progress events directly on the `MCPAdapter` via top‑level callbacks.
 
 ```ts
-import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { MCPAdapter } from "@langchain/mcp-adapters";
 
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     everything: {
       transport: "stdio",
       command: "npx",
@@ -169,7 +250,6 @@ const client = new MultiServerMCPClient({
   // Receive progress updates (e.g. from long‑running tool calls)
   onProgress: (progress, source) => {
     const pct =
-      progress.percentage ??
       (progress.progress != null && progress.total
         ? Math.round((progress.progress / progress.total) * 100)
         : undefined);
@@ -181,8 +261,8 @@ const client = new MultiServerMCPClient({
   },
 
   // Optional: react to server-side list changes
-  onToolsListChanged: (evt, source) => {
-    console.log(`[${source.server}] tools changed (${evt.tools?.length ?? 0})`);
+  onToolsListChanged: (source) => {
+    console.log(`[${source.server}] tools changed`);
   },
 });
 
@@ -194,7 +274,7 @@ await client.close();
 Available notification callbacks you can register:
 
 - **onMessage**: server log/diagnostic messages
-- **onProgress**: progress events (includes `percentage` or `progress`/`total`) with `source` describing origin (e.g., tool name/server)
+- **onProgress**: progress events (`progress` and optional `total`) with `source` describing origin (e.g., tool name/server)
 - **onInitialized**, **onCancelled**
 - **onPromptsListChanged**, **onResourcesListChanged**, **onResourcesUpdated**, **onRootsListChanged**, **onToolsListChanged**
 
@@ -203,10 +283,10 @@ Available notification callbacks you can register:
 Use hooks to customize tool calls:
 
 ```ts
-import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { MCPAdapter } from "@langchain/mcp-adapters";
 
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     math: {
       transport: "stdio",
       command: "npx",
@@ -215,12 +295,11 @@ const client = new MultiServerMCPClient({
   },
 
   // Change args/headers before the tool call
-  beforeToolCall: ({ serverName, name, args }) => {
-    // Add/override an argument
-    const nextArgs = { ...(args as Record<string, unknown>), injected: true };
+  beforeToolCall: () => {
+    // Overrides are merged with the original arguments by the adapter.
     // For HTTP/SSE transports, you may also add per-call headers
     return {
-      args: nextArgs,
+      args: { injected: true },
       headers: { "X-Request-ID": crypto.randomUUID() },
     };
   },
@@ -249,14 +328,14 @@ const out = await t?.invoke({ a: 1, b: 2 });
 Notes:
 
 - **beforeToolCall** can return `{ args?, headers? }`. Headers are supported for HTTP/SSE. Stdio connections do not support custom headers.
-- **afterToolCall** may return either a 2‑tuple `[content, artifact]`, a `ToolMessage`, a `Command` instance, or nothing (to keep the original result).
+- **afterToolCall** may return `{ result }`, where `result` is a string, a 2‑tuple `[content, artifact]`, a `ToolMessage`, or a `Command`. Return nothing to keep the original result.
 
 ## Tool Configuration Options
 
 > [!TIP]
 > The `useStandardContentBlocks` defaults to `false` for backward compatibility, however we recommend setting it to `true` for new applications, as this will likely become the default in a future release.
 
-When loading MCP tools either directly through `loadMcpTools` or via `MultiServerMCPClient`, you can configure the following options:
+When loading MCP tools either directly through `loadMcpTools` or via `MCPAdapter`, you can configure the following options:
 
 | Option                         | Type                                   | Default                                               | Description                                                                                          |
 | ------------------------------ | -------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
@@ -312,7 +391,7 @@ The `outputHandling` option allows you to determine which tool output types are 
 
 The `outputHandling` option can be assigned to `"content"`, `"artifact"`, or an object that maps MCP content block types to either `content` or `artifact`.
 
-When working with `MultiServerMCPClient`, the `outputHandling` field can be assigned to the top-level config object and/or to individual server entries in `mcpServers`. Entries in `mcpServers` override those in the top-level config, and entries in the top-level config override the defaults.
+When working with `MCPAdapter`, the `outputHandling` field can be assigned to the top-level config object and/or to individual server entries in `servers`. Entries in `servers` override those in the top-level config, and entries in the top-level config override the defaults.
 
 For example, consider the following configuration:
 
@@ -323,7 +402,7 @@ const clientConfig = {
     image: "artifact",
     audio: "artifact",
   },
-  mcpServers: {
+  servers: {
     camera-server: {
       url: "...",
       outputHandling: {
@@ -371,8 +450,8 @@ You can configure a global timeout for all tools by setting the `defaultToolTime
 This timeout will be used as the default timeout for all tools unless overridden by a tool-specific timeout.
 
 ```typescript
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     "data-processor": {
       command: "python",
       args: ["data_server.py"],
@@ -400,8 +479,8 @@ const result = await slowTool.invoke({ dataset: "huge_file.csv" });
 MCP tools support timeout configuration through LangChain's standard `RunnableConfig` interface. This allows you to set custom timeouts on a per-tool-call basis:
 
 ```typescript
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     "data-processor": {
       command: "python",
       args: ["data_server.py"],
@@ -484,8 +563,8 @@ class MyOAuthProvider implements OAuthClientProvider {
   // See MCP SDK documentation for complete examples
 }
 
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     "secure-server": {
       url: "https://secure-mcp-server.example.com/mcp",
       authProvider: new MyOAuthProvider({
@@ -570,8 +649,8 @@ Example error handling:
 
 ```ts
 try {
-  const client = new MultiServerMCPClient({
-    mcpServers: {
+  const client = new MCPAdapter({
+    servers: {
       math: {
         transport: "stdio",
         command: "npx",
@@ -630,7 +709,7 @@ Example Zod error for an invalid SSE URL:
 
 ### Connection Error Handling
 
-By default, the `MultiServerMCPClient` will throw an error if any server fails to connect (`onConnectionError: "throw"`). You can change this behavior by setting `onConnectionError: "ignore"` to skip failed servers, or provide a custom error handler function:
+By default, the `MCPAdapter` will throw an error if any server fails to connect (`onConnectionError: "throw"`). You can change this behavior by setting `onConnectionError: "ignore"` to skip failed servers, or provide a custom error handler function:
 
 - `"throw"` (default): Throw an error immediately if any server fails to connect
 - `"ignore"`: Skip failed servers and continue with successfully connected ones
@@ -644,8 +723,8 @@ When set to `"ignore"` or a custom handler that doesn't throw:
 - If no servers successfully connect, a warning is logged but no error is thrown
 
 ```ts
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     "working-server": {
       transport: "stdio",
       command: "npx",
@@ -671,8 +750,8 @@ const brokenClient = await client.getClient("broken-server"); // Returns undefin
 You can also provide a custom error handler function for more control:
 
 ```ts
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     "critical-server": {
       transport: "http",
       url: "http://localhost:8000/mcp",

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -105,7 +105,13 @@ validated after awaiting the callback, for both synchronous and asynchronous
 implementations. Return `undefined` for no change, `{ args, headers }` before a
 call, or `{ result }` after it. Argument overrides must be objects and are merged
 without mutating the original request arguments. Invalid return containers now fail consistently;
-`Command` and `ToolMessage` values must be real native values. Detailed
+`Command` and `ToolMessage` values must pass their framework predicates.
+Content and artifact arrays now check each block's extensible `type`/optional
+`id` boundary; embedded resource artifacts use the SDK's resource guard.
+Provider-specific fields and existing data-block formats remain supported.
+OAuth providers retain their identity, but their six required SDK methods must
+be callable. Metadata getters remain lazy. Numeric timeout overrides in
+`metadata.timeoutMs` are parsed before invoking the SDK. Detailed
 `outputHandling` objects reject unknown content-type keys instead of silently
 ignoring typos; explicit `undefined` destinations remain valid. Callback request `args` is a present field typed `unknown`.
 

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -130,3 +130,12 @@ Hook `state` is typed `unknown`: it is the unchanged LangGraph task input,
 including arrays and primitives from functional entrypoints. Narrow or parse it
 using your application schema before accessing fields. Calls outside LangGraph
 continue to receive `{}`.
+
+## Standard tool content
+
+Remove `useStandardContentBlocks` from adapter and `loadMcpTools` options. Tool
+content always uses standard LangChain blocks: images and audio expose `data`
+and `mimeType`, replacing `image_url`, `source_type`, and `mime_type` shapes.
+`outputHandling` still selects content versus artifact destinations. Artifact
+blocks retain their MCP representation. Resource conversion no longer fetches
+URIs implicitly; use `readResource` explicitly when needed.

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -89,7 +89,9 @@ try {
 The old class name is the same constructor, not a second implementation. Legacy
 configuration remains accepted. Use one server-map spelling and one transport
 selection; conflicting forms and connections combining `command` with `url` fail during construction. Legacy `type` is
-normalized to `transport` in the resolved configuration.
+normalized to a required `transport` discriminator in the resolved configuration.
+Use `connection.transport` to narrow resolved stdio, HTTP, or SSE options;
+resolved connections no longer expose the legacy `type` alias.
 
 The adapter now requires Zod `^4.2.0`; its configuration validation errors are
 Zod4 errors. Remove v3-only dependency overrides for this package. LangChain core
@@ -101,7 +103,8 @@ payloads use the SDK's types and validation; the adapter no longer reconstructs
 and strips their fields through duplicate schemas. Hook modifications are
 validated after awaiting the callback, for both synchronous and asynchronous
 implementations. Return `undefined` for no change, `{ args, headers }` before a
-call, or `{ result }` after it. Invalid return containers now fail consistently;
+call, or `{ result }` after it. Argument overrides must be objects and are merged
+without mutating the original request arguments. Invalid return containers now fail consistently;
 `Command` and `ToolMessage` values must be real native values. Detailed
 `outputHandling` objects reject unknown content-type keys instead of silently
 ignoring typos; explicit `undefined` destinations remain valid. Callback request `args` is a present field typed `unknown`.

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -125,3 +125,8 @@ event. Mutating that snapshot cannot reconfigure the adapter or alter the next
 notification's options. OAuth providers retain their application-owned identity.
 Direct legacy server maps can still contain a server named `servers`; the
 constructor distinguishes a connection definition from the canonical wrapper.
+
+Hook `state` is typed `unknown`: it is the unchanged LangGraph task input,
+including arrays and primitives from functional entrypoints. Narrow or parse it
+using your application schema before accessing fields. Calls outside LangGraph
+continue to receive `{}`.

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -104,9 +104,15 @@ implementations. Return `undefined` for no change, `{ args, headers }` before a
 call, or `{ result }` after it. Invalid return containers now fail consistently;
 `Command` and `ToolMessage` values must be real native values. Detailed
 `outputHandling` objects reject unknown content-type keys instead of silently
-ignoring typos. Callback request `args` is a present field typed `unknown`.
+ignoring typos; explicit `undefined` destinations remain valid. Callback request `args` is a present field typed `unknown`.
 
 `config` remains a snapshot using the legacy `mcpServers` field. Mutable options
 are copied; callback functions and OAuth provider instances retain their
 identity. Treat this as runtime configuration, not a JSON-serializable or
 redacted diagnostic object. Changing a snapshot does not reconfigure the adapter.
+
+Notification callbacks receive a fresh connection-options snapshot for each
+event. Mutating that snapshot cannot reconfigure the adapter or alter the next
+notification's options. OAuth providers retain their application-owned identity.
+Direct legacy server maps can still contain a server named `servers`; the
+constructor distinguishes a connection definition from the canonical wrapper.

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -64,3 +64,49 @@ package is used to exercise legacy-server interoperability.
 
 Both the SDK client and adapter provide ESM and CommonJS exports. The adapter's
 existing Node version requirement remains unchanged.
+
+## Canonical API and Zod4
+
+Rename `MultiServerMCPClient` to `MCPAdapter` and the configuration key
+`mcpServers` to `servers`. Keep `getTools()`, native LangChain tools and `close()`:
+
+```ts
+import { MCPAdapter } from "@langchain/mcp-adapters";
+
+const adapter = new MCPAdapter({
+  servers: {
+    local: { transport: "stdio", command: "node", args: ["./server.js"] },
+  },
+});
+try {
+  const tools = await adapter.getTools();
+  console.log(tools.map((tool) => tool.name));
+} finally {
+  await adapter.close();
+}
+```
+
+The old class name is the same constructor, not a second implementation. Legacy
+configuration remains accepted. Use one server-map spelling and one transport
+selection; conflicting forms and connections combining `command` with `url` fail during construction. Legacy `type` is
+normalized to `transport` in the resolved configuration.
+
+The adapter now requires Zod `^4.2.0`; its configuration validation errors are
+Zod4 errors. Remove v3-only dependency overrides for this package. LangChain core
+may still use Zod3 transitively. Recognition of caller-originated Zod errors uses
+core's interoperability helper and does not import the v3 runtime here.
+
+Callbacks are checked for callability during configuration. Notification
+payloads use the SDK's types and validation; the adapter no longer reconstructs
+and strips their fields through duplicate schemas. Hook modifications are
+validated after awaiting the callback, for both synchronous and asynchronous
+implementations. Return `undefined` for no change, `{ args, headers }` before a
+call, or `{ result }` after it. Invalid return containers now fail consistently;
+`Command` and `ToolMessage` values must be real native values. Detailed
+`outputHandling` objects reject unknown content-type keys instead of silently
+ignoring typos. Callback request `args` is a present field typed `unknown`.
+
+`config` remains a snapshot using the legacy `mcpServers` field. Mutable options
+are copied; callback functions and OAuth provider instances retain their
+identity. Treat this as runtime configuration, not a JSON-serializable or
+redacted diagnostic object. Changing a snapshot does not reconfigure the adapter.

--- a/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
+++ b/libs/langchain-mcp-adapters/docs/sdk-v2-migration.md
@@ -2,13 +2,14 @@
 
 The adapter uses the stable `@modelcontextprotocol/client` 2.x package. Existing
 legacy MCP servers remain supported over stdio, Streamable HTTP, and legacy SSE.
-The SDK upgrade preserves legacy negotiation by default; modern protocol support
-and elicitation require separate adapter features.
+Connections now default to modern protocol negotiation. Add `mode: "legacy"`
+to each existing legacy server configuration; SDK package version 2 does not
+mean a server uses the modern wire protocol.
 
 ## Applications using the adapter
 
-Existing `MultiServerMCPClient` configuration, `getTools()`, and `close()` remain
-available. Applications using these APIs do not need to construct an SDK client.
+The names `MultiServerMCPClient`, `mcpServers`, and `getTools()` remain compatibility
+aliases, but their configurations follow the same new mode validation. Applications using these APIs do not need to construct an SDK client.
 
 ## Applications supplying an SDK client
 
@@ -68,7 +69,7 @@ existing Node version requirement remains unchanged.
 ## Canonical API and Zod4
 
 Rename `MultiServerMCPClient` to `MCPAdapter` and the configuration key
-`mcpServers` to `servers`. Keep `getTools()`, native LangChain tools and `close()`:
+`mcpServers` to `servers`. Prefer `listTools()`; native LangChain tools and `close()` remain:
 
 ```ts
 import { MCPAdapter } from "@langchain/mcp-adapters";
@@ -79,7 +80,7 @@ const adapter = new MCPAdapter({
   },
 });
 try {
-  const tools = await adapter.getTools();
+  const tools = await adapter.listTools();
   console.log(tools.map((tool) => tool.name));
 } finally {
   await adapter.close();
@@ -87,7 +88,7 @@ try {
 ```
 
 The old class name is the same constructor, not a second implementation. Legacy
-configuration remains accepted. Use one server-map spelling and one transport
+configuration names remain accepted; they do not bypass protocol validation. Use one server-map spelling and one transport
 selection; conflicting forms and connections combining `command` with `url` fail during construction. Legacy `type` is
 normalized to a required `transport` discriminator in the resolved configuration.
 Use `connection.transport` to narrow resolved stdio, HTTP, or SSE options;
@@ -139,3 +140,32 @@ and `mimeType`, replacing `image_url`, `source_type`, and `mime_type` shapes.
 `outputHandling` still selects content versus artifact destinations. Artifact
 blocks retain their MCP representation. Resource conversion no longer fetches
 URIs implicitly; use `readResource` explicitly when needed.
+
+## Separate modern and legacy server options
+
+```ts
+const adapter = new MCPAdapter({
+  servers: {
+    modern: { url: "https://example.com/mcp" },
+    legacy: {
+      mode: "legacy",
+      url: "https://legacy.example.com/mcp",
+      automaticSSEFallback: true,
+      onMessage: (message) => console.log(message.data),
+    },
+  },
+});
+```
+
+Omitting `mode` means `"modern"`. Modern connections require the SDK's current
+modern protocol revision; there is no automatic fallback into legacy behavior.
+Explicit legacy mode supports stdio, Streamable HTTP, and SSE. `transport: "sse"`,
+`automaticSSEFallback`, and `onInitialized` require legacy mode. Invalid mode and
+transport combinations, unknown options, and empty server maps fail with Zod
+errors before opening a connection.
+
+Move notification and progress callbacks from the adapter root into each server
+that should receive them. Global LangChain tool hooks and naming/output policies
+remain available. `onRootsListChanged` has been removed: roots notifications
+originate from the client. Use tool arguments, resource URIs, or server
+configuration to supply workspace paths instead.

--- a/libs/langchain-mcp-adapters/examples/calculator_server_shttp_sse.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_server_shttp_sse.ts
@@ -50,10 +50,9 @@ export async function main() {
   app.use(express.json());
 
   // Store transports for each session type
-  const transports: {
-    streamable: Record<string, NodeStreamableHTTPServerTransport>;
-    sse: Record<string, SSEServerTransport>;
-  } = { streamable: {}, sse: {} };
+  const streamable: Record<string, NodeStreamableHTTPServerTransport> = {};
+  const sse: Record<string, SSEServerTransport> = {};
+  const transports = { streamable, sse };
 
   // Streamable HTTP endpoint using legacy protocol sessions
   app.post("/mcp", async (req, res) => {

--- a/libs/langchain-mcp-adapters/examples/calculator_server_shttp_sse.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_server_shttp_sse.ts
@@ -50,10 +50,10 @@ export async function main() {
   app.use(express.json());
 
   // Store transports for each session type
-  const transports = {
-    streamable: {} as Record<string, NodeStreamableHTTPServerTransport>,
-    sse: {} as Record<string, SSEServerTransport>,
-  };
+  const transports: {
+    streamable: Record<string, NodeStreamableHTTPServerTransport>;
+    sse: Record<string, SSEServerTransport>;
+  } = { streamable: {}, sse: {} };
 
   // Streamable HTTP endpoint using legacy protocol sessions
   app.post("/mcp", async (req, res) => {

--- a/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
@@ -59,7 +59,6 @@ export async function runExample(client?: MCPAdapter) {
             }`,
           },
         },
-        useStandardContentBlocks: true,
       });
 
     console.log("Connected to server");

--- a/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
@@ -54,6 +54,8 @@ export async function runExample(client?: MCPAdapter) {
       new MCPAdapter({
         servers: {
           calculator: {
+            mode: "legacy",
+            transport: transportType,
             url: `http://localhost:3000/${
               transportType === "sse" ? "sse" : "mcp"
             }`,

--- a/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
@@ -28,14 +28,14 @@ import dotenv from "dotenv";
 import { main as calculatorServerMain } from "./calculator_server_shttp_sse.js";
 
 // MCP client imports
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 
 // Load environment variables from .env file
 dotenv.config();
 
 const transportType = process.env.MCP_TRANSPORT_TYPE === "sse" ? "sse" : "http";
 
-export async function runExample(client?: MultiServerMCPClient) {
+export async function runExample(client?: MCPAdapter) {
   try {
     console.log("Initializing MCP client...");
 
@@ -51,8 +51,8 @@ export async function runExample(client?: MultiServerMCPClient) {
     // oxlint-disable-next-line no-param-reassign
     client =
       client ??
-      new MultiServerMCPClient({
-        mcpServers: {
+      new MCPAdapter({
+        servers: {
           calculator: {
             url: `http://localhost:3000/${
               transportType === "sse" ? "sse" : "mcp"

--- a/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
+++ b/libs/langchain-mcp-adapters/examples/calculator_sse_shttp_example.ts
@@ -64,7 +64,7 @@ export async function runExample(client?: MCPAdapter) {
     console.log("Connected to server");
 
     // Get all tools (flattened array is the default now)
-    const mcpTools = await client.getTools();
+    const mcpTools = await client.listTools();
 
     if (mcpTools.length === 0) {
       throw new Error("No tools found");

--- a/libs/langchain-mcp-adapters/examples/filesystem_langgraph_example.ts
+++ b/libs/langchain-mcp-adapters/examples/filesystem_langgraph_example.ts
@@ -28,7 +28,7 @@ import fs from "fs";
 import path from "path";
 
 // MCP client imports
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -37,7 +37,7 @@ dotenv.config();
  * Example demonstrating how to use MCP filesystem tools with LangGraph agent flows
  * This example focuses on file operations like reading multiple files and writing files
  */
-export async function runExample(client?: MultiServerMCPClient) {
+export async function runExample(client?: MCPAdapter) {
   try {
     console.log("Initializing MCP client...");
 
@@ -45,9 +45,10 @@ export async function runExample(client?: MultiServerMCPClient) {
     // oxlint-disable-next-line no-param-reassign
     client =
       client ??
-      new MultiServerMCPClient({
-        mcpServers: {
+      new MCPAdapter({
+        servers: {
           filesystem: {
+            mode: "legacy",
             transport: "stdio" as const,
             command: "npx",
             args: [
@@ -58,6 +59,7 @@ export async function runExample(client?: MultiServerMCPClient) {
           },
           // This server is not available - demonstrate onConnectionError: "ignore"
           "optional-math-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:9999/mcp",
           },
@@ -68,7 +70,7 @@ export async function runExample(client?: MultiServerMCPClient) {
     console.log("Connected to servers");
 
     // Get all tools (flattened array is the default now)
-    const mcpTools = await client.getTools();
+    const mcpTools = await client.listTools();
 
     if (mcpTools.length === 0) {
       throw new Error("No tools found");

--- a/libs/langchain-mcp-adapters/examples/filesystem_langgraph_example.ts
+++ b/libs/langchain-mcp-adapters/examples/filesystem_langgraph_example.ts
@@ -63,7 +63,6 @@ export async function runExample(client?: MultiServerMCPClient) {
           },
         },
         onConnectionError: "ignore",
-        useStandardContentBlocks: true,
       });
 
     console.log("Connected to servers");

--- a/libs/langchain-mcp-adapters/examples/firecrawl_custom_config_example.ts
+++ b/libs/langchain-mcp-adapters/examples/firecrawl_custom_config_example.ts
@@ -28,7 +28,6 @@ const config: ClientConfig = {
       },
     },
   },
-  useStandardContentBlocks: true,
 };
 
 /**

--- a/libs/langchain-mcp-adapters/examples/firecrawl_custom_config_example.ts
+++ b/libs/langchain-mcp-adapters/examples/firecrawl_custom_config_example.ts
@@ -10,7 +10,7 @@ import { HumanMessage, createAgent } from "langchain";
 import dotenv from "dotenv";
 
 // MCP client imports
-import { type ClientConfig, MultiServerMCPClient } from "../src/index.js";
+import { type MCPAdapterConfig, MCPAdapter } from "../src/index.js";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -18,9 +18,10 @@ dotenv.config();
 /**
  * A custom configuration for Firecrawl
  */
-const config: ClientConfig = {
-  mcpServers: {
+const config: MCPAdapterConfig = {
+  servers: {
     firecrawl: {
+      mode: "legacy",
       transport: "sse",
       url: process.env.FIRECRAWL_SERVER_URL || "http://localhost:8000/v1/mcp",
       headers: {
@@ -34,7 +35,7 @@ const config: ClientConfig = {
  * Example demonstrating loading from custom configuration
  */
 async function runExample() {
-  let client: MultiServerMCPClient | null = null;
+  let client: MCPAdapter | null = null;
 
   // Add a timeout to prevent the process from hanging indefinitely
   const timeout = setTimeout(() => {
@@ -45,10 +46,10 @@ async function runExample() {
   try {
     // Initialize the MCP client with the custom configuration
     console.log("Initializing MCP client from custom configuration...");
-    client = new MultiServerMCPClient(config);
+    client = new MCPAdapter(config);
 
     // Get Firecrawl tools specifically
-    const firecrawlTools = await client.getTools("firecrawl");
+    const firecrawlTools = await client.listTools("firecrawl");
 
     if (firecrawlTools.length === 0) {
       throw new Error("No Firecrawl tools found");

--- a/libs/langchain-mcp-adapters/examples/firecrawl_multiple_servers_example.ts
+++ b/libs/langchain-mcp-adapters/examples/firecrawl_multiple_servers_example.ts
@@ -9,7 +9,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { HumanMessage, createAgent } from "langchain";
 import dotenv from "dotenv";
 
-import { ClientConfig, MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapterConfig, MCPAdapter } from "../src/index.js";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -17,9 +17,10 @@ dotenv.config();
 /**
  * Configuration for multiple MCP servers
  */
-const multipleServersConfig: ClientConfig = {
-  mcpServers: {
+const multipleServersConfig: MCPAdapterConfig = {
+  servers: {
     firecrawl: {
+      mode: "legacy",
       transport: "stdio",
       command: "npx",
       args: ["-y", "firecrawl-mcp"],
@@ -30,6 +31,7 @@ const multipleServersConfig: ClientConfig = {
     },
     // Math server configuration
     math: {
+      mode: "legacy",
       transport: "stdio",
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-math"],
@@ -42,7 +44,7 @@ const multipleServersConfig: ClientConfig = {
  * This example creates and loads a configuration file with multiple servers
  */
 async function runExample() {
-  let client: MultiServerMCPClient | null = null;
+  let client: MCPAdapter | null = null;
 
   try {
     console.log(
@@ -50,12 +52,12 @@ async function runExample() {
     );
 
     // Create a client from the configuration file
-    client = new MultiServerMCPClient(multipleServersConfig);
+    client = new MCPAdapter(multipleServersConfig);
 
     console.log("Connected to servers from multiple servers configuration");
 
     // Get all tools from all servers
-    const mcpTools = await client.getTools();
+    const mcpTools = await client.listTools();
 
     if (mcpTools.length === 0) {
       throw new Error("No tools found");

--- a/libs/langchain-mcp-adapters/examples/firecrawl_multiple_servers_example.ts
+++ b/libs/langchain-mcp-adapters/examples/firecrawl_multiple_servers_example.ts
@@ -35,7 +35,6 @@ const multipleServersConfig: ClientConfig = {
       args: ["-y", "@modelcontextprotocol/server-math"],
     },
   },
-  useStandardContentBlocks: true,
 };
 
 /**

--- a/libs/langchain-mcp-adapters/examples/hooks.ts
+++ b/libs/langchain-mcp-adapters/examples/hooks.ts
@@ -1,18 +1,19 @@
 /**
  * Basic example showing how to use beforeToolCall and afterToolCall hooks
- * with the MultiServerMCPClient.
+ * with the MCPAdapter.
  *
  * This example connects to the official Filesystem MCP server over stdio,
  * then demonstrates:
  * - beforeToolCall: modifying tool arguments prior to invocation
  * - afterToolCall: modifying the tool result after invocation
  */
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 
 // Create MCP client with global interceptors
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     filesystem: {
+      mode: "legacy",
       transport: "stdio" as const,
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
@@ -45,7 +46,7 @@ const client = new MultiServerMCPClient({
 
 try {
   console.log("Initializing MCP client and discovering tools...");
-  const tools = await client.getTools();
+  const tools = await client.listTools();
 
   // Find the filesystem tool we want to demonstrate
   const listDir = tools.find((t) => t.name.includes("list_directory"));

--- a/libs/langchain-mcp-adapters/examples/langgraph_example.ts
+++ b/libs/langchain-mcp-adapters/examples/langgraph_example.ts
@@ -34,7 +34,7 @@ import { ToolNode } from "@langchain/langgraph/prebuilt";
 import dotenv from "dotenv";
 
 // MCP client imports
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -44,15 +44,16 @@ dotenv.config();
  * This example connects to a everything server and uses its tools
  */
 async function runExample() {
-  let client: MultiServerMCPClient | null = null;
+  let client: MCPAdapter | null = null;
 
   try {
     console.log("Initializing MCP client...");
 
     // Create a client with configurations for the everything server only
-    client = new MultiServerMCPClient({
-      mcpServers: {
+    client = new MCPAdapter({
+      servers: {
         everything: {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "npx",
           args: ["-y", "@modelcontextprotocol/server-everything"],
@@ -61,7 +62,7 @@ async function runExample() {
     });
 
     // Get the tools (flattened array is the default now)
-    const mcpTools = await client.getTools();
+    const mcpTools = await client.listTools();
 
     if (mcpTools.length === 0) {
       throw new Error("No tools found");

--- a/libs/langchain-mcp-adapters/examples/langgraph_example.ts
+++ b/libs/langchain-mcp-adapters/examples/langgraph_example.ts
@@ -58,7 +58,6 @@ async function runExample() {
           args: ["-y", "@modelcontextprotocol/server-everything"],
         },
       },
-      useStandardContentBlocks: true,
     });
 
     // Get the tools (flattened array is the default now)

--- a/libs/langchain-mcp-adapters/examples/mcp_over_docker_example.ts
+++ b/libs/langchain-mcp-adapters/examples/mcp_over_docker_example.ts
@@ -30,7 +30,6 @@ async function runExample() {
         ],
       },
     },
-    useStandardContentBlocks: true,
   });
 
   await runFileSystemExample(client);

--- a/libs/langchain-mcp-adapters/examples/mcp_over_docker_example.ts
+++ b/libs/langchain-mcp-adapters/examples/mcp_over_docker_example.ts
@@ -10,13 +10,14 @@
  * 3. Structured handling of complex multi-file operations
  */
 
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 import { runExample as runFileSystemExample } from "./filesystem_langgraph_example.js";
 
 async function runExample() {
-  const client = new MultiServerMCPClient({
-    mcpServers: {
+  const client = new MCPAdapter({
+    servers: {
       filesystem: {
+        mode: "legacy",
         transport: "stdio" as const,
         command: "docker",
         args: [

--- a/libs/langchain-mcp-adapters/examples/notifications.ts
+++ b/libs/langchain-mcp-adapters/examples/notifications.ts
@@ -22,11 +22,13 @@ const client = new MCPAdapter({
           progress.progress != null && progress.total
             ? Math.round((progress.progress / progress.total) * 100)
             : undefined;
+
         if (pct != null) {
           const origin =
             context.type === "tool"
               ? `${context.server}/${context.name}`
               : "unknown";
+
           console.log(`[progress:${origin}] ${pct}%`);
         }
       },

--- a/libs/langchain-mcp-adapters/examples/notifications.ts
+++ b/libs/langchain-mcp-adapters/examples/notifications.ts
@@ -1,38 +1,38 @@
 /**
  * Simple example showing how to listen for log events and progress updates
- * using @modelcontextprotocol/server-everything with MultiServerMCPClient.
+ * using @modelcontextprotocol/server-everything with MCPAdapter.
  */
 
-import { MultiServerMCPClient } from "../src/index.js";
+import { MCPAdapter } from "../src/index.js";
 
 // Create an MCP client that starts the Everything server over stdio
-const client = new MultiServerMCPClient({
-  mcpServers: {
+const client = new MCPAdapter({
+  servers: {
     everything: {
+      mode: "legacy",
       transport: "stdio" as const,
+      // Receive log/notification messages from the server
+      onMessage: (log, context) => {
+        console.log(`[${context.server}] ${log.data}`);
+      },
+
+      // Receive progress updates (e.g. from long‑running tool calls)
+      onProgress: (progress, context) => {
+        const pct =
+          progress.progress != null && progress.total
+            ? Math.round((progress.progress / progress.total) * 100)
+            : undefined;
+        if (pct != null) {
+          const origin =
+            context.type === "tool"
+              ? `${context.server}/${context.name}`
+              : "unknown";
+          console.log(`[progress:${origin}] ${pct}%`);
+        }
+      },
       command: "npx",
       args: ["-y", "@modelcontextprotocol/server-everything"],
     },
-  },
-
-  // Receive log/notification messages from the server
-  onMessage: (log, context) => {
-    console.log(`[${context.server}] ${log.data}`);
-  },
-
-  // Receive progress updates (e.g. from long‑running tool calls)
-  onProgress: (progress, context) => {
-    const pct =
-      progress.progress != null && progress.total
-        ? Math.round((progress.progress / progress.total) * 100)
-        : undefined;
-    if (pct != null) {
-      const origin =
-        context.type === "tool"
-          ? `${context.server}/${context.name}`
-          : "unknown";
-      console.log(`[progress:${origin}] ${pct}%`);
-    }
   },
 });
 
@@ -40,7 +40,7 @@ try {
   console.log(
     "Connecting to @modelcontextprotocol/server-everything and discovering tools..."
   );
-  const tools = await client.getTools();
+  const tools = await client.listTools();
   console.log(`Loaded ${tools.length} tools`);
 
   if (tools.length === 0) {

--- a/libs/langchain-mcp-adapters/package.json
+++ b/libs/langchain-mcp-adapters/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "debug": "^4.4.3",
-    "zod": "^3.25.76 || ^4",
+    "zod": "^4.2.0",
     "@modelcontextprotocol/client": "^2.0.0"
   },
   "peerDependencies": {

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -520,6 +520,7 @@ export class MCPAdapter {
     try {
       debugLog(`INFO: Reading resource "${uri}" from server "${serverName}"`);
       const result = await client.readResource({ uri });
+
       return result.contents;
     } catch (error) {
       throw new MCPClientError(

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -687,13 +687,16 @@ export class MCPAdapter {
 
     // SDK 2 HTTP errors use status; SSE errors use a numeric code.
     if ("status" in error && isHttpStatus(error.status)) return error.status;
+
     if ("code" in error && isHttpStatus(error.code)) return error.code;
 
     if (!("message" in error) || typeof error.message !== "string") {
       return undefined;
     }
+
     const match = error.message.match(/\(HTTP (\d{3})\)/);
     const status = match ? Number(match[1]) : undefined;
+
     return isHttpStatus(status) ? status : undefined;
   }
 

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -740,6 +740,7 @@ export class MCPAdapter {
     connection: ResolvedStreamableHTTPConnection
   ): Promise<void> {
     const { url, transport: transportType } = connection;
+
     const automaticSSEFallback =
       connection.mode === "legacy" && connection.automaticSSEFallback;
 

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -8,12 +8,12 @@ import type {
 } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import type { DynamicStructuredTool } from "@langchain/core/tools";
-import { z } from "zod/v3";
 import { loadMcpTools } from "./tools.js";
 import { ConnectionManager, type Client } from "./connection.js";
 import { getDebugLog } from "./logging.js";
 import {
   type ClientConfig,
+  type MCPAdapterConfig,
   type Connection,
   type ResolvedClientConfig,
   type ResolvedConnection,
@@ -25,7 +25,6 @@ import {
   type MCPResourceContent,
   type ConnectionErrorHandler,
   clientConfigSchema,
-  connectionSchema,
   type LoadMcpToolsOptions,
   _resolveAndApplyOverrideHandlingOverrides,
 } from "./types.js";
@@ -118,7 +117,7 @@ function isResolvedStreamableHTTPConnection(
 /**
  * Client for connecting to multiple MCP servers and loading LangChain-compatible tools.
  */
-export class MultiServerMCPClient {
+export class MCPAdapter {
   /**
    * Cached map of server names to tools
    */
@@ -155,32 +154,74 @@ export class MultiServerMCPClient {
   #failedServers: Set<string> = new Set();
 
   /**
-   * Returns clone of server config for inspection purposes.
+   * Returns a configuration snapshot. Callbacks and OAuth providers retain their identity.
+   * This is runtime configuration, not a redacted or JSON-serializable diagnostic view.
    *
    * Client does not support config modifications.
    */
   get config(): ClientConfig {
     // clone config so it can't be mutated
-    return JSON.parse(JSON.stringify(this.#config));
+    return {
+      ...this.#config,
+      outputHandling:
+        typeof this.#config.outputHandling === "object"
+          ? { ...this.#config.outputHandling }
+          : this.#config.outputHandling,
+      mcpServers: Object.fromEntries(
+        Object.entries(this.#config.mcpServers).map(([name, connection]) => [
+          name,
+          {
+            ...connection,
+            outputHandling:
+              typeof connection.outputHandling === "object"
+                ? { ...connection.outputHandling }
+                : connection.outputHandling,
+            ...("command" in connection
+              ? {
+                  args: [...connection.args],
+                  env: connection.env && { ...connection.env },
+                  restart: connection.restart && { ...connection.restart },
+                }
+              : {
+                  headers: connection.headers && { ...connection.headers },
+                  reconnect: connection.reconnect && {
+                    ...connection.reconnect,
+                  },
+                }),
+          },
+        ])
+      ),
+    };
   }
 
   /**
-   * Create a new MultiServerMCPClient.
+   * Create an MCP adapter. Construction does not open connections.
    *
    * @param config - Configuration object
    */
-  constructor(config: ClientConfig | Record<string, Connection>) {
+  constructor(config: MCPAdapterConfig);
+  /** @deprecated Use `{ servers: { ... } }`. */
+  constructor(config: ClientConfig | Record<string, Connection>);
+  constructor(
+    config: MCPAdapterConfig | ClientConfig | Record<string, Connection>
+  ) {
     let parsedServerConfig: ResolvedClientConfig;
 
     const configSchema = clientConfigSchema;
 
-    if ("mcpServers" in config) {
+    if ("servers" in config && "mcpServers" in config) {
+      throw new Error("Specify servers or legacy mcpServers, not both");
+    }
+    if ("servers" in config) {
+      const { servers, ...options } = config;
+      parsedServerConfig = configSchema.parse({
+        ...options,
+        mcpServers: servers,
+      });
+    } else if ("mcpServers" in config) {
       parsedServerConfig = configSchema.parse(config);
     } else {
-      // two step parse so parse errors are referencing the correct object paths
-      const parsedMcpServers = z.record(connectionSchema).parse(config);
-
-      parsedServerConfig = configSchema.parse({ mcpServers: parsedMcpServers });
+      parsedServerConfig = configSchema.parse({ mcpServers: config });
     }
 
     if (Object.keys(parsedServerConfig.mcpServers).length === 0) {
@@ -1152,3 +1193,6 @@ export class MultiServerMCPClient {
     return allTools;
   }
 }
+
+/** @deprecated Use MCPAdapter. This alias shares the same implementation. */
+export { MCPAdapter as MultiServerMCPClient };

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   SSEClientTransport,
   StreamableHTTPClientTransport,
@@ -26,9 +27,17 @@ import {
   type ConnectionErrorHandler,
   clientConfigSchema,
   adapterConfigSchema,
+  customHTTPTransportOptionsSchema,
   type LoadMcpToolsOptions,
   _resolveAndApplyOverrideHandlingOverrides,
 } from "./types.js";
+
+const serverSelectionSchema = z.union([
+  z.array(z.string()).transform((servers) => ({ servers, options: undefined })),
+  z
+    .tuple([z.array(z.string()), customHTTPTransportOptionsSchema.optional()])
+    .transform(([servers, options]) => ({ servers, options })),
+]);
 
 const debugLog = getDebugLog();
 
@@ -107,10 +116,6 @@ export class MCPAdapter {
   ) {
     const parsedServerConfig = adapterConfigSchema.parse(config);
 
-    if (Object.keys(parsedServerConfig.mcpServers).length === 0) {
-      throw new MCPClientError("No MCP servers provided");
-    }
-
     for (const [serverName, serverConfig] of Object.entries(
       parsedServerConfig.mcpServers
     )) {
@@ -129,7 +134,7 @@ export class MCPAdapter {
         additionalToolNamePrefix: parsedServerConfig.additionalToolNamePrefix,
         ...(Object.keys(outputHandling).length > 0 ? { outputHandling } : {}),
         ...(defaultToolTimeout ? { defaultToolTimeout } : {}),
-        onProgress: parsedServerConfig.onProgress,
+        onProgress: serverConfig.onProgress,
         /**
          * make sure to place global hooks (e.g. parsedServerConfig) first before
          * server-specific hooks (e.g. serverConfig) so they can override tool call
@@ -142,7 +147,7 @@ export class MCPAdapter {
 
     this.#config = parsedServerConfig;
     this.#mcpServers = parsedServerConfig.mcpServers;
-    this.#clientConnections = new ConnectionManager(parsedServerConfig);
+    this.#clientConnections = new ConnectionManager();
     this.#onConnectionError = parsedServerConfig.onConnectionError;
   }
 
@@ -232,43 +237,46 @@ export class MCPAdapter {
    * @example
    * ```ts
    * // Get tools from all servers
-   * const tools = await client.getTools();
+   * const tools = await client.listTools();
    * ```
    *
    * @example
    * ```ts
    * // Get tools from specific servers
-   * const tools = await client.getTools("server1", "server2");
+   * const tools = await client.listTools("server1", "server2");
    * ```
    *
    * @example
    * ```ts
    * // Get tools from specific servers with custom connection options
-   * const tools = await client.getTools(["server1", "server2"], {
+   * const tools = await client.listTools(["server1", "server2"], {
    *   authProvider: new OAuthClientProvider(),
    *   headers: { "X-Custom-Header": "value" },
    * });
    * ```
    */
+  async listTools(...servers: string[]): Promise<DynamicStructuredTool[]>;
+  async listTools(
+    servers: string[],
+    options?: CustomHTTPTransportOptions
+  ): Promise<DynamicStructuredTool[]>;
+  async listTools(...args: unknown[]): Promise<DynamicStructuredTool[]> {
+    return this.#listTools(args);
+  }
+
+  /** @deprecated Use listTools(). Returns the same LangChain tools. */
   async getTools(...servers: string[]): Promise<DynamicStructuredTool[]>;
+  /** @deprecated Use listTools(). */
   async getTools(
     servers: string[],
     options?: CustomHTTPTransportOptions
   ): Promise<DynamicStructuredTool[]>;
   async getTools(...args: unknown[]): Promise<DynamicStructuredTool[]> {
-    if (args.length === 0 || args.every((arg) => typeof arg === "string")) {
-      await this.initializeConnections();
+    return this.#listTools(args);
+  }
 
-      const servers = args as string[];
-      return servers.length === 0
-        ? this._getAllToolsAsFlatArray()
-        : this._getToolsFromServers(servers);
-    }
-
-    const [servers, options] = args as [
-      string[],
-      CustomHTTPTransportOptions | undefined,
-    ];
+  async #listTools(args: unknown[]): Promise<DynamicStructuredTool[]> {
+    const { servers, options } = serverSelectionSchema.parse(args);
     await this.initializeConnections(options);
     return servers.length === 0
       ? this._getAllToolsAsFlatArray()
@@ -732,7 +740,8 @@ export class MCPAdapter {
     connection: ResolvedStreamableHTTPConnection
   ): Promise<void> {
     const { url, transport: transportType } = connection;
-    const automaticSSEFallback = connection.automaticSSEFallback ?? true;
+    const automaticSSEFallback =
+      connection.mode === "legacy" && connection.automaticSSEFallback;
 
     debugLog(
       `DEBUG: Creating Streamable HTTP transport for server "${serverName}" with URL: ${url}`

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -25,6 +25,8 @@ import {
   type MCPResourceContent,
   type ConnectionErrorHandler,
   clientConfigSchema,
+  connectionSchema,
+  _copyConnection,
   type LoadMcpToolsOptions,
   _resolveAndApplyOverrideHandlingOverrides,
 } from "./types.js";
@@ -170,25 +172,7 @@ export class MCPAdapter {
       mcpServers: Object.fromEntries(
         Object.entries(this.#config.mcpServers).map(([name, connection]) => [
           name,
-          {
-            ...connection,
-            outputHandling:
-              typeof connection.outputHandling === "object"
-                ? { ...connection.outputHandling }
-                : connection.outputHandling,
-            ...("command" in connection
-              ? {
-                  args: [...connection.args],
-                  env: connection.env && { ...connection.env },
-                  restart: connection.restart && { ...connection.restart },
-                }
-              : {
-                  headers: connection.headers && { ...connection.headers },
-                  reconnect: connection.reconnect && {
-                    ...connection.reconnect,
-                  },
-                }),
-          },
+          _copyConnection(connection),
         ])
       ),
     };
@@ -209,10 +193,19 @@ export class MCPAdapter {
 
     const configSchema = clientConfigSchema;
 
-    if ("servers" in config && "mcpServers" in config) {
+    // A direct legacy server map may itself contain a server named "servers".
+    const legacyServerNamedServers =
+      "servers" in config && connectionSchema.safeParse(config.servers).success;
+    if (
+      !legacyServerNamedServers &&
+      "servers" in config &&
+      "mcpServers" in config
+    ) {
       throw new Error("Specify servers or legacy mcpServers, not both");
     }
-    if ("servers" in config) {
+    if (legacyServerNamedServers) {
+      parsedServerConfig = configSchema.parse({ mcpServers: config });
+    } else if ("servers" in config) {
       const { servers, ...options } = config;
       parsedServerConfig = configSchema.parse({
         ...options,

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -520,12 +520,7 @@ export class MCPAdapter {
     try {
       debugLog(`INFO: Reading resource "${uri}" from server "${serverName}"`);
       const result = await client.readResource({ uri });
-      return result.contents.map((content) => ({
-        uri: content.uri,
-        mimeType: content.mimeType,
-        text: "text" in content ? content.text : undefined,
-        blob: "blob" in content ? content.blob : undefined,
-      }));
+      return result.contents;
     } catch (error) {
       throw new MCPClientError(
         `Failed to read resource "${uri}" from server "${serverName}": ${error}`,

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -127,7 +127,6 @@ export class MCPAdapter {
         prefixToolNameWithServerName:
           parsedServerConfig.prefixToolNameWithServerName,
         additionalToolNamePrefix: parsedServerConfig.additionalToolNamePrefix,
-        useStandardContentBlocks: parsedServerConfig.useStandardContentBlocks,
         ...(Object.keys(outputHandling).length > 0 ? { outputHandling } : {}),
         ...(defaultToolTimeout ? { defaultToolTimeout } : {}),
         onProgress: parsedServerConfig.onProgress,

--- a/libs/langchain-mcp-adapters/src/client.ts
+++ b/libs/langchain-mcp-adapters/src/client.ts
@@ -25,8 +25,7 @@ import {
   type MCPResourceContent,
   type ConnectionErrorHandler,
   clientConfigSchema,
-  connectionSchema,
-  _copyConnection,
+  adapterConfigSchema,
   type LoadMcpToolsOptions,
   _resolveAndApplyOverrideHandlingOverrides,
 } from "./types.js";
@@ -44,76 +43,6 @@ export class MCPClientError extends Error {
     super(message);
     this.name = "MCPClientError";
   }
-}
-
-/**
- * Checks if the connection configuration is for a stdio transport
- * @param connection - The connection configuration
- * @returns True if the connection configuration is for a stdio transport
- */
-function isResolvedStdioConnection(
-  connection: unknown
-): connection is ResolvedStdioConnection {
-  if (
-    typeof connection !== "object" ||
-    connection === null ||
-    Array.isArray(connection)
-  ) {
-    return false;
-  }
-
-  if ("transport" in connection && connection.transport === "stdio") {
-    return true;
-  }
-
-  if ("type" in connection && connection.type === "stdio") {
-    return true;
-  }
-
-  if ("command" in connection && typeof connection.command === "string") {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Checks if the connection configuration is for a streamable HTTP transport
- * @param connection - The connection configuration
- * @returns True if the connection configuration is for a streamable HTTP transport
- */
-function isResolvedStreamableHTTPConnection(
-  connection: unknown
-): connection is ResolvedStreamableHTTPConnection {
-  if (
-    typeof connection !== "object" ||
-    connection === null ||
-    Array.isArray(connection)
-  ) {
-    return false;
-  }
-
-  if (
-    ("transport" in connection &&
-      typeof connection.transport === "string" &&
-      ["http", "sse"].includes(connection.transport)) ||
-    ("type" in connection &&
-      typeof connection.type === "string" &&
-      ["http", "sse"].includes(connection.type))
-  ) {
-    return true;
-  }
-
-  if ("url" in connection && typeof connection.url === "string") {
-    try {
-      new URL(connection.url);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  return false;
 }
 
 /**
@@ -161,21 +90,8 @@ export class MCPAdapter {
    *
    * Client does not support config modifications.
    */
-  get config(): ClientConfig {
-    // clone config so it can't be mutated
-    return {
-      ...this.#config,
-      outputHandling:
-        typeof this.#config.outputHandling === "object"
-          ? { ...this.#config.outputHandling }
-          : this.#config.outputHandling,
-      mcpServers: Object.fromEntries(
-        Object.entries(this.#config.mcpServers).map(([name, connection]) => [
-          name,
-          _copyConnection(connection),
-        ])
-      ),
-    };
+  get config(): ResolvedClientConfig {
+    return clientConfigSchema.parse(this.#config);
   }
 
   /**
@@ -189,33 +105,7 @@ export class MCPAdapter {
   constructor(
     config: MCPAdapterConfig | ClientConfig | Record<string, Connection>
   ) {
-    let parsedServerConfig: ResolvedClientConfig;
-
-    const configSchema = clientConfigSchema;
-
-    // A direct legacy server map may itself contain a server named "servers".
-    const legacyServerNamedServers =
-      "servers" in config && connectionSchema.safeParse(config.servers).success;
-    if (
-      !legacyServerNamedServers &&
-      "servers" in config &&
-      "mcpServers" in config
-    ) {
-      throw new Error("Specify servers or legacy mcpServers, not both");
-    }
-    if (legacyServerNamedServers) {
-      parsedServerConfig = configSchema.parse({ mcpServers: config });
-    } else if ("servers" in config) {
-      const { servers, ...options } = config;
-      parsedServerConfig = configSchema.parse({
-        ...options,
-        mcpServers: servers,
-      });
-    } else if ("mcpServers" in config) {
-      parsedServerConfig = configSchema.parse(config);
-    } else {
-      parsedServerConfig = configSchema.parse({ mcpServers: config });
-    }
+    const parsedServerConfig = adapterConfigSchema.parse(config);
 
     if (Object.keys(parsedServerConfig.mcpServers).length === 0) {
       throw new MCPClientError("No MCP servers provided");
@@ -664,7 +554,7 @@ export class MCPAdapter {
     connection: ResolvedConnection,
     customTransportOptions?: CustomHTTPTransportOptions
   ): Promise<void> {
-    if (isResolvedStdioConnection(connection)) {
+    if (connection.transport === "stdio") {
       debugLog(
         `INFO: Initializing stdio connection to server "${serverName}"...`
       );
@@ -677,7 +567,10 @@ export class MCPAdapter {
       }
 
       await this._initializeStdioConnection(serverName, connection);
-    } else if (isResolvedStreamableHTTPConnection(connection)) {
+    } else if (
+      connection.transport === "http" ||
+      connection.transport === "sse"
+    ) {
       /**
        * Users may want to use different connection options for tool calls or tool discovery.
        */
@@ -700,7 +593,7 @@ export class MCPAdapter {
         return;
       }
 
-      if (connection.type === "sse" || connection.transport === "sse") {
+      if (connection.transport === "sse") {
         await this._initializeSSEConnection(serverName, updatedConnection);
       } else {
         await this._initializeStreamableHTTPConnection(
@@ -840,9 +733,8 @@ export class MCPAdapter {
     serverName: string,
     connection: ResolvedStreamableHTTPConnection
   ): Promise<void> {
-    const { url, type: typeField, transport: transportField } = connection;
+    const { url, transport: transportType } = connection;
     const automaticSSEFallback = connection.automaticSSEFallback ?? true;
-    const transportType = typeField || transportField;
 
     debugLog(
       `DEBUG: Creating Streamable HTTP transport for server "${serverName}" with URL: ${url}`
@@ -1103,10 +995,13 @@ export class MCPAdapter {
         }
 
         // Initialize just this connection based on its type
-        if (isResolvedStdioConnection(connection)) {
+        if (connection.transport === "stdio") {
           await this._initializeStdioConnection(serverName, connection);
-        } else if (isResolvedStreamableHTTPConnection(connection)) {
-          if (connection.type === "sse" || connection.transport === "sse") {
+        } else if (
+          connection.transport === "http" ||
+          connection.transport === "sse"
+        ) {
+          if (connection.transport === "sse") {
             await this._initializeSSEConnection(serverName, connection);
           } else {
             await this._initializeStreamableHTTPConnection(

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -15,7 +15,6 @@ import { getDebugLog } from "./logging.js";
 import type {
   ResolvedStreamableHTTPConnection,
   ResolvedStdioConnection,
-  ResolvedClientConfig,
 } from "./types.js";
 
 /**
@@ -57,30 +56,12 @@ export interface Connection {
 
 const transportTypes = ["http", "sse", "stdio"] as const;
 
-type ConnectionManagerConfig = Pick<
-  ResolvedClientConfig,
-  | "onCancelled"
-  | "onInitialized"
-  | "onMessage"
-  | "onPromptsListChanged"
-  | "onResourcesListChanged"
-  | "onResourcesUpdated"
-  | "onRootsListChanged"
-  | "onToolsListChanged"
->;
-
 /**
  * Manages a pool of MCP clients with different transport, server name and connection configurations.
  * This ensures we don't create multiple connections for the same server with the same configuration.
  */
 export class ConnectionManager {
   #connections: Map<ClientKeyObject, Connection> = new Map();
-  #hooks: ConnectionManagerConfig;
-
-  constructor(hooks: ConnectionManagerConfig = {}) {
-    this.#hooks = hooks;
-  }
-
   async createClient(
     type: "stdio",
     serverName: string,
@@ -108,33 +89,42 @@ export class ConnectionManager {
         : type === "sse"
           ? await this.#createSSETransport(serverName, options)
           : await this.#createStdioTransport(options);
-    const mcpClient = new MCPClient({
-      name: packageJson.name,
-      version: packageJson.version,
-    });
+    // SDK LATEST_PROTOCOL_VERSION still names the legacy revision; pin the
+    // modern revision explicitly so negotiation cannot fall back to legacy.
+    const mcpClient = new MCPClient(
+      {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+      {
+        versionNegotiation: {
+          mode: options.mode === "legacy" ? "legacy" : { pin: "2026-07-28" },
+        },
+      }
+    );
     await mcpClient.connect(transport);
 
-    if (this.#hooks.onMessage) {
+    if (options.onMessage) {
       mcpClient.setNotificationHandler(
         "notifications/message",
         (notification) =>
-          this.#hooks.onMessage?.(notification.params, {
+          options.onMessage?.(notification.params, {
             server: serverName,
             options: connectionSchema.parse(options),
           })
       );
     }
 
-    if (this.#hooks.onInitialized) {
+    if (options.onInitialized) {
       mcpClient.setNotificationHandler("notifications/initialized", () =>
-        this.#hooks.onInitialized?.({
+        options.onInitialized?.({
           server: serverName,
           options: connectionSchema.parse(options),
         })
       );
     }
 
-    if (this.#hooks.onCancelled) {
+    if (options.onCancelled) {
       mcpClient.setNotificationHandler(
         "notifications/cancelled",
         (notification) => {
@@ -144,7 +134,7 @@ export class ConnectionManager {
             return;
           }
 
-          const result = this.#hooks.onCancelled?.(
+          const result = options.onCancelled?.(
             { requestId, reason },
             {
               server: serverName,
@@ -161,51 +151,42 @@ export class ConnectionManager {
       );
     }
 
-    if (this.#hooks.onPromptsListChanged) {
+    if (options.onPromptsListChanged) {
       mcpClient.setNotificationHandler(
         "notifications/prompts/list_changed",
         () =>
-          this.#hooks.onPromptsListChanged?.({
+          options.onPromptsListChanged?.({
             server: serverName,
             options: connectionSchema.parse(options),
           })
       );
     }
 
-    if (this.#hooks.onResourcesListChanged) {
+    if (options.onResourcesListChanged) {
       mcpClient.setNotificationHandler(
         "notifications/resources/list_changed",
         () =>
-          this.#hooks.onResourcesListChanged?.({
+          options.onResourcesListChanged?.({
             server: serverName,
             options: connectionSchema.parse(options),
           })
       );
     }
 
-    if (this.#hooks.onResourcesUpdated) {
+    if (options.onResourcesUpdated) {
       mcpClient.setNotificationHandler(
         "notifications/resources/updated",
         (notification) =>
-          this.#hooks.onResourcesUpdated?.(notification.params, {
+          options.onResourcesUpdated?.(notification.params, {
             server: serverName,
             options: connectionSchema.parse(options),
           })
       );
     }
 
-    if (this.#hooks.onRootsListChanged) {
-      mcpClient.setNotificationHandler("notifications/roots/list_changed", () =>
-        this.#hooks.onRootsListChanged?.({
-          server: serverName,
-          options: connectionSchema.parse(options),
-        })
-      );
-    }
-
-    if (this.#hooks.onToolsListChanged) {
+    if (options.onToolsListChanged) {
       mcpClient.setNotificationHandler("notifications/tools/list_changed", () =>
-        this.#hooks.onToolsListChanged?.({
+        options.onToolsListChanged?.({
           server: serverName,
           options: connectionSchema.parse(options),
         })

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -225,15 +225,7 @@ export class ConnectionManager {
       return this.#forkClient(key, headers);
     };
 
-    const client = new Proxy(mcpClient, {
-      get(target, prop) {
-        if (prop === "fork") {
-          return forkClient.bind(this);
-        }
-
-        return target[prop as keyof MCPClient];
-      },
-    }) as Client;
+    const client = Object.assign(mcpClient, { fork: forkClient });
 
     this.#connections.set(key, {
       transport,

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -10,7 +10,7 @@ import type {
   StreamableHTTPClientTransportOptions,
   StreamableHTTPReconnectionOptions,
 } from "@modelcontextprotocol/client";
-import { _copyConnection } from "./types.js";
+import { connectionSchema } from "./types.js";
 import { getDebugLog } from "./logging.js";
 import type {
   ResolvedStreamableHTTPConnection,
@@ -87,12 +87,7 @@ export class ConnectionManager {
     options: ResolvedStdioConnection
   ): Promise<Client>;
   async createClient(
-    type: "http",
-    serverName: string,
-    options: ResolvedStreamableHTTPConnection
-  ): Promise<Client>;
-  async createClient(
-    type: "sse",
+    type: "http" | "sse",
     serverName: string,
     options: ResolvedStreamableHTTPConnection
   ): Promise<Client>;
@@ -125,7 +120,7 @@ export class ConnectionManager {
         (notification) =>
           this.#hooks.onMessage?.(notification.params, {
             server: serverName,
-            options: _copyConnection(options),
+            options: connectionSchema.parse(options),
           })
       );
     }
@@ -134,7 +129,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/initialized", () =>
         this.#hooks.onInitialized?.({
           server: serverName,
-          options: _copyConnection(options),
+          options: connectionSchema.parse(options),
         })
       );
     }
@@ -153,7 +148,7 @@ export class ConnectionManager {
             { requestId, reason },
             {
               server: serverName,
-              options: _copyConnection(options),
+              options: connectionSchema.parse(options),
             }
           );
 
@@ -172,7 +167,7 @@ export class ConnectionManager {
         () =>
           this.#hooks.onPromptsListChanged?.({
             server: serverName,
-            options: _copyConnection(options),
+            options: connectionSchema.parse(options),
           })
       );
     }
@@ -183,7 +178,7 @@ export class ConnectionManager {
         () =>
           this.#hooks.onResourcesListChanged?.({
             server: serverName,
-            options: _copyConnection(options),
+            options: connectionSchema.parse(options),
           })
       );
     }
@@ -194,7 +189,7 @@ export class ConnectionManager {
         (notification) =>
           this.#hooks.onResourcesUpdated?.(notification.params, {
             server: serverName,
-            options: _copyConnection(options),
+            options: connectionSchema.parse(options),
           })
       );
     }
@@ -203,7 +198,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/roots/list_changed", () =>
         this.#hooks.onRootsListChanged?.({
           server: serverName,
-          options: _copyConnection(options),
+          options: connectionSchema.parse(options),
         })
       );
     }
@@ -212,7 +207,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/tools/list_changed", () =>
         this.#hooks.onToolsListChanged?.({
           server: serverName,
-          options: _copyConnection(options),
+          options: connectionSchema.parse(options),
         })
       );
     }
@@ -264,16 +259,15 @@ export class ConnectionManager {
       throw new Error("Transport not found");
     }
 
-    const type =
-      connection.transportOptions.type ?? connection.transportOptions.transport;
-    if (type === "stdio") {
+    const options = connection.transportOptions;
+    if (options.transport === "stdio") {
       throw new Error("Forking stdio transport is not supported");
     }
 
-    return this.createClient(type as "http", key.serverName, {
-      ...connection.transportOptions,
+    return this.createClient(options.transport, key.serverName, {
+      ...options,
       headers,
-    } as ResolvedStreamableHTTPConnection);
+    });
   }
 
   /**

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -252,6 +252,7 @@ export class ConnectionManager {
     }
 
     const options = connection.transportOptions;
+
     if (options.transport === "stdio") {
       throw new Error("Forking stdio transport is not supported");
     }

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -10,6 +10,7 @@ import type {
   StreamableHTTPClientTransportOptions,
   StreamableHTTPReconnectionOptions,
 } from "@modelcontextprotocol/client";
+import { _copyConnection } from "./types.js";
 import { getDebugLog } from "./logging.js";
 import type {
   ResolvedStreamableHTTPConnection,
@@ -124,7 +125,7 @@ export class ConnectionManager {
         (notification) =>
           this.#hooks.onMessage?.(notification.params, {
             server: serverName,
-            options,
+            options: _copyConnection(options),
           })
       );
     }
@@ -133,7 +134,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/initialized", () =>
         this.#hooks.onInitialized?.({
           server: serverName,
-          options,
+          options: _copyConnection(options),
         })
       );
     }
@@ -152,7 +153,7 @@ export class ConnectionManager {
             { requestId, reason },
             {
               server: serverName,
-              options,
+              options: _copyConnection(options),
             }
           );
 
@@ -171,7 +172,7 @@ export class ConnectionManager {
         () =>
           this.#hooks.onPromptsListChanged?.({
             server: serverName,
-            options,
+            options: _copyConnection(options),
           })
       );
     }
@@ -182,7 +183,7 @@ export class ConnectionManager {
         () =>
           this.#hooks.onResourcesListChanged?.({
             server: serverName,
-            options,
+            options: _copyConnection(options),
           })
       );
     }
@@ -193,7 +194,7 @@ export class ConnectionManager {
         (notification) =>
           this.#hooks.onResourcesUpdated?.(notification.params, {
             server: serverName,
-            options,
+            options: _copyConnection(options),
           })
       );
     }
@@ -202,7 +203,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/roots/list_changed", () =>
         this.#hooks.onRootsListChanged?.({
           server: serverName,
-          options,
+          options: _copyConnection(options),
         })
       );
     }
@@ -211,7 +212,7 @@ export class ConnectionManager {
       mcpClient.setNotificationHandler("notifications/tools/list_changed", () =>
         this.#hooks.onToolsListChanged?.({
           server: serverName,
-          options,
+          options: _copyConnection(options),
         })
       );
     }

--- a/libs/langchain-mcp-adapters/src/connection.ts
+++ b/libs/langchain-mcp-adapters/src/connection.ts
@@ -89,6 +89,7 @@ export class ConnectionManager {
         : type === "sse"
           ? await this.#createSSETransport(serverName, options)
           : await this.#createStdioTransport(options);
+
     // SDK LATEST_PROTOCOL_VERSION still names the legacy revision; pin the
     // modern revision explicitly so negotiation cannot fall back to legacy.
     const mcpClient = new MCPClient(
@@ -102,6 +103,7 @@ export class ConnectionManager {
         },
       }
     );
+
     await mcpClient.connect(transport);
 
     if (options.onMessage) {

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod";
 import { isCommand, type Command } from "@langchain/langgraph";
 import type { EmbeddedResource } from "@modelcontextprotocol/client";
 import type { ContentBlock } from "@langchain/core/messages";
@@ -13,17 +13,18 @@ import { ToolMessage } from "@langchain/core/messages";
  */
 export type State = Record<string, unknown>;
 
-export interface ToolCallRequest {
-  serverName: string;
-  name: string;
-  args: unknown;
-}
+const toolCallRequestSchema = z.object({
+  serverName: z.string(),
+  name: z.string(),
+  args: z.unknown(),
+});
+export type ToolCallRequest = z.output<typeof toolCallRequestSchema>;
 
 type ToolContent =
   | string
   | (ContentBlock | ContentBlock.Data.DataContentBlock)[];
 type ToolArtifacts = (EmbeddedResource | ContentBlock.Multimodal.Standard)[];
-type ToolResultBefore = [ToolContent, ToolArtifacts];
+type ToolResultBefore = z.output<typeof toolResultBeforeSchema>;
 
 // Validate the hook's result container; native content and artifact semantics
 // belong to the result adapter rather than a duplicate core/MCP schema here.
@@ -55,9 +56,12 @@ const toolResultSchema = z.union([
    */
   z.custom<ToolMessage>(ToolMessage.isInstance),
 ]);
-export type ToolResult = string | Command | ToolResultBefore | ToolMessage;
+export type ToolResult = z.output<typeof toolResultSchema>;
 
-export type ModifiedToolCallResult = ToolCallRequest & { result: ToolResult };
+const toolCallResultSchema = toolCallRequestSchema.extend({
+  result: toolResultSchema,
+});
+export type ModifiedToolCallResult = z.output<typeof toolCallResultSchema>;
 
 export const toolCallResultModificationSchema = z.object({
   result: toolResultSchema,
@@ -66,7 +70,7 @@ export const toolCallResultModificationSchema = z.object({
 export const toolCallModificationSchema = z
   .object({
     headers: z.record(z.string(), z.string()),
-    args: z.unknown(),
+    args: z.record(z.string(), z.unknown()),
   })
   .partial();
 export type ToolCallModification = z.output<typeof toolCallModificationSchema>;
@@ -99,7 +103,13 @@ export const toolHooksSchema = z.object({
    * ```
    */
   beforeToolCall: z
-    .custom<NonNullable<ToolHooks["beforeToolCall"]>>(
+    .custom<
+      (
+        request: ToolCallRequest,
+        state: State,
+        config: RunnableConfig
+      ) => ToolCallModification | void | Promise<ToolCallModification | void>
+    >(
       (value) => typeof value === "function",
       "Expected a beforeToolCall callback"
     )
@@ -129,26 +139,21 @@ export const toolHooksSchema = z.object({
    * ```
    */
   afterToolCall: z
-    .custom<NonNullable<ToolHooks["afterToolCall"]>>(
+    .custom<
+      (
+        request: ToolCallRequest & { result: ToolResultBefore },
+        state: State,
+        config: RunnableConfig
+      ) =>
+        | z.output<typeof toolCallResultModificationSchema>
+        | void
+        | Promise<z.output<typeof toolCallResultModificationSchema> | void>
+    >(
       (value) => typeof value === "function",
       "Expected an afterToolCall callback"
     )
     .optional(),
 });
 
-/** Hooks receive native values. Their returned modifications are parsed after awaiting them. */
-export interface ToolHooks {
-  beforeToolCall?: (
-    request: ToolCallRequest,
-    state: State,
-    config: RunnableConfig
-  ) => ToolCallModification | void | Promise<ToolCallModification | void>;
-  afterToolCall?: (
-    request: ToolCallRequest & { result: ToolResultBefore },
-    state: State,
-    config: RunnableConfig
-  ) =>
-    | Pick<ModifiedToolCallResult, "result">
-    | void
-    | Promise<Pick<ModifiedToolCallResult, "result"> | void>;
-}
+/** Hooks preserve native inputs; awaited modifications are parsed at invocation. */
+export type ToolHooks = z.input<typeof toolHooksSchema>;

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { isCommand, type Command } from "@langchain/langgraph";
-import type { EmbeddedResource } from "@modelcontextprotocol/client";
+import {
+  isSpecType,
+  type EmbeddedResource,
+} from "@modelcontextprotocol/client";
 import type { ContentBlock } from "@langchain/core/messages";
 import type { RunnableConfig } from "@langchain/core/runnables";
 import { ToolMessage } from "@langchain/core/messages";
@@ -20,20 +23,28 @@ const toolCallRequestSchema = z.object({
 });
 export type ToolCallRequest = z.output<typeof toolCallRequestSchema>;
 
-type ToolContent =
-  | string
-  | (ContentBlock | ContentBlock.Data.DataContentBlock)[];
-type ToolArtifacts = (EmbeddedResource | ContentBlock.Multimodal.Standard)[];
-type ToolResultBefore = z.output<typeof toolResultBeforeSchema>;
+// Core content blocks are extensible records, not a closed list of provider
+// formats. Preserve extension fields without claiming their format is validated.
+const contentBlockSchema = z.looseObject({
+  type: z.string(),
+  id: z.string().optional(),
+}) satisfies z.ZodType<ContentBlock>;
 
-// Validate the hook's result container; native content and artifact semantics
-// belong to the result adapter rather than a duplicate core/MCP schema here.
-const toolResultBeforeSchema = z.tuple([
-  z.custom<ToolContent>(
-    (value) => typeof value === "string" || Array.isArray(value)
-  ),
-  z.custom<ToolArtifacts>(Array.isArray),
+const toolContentSchema = z.union([z.string(), z.array(contentBlockSchema)]);
+
+// MCP owns embedded resource semantics. Other artifacts include both legacy
+// data blocks and current LangChain blocks, so validate their shared boundary.
+const toolArtifactSchema = z.union([
+  z.custom<EmbeddedResource>(isSpecType.EmbeddedResource),
+  contentBlockSchema.refine((block) => block.type !== "resource", {
+    error: "Expected a valid MCP embedded resource",
+  }),
 ]);
+const toolResultBeforeSchema = z.tuple([
+  toolContentSchema,
+  z.array(toolArtifactSchema),
+]);
+type ToolResultBefore = z.output<typeof toolResultBeforeSchema>;
 
 /**
  * Tool result schema that users can return within the `afterToolCall` callback

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -9,12 +9,11 @@ import type { RunnableConfig } from "@langchain/core/runnables";
 import { ToolMessage } from "@langchain/core/messages";
 
 /**
- * state messages
- *
- * Note: this may not be defined in cases you don't use LangGraph or a LangGraph implementation like `createAgent`.
- * Also state can be defined arbitrarily by the user.
+ * Application-owned LangGraph task input, forwarded unchanged to hooks.
+ * Functional entrypoints may receive records, arrays, or primitives.
+ * Outside LangGraph, hooks receive an empty object.
  */
-export type State = Record<string, unknown>;
+export type State = unknown;
 
 const toolCallRequestSchema = z.object({
   serverName: z.string(),

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -1,9 +1,9 @@
-import { z } from "zod/v3";
-import type { Command } from "@langchain/langgraph";
+import { z } from "zod/v4";
+import { isCommand, type Command } from "@langchain/langgraph";
 import type { EmbeddedResource } from "@modelcontextprotocol/client";
 import type { ContentBlock } from "@langchain/core/messages";
 import type { RunnableConfig } from "@langchain/core/runnables";
-import type { ToolMessage } from "@langchain/core/messages";
+import { ToolMessage } from "@langchain/core/messages";
 
 /**
  * state messages
@@ -13,21 +13,25 @@ import type { ToolMessage } from "@langchain/core/messages";
  */
 export type State = Record<string, unknown>;
 
-const toolCallRequestSchema = z.object({
-  serverName: z.string(),
-  name: z.string(),
-  args: z.unknown(),
-});
-export type ToolCallRequest = z.output<typeof toolCallRequestSchema>;
+export interface ToolCallRequest {
+  serverName: string;
+  name: string;
+  args: unknown;
+}
 
+type ToolContent =
+  | string
+  | (ContentBlock | ContentBlock.Data.DataContentBlock)[];
+type ToolArtifacts = (EmbeddedResource | ContentBlock.Multimodal.Standard)[];
+type ToolResultBefore = [ToolContent, ToolArtifacts];
+
+// Validate the hook's result container; native content and artifact semantics
+// belong to the result adapter rather than a duplicate core/MCP schema here.
 const toolResultBeforeSchema = z.tuple([
-  z.custom<string | (ContentBlock | ContentBlock.Data.DataContentBlock)[]>(),
-  z.array(
-    z.union([
-      z.custom<EmbeddedResource>(),
-      z.custom<ContentBlock.Multimodal.Standard>(),
-    ])
+  z.custom<ToolContent>(
+    (value) => typeof value === "string" || Array.isArray(value)
   ),
+  z.custom<ToolArtifacts>(Array.isArray),
 ]);
 
 /**
@@ -41,7 +45,7 @@ const toolResultSchema = z.union([
   /**
    * Command from LangGraph
    */
-  z.custom<Command>(),
+  z.custom<Command>(isCommand),
   /**
    * 2-tuple of content, artifact
    */
@@ -49,26 +53,19 @@ const toolResultSchema = z.union([
   /**
    * ToolMessage return
    */
-  z.custom<ToolMessage>(),
+  z.custom<ToolMessage>(ToolMessage.isInstance),
 ]);
-export type ToolResult = z.output<typeof toolResultSchema>;
+export type ToolResult = string | Command | ToolResultBefore | ToolMessage;
 
-const toolCallResultSchema = z.object({
-  ...toolCallRequestSchema.shape,
-  result: toolResultBeforeSchema,
-});
+export type ModifiedToolCallResult = ToolCallRequest & { result: ToolResult };
 
-const modifiedToolCallResultSchema = z.object({
-  ...toolCallRequestSchema.shape,
+export const toolCallResultModificationSchema = z.object({
   result: toolResultSchema,
 });
-export type ModifiedToolCallResult = z.output<
-  typeof modifiedToolCallResultSchema
->;
 
-const toolCallModificationSchema = z
+export const toolCallModificationSchema = z
   .object({
-    headers: z.record(z.string()),
+    headers: z.record(z.string(), z.string()),
     args: z.unknown(),
   })
   .partial();
@@ -95,22 +92,16 @@ export const toolHooksSchema = z.object({
    *         ...toolCallRequest.args,
    *         custom: "Custom Value"
    *       },
-   *       header: { "X-Custom-Header": "Custom Value" }
+   *       headers: { "X-Custom-Header": "Custom Value" }
    *     };
    *   },
    * };
    * ```
    */
   beforeToolCall: z
-    .function()
-    .args(toolCallRequestSchema, z.custom<State>(), z.custom<RunnableConfig>())
-    .returns(
-      z.union([
-        z.promise(toolCallModificationSchema),
-        toolCallModificationSchema,
-        z.void(),
-        z.promise(z.void()),
-      ])
+    .custom<NonNullable<ToolHooks["beforeToolCall"]>>(
+      (value) => typeof value === "function",
+      "Expected a beforeToolCall callback"
     )
     .optional(),
 
@@ -130,24 +121,34 @@ export const toolHooksSchema = z.object({
    * const interceptor = {
    *   afterToolCall: (toolCallResult, state, runtime) => {
    *     if (toolCallResult.name === "calculator") {
-   *       return ["Custom Value", []];
+   *       return { result: ["Custom Value", []] };
    *     }
-   *     return toolCallResult.result;
+   *     return { result: toolCallResult.result };
    *   },
    * };
    * ```
    */
   afterToolCall: z
-    .function()
-    .args(toolCallResultSchema, z.custom<State>(), z.custom<RunnableConfig>())
-    .returns(
-      z.union([
-        z.promise(modifiedToolCallResultSchema.pick({ result: true })),
-        modifiedToolCallResultSchema.pick({ result: true }),
-        z.void(),
-        z.promise(z.void()),
-      ])
+    .custom<NonNullable<ToolHooks["afterToolCall"]>>(
+      (value) => typeof value === "function",
+      "Expected an afterToolCall callback"
     )
     .optional(),
 });
-export type ToolHooks = z.input<typeof toolHooksSchema>;
+
+/** Hooks receive native values. Their returned modifications are parsed after awaiting them. */
+export interface ToolHooks {
+  beforeToolCall?: (
+    request: ToolCallRequest,
+    state: State,
+    config: RunnableConfig
+  ) => ToolCallModification | void | Promise<ToolCallModification | void>;
+  afterToolCall?: (
+    request: ToolCallRequest & { result: ToolResultBefore },
+    state: State,
+    config: RunnableConfig
+  ) =>
+    | Pick<ModifiedToolCallResult, "result">
+    | void
+    | Promise<Pick<ModifiedToolCallResult, "result"> | void>;
+}

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -32,10 +32,12 @@ const toolArtifactSchema = z.union([
     error: "Expected a valid MCP embedded resource",
   }),
 ]);
+
 const toolResultBeforeSchema = z.tuple([
   toolContentSchema,
   z.array(toolArtifactSchema),
 ]);
+
 type ToolResultBefore = z.output<typeof toolResultBeforeSchema>;
 
 /**
@@ -64,6 +66,7 @@ export type ToolResult = z.output<typeof toolResultSchema>;
 const toolCallResultSchema = toolCallRequestSchema.extend({
   result: toolResultSchema,
 });
+
 export type ModifiedToolCallResult = z.output<typeof toolCallResultSchema>;
 
 export const toolCallResultModificationSchema = z.object({

--- a/libs/langchain-mcp-adapters/src/hooks.ts
+++ b/libs/langchain-mcp-adapters/src/hooks.ts
@@ -8,13 +8,6 @@ import type { ContentBlock } from "@langchain/core/messages";
 import type { RunnableConfig } from "@langchain/core/runnables";
 import { ToolMessage } from "@langchain/core/messages";
 
-/**
- * Application-owned LangGraph task input, forwarded unchanged to hooks.
- * Functional entrypoints may receive records, arrays, or primitives.
- * Outside LangGraph, hooks receive an empty object.
- */
-export type State = unknown;
-
 const toolCallRequestSchema = z.object({
   serverName: z.string(),
   name: z.string(),
@@ -116,7 +109,8 @@ export const toolHooksSchema = z.object({
     .custom<
       (
         request: ToolCallRequest,
-        state: State,
+        /** Application-owned task input, unchanged; `{}` outside LangGraph. */
+        state: unknown,
         config: RunnableConfig
       ) => ToolCallModification | void | Promise<ToolCallModification | void>
     >(
@@ -152,7 +146,8 @@ export const toolHooksSchema = z.object({
     .custom<
       (
         request: ToolCallRequest & { result: ToolResultBefore },
-        state: State,
+        /** Application-owned task input, unchanged; `{}` outside LangGraph. */
+        state: unknown,
         config: RunnableConfig
       ) =>
         | z.output<typeof toolCallResultModificationSchema>

--- a/libs/langchain-mcp-adapters/src/index.ts
+++ b/libs/langchain-mcp-adapters/src/index.ts
@@ -1,10 +1,11 @@
 import { type StreamableHTTPConnection } from "./types.js";
 
-export { MultiServerMCPClient } from "./client.js";
+export { MCPAdapter, MultiServerMCPClient } from "./client.js";
 export type { OAuthClientProvider } from "@modelcontextprotocol/client";
 
 export type {
   ClientConfig,
+  MCPAdapterConfig,
   Connection,
   LoadMcpToolsOptions,
   OutputHandling,
@@ -21,3 +22,11 @@ export type {
 export type SSEConnection = StreamableHTTPConnection;
 
 export { loadMcpTools } from "./tools.js";
+
+export type {
+  ToolHooks,
+  ToolCallRequest,
+  ToolCallModification,
+  ToolResult,
+} from "./hooks.js";
+export type { Notifications, ConnectionErrorHandler } from "./types.js";

--- a/libs/langchain-mcp-adapters/src/index.ts
+++ b/libs/langchain-mcp-adapters/src/index.ts
@@ -1,6 +1,7 @@
 import { type StreamableHTTPConnection } from "./types.js";
 
 export { MCPAdapter, MultiServerMCPClient } from "./client.js";
+
 export type { OAuthClientProvider } from "@modelcontextprotocol/client";
 
 export type {
@@ -29,4 +30,5 @@ export type {
   ToolCallModification,
   ToolResult,
 } from "./hooks.js";
+
 export type { Notifications, ConnectionErrorHandler } from "./types.js";

--- a/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
+++ b/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
@@ -8,6 +8,7 @@ import { vi, type Mock } from "vitest";
 const actual = await vi.importActual<
   typeof import("@modelcontextprotocol/client")
 >("@modelcontextprotocol/client");
+
 export const SdkHttpError = actual.SdkHttpError;
 
 export const isSpecType = actual.isSpecType;
@@ -45,6 +46,7 @@ const clientPrototype = {
     .fn<InstanceType<typeof actual.Client>["close"]>()
     .mockResolvedValue(undefined),
 };
+
 function mockClient(
   ...[clientInfo, options]: ConstructorParameters<typeof actual.Client>
 ) {
@@ -54,6 +56,7 @@ function mockClient(
     options,
   };
 }
+
 export const Client: Mock<typeof mockClient> = vi.fn(mockClient);
 
 Client.prototype = clientPrototype;
@@ -69,6 +72,7 @@ const sseClientTransportPrototype = {
     .fn<InstanceType<typeof actual.SSEClientTransport>["close"]>()
     .mockResolvedValue(undefined),
 };
+
 function mockSSEClientTransport(
   ...[url, options]: ConstructorParameters<typeof actual.SSEClientTransport>
 ) {
@@ -78,6 +82,7 @@ function mockSSEClientTransport(
     options,
   };
 }
+
 export const SSEClientTransport: Mock<typeof mockSSEClientTransport> = vi.fn(
   mockSSEClientTransport
 );
@@ -95,6 +100,7 @@ const streamableHTTPClientTransportPrototype = {
     .fn<InstanceType<typeof actual.StreamableHTTPClientTransport>["close"]>()
     .mockResolvedValue(undefined),
 };
+
 function mockStreamableHTTPClientTransport(
   ...[url, options]: ConstructorParameters<
     typeof actual.StreamableHTTPClientTransport
@@ -106,6 +112,7 @@ function mockStreamableHTTPClientTransport(
     options,
   };
 }
+
 export const StreamableHTTPClientTransport: Mock<
   typeof mockStreamableHTTPClientTransport
 > = vi.fn(mockStreamableHTTPClientTransport);

--- a/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
+++ b/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
@@ -9,6 +9,7 @@ const actual = await vi.importActual<
   typeof import("@modelcontextprotocol/client")
 >("@modelcontextprotocol/client");
 export const SdkHttpError = actual.SdkHttpError;
+
 export const isSpecType = actual.isSpecType;
 
 const clientPrototype = {

--- a/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
+++ b/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client.ts
@@ -4,11 +4,12 @@ import { vi, type Mock } from "vitest";
 // separate subpaths (client/index.js, client/sse.js, client/streamableHttp.js); v2
 // re-exports them all from the package root, so their mocks are colocated here.
 
-// Keep SDK error construction identical to production.
+// Keep SDK error construction and protocol guards identical to production.
 const actual = await vi.importActual<
   typeof import("@modelcontextprotocol/client")
 >("@modelcontextprotocol/client");
 export const SdkHttpError = actual.SdkHttpError;
+export const isSpecType = actual.isSpecType;
 
 const clientPrototype = {
   connect: vi

--- a/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client/stdio.ts
+++ b/libs/langchain-mcp-adapters/src/tests/__mocks__/@modelcontextprotocol/client/stdio.ts
@@ -10,6 +10,7 @@ const stdioClientTransportPrototype = {
   send: vi.fn<SDKTransport["send"]>().mockResolvedValue(undefined),
   close: vi.fn<SDKTransport["close"]>().mockResolvedValue(undefined),
 };
+
 function mockStdioClientTransport(
   ...[config]: ConstructorParameters<
     typeof import("@modelcontextprotocol/client/stdio").StdioClientTransport
@@ -20,6 +21,7 @@ function mockStdioClientTransport(
     config,
   };
 }
+
 export const StdioClientTransport: Mock<typeof mockStdioClientTransport> =
   vi.fn(mockStdioClientTransport);
 

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -113,9 +113,11 @@ describe("MultiServerMCPClient", () => {
       "handles %j without losing the original transport failure",
       async (error, fallsBack) => {
         vi.mocked(Client.prototype.connect).mockRejectedValueOnce(error);
+
         const client = new MultiServerMCPClient({
           remote: { transport: "http", url: "https://example.com/mcp" },
         });
+
         try {
           if (fallsBack) {
             await client.initializeConnections();

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -7,7 +7,7 @@ import {
   afterEach,
   type Mock,
 } from "vitest";
-import { ZodError } from "zod/v4";
+import { ZodError } from "zod";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import {
   Client,
@@ -1021,6 +1021,7 @@ describe("MCPAdapter configuration boundary", () => {
       () =>
         new MCPAdapter({
           servers: {
+            // @ts-expect-error Conflicting transport aliases are invalid input.
             remote: {
               transport: "http",
               type: "sse",
@@ -1037,6 +1038,7 @@ describe("MCPAdapter configuration boundary", () => {
         remote: { command: "node", args: [], url: "https://example.com/mcp" },
       },
     };
+    // @ts-expect-error A command and URL cannot belong to the same connection.
     expect(() => new MCPAdapter(ambiguous)).toThrow(/command or an HTTP URL/);
   });
 
@@ -1065,12 +1067,12 @@ describe("MCPAdapter configuration boundary", () => {
     expect(snapshot.onMessage).toBe(onMessage);
     expect(snapshot.beforeToolCall).toBe(beforeToolCall);
     const local = snapshot.mcpServers.local;
-    if (!("command" in local)) throw new Error("Expected stdio config");
+    if (local.transport !== "stdio") throw new Error("Expected stdio config");
     local.args.push("changed");
     local.env!.MODE = "changed";
     local.restart!.enabled = true;
     const remote = snapshot.mcpServers.remote;
-    if (!("url" in remote)) throw new Error("Expected HTTP config");
+    if (remote.transport !== "http") throw new Error("Expected HTTP config");
     remote.headers!["X-Test"] = "changed";
     remote.reconnect!.enabled = true;
     expect(adapter.config.mcpServers.local).toMatchObject({

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -99,9 +99,11 @@ describe("MultiServerMCPClient", () => {
       vi.mocked(Client.prototype.connect).mockRejectedValueOnce({
         status: 404,
       });
+
       const client = new MCPAdapter({
         servers: { remote: { url: "https://example.com/mcp" } },
       });
+
       try {
         await expect(client.listTools()).rejects.toThrow();
         expect(SSEClientTransport).not.toHaveBeenCalled();
@@ -1260,6 +1262,7 @@ describe("protocol-specific server configuration", () => {
   test("keeps callbacks on their owning server and preserves their identity", () => {
     const onMessage = vi.fn();
     const onInitialized = vi.fn();
+
     const client = new MCPAdapter({
       servers: {
         modern: { url: "https://example.com/mcp", onMessage },
@@ -1270,6 +1273,7 @@ describe("protocol-specific server configuration", () => {
         },
       },
     });
+
     expect(client.config.mcpServers.modern.onMessage).toBe(onMessage);
     expect(client.config.mcpServers.legacy.onMessage).toBeUndefined();
     expect(client.config.mcpServers.legacy.onInitialized).toBe(onInitialized);
@@ -1284,6 +1288,7 @@ describe("protocol-specific server configuration", () => {
     "rejects invalid modern fields in all constructor shapes: %j",
     (invalid) => {
       const remote = { url: "https://example.com/mcp", ...invalid };
+
       for (const config of [
         { servers: { remote } },
         { mcpServers: { remote } },
@@ -1299,6 +1304,7 @@ describe("protocol-specific server configuration", () => {
       servers: { remote: { url: "https://example.com/mcp" } },
       onMessage: () => undefined,
     };
+
     // @ts-expect-error Protocol callbacks belong to a server, even on predeclared configs.
     expect(() => new MCPAdapter(config)).toThrow(/onMessage/);
   });

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -15,7 +15,7 @@ import {
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
 import { MCPAdapter, MultiServerMCPClient, MCPClientError } from "../client.js";
-import { oAuthClientProviderSchema } from "../types.js";
+import { adapterConfigSchema, oAuthClientProviderSchema } from "../types.js";
 
 vi.mock(
   "@modelcontextprotocol/client",
@@ -95,6 +95,21 @@ describe("MultiServerMCPClient", () => {
   });
 
   describe("HTTP error handling", () => {
+    test("does not fall back to SSE for a default modern connection", async () => {
+      vi.mocked(Client.prototype.connect).mockRejectedValueOnce({
+        status: 404,
+      });
+      const client = new MCPAdapter({
+        servers: { remote: { url: "https://example.com/mcp" } },
+      });
+      try {
+        await expect(client.listTools()).rejects.toThrow();
+        expect(SSEClientTransport).not.toHaveBeenCalled();
+      } finally {
+        await client.close();
+      }
+    });
+
     test.each([
       [{ status: 404, code: "HTTP_ERROR" }, true],
       [{ code: 405 }, true],
@@ -115,7 +130,11 @@ describe("MultiServerMCPClient", () => {
         vi.mocked(Client.prototype.connect).mockRejectedValueOnce(error);
 
         const client = new MultiServerMCPClient({
-          remote: { transport: "http", url: "https://example.com/mcp" },
+          remote: {
+            mode: "legacy",
+            transport: "http",
+            url: "https://example.com/mcp",
+          },
         });
 
         try {
@@ -136,12 +155,13 @@ describe("MultiServerMCPClient", () => {
   // Constructor functionality tests
   describe("constructor", () => {
     test("should throw if initialized with empty connections", () => {
-      expect(() => new MultiServerMCPClient({})).toThrow(MCPClientError);
+      expect(() => new MultiServerMCPClient({})).toThrow(ZodError);
     });
 
     test("should process valid stdio connection config", () => {
       new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
@@ -152,6 +172,7 @@ describe("MultiServerMCPClient", () => {
     test("should process valid SSE connection config", () => {
       new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "sse",
           url: "http://localhost:8000/sse",
           headers: { Authorization: "Bearer token" },
@@ -162,6 +183,7 @@ describe("MultiServerMCPClient", () => {
     test("should process valid streamable HTTP connection config", () => {
       new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -185,6 +207,7 @@ describe("MultiServerMCPClient", () => {
     test("should initialize stdio connections correctly", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
@@ -193,10 +216,13 @@ describe("MultiServerMCPClient", () => {
 
       await client.initializeConnections();
 
-      expect(Client).toHaveBeenCalledWith({
-        name: "@langchain/mcp-adapters",
-        version: expect.any(String),
-      });
+      expect(Client).toHaveBeenCalledWith(
+        {
+          name: "@langchain/mcp-adapters",
+          version: expect.any(String),
+        },
+        { versionNegotiation: { mode: "legacy" } }
+      );
 
       expect(StdioClientTransport).toHaveBeenCalledWith({
         command: "python",
@@ -213,6 +239,7 @@ describe("MultiServerMCPClient", () => {
     test("should initialize SSE connections correctly", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "sse",
           url: "http://localhost:8000/sse",
         },
@@ -229,6 +256,7 @@ describe("MultiServerMCPClient", () => {
     test("should initialize streamable HTTP connections correctly", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -261,6 +289,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
@@ -285,6 +314,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
@@ -301,6 +331,7 @@ describe("MultiServerMCPClient", () => {
       test("should attempt to reconnect stdio transport when enabled", async () => {
         const client = new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "stdio",
             command: "python",
             args: ["./script.py"],
@@ -340,6 +371,7 @@ describe("MultiServerMCPClient", () => {
       test("should attempt to reconnect SSE transport when enabled", async () => {
         const client = new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "sse",
             url: "http://localhost:8000/sse",
             reconnect: {
@@ -375,6 +407,7 @@ describe("MultiServerMCPClient", () => {
       test("should respect maxAttempts setting for reconnection", async () => {
         const client = new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "stdio",
             command: "python",
             args: ["./script.py"],
@@ -414,6 +447,7 @@ describe("MultiServerMCPClient", () => {
       test("should not attempt reconnection when not enabled", async () => {
         const client = new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "sse",
             url: "http://localhost:8000/sse",
             // reconnect not provided -> disabled
@@ -461,11 +495,13 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         server1: {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script1.py"],
         },
         server2: {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script2.py"],
@@ -491,6 +527,7 @@ describe("MultiServerMCPClient", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             "test-server": {
+              mode: "legacy",
               transport: "stdio",
               command: "python",
               args: ["./script.py"],
@@ -508,6 +545,7 @@ describe("MultiServerMCPClient", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             "test-server": {
+              mode: "legacy",
               transport: "stdio",
               command: "python",
               args: ["./script.py"],
@@ -525,6 +563,7 @@ describe("MultiServerMCPClient", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             "test-server": {
+              mode: "legacy",
               transport: "stdio",
               command: "python",
               args: ["./script.py"],
@@ -542,6 +581,7 @@ describe("MultiServerMCPClient", () => {
       test("shouldn't apply prefixes by default", async () => {
         const client = new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "stdio",
             command: "python",
             args: ["./script.py"],
@@ -561,15 +601,18 @@ describe("MultiServerMCPClient", () => {
     test("should close all connections properly", async () => {
       const client = new MultiServerMCPClient({
         server1: {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script1.py"],
         },
         server2: {
+          mode: "legacy",
           transport: "sse",
           url: "http://localhost:8000/sse",
         },
         server3: {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -591,6 +634,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
@@ -611,6 +655,7 @@ describe("MultiServerMCPClient", () => {
         new MultiServerMCPClient({
           // @ts-expect-error missing url field
           "test-server": {
+            mode: "legacy",
             transport: "http",
             // Missing url field
           },
@@ -622,6 +667,7 @@ describe("MultiServerMCPClient", () => {
       expect(() => {
         new MultiServerMCPClient({
           "test-server": {
+            mode: "legacy",
             transport: "http",
             url: "invalid-url", // Invalid URL format
           },
@@ -632,15 +678,18 @@ describe("MultiServerMCPClient", () => {
     test("should handle mixed transport types including streamable HTTP", async () => {
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           transport: "stdio",
           command: "python",
           args: ["./script.py"],
         },
         "sse-server": {
+          mode: "legacy",
           transport: "sse",
           url: "http://localhost:8000/sse",
         },
         "streamable-server": {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -670,6 +719,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -688,6 +738,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "http",
           url: "http://localhost:8000/mcp",
         },
@@ -724,10 +775,12 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8123/mcp",
           },
           "working-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8001/mcp",
           },
@@ -763,6 +816,7 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
@@ -789,10 +843,12 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "server-1": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
           "server-2": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8001/mcp",
           },
@@ -841,10 +897,12 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
           "working-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8001/mcp",
           },
@@ -889,6 +947,7 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
@@ -933,10 +992,12 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
           "working-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8001/mcp",
           },
@@ -981,10 +1042,12 @@ describe("MultiServerMCPClient", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "failing-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8000/mcp",
           },
           "working-server": {
+            mode: "legacy",
             transport: "http",
             url: "http://localhost:8001/mcp",
           },
@@ -1016,10 +1079,13 @@ describe("MCPAdapter configuration boundary", () => {
     expect(MCPAdapter).toBe(MultiServerMCPClient);
 
     const adapter = new MCPAdapter({
-      servers: { remote: { type: "sse", url: "https://example.com/mcp" } },
+      servers: {
+        remote: { mode: "legacy", type: "sse", url: "https://example.com/mcp" },
+      },
     });
 
     expect(adapter.config.mcpServers.remote).toMatchObject({
+      mode: "legacy",
       transport: "sse",
     });
     expect(adapter.config.mcpServers.remote).not.toHaveProperty("type");
@@ -1089,6 +1155,7 @@ describe("MCPAdapter configuration boundary", () => {
           servers: {
             // @ts-expect-error Conflicting transport aliases are invalid input.
             remote: {
+              mode: "legacy",
               transport: "http",
               type: "sse",
               url: "https://example.com/mcp",
@@ -1116,6 +1183,7 @@ describe("MCPAdapter configuration boundary", () => {
     const adapter = new MCPAdapter({
       servers: {
         local: {
+          onMessage,
           command: "node",
           args: ["server.js"],
           env: { MODE: "test" },
@@ -1128,12 +1196,11 @@ describe("MCPAdapter configuration boundary", () => {
         },
       },
       outputHandling: { text: "content" },
-      onMessage,
       beforeToolCall,
     });
 
     const snapshot = adapter.config;
-    expect(snapshot.onMessage).toBe(onMessage);
+    expect(snapshot.mcpServers.local.onMessage).toBe(onMessage);
     expect(snapshot.beforeToolCall).toBe(beforeToolCall);
     const local = snapshot.mcpServers.local;
 
@@ -1173,6 +1240,82 @@ describe("MCPAdapter configuration boundary", () => {
             '{"servers":{"remote":{"url":"https://example.com/mcp"}},"outputHandling":{"typo":"content"}}'
           )
         )
+    ).toThrow(ZodError);
+  });
+});
+
+describe("protocol-specific server configuration", () => {
+  test("defaults each connection to modern without changing compatibility aliases", () => {
+    for (const config of [
+      { servers: { remote: { url: "https://example.com/mcp" } } },
+      { mcpServers: { remote: { url: "https://example.com/mcp" } } },
+      { remote: { url: "https://example.com/mcp" } },
+    ]) {
+      expect(adapterConfigSchema.parse(config).mcpServers.remote.mode).toBe(
+        "modern"
+      );
+    }
+  });
+
+  test("keeps callbacks on their owning server and preserves their identity", () => {
+    const onMessage = vi.fn();
+    const onInitialized = vi.fn();
+    const client = new MCPAdapter({
+      servers: {
+        modern: { url: "https://example.com/mcp", onMessage },
+        legacy: {
+          mode: "legacy",
+          url: "https://example.com/old",
+          onInitialized,
+        },
+      },
+    });
+    expect(client.config.mcpServers.modern.onMessage).toBe(onMessage);
+    expect(client.config.mcpServers.legacy.onMessage).toBeUndefined();
+    expect(client.config.mcpServers.legacy.onInitialized).toBe(onInitialized);
+  });
+
+  test.each([
+    { automaticSSEFallback: true },
+    { onInitialized: () => undefined },
+    { onRootsListChanged: () => undefined },
+    { unexpectedOption: true },
+  ])(
+    "rejects invalid modern fields in all constructor shapes: %j",
+    (invalid) => {
+      const remote = { url: "https://example.com/mcp", ...invalid };
+      for (const config of [
+        { servers: { remote } },
+        { mcpServers: { remote } },
+        { remote },
+      ]) {
+        expect(() => adapterConfigSchema.parse(config)).toThrow(ZodError);
+      }
+    }
+  );
+
+  test("rejects top-level protocol callbacks instead of silently dropping them", () => {
+    const config = {
+      servers: { remote: { url: "https://example.com/mcp" } },
+      onMessage: () => undefined,
+    };
+    // @ts-expect-error Protocol callbacks belong to a server, even on predeclared configs.
+    expect(() => new MCPAdapter(config)).toThrow(/onMessage/);
+  });
+
+  test("rejects explicit modern SSE at the configuration boundary", () => {
+    expect(
+      () =>
+        new MCPAdapter({
+          servers: {
+            // @ts-expect-error SSE requires explicit legacy mode.
+            remote: {
+              mode: "modern",
+              transport: "sse",
+              url: "https://example.com/sse",
+            },
+          },
+        })
     ).toThrow(ZodError);
   });
 });

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -963,6 +963,55 @@ describe("MCPAdapter configuration boundary", () => {
     expect(Client.prototype.connect).not.toHaveBeenCalled();
   });
 
+  test.each([
+    { url: "https://example.com/mcp" },
+    { command: "node", args: ["server.js"] },
+  ])("accepts a legacy server named servers: %j", (connection) => {
+    const adapter = new MultiServerMCPClient({
+      servers: connection,
+      other: { url: "https://example.com/other" },
+    });
+    expect(Object.keys(adapter.config.mcpServers)).toEqual([
+      "servers",
+      "other",
+    ]);
+    expect(adapter.config.mcpServers.servers).toMatchObject(connection);
+  });
+
+  test("keeps canonical server names independent of connection field names", () => {
+    const adapter = new MCPAdapter({
+      servers: {
+        url: { url: "https://example.com/mcp" },
+        command: { command: "node", args: [] },
+        servers: { url: "https://example.com/other" },
+      },
+    });
+    expect(Object.keys(adapter.config.mcpServers)).toEqual([
+      "url",
+      "command",
+      "servers",
+    ]);
+  });
+
+  test("accepts undefined output destinations at global and server scope", () => {
+    const adapter = new MCPAdapter({
+      servers: {
+        remote: {
+          url: "https://example.com/mcp",
+          outputHandling: { image: undefined },
+        },
+      },
+      outputHandling: { text: undefined, audio: "artifact" },
+    });
+    expect(adapter.config.outputHandling).toEqual({
+      text: undefined,
+      audio: "artifact",
+    });
+    expect(adapter.config.mcpServers.remote.outputHandling).toEqual({
+      image: undefined,
+    });
+  });
+
   test("rejects mixed configuration spellings and conflicting transport choices", () => {
     // @ts-expect-error Conflicting configuration keys must also fail at runtime.
     expect(() => new MCPAdapter({ servers: {}, mcpServers: {} })).toThrow(

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -15,6 +15,7 @@ import {
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
 import { MCPAdapter, MultiServerMCPClient, MCPClientError } from "../client.js";
+import { oAuthClientProviderSchema } from "../types.js";
 
 vi.mock(
   "@modelcontextprotocol/client",
@@ -33,6 +34,63 @@ describe("MultiServerMCPClient", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("OAuth provider parsing", () => {
+    class Provider {
+      get redirectUrl(): undefined {
+        throw new Error("Read redirectUrl only during authorization");
+      }
+
+      get clientMetadata(): never {
+        throw new Error("Read clientMetadata only during authorization");
+      }
+
+      clientInformation() {
+        return undefined;
+      }
+      tokens() {
+        return undefined;
+      }
+      saveTokens() {}
+      redirectToAuthorization() {}
+      saveCodeVerifier() {}
+      codeVerifier() {
+        return "verifier";
+      }
+    }
+
+    test("preserves provider identity, prototype methods, and lazy metadata", () => {
+      const provider = new Provider();
+      const parsed = oAuthClientProviderSchema.parse(provider);
+      expect(parsed).toBe(provider);
+      expect(parsed.tokens).toBe(provider.tokens);
+    });
+
+    test.each([
+      "clientInformation",
+      "tokens",
+      "saveTokens",
+      "redirectToAuthorization",
+      "saveCodeVerifier",
+      "codeVerifier",
+    ])("rejects a non-callable %s before connecting", (method) => {
+      const provider = Object.assign(new Provider(), { [method]: 42 });
+      const result = oAuthClientProviderSchema.safeParse(provider);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual([method]);
+      }
+    });
+
+    test.each([null, undefined, "provider", {}])(
+      "rejects invalid provider %j",
+      (provider) => {
+        expect(oAuthClientProviderSchema.safeParse(provider).success).toBe(
+          false
+        );
+      }
+    );
   });
 
   describe("HTTP error handling", () => {

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -7,14 +7,14 @@ import {
   afterEach,
   type Mock,
 } from "vitest";
-import { ZodError } from "zod/v3";
+import { ZodError } from "zod/v4";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import {
   Client,
   SSEClientTransport,
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
-import { MultiServerMCPClient, MCPClientError } from "../client.js";
+import { MCPAdapter, MultiServerMCPClient, MCPClientError } from "../client.js";
 
 vi.mock(
   "@modelcontextprotocol/client",
@@ -946,5 +946,111 @@ describe("MultiServerMCPClient", () => {
       expect(workingClient1).toBeDefined();
       expect(workingClient2).toBeDefined();
     });
+  });
+});
+
+describe("MCPAdapter configuration boundary", () => {
+  test("shares the implementation and normalizes legacy transport names without connecting", () => {
+    vi.clearAllMocks();
+    expect(MCPAdapter).toBe(MultiServerMCPClient);
+    const adapter = new MCPAdapter({
+      servers: { remote: { type: "sse", url: "https://example.com/mcp" } },
+    });
+    expect(adapter.config.mcpServers.remote).toMatchObject({
+      transport: "sse",
+    });
+    expect(adapter.config.mcpServers.remote).not.toHaveProperty("type");
+    expect(Client.prototype.connect).not.toHaveBeenCalled();
+  });
+
+  test("rejects mixed configuration spellings and conflicting transport choices", () => {
+    // @ts-expect-error Conflicting configuration keys must also fail at runtime.
+    expect(() => new MCPAdapter({ servers: {}, mcpServers: {} })).toThrow(
+      /not both/
+    );
+    expect(
+      () =>
+        new MCPAdapter({
+          servers: {
+            remote: {
+              transport: "http",
+              type: "sse",
+              url: "https://example.com/mcp",
+            },
+          },
+        })
+    ).toThrow(/conflicts with transport/);
+  });
+
+  test("rejects a connection that mixes a command and URL before dropping unknown keys", () => {
+    const ambiguous = {
+      servers: {
+        remote: { command: "node", args: [], url: "https://example.com/mcp" },
+      },
+    };
+    expect(() => new MCPAdapter(ambiguous)).toThrow(/command or an HTTP URL/);
+  });
+
+  test("retains callback identity and isolates mutable configuration snapshots", () => {
+    const onMessage = vi.fn();
+    const beforeToolCall = vi.fn();
+    const adapter = new MCPAdapter({
+      servers: {
+        local: {
+          command: "node",
+          args: ["server.js"],
+          env: { MODE: "test" },
+          restart: { enabled: false },
+        },
+        remote: {
+          url: "https://example.com/mcp",
+          headers: { "X-Test": "original" },
+          reconnect: { enabled: false },
+        },
+      },
+      outputHandling: { text: "content" },
+      onMessage,
+      beforeToolCall,
+    });
+    const snapshot = adapter.config;
+    expect(snapshot.onMessage).toBe(onMessage);
+    expect(snapshot.beforeToolCall).toBe(beforeToolCall);
+    const local = snapshot.mcpServers.local;
+    if (!("command" in local)) throw new Error("Expected stdio config");
+    local.args.push("changed");
+    local.env!.MODE = "changed";
+    local.restart!.enabled = true;
+    const remote = snapshot.mcpServers.remote;
+    if (!("url" in remote)) throw new Error("Expected HTTP config");
+    remote.headers!["X-Test"] = "changed";
+    remote.reconnect!.enabled = true;
+    expect(adapter.config.mcpServers.local).toMatchObject({
+      args: ["server.js"],
+      env: { MODE: "test" },
+      restart: { enabled: false },
+    });
+    expect(adapter.config.mcpServers.remote).toMatchObject({
+      headers: { "X-Test": "original" },
+      reconnect: { enabled: false },
+    });
+  });
+
+  test("rejects invalid callbacks and unknown output destinations with Zod4", () => {
+    expect(
+      () =>
+        new MCPAdapter(
+          JSON.parse(
+            '{"servers":{"remote":{"url":"https://example.com/mcp"}},"beforeToolCall":"invalid"}'
+          )
+        )
+    ).toThrow(ZodError);
+    expect(
+      () =>
+        new MCPAdapter(
+          JSON.parse(
+            '{"servers":{"remote":{"url":"https://example.com/mcp"}},"outputHandling":{"typo":"content"}}'
+          )
+        )
+    ).toThrow(ZodError);
   });
 });

--- a/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.basic.test.ts
@@ -78,6 +78,7 @@ describe("MultiServerMCPClient", () => {
       const provider = Object.assign(new Provider(), { [method]: 42 });
       const result = oAuthClientProviderSchema.safeParse(provider);
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.issues[0].path).toEqual([method]);
       }
@@ -1011,9 +1012,11 @@ describe("MCPAdapter configuration boundary", () => {
   test("shares the implementation and normalizes legacy transport names without connecting", () => {
     vi.clearAllMocks();
     expect(MCPAdapter).toBe(MultiServerMCPClient);
+
     const adapter = new MCPAdapter({
       servers: { remote: { type: "sse", url: "https://example.com/mcp" } },
     });
+
     expect(adapter.config.mcpServers.remote).toMatchObject({
       transport: "sse",
     });
@@ -1029,6 +1032,7 @@ describe("MCPAdapter configuration boundary", () => {
       servers: connection,
       other: { url: "https://example.com/other" },
     });
+
     expect(Object.keys(adapter.config.mcpServers)).toEqual([
       "servers",
       "other",
@@ -1044,6 +1048,7 @@ describe("MCPAdapter configuration boundary", () => {
         servers: { url: "https://example.com/other" },
       },
     });
+
     expect(Object.keys(adapter.config.mcpServers)).toEqual([
       "url",
       "command",
@@ -1061,6 +1066,7 @@ describe("MCPAdapter configuration boundary", () => {
       },
       outputHandling: { text: undefined, audio: "artifact" },
     });
+
     expect(adapter.config.outputHandling).toEqual({
       text: undefined,
       audio: "artifact",
@@ -1096,6 +1102,7 @@ describe("MCPAdapter configuration boundary", () => {
         remote: { command: "node", args: [], url: "https://example.com/mcp" },
       },
     };
+
     // @ts-expect-error A command and URL cannot belong to the same connection.
     expect(() => new MCPAdapter(ambiguous)).toThrow(/command or an HTTP URL/);
   });
@@ -1103,6 +1110,7 @@ describe("MCPAdapter configuration boundary", () => {
   test("retains callback identity and isolates mutable configuration snapshots", () => {
     const onMessage = vi.fn();
     const beforeToolCall = vi.fn();
+
     const adapter = new MCPAdapter({
       servers: {
         local: {
@@ -1121,15 +1129,18 @@ describe("MCPAdapter configuration boundary", () => {
       onMessage,
       beforeToolCall,
     });
+
     const snapshot = adapter.config;
     expect(snapshot.onMessage).toBe(onMessage);
     expect(snapshot.beforeToolCall).toBe(beforeToolCall);
     const local = snapshot.mcpServers.local;
+
     if (local.transport !== "stdio") throw new Error("Expected stdio config");
     local.args.push("changed");
     local.env!.MODE = "changed";
     local.restart!.enabled = true;
     const remote = snapshot.mcpServers.remote;
+
     if (remote.transport !== "http") throw new Error("Expected HTTP config");
     remote.headers!["X-Test"] = "changed";
     remote.reconnect!.enabled = true;

--- a/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
@@ -9,7 +9,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 
 // Import modules after mocking
 import type { Connection } from "../types.js";
-import { MultiServerMCPClient, MCPClientError } from "../client.js";
+import { MultiServerMCPClient } from "../client.js";
 
 vi.mock(
   "@modelcontextprotocol/client",
@@ -27,17 +27,18 @@ beforeEach(() => {
 describe("MultiServerMCPClient", () => {
   describe("Constructor", () => {
     test("should throw when initialized with empty connections", async () => {
-      expect(() => new MultiServerMCPClient({})).toThrow(MCPClientError);
+      expect(() => new MultiServerMCPClient({})).toThrow(ZodError);
     });
 
     test("should process valid stdio connection config", async () => {
       const config = {
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
         },
-      };
+      } satisfies Record<string, Connection>;
 
       const client = new MultiServerMCPClient(config);
       expect(client).toBeDefined();
@@ -51,10 +52,11 @@ describe("MultiServerMCPClient", () => {
     test("should process valid streamable HTTP connection config", async () => {
       const config = {
         "test-server": {
+          mode: "legacy",
           transport: "http" as const,
           url: "http://localhost:8000/mcp",
         },
-      };
+      } satisfies Record<string, Connection>;
 
       const client = new MultiServerMCPClient(config);
       expect(client).toBeDefined();
@@ -68,12 +70,12 @@ describe("MultiServerMCPClient", () => {
     test("should process valid SSE connection config", async () => {
       const config = {
         "test-server": {
+          mode: "legacy",
           transport: "sse" as const,
           url: "http://localhost:8000/sse",
           headers: { Authorization: "Bearer token" },
-          useNodeEventSource: true,
         },
-      };
+      } satisfies Record<string, Connection>;
 
       const client = new MultiServerMCPClient(config);
       expect(client).toBeDefined();
@@ -112,6 +114,7 @@ describe("MultiServerMCPClient", () => {
       // Create a client instance with the config
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -141,6 +144,7 @@ describe("MultiServerMCPClient", () => {
       // Create a client instance with the config
       const client = new MultiServerMCPClient({
         "sse-server": {
+          mode: "legacy",
           transport: "sse" as const,
           url: "http://example.com/sse",
         },
@@ -168,6 +172,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -186,6 +191,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -201,6 +207,7 @@ describe("MultiServerMCPClient", () => {
     test("should attempt to reconnect stdio transport when enabled", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -242,6 +249,7 @@ describe("MultiServerMCPClient", () => {
     test("should attempt to reconnect SSE transport when enabled", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "sse" as const,
           url: "http://localhost:8000/sse",
           reconnect: {
@@ -284,6 +292,7 @@ describe("MultiServerMCPClient", () => {
       const maxAttempts = 2;
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -337,6 +346,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         server1: {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script1.py"],
@@ -369,6 +379,7 @@ describe("MultiServerMCPClient", () => {
     test("should get client for a specific server", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -390,11 +401,13 @@ describe("MultiServerMCPClient", () => {
     test("should close all connections properly", async () => {
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script1.py"],
         },
         "sse-server": {
+          mode: "legacy",
           transport: "sse" as const,
           url: "http://localhost:8000/sse",
         },
@@ -415,6 +428,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -438,11 +452,13 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script1.py"],
         },
         "sse-server": {
+          mode: "legacy",
           transport: "sse" as const,
           url: "http://localhost:8000/sse",
         },
@@ -458,6 +474,7 @@ describe("MultiServerMCPClient", () => {
     test("should clear internal state after close", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -477,6 +494,7 @@ describe("MultiServerMCPClient", () => {
     test("should handle invalid server name when getting client", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -489,6 +507,7 @@ describe("MultiServerMCPClient", () => {
     test("should handle invalid server name when getting tools", async () => {
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -510,6 +529,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "stdio" as const,
           command: "python",
           args: ["./script.py"],
@@ -538,6 +558,7 @@ describe("MultiServerMCPClient", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           transport: "http" as const,
           url: "http://localhost:8000/mcp",
         },

--- a/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, test, expect, beforeEach, type Mock } from "vitest";
-import { ZodError } from "zod/v3";
+import { ZodError } from "zod/v4";
 import {
   SSEClientTransport,
   StreamableHTTPClientTransport,

--- a/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.comprehensive.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, test, expect, beforeEach, type Mock } from "vitest";
-import { ZodError } from "zod/v4";
+import { ZodError } from "zod";
 import {
   SSEClientTransport,
   StreamableHTTPClientTransport,

--- a/libs/langchain-mcp-adapters/src/tests/client.list_tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.list_tools.test.ts
@@ -10,24 +10,29 @@ describe("adapter tool listing", () => {
     vi.spyOn(ConnectionManager.prototype, "createClient").mockImplementation(
       async (_transport, serverName) => {
         const client = new Client({ name: serverName, version: "1" });
+
         const connected = Object.assign(client, {
           fork: async () => connected,
         });
+
         vi.spyOn(client, "listTools").mockResolvedValue({
           tools: [{ name: serverName, inputSchema: { type: "object" } }],
         });
         vi.spyOn(client, "callTool").mockResolvedValue({
           content: [{ type: "text", text: serverName }],
         });
+
         return connected;
       }
     );
+
     const adapter = new MCPAdapter({
       servers: {
         first: { command: "node", args: [] },
         second: { command: "node", args: [] },
       },
     });
+
     try {
       expect((await adapter.listTools()).map((tool) => tool.name)).toEqual([
         "first",

--- a/libs/langchain-mcp-adapters/src/tests/client.list_tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.list_tools.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/client";
+import { MCPAdapter } from "../client.js";
+import { ConnectionManager } from "../connection.js";
+
+describe("adapter tool listing", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  test("listTools and the deprecated alias share selection and invocation behavior", async () => {
+    vi.spyOn(ConnectionManager.prototype, "createClient").mockImplementation(
+      async (_transport, serverName) => {
+        const client = new Client({ name: serverName, version: "1" });
+        const connected = Object.assign(client, {
+          fork: async () => connected,
+        });
+        vi.spyOn(client, "listTools").mockResolvedValue({
+          tools: [{ name: serverName, inputSchema: { type: "object" } }],
+        });
+        vi.spyOn(client, "callTool").mockResolvedValue({
+          content: [{ type: "text", text: serverName }],
+        });
+        return connected;
+      }
+    );
+    const adapter = new MCPAdapter({
+      servers: {
+        first: { command: "node", args: [] },
+        second: { command: "node", args: [] },
+      },
+    });
+    try {
+      expect((await adapter.listTools()).map((tool) => tool.name)).toEqual([
+        "first",
+        "second",
+      ]);
+      const [selected] = await adapter.listTools("second");
+      expect(selected.name).toBe("second");
+      expect(await selected.invoke({})).toBe("second");
+      expect(
+        (await adapter.getTools(["second"])).map((tool) => tool.name)
+      ).toEqual(["second"]);
+      expect(
+        (await adapter.listTools(["first"], { headers: {} })).map(
+          (tool) => tool.name
+        )
+      ).toEqual(["first"]);
+    } finally {
+      await adapter.close();
+    }
+  });
+});

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -1512,7 +1512,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             },
           },
           // Ensure we test with standard content blocks as per README recommendation for new apps
-          useStandardContentBlocks: true,
         });
 
         try {
@@ -1547,8 +1546,8 @@ describe("MultiServerMCPClient Integration Tests", () => {
             (c) => c.type === "audio"
           ) as ContentBlock.Multimodal.Audio;
           expect(audioBlock).toBeDefined();
-          expect(audioBlock.source_type).toBe("base64");
-          expect(audioBlock.mime_type).toBe("audio/wav");
+          expect(audioBlock.source_type).toBeUndefined();
+          expect(audioBlock.mimeType).toBe("audio/wav");
           expect(typeof audioBlock.data).toBe("string");
           expect(audioBlock.data?.length).toBeGreaterThan(10);
         } finally {
@@ -1558,7 +1557,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
     );
   });
 
-  describe("useStandardContentBlocks Configuration", () => {
+  describe("Standard content blocks", () => {
     const serverName = "content-block-test-server";
     const toolInput = { input: "test standard blocks" };
     const fakeToolCallBase = {
@@ -1567,7 +1566,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
     };
 
     it.each(["http", "sse"] as const)(
-      "should use Standard Content Blocks when useStandardContentBlocks is true (%s)",
+      "should use Standard Content Blocks by default (%s)",
       async (transport) => {
         const { baseUrl } = await testServers.createHTTPServer(
           "http-std-true",
@@ -1583,7 +1582,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
           },
-          useStandardContentBlocks: true,
         });
 
         try {
@@ -1612,8 +1610,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
           const imgBlock = imgContentArray.find(
             (c) => c.type === "image"
           ) as ContentBlock.Multimodal.Data;
-          expect(imgBlock.source_type).toBe("base64");
-          expect(imgBlock.mime_type).toBe("image/png");
+
+          expect(imgBlock.source_type).toBeUndefined();
+          expect(imgBlock.mimeType).toBe("image/png");
           expect(typeof imgBlock.data).toBe("string");
 
           // Test Audio Tool (should always use StandardAudioBlock)
@@ -1635,78 +1634,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
           const audioBlock = audioContentArray.find(
             (c) => c.type === "audio"
           ) as ContentBlock.Multimodal.Audio;
-          expect(audioBlock.source_type).toBe("base64");
-          expect(audioBlock.mime_type).toBe("audio/wav");
-        } finally {
-          await client.close();
-        }
-      }
-    );
 
-    it.each(["http", "sse"] as const)(
-      "should use legacy ImageUrl when useStandardContentBlocks is false (%s)",
-      async (transport) => {
-        const { baseUrl } = await testServers.createHTTPServer(
-          "http-std-false",
-          {
-            disableStreamableHttp: transport === "sse",
-            supportSSEFallback: transport === "sse",
-          }
-        );
-        const client = new MultiServerMCPClient({
-          mcpServers: {
-            [serverName]: {
-              url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
-            },
-          },
-          /* useStandardContentBlocks: false */ // defaults to false
-        });
-
-        try {
-          const tools = await client.getTools();
-          const imageTool = tools.find((t) => t.name.includes("image_tool"));
-          expect(imageTool).toBeDefined();
-
-          const { content: imgContent, artifact: imgArtifact } =
-            await imageTool!.invoke({
-              ...fakeToolCallBase,
-              name: imageTool!.name,
-              args: toolInput,
-            });
-          expect(imgArtifact).toEqual([]);
-          const imgContentArray = imgContent as ContentBlock[];
-
-          const imgTextBlock = imgContentArray.find(
-            (c) => c.type === "text"
-          ) as ContentBlock.Text;
-          expect(imgTextBlock.text).toContain(
-            "Image input was: test standard blocks"
-          );
-          // Check for legacy image_url format
-          const imgUrlBlock = imgContentArray.find(
-            (c) => c.type === "image_url"
-          ) as ContentBlock.Multimodal.Data;
-          expect(imgUrlBlock).toBeDefined();
-          // @ts-expect-error image_url is unknown
-          const imageUrl = imgUrlBlock.image_url?.url;
-          expect(imageUrl).toMatch(/^data:image\/png;base64,/);
-
-          // Audio should still use StandardAudioBlock
-          const audioTool = tools.find((t) => t.name.includes("audio_tool"));
-          expect(audioTool).toBeDefined();
-          const { content: audioContent, artifact: audioArtifact } =
-            await audioTool!.invoke({
-              ...fakeToolCallBase,
-              name: audioTool!.name,
-              args: toolInput,
-            });
-          expect(audioArtifact).toEqual([]);
-          const audioContentArray = audioContent as ContentBlock[];
-          const audioBlock = audioContentArray.find(
-            (c) => c.type === "audio"
-          ) as ContentBlock.Multimodal.Audio;
-          expect(audioBlock.source_type).toBe("base64");
-          expect(audioBlock.mime_type).toBe("audio/wav");
+          expect(audioBlock.source_type).toBeUndefined();
+          expect(audioBlock.mimeType).toBe("audio/wav");
         } finally {
           await client.close();
         }
@@ -1783,10 +1713,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
                 ),
               }),
               expect.objectContaining({
-                type: "image_url",
-                image_url: expect.objectContaining({
-                  url: expect.stringMatching(/^data:image\/png;base64,/),
-                }),
+                type: "image",
+                mimeType: "image/png",
+                data: expect.any(String),
               }),
             ])
           );
@@ -1844,7 +1773,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             },
           },
           outputHandling: "artifact",
-          useStandardContentBlocks: false,
         });
 
         try {
@@ -1934,7 +1862,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             },
           },
           outputHandling: "content",
-          useStandardContentBlocks: false,
         });
 
         try {
@@ -1957,10 +1884,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
                 ),
               }),
               expect.objectContaining({
-                type: "image_url",
-                image_url: expect.objectContaining({
-                  url: expect.stringMatching(/^data:image\/png;base64,/),
-                }),
+                type: "image",
+                mimeType: "image/png",
+                data: expect.any(String),
               }),
             ])
           );
@@ -1980,9 +1906,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
                 ),
               }),
               expect.objectContaining({
-                type: "file",
-                source_type: "text",
-                mime_type: "text/plain",
+                type: "text",
                 text: "This is a test resource.",
                 metadata: { uri: "mem://test.txt" },
               }),
@@ -2015,7 +1939,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             audio: "content",
             resource: "content",
           },
-          useStandardContentBlocks: false,
         });
 
         try {
@@ -2050,7 +1973,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
             expect.arrayContaining([
               expect.objectContaining({ type: "text" }),
               expect.objectContaining({
-                type: "file",
+                type: "text",
                 metadata: { uri: "mem://test.txt" },
               }),
             ])
@@ -2081,7 +2004,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             },
           },
           outputHandling: "artifact",
-          useStandardContentBlocks: false,
         };
         const client = new MultiServerMCPClient(clientConfig);
 
@@ -2095,10 +2017,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
           const imgContentArray = imgContent as ContentBlock[];
           expect(imgContentArray).toHaveLength(1);
           expect(imgContentArray[0]).toEqual({
-            image_url: {
-              url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-            },
-            type: "image_url",
+            type: "image",
+            mimeType: "image/png",
+            data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
           });
           expect(imgArtifact).toHaveLength(1);
           expect(imgArtifact[0]).toEqual({
@@ -2126,7 +2047,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
     );
 
     it.each(["http", "sse"] as const)(
-      "should respect outputHandling with useStandardContentBlocks=true (%s)",
+      "should respect outputHandling with standard content (%s)",
       async (transport) => {
         const serverName = `${serverNameBase}-std-blocks-${transport}`;
         const { baseUrl } = await testServers.createHTTPServer(serverName, {
@@ -2146,7 +2067,6 @@ describe("MultiServerMCPClient Integration Tests", () => {
             audio: "content",
             resource: "artifact",
           },
-          useStandardContentBlocks: true,
         });
 
         try {
@@ -2163,7 +2083,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
             const imgContentArray = imgContent as ContentBlock[];
             expect(imgContentArray).toHaveLength(1);
             expect(imgContentArray[0]).toEqual(
-              expect.objectContaining({ type: "text", source_type: "text" })
+              expect.objectContaining({ type: "text" })
             );
           } else {
             expect(imgContent).toEqual([]);
@@ -2172,8 +2092,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
           expect(imgArtifact[0]).toEqual(
             expect.objectContaining({
               type: "image",
-              source_type: "base64",
-              mime_type: "image/png",
+              mimeType: "image/png",
             })
           );
 
@@ -2184,11 +2103,10 @@ describe("MultiServerMCPClient Integration Tests", () => {
           expect(audioContentArray).toHaveLength(2);
           expect(audioContentArray).toEqual(
             expect.arrayContaining([
-              expect.objectContaining({ type: "text", source_type: "text" }),
+              expect.objectContaining({ type: "text" }),
               expect.objectContaining({
                 type: "audio",
-                source_type: "base64",
-                mime_type: "audio/wav",
+                mimeType: "audio/wav",
               }),
             ])
           );
@@ -2201,7 +2119,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
             const resContentArray = resContent as ContentBlock[];
             expect(resContentArray).toHaveLength(1);
             expect(resContentArray[0]).toEqual(
-              expect.objectContaining({ type: "text", source_type: "text" })
+              expect.objectContaining({ type: "text" })
             );
           } else {
             expect(resContent).toEqual([]);
@@ -2209,10 +2127,12 @@ describe("MultiServerMCPClient Integration Tests", () => {
           expect(resArtifact).toHaveLength(1);
           expect(resArtifact[0]).toEqual(
             expect.objectContaining({
-              type: "file",
-              source_type: "text",
-              mime_type: "text/plain",
-              metadata: { uri: "mem://test.txt" },
+              type: "resource",
+              resource: {
+                uri: "mem://test.txt",
+                mimeType: "text/plain",
+                text: "This is a test resource.",
+              },
             })
           );
         } finally {

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -2331,9 +2331,12 @@ describe("MultiServerMCPClient Integration Tests", () => {
         async ({ value }) => ({ content: [{ type: "text", text: value }] })
       );
       const client = new SDKClient({ name: "consumer", version: "1.0.0" });
+
       const [clientTransport, serverTransport] =
         InMemoryTransport.createLinkedPair();
+
       await server.connect(serverTransport);
+
       try {
         await client.connect(clientTransport);
         const callTool = vi.spyOn(client, "callTool");
@@ -2365,9 +2368,12 @@ describe("MultiServerMCPClient Integration Tests", () => {
       const server = new McpServer({ name: "compatibility", version: "1.0.0" });
       configure(server);
       const client = new SDKClient({ name: "consumer", version: "1.0.0" });
+
       const [clientTransport, serverTransport] =
         InMemoryTransport.createLinkedPair();
+
       await server.connect(serverTransport);
+
       try {
         await client.connect(clientTransport);
         await run(client, serverTransport);
@@ -2392,9 +2398,11 @@ describe("MultiServerMCPClient Integration Tests", () => {
           const request = client.request.bind(client);
           vi.spyOn(client, "request").mockImplementation(async (...args) => {
             const result = await request(...args);
+
             if (args[0].method === "tools/call") {
               return { content: [], structuredContent: { value: 123 } };
             }
+
             return result;
           });
           await expect(tool.invoke({})).rejects.toThrow(/schema|validat/i);
@@ -2410,6 +2418,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
             { inputSchema: z.object({}) },
             async (_args, extra) => {
               const progressToken = extra.mcpReq._meta?.progressToken;
+
               if (progressToken === undefined)
                 throw new Error("Missing progress token");
               await server.server.notification({
@@ -2420,6 +2429,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
                   total: 1,
                 },
               });
+
               return { content: [{ type: "text", text: "done" }] };
             }
           );
@@ -2440,33 +2450,40 @@ describe("MultiServerMCPClient Integration Tests", () => {
       "honors %s through the SDK 2 call options",
       async (mode) => {
         let started!: () => void;
+
         const toolStarted = new Promise<void>((resolve) => {
           started = resolve;
         });
+
         await withClient(
           (server) => {
             server.registerTool("slow", {}, async () => {
               started();
               await new Promise((resolve) => setTimeout(resolve, 50));
+
               return { content: [{ type: "text", text: "done" }] };
             });
           },
           async (client) => {
             const [tool] = await loadMcpTools("external", client);
             const controller = new AbortController();
+
             const result = tool.invoke(
               {},
               mode === "timeout"
                 ? { metadata: { timeoutMs: 5 } }
                 : { signal: controller.signal }
             );
+
             const rejected = expect(result).rejects.toThrow(
               /timeout|timed out|abort/i
             );
+
             if (mode === "abort") {
               await toolStarted;
               controller.abort();
             }
+
             await rejected;
           }
         );

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -2241,7 +2241,10 @@ describe("MultiServerMCPClient Integration Tests", () => {
           expect(content.length).toBeGreaterThan(0);
           expect(content[0].uri).toBe("mem://test.txt");
           expect(content[0].mimeType).toBe("text/plain");
-          expect(content[0].text).toBe("This is a test resource content.");
+          expect(content[0]).toMatchObject({
+            text: "This is a test resource content.",
+            _meta: { revision: "test-revision" },
+          });
         } finally {
           await client.close();
         }

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -2580,6 +2580,7 @@ describe("explicit protocol modes with live HTTP servers", () => {
   it("connects a default modern server and an explicit legacy server in one adapter", async () => {
     const legacyServers = new TestMCPServers();
     const { baseUrl } = await legacyServers.createHTTPServer("legacy-mode");
+
     const handler = createMcpHandler(
       () => {
         const server = new McpServer({ name: "modern-mode", version: "1" });
@@ -2588,28 +2589,35 @@ describe("explicit protocol modes with live HTTP servers", () => {
           { inputSchema: z.object({ value: z.string() }) },
           ({ value }) => ({ content: [{ type: "text", text: value }] })
         );
+
         return server;
       },
       { legacy: "reject" }
     );
+
     const http = createServer(toNodeHandler(handler));
     http.listen(0, "127.0.0.1");
     await once(http, "listening");
     const address = http.address();
+
     if (!address || typeof address === "string")
       throw new Error("Missing HTTP address");
+
     const adapter = new MCPAdapter({
       servers: {
         modern: { url: `http://127.0.0.1:${address.port}` },
         legacy: { mode: "legacy", url: `${baseUrl}/mcp` },
       },
     });
+
     const mismatch = new MCPAdapter({
       servers: { wrong: { url: `${baseUrl}/mcp` } },
     });
+
     try {
       const tools = await adapter.listTools();
       const modern = tools.find((tool) => tool.name === "modern_echo");
+
       if (!modern) throw new Error("Modern tool was not discovered");
       expect(await modern.invoke({ value: "modern response" })).toContain(
         "modern response"

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -3,7 +3,7 @@ import {
   InMemoryTransport,
 } from "@modelcontextprotocol/client";
 import { McpServer } from "@modelcontextprotocol/server";
-import { z } from "zod/v4";
+import { z } from "zod";
 import { MCPAdapter, loadMcpTools } from "../index.js";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Server } from "node:http";

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@modelcontextprotocol/client";
 import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod/v4";
-import { loadMcpTools } from "../index.js";
+import { MCPAdapter, loadMcpTools } from "../index.js";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Server } from "node:http";
 import { join } from "node:path";
@@ -145,9 +145,9 @@ describe("MultiServerMCPClient Integration Tests", () => {
     it("should connect to and communicate with an HTTP MCP server", async () => {
       const { baseUrl } = await testServers.createHTTPServer("http-test");
 
-      const client = new MultiServerMCPClient({
-        "http-server": {
-          url: `${baseUrl}/mcp`,
+      const client = new MCPAdapter({
+        servers: {
+          "http-server": { transport: "http", url: `${baseUrl}/mcp` },
         },
       });
 

--- a/libs/langchain-mcp-adapters/src/tests/client.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/client.test.ts
@@ -2,11 +2,13 @@ import {
   Client as SDKClient,
   InMemoryTransport,
 } from "@modelcontextprotocol/client";
-import { McpServer } from "@modelcontextprotocol/server";
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { MCPAdapter, loadMcpTools } from "../index.js";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { Server } from "node:http";
+import { createServer, Server } from "node:http";
+import { once } from "node:events";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import { join } from "node:path";
 import type {
   OAuthClientProvider,
@@ -90,6 +92,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           command,
           args,
           env: { TEST_VAR: "test-value" },
@@ -122,6 +125,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "stdio-server": {
+          mode: "legacy",
           command,
           args,
           restart: {
@@ -147,7 +151,11 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MCPAdapter({
         servers: {
-          "http-server": { transport: "http", url: `${baseUrl}/mcp` },
+          "http-server": {
+            mode: "legacy",
+            transport: "http",
+            url: `${baseUrl}/mcp`,
+          },
         },
       });
 
@@ -173,6 +181,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "http-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           headers: {
             Authorization: "Bearer test-token",
@@ -195,6 +204,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "http-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           headers: {
             Authorization: "Bearer invalid-token",
@@ -232,6 +242,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "streamable-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           headers: {
             Authorization: "Bearer test-token",
@@ -274,6 +285,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "streamable-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           headers: {
             Authorization: "Bearer wrong-token",
@@ -308,6 +320,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
       // but with SSE fallback available
       const client = new MultiServerMCPClient({
         "http-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
         },
       });
@@ -330,6 +343,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
         },
@@ -361,6 +375,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           headers: {
@@ -399,6 +414,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           headers: {
@@ -428,6 +444,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           // No headers provided - should still work
@@ -465,13 +482,16 @@ describe("MultiServerMCPClient Integration Tests", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "stdio-server": {
+            mode: "legacy",
             command,
             args,
           },
           "http-server": {
+            mode: "legacy",
             url: `${streamableHttpBaseUrl}/mcp`,
           },
           "sse-server": {
+            mode: "legacy",
             url: `${sseBaseUrl}/sse`,
             transport: "sse",
           },
@@ -513,10 +533,12 @@ describe("MultiServerMCPClient Integration Tests", () => {
       const client = new MultiServerMCPClient({
         mcpServers: {
           "stdio-server": {
+            mode: "legacy",
             command,
             args,
           },
           "http-server": {
+            mode: "legacy",
             url: `${streamableHttpBaseUrl}/mcp`,
           },
         },
@@ -545,6 +567,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "test-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
         },
       });
@@ -566,6 +589,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
     it("should handle connection failures gracefully", async () => {
       const client = new MultiServerMCPClient({
         "failing-server": {
+          mode: "legacy",
           url: "http://totally-not-a-server.fakeurl.example.com:9999/mcp", // Non-existent server
         },
       });
@@ -614,6 +638,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
       const clientWithPrefix = new MultiServerMCPClient({
         mcpServers: {
           "test-server": {
+            mode: "legacy",
             url: `${baseUrl}/mcp`,
           },
         },
@@ -624,6 +649,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
       const clientWithoutPrefix = new MultiServerMCPClient({
         mcpServers: {
           "test-server": {
+            mode: "legacy",
             url: `${baseUrl}/mcp`,
           },
         },
@@ -651,9 +677,10 @@ describe("MultiServerMCPClient Integration Tests", () => {
     });
 
     it("should allow config inspection", async () => {
-      const config = {
+      const config: ClientConfig = {
         mcpServers: {
           "test-server": {
+            mode: "legacy",
             url: "http://example.com/mcp",
           },
         },
@@ -721,6 +748,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "oauth-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           authProvider: mockAuthProvider,
         },
@@ -785,6 +813,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-oauth-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           authProvider: mockAuthProvider,
@@ -853,6 +882,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "oauth-invalid-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           authProvider: mockAuthProvider,
         },
@@ -915,6 +945,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "oauth-no-tokens-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           authProvider: mockAuthProvider,
         },
@@ -978,6 +1009,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-oauth-error-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           authProvider: mockAuthProvider,
@@ -1046,6 +1078,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "oauth-headers-server": {
+          mode: "legacy",
           url: `${baseUrl}/mcp`,
           authProvider: mockAuthProvider,
           headers: {
@@ -1139,6 +1172,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-oauth-headers-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           authProvider: mockAuthProvider,
@@ -1234,6 +1268,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "sse-oauth-invalid-server": {
+          mode: "legacy",
           transport: "sse",
           url: `${baseUrl}/sse`,
           authProvider: mockAuthProvider,
@@ -1267,6 +1302,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
       const client = new MultiServerMCPClient({
         "timeout-server": {
+          mode: "legacy",
           transport: "http",
           url: `${baseUrl}/mcp`,
         },
@@ -1303,6 +1339,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
         const client = new MultiServerMCPClient({
           "timeout-server": {
+            mode: "legacy",
             transport,
             url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
           },
@@ -1338,6 +1375,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
         const client = new MultiServerMCPClient({
           "timeout-server": {
+            mode: "legacy",
             transport,
             url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
           },
@@ -1372,6 +1410,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
         const client = new MultiServerMCPClient({
           "timeout-server": {
+            mode: "legacy",
             transport,
             url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             defaultToolTimeout: 1000,
@@ -1402,6 +1441,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
         const client = new MultiServerMCPClient({
           "timeout-server": {
+            mode: "legacy",
             transport,
             url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             defaultToolTimeout: 5, // 5 milliseconds
@@ -1434,6 +1474,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
 
         const client = new MultiServerMCPClient({
           "timeout-server": {
+            mode: "legacy",
             transport,
             url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
           },
@@ -1468,6 +1509,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             "timeout-server": {
+              mode: "legacy",
               transport,
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1507,6 +1549,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             "audio-server": {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1578,6 +1621,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1684,6 +1728,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1768,6 +1813,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1857,6 +1903,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1929,6 +1976,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -1995,6 +2043,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const clientConfig: ClientConfig = {
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
               outputHandling: {
@@ -2057,6 +2106,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2154,6 +2204,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2190,6 +2241,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2226,6 +2278,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2262,6 +2315,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2291,6 +2345,7 @@ describe("MultiServerMCPClient Integration Tests", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             [serverName]: {
+              mode: "legacy",
               transport: transport as "http" | "sse",
               url: `${baseUrl}/${transport === "http" ? "mcp" : "sse"}`,
             },
@@ -2518,5 +2573,60 @@ describe("MultiServerMCPClient Integration Tests", () => {
         }
       );
     });
+  });
+});
+
+describe("explicit protocol modes with live HTTP servers", () => {
+  it("connects a default modern server and an explicit legacy server in one adapter", async () => {
+    const legacyServers = new TestMCPServers();
+    const { baseUrl } = await legacyServers.createHTTPServer("legacy-mode");
+    const handler = createMcpHandler(
+      () => {
+        const server = new McpServer({ name: "modern-mode", version: "1" });
+        server.registerTool(
+          "modern_echo",
+          { inputSchema: z.object({ value: z.string() }) },
+          ({ value }) => ({ content: [{ type: "text", text: value }] })
+        );
+        return server;
+      },
+      { legacy: "reject" }
+    );
+    const http = createServer(toNodeHandler(handler));
+    http.listen(0, "127.0.0.1");
+    await once(http, "listening");
+    const address = http.address();
+    if (!address || typeof address === "string")
+      throw new Error("Missing HTTP address");
+    const adapter = new MCPAdapter({
+      servers: {
+        modern: { url: `http://127.0.0.1:${address.port}` },
+        legacy: { mode: "legacy", url: `${baseUrl}/mcp` },
+      },
+    });
+    const mismatch = new MCPAdapter({
+      servers: { wrong: { url: `${baseUrl}/mcp` } },
+    });
+    try {
+      const tools = await adapter.listTools();
+      const modern = tools.find((tool) => tool.name === "modern_echo");
+      if (!modern) throw new Error("Modern tool was not discovered");
+      expect(await modern.invoke({ value: "modern response" })).toContain(
+        "modern response"
+      );
+      expect((await adapter.getClient("modern"))?.getProtocolEra()).toBe(
+        "modern"
+      );
+      expect((await adapter.getClient("legacy"))?.getProtocolEra()).toBe(
+        "legacy"
+      );
+      await expect(mismatch.listTools()).rejects.toThrow();
+    } finally {
+      await Promise.all([adapter.close(), mismatch.close()]);
+      await legacyServers.cleanup();
+      await new Promise<void>((resolve, reject) =>
+        http.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
   });
 });

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -4,6 +4,8 @@ import {
   Client as SDKClient,
   SSEClientTransport,
   StreamableHTTPClientTransport,
+  type NotificationMethod,
+  type NotificationTypeMap,
 } from "@modelcontextprotocol/client";
 import type { ResolvedConnection, ServerMessageSource } from "../types.js";
 import { ConnectionManager, type Client } from "../connection.js";
@@ -78,37 +80,34 @@ describe("ConnectionManager", () => {
         if ("command" in options)
           await manager.createClient("stdio", "test", options);
         else await manager.createClient("http", "test", options);
-        const handlers = vi.mocked(SDKClient.prototype.setNotificationHandler)
-          .mock.calls;
-        const message = handlers.find(
-          ([method]) => method === "notifications/message"
-        )![1];
-        const changed = handlers.find(
-          ([method]) => method === "notifications/resources/list_changed"
-        )![1];
-        // The SDK overload also accepts a schema argument in this position.
-        if (typeof message !== "function" || typeof changed !== "function") {
+        const registerNotification: <M extends NotificationMethod>(
+          method: M,
+          handler: (
+            notification: NotificationTypeMap[M]
+          ) => void | Promise<void>
+        ) => void = SDKClient.prototype.setNotificationHandler;
+        const message = vi
+          .mocked(registerNotification<"notifications/message">)
+          .mock.calls.find(
+            ([method]) => method === "notifications/message"
+          )?.[1];
+        const changed = vi
+          .mocked(registerNotification<"notifications/resources/list_changed">)
+          .mock.calls.find(
+            ([method]) => method === "notifications/resources/list_changed"
+          )?.[1];
+        if (!message || !changed) {
           throw new Error("Expected registered notification handlers");
         }
         const params = {
           level: "info",
           data: "test",
           _meta: { extension: true },
-        };
+        } satisfies Parameters<typeof message>[0]["params"];
         try {
-          // Exercise the actual registered dispatch functions with an unused SDK context.
-          await Reflect.apply(message, undefined, [
-            { method: "notifications/message", params },
-            {},
-          ]);
-          await Reflect.apply(message, undefined, [
-            { method: "notifications/message", params },
-            {},
-          ]);
-          await Reflect.apply(changed, undefined, [
-            { method: "notifications/resources/list_changed" },
-            {},
-          ]);
+          await message({ method: "notifications/message", params });
+          await message({ method: "notifications/message", params });
+          await changed({ method: "notifications/resources/list_changed" });
           expect(onMessage.mock.calls[0][0]).toBe(params);
           expect(options.outputHandling).toEqual({ text: "content" });
           expect(observed).toHaveLength(3);

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -59,6 +59,7 @@ describe("ConnectionManager", () => {
         const options: ResolvedConnection =
           transport === "http"
             ? {
+                transport: "http",
                 url: "https://example.com/mcp",
                 automaticSSEFallback: false,
                 headers: { "X-Test": "original" },
@@ -66,6 +67,7 @@ describe("ConnectionManager", () => {
                 outputHandling: { text: "content" },
               }
             : {
+                transport: "stdio",
                 command: "node",
                 args: ["server.js"],
                 stderr: "inherit",

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -5,6 +5,7 @@ import {
   SSEClientTransport,
   StreamableHTTPClientTransport,
 } from "@modelcontextprotocol/client";
+import type { ResolvedConnection, ServerMessageSource } from "../types.js";
 import { ConnectionManager, type Client } from "../connection.js";
 
 vi.mock(
@@ -22,6 +23,101 @@ describe("ConnectionManager", () => {
   });
 
   describe("createClient", () => {
+    test.each(["http", "stdio"] as const)(
+      "isolates notification options for %s clients",
+      async (transport) => {
+        const observed: ResolvedConnection[] = [];
+        const mutateOptions = (source: ServerMessageSource) => {
+          const options = source.options;
+          observed.push(options);
+          expect(options.outputHandling).toEqual({ text: "content" });
+          if (typeof options.outputHandling === "object")
+            options.outputHandling.text = "artifact";
+          if ("command" in options) {
+            expect(options.args).toEqual(["server.js"]);
+            expect(options.env).toEqual({ MODE: "test" });
+            expect(options.restart).toEqual({ enabled: false });
+            options.args.push("changed");
+            options.env!.MODE = "changed";
+            options.restart!.enabled = true;
+          } else {
+            expect(options.url).toBe("https://example.com/mcp");
+            expect(options.headers).toEqual({ "X-Test": "original" });
+            expect(options.reconnect).toEqual({ enabled: false });
+            options.url = "https://example.com/changed";
+            options.headers!["X-Test"] = "changed";
+            options.reconnect!.enabled = true;
+          }
+        };
+        const onMessage = vi.fn((_message, source: ServerMessageSource) =>
+          mutateOptions(source)
+        );
+        const manager = new ConnectionManager({
+          onMessage,
+          onResourcesListChanged: mutateOptions,
+        });
+        const options: ResolvedConnection =
+          transport === "http"
+            ? {
+                url: "https://example.com/mcp",
+                automaticSSEFallback: false,
+                headers: { "X-Test": "original" },
+                reconnect: { enabled: false },
+                outputHandling: { text: "content" },
+              }
+            : {
+                command: "node",
+                args: ["server.js"],
+                stderr: "inherit",
+                env: { MODE: "test" },
+                restart: { enabled: false },
+                outputHandling: { text: "content" },
+              };
+        if ("command" in options)
+          await manager.createClient("stdio", "test", options);
+        else await manager.createClient("http", "test", options);
+        const handlers = vi.mocked(SDKClient.prototype.setNotificationHandler)
+          .mock.calls;
+        const message = handlers.find(
+          ([method]) => method === "notifications/message"
+        )![1];
+        const changed = handlers.find(
+          ([method]) => method === "notifications/resources/list_changed"
+        )![1];
+        // The SDK overload also accepts a schema argument in this position.
+        if (typeof message !== "function" || typeof changed !== "function") {
+          throw new Error("Expected registered notification handlers");
+        }
+        const params = {
+          level: "info",
+          data: "test",
+          _meta: { extension: true },
+        };
+        try {
+          // Exercise the actual registered dispatch functions with an unused SDK context.
+          await Reflect.apply(message, undefined, [
+            { method: "notifications/message", params },
+            {},
+          ]);
+          await Reflect.apply(message, undefined, [
+            { method: "notifications/message", params },
+            {},
+          ]);
+          await Reflect.apply(changed, undefined, [
+            { method: "notifications/resources/list_changed" },
+            {},
+          ]);
+          expect(onMessage.mock.calls[0][0]).toBe(params);
+          expect(options.outputHandling).toEqual({ text: "content" });
+          expect(observed).toHaveLength(3);
+          expect(observed[0]).not.toBe(options);
+          expect(observed[0]).not.toBe(observed[1]);
+        } finally {
+          await manager.delete();
+        }
+      }
+    );
+
     test("creates stdio client and connects", async () => {
       const mgr = new ConnectionManager();
 

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -59,22 +59,23 @@ describe("ConnectionManager", () => {
           mutateOptions(source)
         );
 
-        const manager = new ConnectionManager({
-          onMessage,
-          onResourcesListChanged: mutateOptions,
-        });
+        const manager = new ConnectionManager();
 
         const options: ResolvedConnection =
           transport === "http"
             ? {
+                mode: "legacy",
                 transport: "http",
                 url: "https://example.com/mcp",
                 automaticSSEFallback: false,
                 headers: { "X-Test": "original" },
                 reconnect: { enabled: false },
                 outputHandling: { text: "content" },
+                onMessage,
+                onResourcesListChanged: mutateOptions,
               }
             : {
+                mode: "legacy",
                 transport: "stdio",
                 command: "node",
                 args: ["server.js"],
@@ -82,6 +83,8 @@ describe("ConnectionManager", () => {
                 env: { MODE: "test" },
                 restart: { enabled: false },
                 outputHandling: { text: "content" },
+                onMessage,
+                onResourcesListChanged: mutateOptions,
               };
 
         if ("command" in options)
@@ -136,6 +139,7 @@ describe("ConnectionManager", () => {
       const mgr = new ConnectionManager();
 
       const client = await mgr.createClient("stdio", "stdio-server", {
+        mode: "legacy",
         transport: "stdio",
         command: "python",
         args: ["./script.py"],
@@ -153,6 +157,7 @@ describe("ConnectionManager", () => {
       const mgr = new ConnectionManager();
 
       const client = await mgr.createClient("stdio", "stdio-server", {
+        mode: "legacy",
         transport: "stdio",
         command: "node",
         args: ["./server.js"],
@@ -174,6 +179,7 @@ describe("ConnectionManager", () => {
       const mgr = new ConnectionManager();
 
       await mgr.createClient("http", "http-server", {
+        mode: "legacy",
         transport: "http",
         url: "http://localhost:8000/mcp",
         automaticSSEFallback: true,
@@ -204,6 +210,7 @@ describe("ConnectionManager", () => {
       } as never;
 
       await mgr.createClient("sse", "sse-server", {
+        mode: "legacy",
         transport: "sse",
         url: "http://localhost:8000/sse",
         automaticSSEFallback: true,
@@ -228,12 +235,14 @@ describe("ConnectionManager", () => {
       const mgr = new ConnectionManager();
 
       const c1 = await mgr.createClient("http", "svc", {
+        mode: "legacy",
         transport: "http",
         url: "http://localhost:8000/mcp",
         automaticSSEFallback: true,
         headers: { A: "1" },
       });
       const c2 = await mgr.createClient("http", "svc", {
+        mode: "legacy",
         transport: "http",
         url: "http://localhost:8000/mcp",
         automaticSSEFallback: true,
@@ -259,6 +268,7 @@ describe("ConnectionManager", () => {
       };
       const client = await mgr.createClient("stdio", "s", {
         ...config,
+        mode: "legacy",
         transport: "stdio",
       });
 
@@ -276,12 +286,14 @@ describe("ConnectionManager", () => {
     test("deletes specific connection and all connections", async () => {
       const mgr = new ConnectionManager();
       await mgr.createClient("http", "svc", {
+        mode: "legacy",
         transport: "http",
         url: "http://localhost:8000/mcp",
         automaticSSEFallback: true,
         headers: { A: "1" },
       });
       await mgr.createClient("sse", "svc", {
+        mode: "legacy",
         transport: "sse",
         url: "http://localhost:8000/sse",
         automaticSSEFallback: true,
@@ -301,6 +313,7 @@ describe("ConnectionManager", () => {
     test("forks HTTP client with new headers and creates a new connection", async () => {
       const mgr = new ConnectionManager();
       const base = await mgr.createClient("http", "svc", {
+        mode: "legacy",
         transport: "http",
         url: "http://localhost:8000/mcp",
         automaticSSEFallback: true,
@@ -316,6 +329,7 @@ describe("ConnectionManager", () => {
     test("forking stdio client is not supported", async () => {
       const mgr = new ConnectionManager();
       const stdio = await mgr.createClient("stdio", "svc", {
+        mode: "legacy",
         transport: "stdio",
         command: "python",
         args: ["./script.py"],

--- a/libs/langchain-mcp-adapters/src/tests/connection.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/connection.test.ts
@@ -29,12 +29,15 @@ describe("ConnectionManager", () => {
       "isolates notification options for %s clients",
       async (transport) => {
         const observed: ResolvedConnection[] = [];
+
         const mutateOptions = (source: ServerMessageSource) => {
           const options = source.options;
           observed.push(options);
           expect(options.outputHandling).toEqual({ text: "content" });
+
           if (typeof options.outputHandling === "object")
             options.outputHandling.text = "artifact";
+
           if ("command" in options) {
             expect(options.args).toEqual(["server.js"]);
             expect(options.env).toEqual({ MODE: "test" });
@@ -51,13 +54,16 @@ describe("ConnectionManager", () => {
             options.reconnect!.enabled = true;
           }
         };
+
         const onMessage = vi.fn((_message, source: ServerMessageSource) =>
           mutateOptions(source)
         );
+
         const manager = new ConnectionManager({
           onMessage,
           onResourcesListChanged: mutateOptions,
         });
+
         const options: ResolvedConnection =
           transport === "http"
             ? {
@@ -77,33 +83,40 @@ describe("ConnectionManager", () => {
                 restart: { enabled: false },
                 outputHandling: { text: "content" },
               };
+
         if ("command" in options)
           await manager.createClient("stdio", "test", options);
         else await manager.createClient("http", "test", options);
+
         const registerNotification: <M extends NotificationMethod>(
           method: M,
           handler: (
             notification: NotificationTypeMap[M]
           ) => void | Promise<void>
         ) => void = SDKClient.prototype.setNotificationHandler;
+
         const message = vi
           .mocked(registerNotification<"notifications/message">)
           .mock.calls.find(
             ([method]) => method === "notifications/message"
           )?.[1];
+
         const changed = vi
           .mocked(registerNotification<"notifications/resources/list_changed">)
           .mock.calls.find(
             ([method]) => method === "notifications/resources/list_changed"
           )?.[1];
+
         if (!message || !changed) {
           throw new Error("Expected registered notification handlers");
         }
+
         const params = {
           level: "info",
           data: "test",
           _meta: { extension: true },
         } satisfies Parameters<typeof message>[0]["params"];
+
         try {
           await message({ method: "notifications/message", params });
           await message({ method: "notifications/message", params });

--- a/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
+++ b/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
@@ -333,10 +333,9 @@ export function createDummyHttpServer(
   app.use(express.json());
 
   // Store transports and metadata
-  const transports: {
-    streamable: Record<string, NodeStreamableHTTPServerTransport>;
-    sse: Record<string, SSEServerTransport>;
-  } = { streamable: {}, sse: {} };
+  const streamable: Record<string, NodeStreamableHTTPServerTransport> = {};
+  const sse: Record<string, SSEServerTransport> = {};
+  const transports = { streamable, sse };
 
   // Helper function to capture headers
   const captureHeaders = (req: express.Request, sessionId: string) => {

--- a/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
+++ b/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
@@ -61,6 +61,7 @@ export function createDummyHttpServer(
 
         // Progress with token if present
         const progressToken = extra.mcpReq._meta?.progressToken;
+
         if (progressToken !== undefined) {
           const steps = 3;
           for (let i = 1; i <= steps; i++) {
@@ -332,10 +333,10 @@ export function createDummyHttpServer(
   app.use(express.json());
 
   // Store transports and metadata
-  const transports = {
-    streamable: {} as Record<string, NodeStreamableHTTPServerTransport>,
-    sse: {} as Record<string, SSEServerTransport>,
-  };
+  const transports: {
+    streamable: Record<string, NodeStreamableHTTPServerTransport>;
+    sse: Record<string, SSEServerTransport>;
+  } = { streamable: {}, sse: {} };
 
   // Helper function to capture headers
   const captureHeaders = (req: express.Request, sessionId: string) => {

--- a/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
+++ b/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-http-server.ts
@@ -276,6 +276,7 @@ export function createDummyHttpServer(
               uri: "mem://test.txt",
               mimeType: "text/plain",
               text: "This is a test resource content.",
+              _meta: { revision: "test-revision" },
             },
           ],
         };

--- a/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-stdio-server.ts
+++ b/libs/langchain-mcp-adapters/src/tests/fixtures/dummy-stdio-server.ts
@@ -35,6 +35,7 @@ server.registerTool(
 
     // Simulate progress updates using progressToken if present
     const progressToken = extra.mcpReq._meta?.progressToken;
+
     if (progressToken !== undefined) {
       const steps = 3;
       for (let i = 1; i <= steps; i++) {

--- a/libs/langchain-mcp-adapters/src/tests/hooks.schemas.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { toolCallResultModificationSchema } from "../hooks.js";
+
+describe("hook result parsing", () => {
+  test("preserves provider extensions and legacy artifact blocks", () => {
+    const modification = {
+      result: [
+        [{ type: "provider_block", provider: { value: 42 } }],
+        [
+          {
+            type: "image",
+            source_type: "base64",
+            data: "aGVsbG8=",
+            mime_type: "image/png",
+          },
+        ],
+      ],
+    };
+    expect(toolCallResultModificationSchema.parse(modification)).toEqual(
+      modification
+    );
+  });
+
+  test("accepts MCP resources through the SDK schema", () => {
+    const modification = {
+      result: [
+        "result",
+        [
+          {
+            type: "resource",
+            resource: { uri: "file:///test.txt", text: "hello" },
+          },
+        ],
+      ],
+    };
+    expect(toolCallResultModificationSchema.parse(modification)).toEqual(
+      modification
+    );
+  });
+
+  test.each([
+    { result: [[42], []] },
+    { result: ["result", [null]] },
+    { result: ["result", [{ type: "resource", resource: {} }]] },
+    { result: ["result", [{ data: "missing type" }]] },
+    { result: [[{ type: "text", id: 42 }], []] },
+  ])("rejects malformed result blocks: %j", (modification) => {
+    expect(
+      toolCallResultModificationSchema.safeParse(modification).success
+    ).toBe(false);
+  });
+});

--- a/libs/langchain-mcp-adapters/src/tests/hooks.schemas.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.schemas.test.ts
@@ -16,6 +16,7 @@ describe("hook result parsing", () => {
         ],
       ],
     };
+
     expect(toolCallResultModificationSchema.parse(modification)).toEqual(
       modification
     );
@@ -33,6 +34,7 @@ describe("hook result parsing", () => {
         ],
       ],
     };
+
     expect(toolCallResultModificationSchema.parse(modification)).toEqual(
       modification
     );

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -1,3 +1,5 @@
+import { MCPAdapter } from "../index.js";
+import type { LoggingMessageNotificationParams } from "@modelcontextprotocol/client";
 import { test, expectTypeOf } from "vitest";
 import { ToolMessage } from "@langchain/core/messages";
 import { RunnableConfig } from "@langchain/core/runnables";
@@ -22,7 +24,7 @@ test("check tool hooks types", () => {
       expectTypeOf(toolCallRequest).toEqualTypeOf<{
         name: string;
         serverName: string;
-        args?: unknown;
+        args: unknown;
       }>();
     },
     afterToolCall: (toolCallResult, state, runtime) => {
@@ -57,7 +59,7 @@ test("check tool hooks types", () => {
             type: "tool";
             name: string;
             server: string;
-            args?: unknown;
+            args: unknown;
           }
         | {
             type: "unknown";
@@ -115,4 +117,19 @@ test("check tool hooks types", () => {
       }>();
     },
   });
+});
+
+test("canonical adapter API retains typed SDK callbacks and native tools", () => {
+  const adapter = new MCPAdapter({
+    servers: { remote: { transport: "http", url: "https://example.com/mcp" } },
+    onMessage: (message) => {
+      expectTypeOf(message).toEqualTypeOf<LoggingMessageNotificationParams>();
+    },
+    beforeToolCall: async ({ args }) => {
+      expectTypeOf(args).toEqualTypeOf<unknown>();
+      return { args: { value: 1 } };
+    },
+  });
+  expectTypeOf(adapter).toEqualTypeOf<MultiServerMCPClient>();
+  expectTypeOf(adapter.close()).toEqualTypeOf<Promise<void>>();
 });

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -127,9 +127,11 @@ test("canonical adapter API retains typed SDK callbacks and native tools", () =>
     },
     beforeToolCall: async ({ args }) => {
       expectTypeOf(args).toEqualTypeOf<unknown>();
+
       return { args: { value: 1 } };
     },
   });
+
   expectTypeOf(adapter).toEqualTypeOf<MultiServerMCPClient>();
   expectTypeOf(adapter.close()).toEqualTypeOf<Promise<void>>();
 });

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -23,7 +23,77 @@ test("check tool hooks types", () => {
   new MultiServerMCPClient({
     mcpServers: {
       filesystem: {
+        mode: "legacy",
         transport: "stdio",
+        onMessage: (message, server) => {
+          expectTypeOf(message.logger).toEqualTypeOf<string | undefined>();
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+        onProgress: (progress, eventSource) => {
+          expectTypeOf(progress).toMatchTypeOf<{
+            percentage?: number;
+            progress?: number;
+            total?: number;
+            message?: string;
+          }>();
+          expectTypeOf(eventSource).toEqualTypeOf<
+            | {
+                type: "tool";
+                name: string;
+                server: string;
+                args: unknown;
+              }
+            | {
+                type: "unknown";
+              }
+          >();
+        },
+        onCancelled: (notification, server) => {
+          expectTypeOf(notification.reason).toEqualTypeOf<string | undefined>();
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+
+        onInitialized: (server) => {
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+
+        onPromptsListChanged: (server) => {
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+
+        onResourcesListChanged: (server) => {
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+
+        onResourcesUpdated: (notification, server) => {
+          expectTypeOf(notification.uri).toEqualTypeOf<string>();
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
+
+        onToolsListChanged: (server) => {
+          expectTypeOf(server).toEqualTypeOf<{
+            server: string;
+            options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
+          }>();
+        },
         command: "npx",
         args: ["-y", "@modelcontextprotocol/server-filesystem", "./"],
       },
@@ -50,90 +120,21 @@ test("check tool hooks types", () => {
         }),
       };
     },
-    onMessage: (message, server) => {
-      expectTypeOf(message.logger).toEqualTypeOf<string | undefined>();
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-    onProgress: (progress, eventSource) => {
-      expectTypeOf(progress).toMatchTypeOf<{
-        percentage?: number;
-        progress?: number;
-        total?: number;
-        message?: string;
-      }>();
-      expectTypeOf(eventSource).toEqualTypeOf<
-        | {
-            type: "tool";
-            name: string;
-            server: string;
-            args: unknown;
-          }
-        | {
-            type: "unknown";
-          }
-      >();
-    },
-    onCancelled: (notification, server) => {
-      expectTypeOf(notification.reason).toEqualTypeOf<string | undefined>();
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onInitialized: (server) => {
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onPromptsListChanged: (server) => {
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onResourcesListChanged: (server) => {
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onResourcesUpdated: (notification, server) => {
-      expectTypeOf(notification.uri).toEqualTypeOf<string>();
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onRootsListChanged: (server) => {
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
-
-    onToolsListChanged: (server) => {
-      expectTypeOf(server).toEqualTypeOf<{
-        server: string;
-        options: ResolvedStreamableHTTPConnection | ResolvedStdioConnection;
-      }>();
-    },
   });
 });
 
 test("canonical adapter API retains typed SDK callbacks and native tools", () => {
   const adapter = new MCPAdapter({
-    servers: { remote: { transport: "http", url: "https://example.com/mcp" } },
-    onMessage: (message) => {
-      expectTypeOf(message).toEqualTypeOf<LoggingMessageNotificationParams>();
+    servers: {
+      remote: {
+        transport: "http",
+        url: "https://example.com/mcp",
+        onMessage: (message) => {
+          expectTypeOf(
+            message
+          ).toEqualTypeOf<LoggingMessageNotificationParams>();
+        },
+      },
     },
     beforeToolCall: async ({ args }) => {
       expectTypeOf(args).toEqualTypeOf<unknown>();
@@ -159,4 +160,19 @@ test("resource and content types follow the SDK", () => {
   expectTypeOf<CallToolResultContentType>().toEqualTypeOf<
     CallToolResult["content"][number]["type"]
   >();
+});
+
+test("protocol modes reject fields belonging to the other server interface", () => {
+  // @ts-expect-error Legacy initialization observers are forbidden without legacy mode.
+  const modern: import("../types.js").Connection = {
+    url: "https://example.com/mcp",
+    onInitialized: () => undefined,
+  };
+  const legacy: import("../types.js").Connection = {
+    mode: "legacy",
+    url: "https://example.com/mcp",
+    onInitialized: () => undefined,
+  };
+  expectTypeOf(modern).toMatchTypeOf<import("../types.js").Connection>();
+  expectTypeOf(legacy).toMatchTypeOf<import("../types.js").Connection>();
 });

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -168,11 +168,13 @@ test("protocol modes reject fields belonging to the other server interface", () 
     url: "https://example.com/mcp",
     onInitialized: () => undefined,
   };
+
   const legacy: import("../types.js").Connection = {
     mode: "legacy",
     url: "https://example.com/mcp",
     onInitialized: () => undefined,
   };
+
   expectTypeOf(modern).toMatchTypeOf<import("../types.js").Connection>();
   expectTypeOf(legacy).toMatchTypeOf<import("../types.js").Connection>();
 });

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -19,7 +19,7 @@ test("check tool hooks types", () => {
       },
     },
     beforeToolCall: (toolCallRequest, state, runtime) => {
-      expectTypeOf(state).toEqualTypeOf<Record<string, unknown>>();
+      expectTypeOf(state).toEqualTypeOf<unknown>();
       expectTypeOf(runtime).toEqualTypeOf<RunnableConfig>();
       expectTypeOf(toolCallRequest).toEqualTypeOf<{
         name: string;
@@ -28,7 +28,7 @@ test("check tool hooks types", () => {
       }>();
     },
     afterToolCall: (toolCallResult, state, runtime) => {
-      expectTypeOf(state).toEqualTypeOf<Record<string, unknown>>();
+      expectTypeOf(state).toEqualTypeOf<unknown>();
       expectTypeOf(runtime).toEqualTypeOf<RunnableConfig>();
       expectTypeOf(toolCallResult.name).toEqualTypeOf<string>();
       expectTypeOf(toolCallResult.args).toEqualTypeOf<unknown>();

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test-d.ts
@@ -1,10 +1,20 @@
 import { MCPAdapter } from "../index.js";
-import type { LoggingMessageNotificationParams } from "@modelcontextprotocol/client";
+import type {
+  CallToolResult,
+  ListResourcesResult,
+  ListResourceTemplatesResult,
+  ReadResourceResult,
+  LoggingMessageNotificationParams,
+} from "@modelcontextprotocol/client";
 import { test, expectTypeOf } from "vitest";
 import { ToolMessage } from "@langchain/core/messages";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { MultiServerMCPClient } from "../client.js";
 import type {
+  MCPResource,
+  MCPResourceTemplate,
+  MCPResourceContent,
+  CallToolResultContentType,
   ResolvedStreamableHTTPConnection,
   ResolvedStdioConnection,
 } from "../types.js";
@@ -134,4 +144,19 @@ test("canonical adapter API retains typed SDK callbacks and native tools", () =>
 
   expectTypeOf(adapter).toEqualTypeOf<MultiServerMCPClient>();
   expectTypeOf(adapter.close()).toEqualTypeOf<Promise<void>>();
+});
+
+test("resource and content types follow the SDK", () => {
+  expectTypeOf<MCPResource>().toEqualTypeOf<
+    ListResourcesResult["resources"][number]
+  >();
+  expectTypeOf<MCPResourceTemplate>().toEqualTypeOf<
+    ListResourceTemplatesResult["resourceTemplates"][number]
+  >();
+  expectTypeOf<MCPResourceContent>().toEqualTypeOf<
+    ReadResourceResult["contents"][number]
+  >();
+  expectTypeOf<CallToolResultContentType>().toEqualTypeOf<
+    CallToolResult["content"][number]["type"]
+  >();
 });

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -294,6 +294,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const { baseUrl } = await servers.createHTTP("http-interceptor", {
       testHeaders: true,
     });
+
     const stateCalls: unknown[] = [];
     const runtimeCalls: RunnableConfig[] = [];
     const client = new MultiServerMCPClient({
@@ -335,6 +336,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
   test("hooks preserve arbitrary functional entrypoint inputs", async () => {
     const { baseUrl } = await servers.createHTTP("entrypoint-input");
     const observed: unknown[] = [];
+
     const client = new MultiServerMCPClient({
       mcpServers: { http: { url: `${baseUrl}/mcp` } },
       beforeToolCall: (_, state) => {
@@ -347,10 +349,13 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
 
     try {
       const [tool] = await client.getTools();
+
       const workflow = entrypoint("hook-input", async (input: unknown) => {
         await tool.invoke({ input: "orig" });
+
         return input;
       });
+
       for (const input of [
         ["retained-input"],
         "text",

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/client";
+import { loadMcpTools } from "../tools.js";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { Server } from "node:http";
 import { join } from "node:path";
 import { ToolMessage, BaseMessage } from "@langchain/core/messages";
@@ -53,6 +55,61 @@ class TestServers {
     this.httpServers = [];
   }
 }
+
+test.each(["sync", "async"])(
+  "preserves MCP artifacts through a %s pass-through hook",
+  async (mode) => {
+    const client = new Client({ name: "artifact-test", version: "1" });
+
+    const artifacts = [
+      { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+      { type: "audio", data: "YXVkaW8=", mimeType: "audio/wav" },
+      { type: "text", text: "artifact text" },
+      { type: "resource_link", uri: "memory://linked", name: "linked" },
+      {
+        type: "resource",
+        resource: { uri: "memory://embedded", text: "embedded" },
+      },
+    ] satisfies Awaited<ReturnType<Client["callTool"]>>["content"];
+
+    vi.spyOn(client, "listTools").mockResolvedValue({
+      tools: [
+        { name: "echo", inputSchema: { type: "object", properties: {} } },
+      ],
+    });
+    vi.spyOn(client, "callTool").mockResolvedValue({ content: artifacts });
+
+    const afterToolCall = vi.fn(
+      ({
+        result,
+      }: Parameters<NonNullable<ClientConfig["afterToolCall"]>>[0]) => {
+        expect(result).toEqual([expect.anything(), artifacts]);
+
+        return mode === "async" ? Promise.resolve({ result }) : { result };
+      }
+    );
+
+    try {
+      const [tool] = await loadMcpTools("test", client, {
+        outputHandling: "artifact",
+        afterToolCall,
+      });
+
+      const output = await tool.invoke({
+        type: "tool_call",
+        id: "call",
+        name: "echo",
+        args: {},
+      });
+
+      expect(output.artifact).toEqual(artifacts);
+      expect(afterToolCall).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.restoreAllMocks();
+      await client.close();
+    }
+  }
+);
 
 describe("Interceptor hooks (stdio/http/sse)", () => {
   let servers: TestServers;

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { Client } from "@modelcontextprotocol/client";
 import { loadMcpTools } from "../tools.js";
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
@@ -136,6 +137,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             stdio: {
+              mode: "legacy",
               transport: "stdio",
               command,
               args,
@@ -164,6 +166,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             http: {
+              mode: "legacy",
               transport: "http",
               url: `${baseUrl}/mcp`,
               automaticSSEFallback: true,
@@ -193,6 +196,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         const client = new MultiServerMCPClient({
           mcpServers: {
             sse: {
+              mode: "legacy",
               transport: "sse",
               url: `${baseUrl}/sse`,
             },
@@ -315,25 +319,19 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const client = new MultiServerMCPClient({
       mcpServers: {
         http: {
+          mode: "legacy",
           transport: "http",
           url: `${baseUrl}/mcp`,
+          onMessage: (log) => {
+            logs.push(z.string().parse(log.data));
+          },
+          onProgress: (p) => {
+            progresses.push(
+              p.total ? Math.round((p.progress / p.total) * 100) : p.progress
+            );
+          },
           automaticSSEFallback: true,
         },
-      },
-      onMessage: (log) => {
-        logs.push((log.data as string) ?? "");
-      },
-      onProgress: (p) => {
-        const anyP = p as unknown as {
-          percentage?: number;
-          progress?: number;
-          total?: number;
-        };
-        let pct = anyP.percentage;
-        if (pct == null && anyP.progress != null && anyP.total) {
-          pct = Math.round((anyP.progress / anyP.total) * 100);
-        }
-        progresses.push(Number(pct ?? 0));
       },
     });
     try {
@@ -357,6 +355,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const client = new MultiServerMCPClient({
       mcpServers: {
         http: {
+          mode: "legacy",
           transport: "http",
           url: `${baseUrl}/mcp`,
           automaticSSEFallback: true,
@@ -395,7 +394,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const observed: unknown[] = [];
 
     const client = new MultiServerMCPClient({
-      mcpServers: { http: { url: `${baseUrl}/mcp` } },
+      mcpServers: { http: { mode: "legacy", url: `${baseUrl}/mcp` } },
       beforeToolCall: (_, state) => {
         observed.push(state);
       },
@@ -443,6 +442,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const client = new MultiServerMCPClient({
       mcpServers: {
         http: {
+          mode: "legacy",
           transport: "http",
           url: `${baseUrl}/mcp`,
           automaticSSEFallback: true,

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -3,6 +3,7 @@ import { Server } from "node:http";
 import { join } from "node:path";
 import { ToolMessage, BaseMessage } from "@langchain/core/messages";
 import { createAgent, FakeToolCallingModel } from "langchain";
+import { entrypoint } from "@langchain/langgraph";
 import type { RunnableConfig } from "@langchain/core/runnables";
 
 import { createDummyHttpServer } from "./fixtures/dummy-http-server.js";
@@ -327,6 +328,43 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
         recursionLimit: 25,
         runName: "test_tool",
       });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("hooks preserve arbitrary functional entrypoint inputs", async () => {
+    const { baseUrl } = await servers.createHTTP("entrypoint-input");
+    const observed: unknown[] = [];
+    const client = new MultiServerMCPClient({
+      mcpServers: { http: { url: `${baseUrl}/mcp` } },
+      beforeToolCall: (_, state) => {
+        observed.push(state);
+      },
+      afterToolCall: (_, state) => {
+        observed.push(state);
+      },
+    });
+
+    try {
+      const [tool] = await client.getTools();
+      const workflow = entrypoint("hook-input", async (input: unknown) => {
+        await tool.invoke({ input: "orig" });
+        return input;
+      });
+      for (const input of [
+        ["retained-input"],
+        "text",
+        0,
+        false,
+        { value: 1 },
+      ]) {
+        observed.length = 0;
+        await workflow.invoke(input);
+        expect(observed).toHaveLength(2);
+        expect(observed[0]).toBe(input);
+        expect(observed[1]).toBe(input);
+      }
     } finally {
       await client.close();
     }

--- a/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/hooks.test.ts
@@ -8,7 +8,6 @@ import type { RunnableConfig } from "@langchain/core/runnables";
 
 import { createDummyHttpServer } from "./fixtures/dummy-http-server.js";
 import { MultiServerMCPClient } from "../client.js";
-import type { State } from "../hooks.js";
 import type { ClientConfig } from "../types.js";
 
 type TransportKind = "stdio" | "http" | "sse";
@@ -295,7 +294,7 @@ describe("Interceptor hooks (stdio/http/sse)", () => {
     const { baseUrl } = await servers.createHTTP("http-interceptor", {
       testHeaders: true,
     });
-    const stateCalls: State[] = [];
+    const stateCalls: unknown[] = [];
     const runtimeCalls: RunnableConfig[] = [];
     const client = new MultiServerMCPClient({
       mcpServers: {

--- a/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
@@ -38,6 +38,19 @@ describe("ToolException error formatting", () => {
     expect(new ToolException("Original failure", cause).cause).toBe(cause);
   });
 
+  test("formats valid issues even when an external Zod error has a malformed stack", () => {
+    class ZodError extends Error {
+      issues = [{ message: "Required", path: ["args"] }];
+    }
+
+    const cause = new ZodError("Verbose details");
+    Object.defineProperty(cause, "stack", { value: 42 });
+    expect(new ToolException("Invalid input", cause).cause).toMatchObject({
+      message: "✖ Required\n  → at args",
+      stack: undefined,
+    });
+  });
+
   test("preserves ordinary and non-Error causes", () => {
     const cause = new Error("Connection failed");
     expect(new ToolException("Failure", cause).cause).toBe(cause);

--- a/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
@@ -5,6 +5,7 @@ import { ToolException } from "../tools.js";
 describe("ToolException error formatting", () => {
   test("formats parsed Zod issues with their nested paths", () => {
     const result = z.object({ count: z.number() }).safeParse({ count: "one" });
+
     if (result.success) throw new Error("Expected invalid input");
 
     const error = new ToolException("Invalid hook result", result.error);
@@ -18,6 +19,7 @@ describe("ToolException error formatting", () => {
     class ZodError extends Error {
       issues = [{ message: "Required", path: ["args", 0] }];
     }
+
     const cause = new ZodError("Verbose details");
     cause.stack = "Verbose details\n    at caller (example.ts:1:1)";
     const error = new ToolException("Invalid hook result", cause);
@@ -31,6 +33,7 @@ describe("ToolException error formatting", () => {
     class ZodError extends Error {
       issues = [{ message: 42, path: null }];
     }
+
     const cause = new ZodError("Malformed details");
     expect(new ToolException("Original failure", cause).cause).toBe(cause);
   });

--- a/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
@@ -19,9 +19,11 @@ describe("ToolException error formatting", () => {
       issues = [{ message: "Required", path: ["args", 0] }];
     }
     const cause = new ZodError("Verbose details");
+    cause.stack = "Verbose details\n    at caller (example.ts:1:1)";
     const error = new ToolException("Invalid hook result", cause);
     expect(error.cause).toMatchObject({
       message: "✖ Required\n  → at args[0]",
+      stack: "    at caller (example.ts:1:1)",
     });
   });
 

--- a/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { ToolException } from "../tools.js";
+
+describe("ToolException error formatting", () => {
+  test("formats parsed Zod issues with their nested paths", () => {
+    const result = z.object({ count: z.number() }).safeParse({ count: "one" });
+    if (result.success) throw new Error("Expected invalid input");
+
+    const error = new ToolException("Invalid hook result", result.error);
+    expect(error.cause).toMatchObject({
+      message: z.prettifyError(result.error),
+    });
+    expect(error.cause).not.toBe(result.error);
+  });
+
+  test("accepts the issue projection from another Zod implementation", () => {
+    class ZodError extends Error {
+      issues = [{ message: "Required", path: ["args", 0] }];
+    }
+    const cause = new ZodError("Verbose details");
+    const error = new ToolException("Invalid hook result", cause);
+    expect(error.cause).toMatchObject({
+      message: "✖ Required\n  → at args[0]",
+    });
+  });
+
+  test("preserves malformed error lookalikes instead of throwing while formatting", () => {
+    class ZodError extends Error {
+      issues = [{ message: 42, path: null }];
+    }
+    const cause = new ZodError("Malformed details");
+    expect(new ToolException("Original failure", cause).cause).toBe(cause);
+  });
+
+  test("preserves ordinary and non-Error causes", () => {
+    const cause = new Error("Connection failed");
+    expect(new ToolException("Failure", cause).cause).toBe(cause);
+    expect(new ToolException("Failure", null).cause).toBeNull();
+    expect(new ToolException("Failure", false).cause).toBe(false);
+  });
+});

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -17,7 +17,6 @@ import type {
 } from "@langchain/core/messages";
 
 import { z } from "zod";
-import type { ToolHooks } from "../hooks.js";
 import { loadMcpTools } from "../tools.js";
 
 vi.mock(
@@ -116,10 +115,9 @@ describe("Simplified Tool Adapter Tests", () => {
       "validates before hooks after awaiting them (async=%s)",
       async (asyncHook) => {
         const invalid = { headers: { test: 42 } };
-        const beforeToolCall = (asyncHook
-          ? async () => invalid
-          : () => invalid) as unknown as ToolHooks["beforeToolCall"];
+        const beforeToolCall = asyncHook ? async () => invalid : () => invalid;
         const [tool] = await loadMcpTools("test", mockClient, {
+          // @ts-expect-error Exercise malformed JavaScript callback results.
           beforeToolCall,
         });
         await expect(tool.invoke({})).rejects.toThrow(/string/);
@@ -130,10 +128,11 @@ describe("Simplified Tool Adapter Tests", () => {
     test.each([false, true])(
       "validates after hooks after awaiting them (async=%s)",
       async (asyncHook) => {
-        const afterToolCall = (asyncHook
+        const afterToolCall = asyncHook
           ? async () => ({ result: 42 })
-          : () => ({ result: 42 })) as unknown as ToolHooks["afterToolCall"];
+          : () => ({ result: 42 });
         const [tool] = await loadMcpTools("test", mockClient, {
+          // @ts-expect-error Exercise malformed JavaScript callback results.
           afterToolCall,
         });
         await expect(tool.invoke({})).rejects.toThrow();

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -15,7 +15,7 @@ import type {
   ToolMessage,
 } from "@langchain/core/messages";
 
-import { z } from "zod/v4";
+import { z } from "zod";
 import type { ToolHooks } from "../hooks.js";
 import { loadMcpTools } from "../tools.js";
 
@@ -51,6 +51,31 @@ describe("Simplified Tool Adapter Tests", () => {
       mockClient.callTool.mockResolvedValue({
         content: [{ type: "text", text: "original" }],
       });
+    });
+
+    test("does not mutate the arguments previously passed to a hook", async () => {
+      let observed: unknown;
+      const [tool] = await loadMcpTools("test", mockClient, {
+        beforeToolCall: ({ args }) => {
+          observed = args;
+          return { args: { value: "effective" } };
+        },
+      });
+      await tool.invoke({});
+      expect(observed).toEqual({});
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: "echo",
+        arguments: { value: "effective" },
+      });
+    });
+
+    test("rejects scalar argument overrides before issuing a request", async () => {
+      const [tool] = await loadMcpTools("test", mockClient, {
+        // @ts-expect-error Invalid JavaScript callback input is rejected at runtime too.
+        beforeToolCall: () => ({ args: "invalid" }),
+      });
+      await expect(tool.invoke({})).rejects.toThrow();
+      expect(mockClient.callTool).not.toHaveBeenCalled();
     });
 
     test.each([false, true])(

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -4,6 +4,7 @@ import type {
   EmbeddedResource,
   ImageContent,
   TextContent,
+  Tool,
 } from "@modelcontextprotocol/client";
 import {
   StructuredTool,
@@ -39,6 +40,39 @@ describe("Simplified Tool Adapter Tests", () => {
     } as MockedObject<Client>;
 
     vi.clearAllMocks();
+  });
+
+  test("schema parsing preserves boolean schemas and extension values", async () => {
+    const inputSchema = {
+      type: "object",
+      properties: {
+        anything: true,
+        never: false,
+        value: { type: ["string", "null"] },
+      },
+      "x-provider": { choices: [1, "two", null, { enabled: true }] },
+    } satisfies Tool["inputSchema"];
+    mockClient.listTools.mockResolvedValue({
+      tools: [{ name: "schema", inputSchema }],
+    });
+    const [tool] = await loadMcpTools("test", mockClient);
+    expect(tool.schema).toEqual(inputSchema);
+  });
+
+  test("rejects invalid consumed schema keywords instead of dropping them", async () => {
+    mockClient.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: "schema",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            allOf: [{ required: [42] }],
+          },
+        },
+      ],
+    });
+    await expect(loadMcpTools("test", mockClient)).rejects.toThrow(z.ZodError);
   });
 
   describe("hook return validation", () => {

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -51,6 +51,7 @@ describe("Simplified Tool Adapter Tests", () => {
       },
       "x-provider": { choices: [1, "two", null, { enabled: true }] },
     } satisfies Tool["inputSchema"];
+
     mockClient.listTools.mockResolvedValue({
       tools: [{ name: "schema", inputSchema }],
     });
@@ -88,12 +89,15 @@ describe("Simplified Tool Adapter Tests", () => {
 
     test("does not mutate the arguments previously passed to a hook", async () => {
       let observed: unknown;
+
       const [tool] = await loadMcpTools("test", mockClient, {
         beforeToolCall: ({ args }) => {
           observed = args;
+
           return { args: { value: "effective" } };
         },
       });
+
       await tool.invoke({});
       expect(observed).toEqual({});
       expect(mockClient.callTool).toHaveBeenCalledWith({
@@ -107,6 +111,7 @@ describe("Simplified Tool Adapter Tests", () => {
         // @ts-expect-error Invalid JavaScript callback input is rejected at runtime too.
         beforeToolCall: () => ({ args: "invalid" }),
       });
+
       await expect(tool.invoke({})).rejects.toThrow();
       expect(mockClient.callTool).not.toHaveBeenCalled();
     });
@@ -116,10 +121,12 @@ describe("Simplified Tool Adapter Tests", () => {
       async (asyncHook) => {
         const invalid = { headers: { test: 42 } };
         const beforeToolCall = asyncHook ? async () => invalid : () => invalid;
+
         const [tool] = await loadMcpTools("test", mockClient, {
           // @ts-expect-error Exercise malformed JavaScript callback results.
           beforeToolCall,
         });
+
         await expect(tool.invoke({})).rejects.toThrow(/string/);
         expect(mockClient.callTool).not.toHaveBeenCalled();
       }
@@ -131,10 +138,12 @@ describe("Simplified Tool Adapter Tests", () => {
         const afterToolCall = asyncHook
           ? async () => ({ result: 42 })
           : () => ({ result: 42 });
+
         const [tool] = await loadMcpTools("test", mockClient, {
           // @ts-expect-error Exercise malformed JavaScript callback results.
           afterToolCall,
         });
+
         await expect(tool.invoke({})).rejects.toThrow();
         expect(mockClient.callTool).toHaveBeenCalledTimes(1);
       }
@@ -145,16 +154,19 @@ describe("Simplified Tool Adapter Tests", () => {
         beforeToolCall: async () => ({ args: { value: "effective" } }),
         afterToolCall: async () => ({ result: "changed" }),
       });
+
       expect(await tool.invoke({})).toBe("changed");
       expect(mockClient.callTool).toHaveBeenCalledWith({
         name: "echo",
         arguments: { value: "effective" },
       });
+
       const [invalid] = await loadMcpTools("test", mockClient, {
         beforeToolCall: () => {
           z.string().parse(123);
         },
       });
+
       await expect(invalid.invoke({})).rejects.toThrow(/string/);
     });
   });

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -698,10 +698,9 @@ describe("Simplified Tool Adapter Tests", () => {
           text: "Here is your image",
         },
         {
-          type: "image_url",
-          image_url: {
-            url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
-          },
+          type: "image",
+          mimeType: "image/png",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
         },
       ];
 

--- a/libs/langchain-mcp-adapters/src/tests/tools.test.ts
+++ b/libs/langchain-mcp-adapters/src/tests/tools.test.ts
@@ -15,6 +15,8 @@ import type {
   ToolMessage,
 } from "@langchain/core/messages";
 
+import { z } from "zod/v4";
+import type { ToolHooks } from "../hooks.js";
 import { loadMcpTools } from "../tools.js";
 
 vi.mock(
@@ -37,6 +39,66 @@ describe("Simplified Tool Adapter Tests", () => {
     } as MockedObject<Client>;
 
     vi.clearAllMocks();
+  });
+
+  describe("hook return validation", () => {
+    beforeEach(() => {
+      mockClient.listTools.mockResolvedValue({
+        tools: [
+          { name: "echo", inputSchema: { type: "object", properties: {} } },
+        ],
+      });
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "original" }],
+      });
+    });
+
+    test.each([false, true])(
+      "validates before hooks after awaiting them (async=%s)",
+      async (asyncHook) => {
+        const invalid = { headers: { test: 42 } };
+        const beforeToolCall = (asyncHook
+          ? async () => invalid
+          : () => invalid) as unknown as ToolHooks["beforeToolCall"];
+        const [tool] = await loadMcpTools("test", mockClient, {
+          beforeToolCall,
+        });
+        await expect(tool.invoke({})).rejects.toThrow(/string/);
+        expect(mockClient.callTool).not.toHaveBeenCalled();
+      }
+    );
+
+    test.each([false, true])(
+      "validates after hooks after awaiting them (async=%s)",
+      async (asyncHook) => {
+        const afterToolCall = (asyncHook
+          ? async () => ({ result: 42 })
+          : () => ({ result: 42 })) as unknown as ToolHooks["afterToolCall"];
+        const [tool] = await loadMcpTools("test", mockClient, {
+          afterToolCall,
+        });
+        await expect(tool.invoke({})).rejects.toThrow();
+        expect(mockClient.callTool).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    test("preserves successful async modifications and formats Zod4 hook failures", async () => {
+      const [tool] = await loadMcpTools("test", mockClient, {
+        beforeToolCall: async () => ({ args: { value: "effective" } }),
+        afterToolCall: async () => ({ result: "changed" }),
+      });
+      expect(await tool.invoke({})).toBe("changed");
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: "echo",
+        arguments: { value: "effective" },
+      });
+      const [invalid] = await loadMcpTools("test", mockClient, {
+        beforeToolCall: () => {
+          z.string().parse(123);
+        },
+      });
+      await expect(invalid.invoke({})).rejects.toThrow(/string/);
+    });
   });
 
   describe("loadMcpTools", () => {

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -469,6 +469,7 @@ type MCPInstance = Client | MCPClient;
 const errorPathKeySchema = z.union([z.string(), z.number(), z.symbol()]);
 
 const zodErrorDetailsSchema = z.object({
+  stack: z.string().optional().catch(undefined),
   issues: z.array(
     z.object({
       message: z.string(),
@@ -497,13 +498,7 @@ export class ToolException extends Error {
     if (details) {
       const minifiedZodError = new Error(z.prettifyError(details));
 
-      const stackLines =
-        typeof cause === "object" &&
-        cause !== null &&
-        "stack" in cause &&
-        typeof cause.stack === "string"
-          ? cause.stack.split("\n")
-          : [];
+      const stackLines = details.stack?.split("\n") ?? [];
 
       const firstFrame = stackLines.findIndex((line) =>
         line.includes("    at")

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -8,8 +8,6 @@ import type {
   CallToolResult,
   ContentBlock as MCPContentBlock,
   Client as MCPClient,
-  EmbeddedResource,
-  ReadResourceResult,
   Tool as MCPTool,
   ListToolsResult,
   RequestOptions,
@@ -530,202 +528,78 @@ export function isToolException(error: unknown): error is ToolException {
   );
 }
 
-function isResourceReference(
-  resource:
-    | EmbeddedResource["resource"]
-    | ReadResourceResult["contents"][number]
-): boolean {
-  return (
-    typeof resource === "object" &&
-    resource !== null &&
-    "uri" in resource &&
-    typeof resource.uri === "string" &&
-    (!("blob" in resource) || resource.blob == null) &&
-    (!("text" in resource) || resource.text == null)
-  );
-}
-
-async function* _embeddedResourceToStandardFileBlocks(
-  resource:
-    | EmbeddedResource["resource"]
-    | ReadResourceResult["contents"][number],
-  client: MCPInstance
-): AsyncGenerator<
-  | (ContentBlock.Data.StandardFileBlock & ContentBlock.Data.Base64ContentBlock)
-  | (ContentBlock.Data.StandardFileBlock &
-      ContentBlock.Data.PlainTextContentBlock)
-> {
-  if (isResourceReference(resource)) {
-    const response: ReadResourceResult = await client.readResource({
-      uri: resource.uri,
-    });
-    for (const content of response.contents) {
-      yield* _embeddedResourceToStandardFileBlocks(content, client);
-    }
-    return;
-  }
-
-  if ("blob" in resource && resource.blob != null) {
-    yield {
-      type: "file",
-      source_type: "base64",
-      data: resource.blob,
-      mime_type: resource.mimeType,
-      ...(resource.uri != null ? { metadata: { uri: resource.uri } } : {}),
-    } satisfies ContentBlock.Data.StandardFileBlock &
-      ContentBlock.Data.Base64ContentBlock;
-  }
-  if ("text" in resource && resource.text != null) {
-    yield {
-      type: "file",
-      source_type: "text",
-      mime_type: resource.mimeType,
-      text: resource.text,
-      ...(resource.uri != null ? { metadata: { uri: resource.uri } } : {}),
-    } satisfies ContentBlock.Data.StandardFileBlock &
-      ContentBlock.Data.PlainTextContentBlock;
-  }
-}
-
-async function _toolOutputToContentBlocks(
+/** Terminal conversion never dereferences resource URIs or performs network IO. */
+function _toolOutputToContentBlocks(
   content: MCPContentBlock,
-  useStandardContentBlocks: true,
-  client: MCPInstance,
   toolName: string,
   serverName: string
-): Promise<ContentBlock.Multimodal.Standard[]>;
-async function _toolOutputToContentBlocks(
-  content: MCPContentBlock,
-  useStandardContentBlocks: false | undefined,
-  client: MCPInstance,
-  toolName: string,
-  serverName: string
-): Promise<ContentBlock[]>;
-async function _toolOutputToContentBlocks(
-  content: MCPContentBlock,
-  useStandardContentBlocks: boolean | undefined,
-  client: MCPInstance,
-  toolName: string,
-  serverName: string
-): Promise<(ContentBlock | ContentBlock.Multimodal.Standard)[]>;
-async function _toolOutputToContentBlocks(
-  content: MCPContentBlock,
-  useStandardContentBlocks: boolean | undefined,
-  client: MCPInstance,
-  toolName: string,
-  serverName: string
-): Promise<(ContentBlock | ContentBlock.Multimodal.Standard)[]> {
-  const blocks: ContentBlock.Data.StandardFileBlock[] = [];
+): ContentBlock[] {
   const contentType = content.type;
 
   switch (content.type) {
     case "text":
-      return [
-        {
-          type: "text",
-          ...(useStandardContentBlocks
-            ? {
-                source_type: "text",
-              }
-            : {}),
-          text: content.text,
-        } satisfies ContentBlock.Text,
-      ];
+      return [{ type: "text", text: content.text }];
     case "image":
-      if (useStandardContentBlocks) {
-        return [
-          {
-            type: "image",
-            source_type: "base64",
-            data: content.data,
-            mime_type: content.mimeType,
-          } satisfies ContentBlock.Data.StandardImageBlock,
-        ];
-      }
       return [
         {
-          type: "image_url",
-          image_url: {
-            url: `data:${content.mimeType};base64,${content.data}`,
-          },
-        } satisfies ContentBlock,
+          type: "image",
+          data: content.data,
+          mimeType: content.mimeType,
+        } satisfies ContentBlock.Multimodal.Image,
       ];
     case "audio":
-      // We don't check `useStandardContentBlocks` here because we only support audio via
-      // standard content blocks
       return [
         {
           type: "audio",
-          source_type: "base64",
           data: content.data,
-          mime_type: content.mimeType,
-        } satisfies ContentBlock.Data.StandardAudioBlock,
+          mimeType: content.mimeType,
+        } satisfies ContentBlock.Multimodal.Audio,
       ];
-    case "resource":
-      for await (const block of _embeddedResourceToStandardFileBlocks(
-        content.resource,
-        client
-      )) {
-        blocks.push(block);
+    case "resource": {
+      const resource = content.resource;
+      const metadata = { uri: resource.uri };
+
+      if ("text" in resource) {
+        return [{ type: "text", text: resource.text, metadata }];
       }
-      return blocks;
+
+      const mimeType = resource.mimeType ?? "application/octet-stream";
+
+      return [
+        {
+          type: mimeType.startsWith("image/")
+            ? "image"
+            : mimeType.startsWith("audio/")
+              ? "audio"
+              : "file",
+          data: resource.blob,
+          mimeType,
+          metadata,
+        } satisfies ContentBlock.Multimodal.Standard,
+      ];
+    }
+
     case "resource_link": {
+      const metadata = {
+        uri: content.uri,
+        name: content.name,
+        ...(content.title !== undefined ? { title: content.title } : {}),
+      };
+
       return [
         {
           type: "file",
-          source_type: "url",
           url: content.uri,
-          mime_type: content.mimeType,
-        } satisfies ContentBlock.Data.StandardFileBlock &
-          ContentBlock.Data.URLContentBlock,
+          mimeType: content.mimeType,
+          metadata,
+        } satisfies ContentBlock.Multimodal.File,
       ];
     }
     default:
       throw new ToolException(
-        `MCP tool '${toolName}' on server '${serverName}' returned a content block with unexpected type "${
-          contentType
-        }." Expected one of ${callToolResultContentTypes.map((t: string) => `"${t}"`).join(", ")}.`
+        `MCP tool '${toolName}' on server '${serverName}' returned unexpected content type "${contentType}". Expected ${callToolResultContentTypes.join(", ")}.`
       );
   }
-}
-
-async function _embeddedResourceToArtifact(
-  resource: MCPContentBlock,
-  useStandardContentBlocks: boolean | undefined,
-  client: MCPInstance,
-  toolName: string,
-  serverName: string
-): Promise<(MCPContentBlock | ContentBlock)[]> {
-  if (useStandardContentBlocks) {
-    return _toolOutputToContentBlocks(
-      resource,
-      useStandardContentBlocks,
-      client,
-      toolName,
-      serverName
-    );
-  }
-
-  if (
-    (!("blob" in resource) || resource.blob == null) &&
-    (!("text" in resource) || resource.text == null) &&
-    "uri" in resource &&
-    typeof resource.uri === "string"
-  ) {
-    const response: ReadResourceResult = await client.readResource({
-      uri: resource.uri,
-    });
-
-    return response.contents.map(
-      (content: ReadResourceResult["contents"][number]) => ({
-        type: "resource",
-        resource: {
-          ...content,
-        },
-      })
-    );
-  }
-  return [resource];
 }
 
 /**
@@ -785,15 +659,6 @@ type ConvertCallToolResultArgs = {
    */
   result: CallToolResult;
   /**
-   * The MCP client that was used to call the tool
-   */
-  client: Client | MCPClient;
-  /**
-   * If true, the tool will use LangChain's standard multimodal content blocks for tools that output
-   * image or audio content. This option has no effect on handling of embedded resource tool output.
-   */
-  useStandardContentBlocks?: boolean;
-  /**
    * Defines where to place each tool output type in the LangChain ToolMessage.
    */
   outputHandling?: OutputHandling;
@@ -828,8 +693,6 @@ async function _convertCallToolResult({
   serverName,
   toolName,
   result,
-  client,
-  useStandardContentBlocks,
   outputHandling,
 }: ConvertCallToolResultArgs): Promise<[ExtendedContent, ExtendedArtifact[]]> {
   if (!result) {
@@ -864,37 +727,15 @@ async function _convertCallToolResult({
               "content"
           )
           .map((content: MCPContentBlock) =>
-            _toolOutputToContentBlocks(
-              content,
-              useStandardContentBlocks,
-              client,
-              toolName,
-              serverName
-            )
+            _toolOutputToContentBlocks(content, toolName, serverName)
           )
       )
     ).flat();
 
-  // Create the text content output
-  const artifacts = (
-    await Promise.all(
-      result.content
-        .filter(
-          (content: MCPContentBlock) =>
-            _getOutputTypeForContentType(content.type, outputHandling) ===
-            "artifact"
-        )
-        .map((content) => {
-          return _embeddedResourceToArtifact(
-            content,
-            useStandardContentBlocks,
-            client,
-            toolName,
-            serverName
-          );
-        })
-    )
-  ).flat();
+  const artifacts = result.content.filter(
+    (content) =>
+      _getOutputTypeForContentType(content.type, outputHandling) === "artifact"
+  );
 
   // Extract structuredContent and _meta from result
   // These are optional fields that are part of the CallToolResult type
@@ -976,11 +817,6 @@ type CallToolArgs = {
    */
   config?: RunnableConfig;
   /**
-   * If true, the tool will use LangChain's standard multimodal content blocks for tools that output
-   * image or audio content. This option has no effect on handling of embedded resource tool output.
-   */
-  useStandardContentBlocks?: boolean;
-  /**
    * Defines where to place each tool output type in the LangChain ToolMessage.
    */
   outputHandling?: OutputHandling;
@@ -1020,7 +856,6 @@ async function _callTool({
   client,
   args,
   config,
-  useStandardContentBlocks,
   outputHandling,
   onProgress,
   beforeToolCall,
@@ -1114,8 +949,6 @@ async function _callTool({
       serverName,
       toolName,
       result,
-      client: finalClient,
-      useStandardContentBlocks,
       outputHandling,
     });
 
@@ -1196,7 +1029,6 @@ const defaultLoadMcpToolsOptions: LoadMcpToolsOptions = {
   throwOnLoadError: true,
   prefixToolNameWithServerName: false,
   additionalToolNamePrefix: "",
-  useStandardContentBlocks: false,
 };
 
 /**
@@ -1215,7 +1047,6 @@ export async function loadMcpTools(
     throwOnLoadError,
     prefixToolNameWithServerName,
     additionalToolNamePrefix,
-    useStandardContentBlocks,
     outputHandling,
     defaultToolTimeout,
   } = {
@@ -1287,7 +1118,6 @@ export async function loadMcpTools(
                   client,
                   args,
                   config,
-                  useStandardContentBlocks,
                   outputHandling,
                   onProgress: options?.onProgress,
                   beforeToolCall: options?.beforeToolCall,

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -750,7 +750,6 @@ async function _convertCallToolResult({
     });
   }
 
-  // If we have structuredContent or meta, create an enhanced content that includes all info
   const firstBlock = convertedContent[0];
 
   if (
@@ -766,18 +765,6 @@ async function _convertCallToolResult({
     } satisfies ContentBlock.Text;
 
     const textContent = textBlock.text;
-
-    // If we have structuredContent or meta, wrap the content with additional info
-    if (structuredContent || meta) {
-      return [
-        {
-          ...textBlock,
-          ...(structuredContent ? { structuredContent } : {}),
-          ...(meta ? { meta } : {}),
-        } satisfies ExtendedContent,
-        enhancedArtifacts,
-      ];
-    }
 
     return [textContent, enhancedArtifacts];
   }

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -1,5 +1,9 @@
-import { z, ZodError as ZodErrorV4 } from "zod/v4";
-import { ZodError as ZodErrorV3 } from "zod/v3";
+import { z } from "zod/v4";
+import { isInteropZodError } from "@langchain/core/utils/types";
+import {
+  toolCallModificationSchema,
+  toolCallResultModificationSchema,
+} from "./hooks.js";
 import type {
   CallToolResult,
   ContentBlock as MCPContentBlock,
@@ -493,12 +497,8 @@ export class ToolException extends Error {
     /**
      * don't display the large ZodError stack trace
      */
-    if (
-      cause &&
-      // oxlint-disable-next-line no-instanceof/no-instanceof
-      (cause instanceof ZodErrorV4 || cause instanceof ZodErrorV3)
-    ) {
-      const minifiedZodError = new Error(z.prettifyError(cause));
+    if (cause && isInteropZodError(cause)) {
+      const minifiedZodError = new Error(z.prettifyError(cause as z.ZodError));
       const stackByLine = cause.stack?.split("\n") || [];
       minifiedZodError.stack = cause.stack
         ?.split("\n")
@@ -1038,15 +1038,19 @@ async function _callTool({
       );
     }
 
-    const beforeToolCallInterception = await beforeToolCall?.(
-      {
-        name: toolName,
-        args,
-        serverName,
-      },
-      state,
-      config ?? {}
-    );
+    const beforeToolCallInterception = toolCallModificationSchema
+      .optional()
+      .parse(
+        await beforeToolCall?.(
+          {
+            name: toolName,
+            args,
+            serverName,
+          },
+          state,
+          config ?? {}
+        )
+      );
 
     const finalArgs = Object.assign(
       args,
@@ -1124,15 +1128,17 @@ async function _callTool({
           "source_type" in artifact)
     ) as (EmbeddedResource | ContentBlock.Multimodal.Standard)[];
 
-    const interceptedResult = await afterToolCall?.(
-      {
-        name: toolName,
-        args: finalArgs,
-        result: [normalizedContent, normalizedArtifacts],
-        serverName,
-      },
-      state,
-      config ?? {}
+    const interceptedResult = toolCallResultModificationSchema.optional().parse(
+      await afterToolCall?.(
+        {
+          name: toolName,
+          args: finalArgs,
+          result: [normalizedContent, normalizedArtifacts],
+          serverName,
+        },
+        state,
+        config ?? {}
+      )
     );
 
     if (!interceptedResult) {
@@ -1161,8 +1167,8 @@ async function _callTool({
     );
   } catch (error) {
     // oxlint-disable-next-line no-instanceof/no-instanceof
-    if (error instanceof ZodErrorV4 || error instanceof ZodErrorV3) {
-      throw new ToolException(z.prettifyError(error), error);
+    if (error instanceof Error && isInteropZodError(error)) {
+      throw new ToolException(z.prettifyError(error as z.ZodError), error);
     }
 
     debugLog(`Error calling tool ${toolName}: ${String(error)}`);

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -389,10 +389,9 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
 
     // Merge the collected properties
     if (Object.keys(mergedProperties).length > 0) {
-      result.properties = {
-        ...(isSchemaRecord(result.properties) ? result.properties : {}),
-        ...mergedProperties,
-      };
+      result.properties = isSchemaRecord(result.properties)
+        ? { ...result.properties, ...mergedProperties }
+        : { ...mergedProperties };
     }
 
     // Only add required fields that are common to ALL schemas (intersection)
@@ -580,11 +579,10 @@ function _toolOutputToContentBlocks(
     }
 
     case "resource_link": {
-      const metadata = {
-        uri: content.uri,
-        name: content.name,
-        ...(content.title !== undefined ? { title: content.title } : {}),
-      };
+      const metadata =
+        content.title === undefined
+          ? { uri: content.uri, name: content.name }
+          : { uri: content.uri, name: content.name, title: content.title };
 
       return [
         {

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -45,6 +45,7 @@ const debugLog = getDebugLog("tools");
 // Decode JSON once at discovery; only parse the schema keywords this
 // simplifier consumes. Extension keywords remain intact.
 const jsonObjectSchema = z.record(z.string(), z.json());
+
 const schemaKeywordsSchema = z
   .object({
     properties: jsonObjectSchema.optional(),
@@ -191,6 +192,7 @@ function deepMergeSchemas(target: JSONObject, source: JSONObject): JSONObject {
     } else if (key === "enum" && Array.isArray(sourceValue)) {
       // Merge enum values (union of all possible values)
       const values = new Set<JSONValue>();
+
       if (Array.isArray(targetValue)) {
         for (const v of targetValue) values.add(v);
       }
@@ -208,6 +210,7 @@ function deepMergeSchemas(target: JSONObject, source: JSONObject): JSONObject {
     ) {
       // Recursively merge properties - merge each property individually
       const mergedProps: JSONObject = { ...targetValue };
+
       for (const [propKey, propValue] of Object.entries(sourceValue)) {
         if (isSchemaRecord(mergedProps[propKey]) && isSchemaRecord(propValue)) {
           mergedProps[propKey] = deepMergeSchemas(
@@ -247,6 +250,7 @@ function extractPropertiesFromConditional(schema: JSONObject): JSONObject {
   // Extract properties from 'then' branch
   if (isSchemaRecord(schema.then)) {
     const thenSchema = schemaKeywordsSchema.parse(schema.then);
+
     if (thenSchema.properties) {
       result = deepMergeSchemas(result, { properties: thenSchema.properties });
     }
@@ -263,6 +267,7 @@ function extractPropertiesFromConditional(schema: JSONObject): JSONObject {
   // Extract properties from 'else' branch
   if (isSchemaRecord(schema.else)) {
     const elseSchema = schemaKeywordsSchema.parse(schema.else);
+
     if (elseSchema.properties) {
       result = deepMergeSchemas(result, { properties: elseSchema.properties });
     }
@@ -322,6 +327,7 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
       then: schemaThen,
       else: schemaElse,
     });
+
     result = deepMergeSchemas(result, conditionalProps);
     debugLog(`INFO: Extracted properties from if/then/else conditional`);
   }
@@ -330,6 +336,7 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
   if (Array.isArray(allOf)) {
     for (const subSchema of allOf) {
       if (!isSchemaRecord(subSchema)) continue;
+
       // First extract properties from any if/then/else in this subschema
       if (subSchema.if || subSchema.then || subSchema.else) {
         const conditionalProps = extractPropertiesFromConditional(subSchema);
@@ -348,9 +355,11 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
   // Note: When merging anyOf/oneOf, we only merge properties but NOT required arrays,
   // because the union semantics mean any ONE of the schemas should match, not all.
   const rawUnionSchemas = anyOf || oneOf;
+
   const unionSchemas = Array.isArray(rawUnionSchemas)
     ? rawUnionSchemas.filter(isSchemaRecord)
     : [];
+
   if (unionSchemas.length > 0) {
     // Collect all properties from all schemas, but only keep required fields
     // that are common to ALL schemas (intersection)
@@ -365,6 +374,7 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
       const simplified = schemaKeywordsSchema.parse(
         simplifyJsonSchemaForLLM(subSchema)
       );
+
       // Merge properties
       if (isSchemaRecord(simplified.properties)) {
         Object.assign(mergedProperties, simplified.properties);
@@ -415,6 +425,7 @@ function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
   // Recursively simplify nested schemas in properties
   if (isSchemaRecord(result.properties)) {
     const simplifiedProperties: JSONObject = {};
+
     for (const [propName, propSchema] of Object.entries(result.properties)) {
       if (isSchemaRecord(propSchema)) {
         simplifiedProperties[propName] = simplifyJsonSchemaForLLM(propSchema);
@@ -459,6 +470,7 @@ type MCPInstance = Client | MCPClient;
 // Parse only the Zod issue fields needed for formatting, without depending
 // on a particular Zod version or constructor.
 const errorPathKeySchema = z.union([z.string(), z.number(), z.symbol()]);
+
 const zodErrorDetailsSchema = z.object({
   issues: z.array(
     z.object({
@@ -471,6 +483,7 @@ const zodErrorDetailsSchema = z.object({
 function parseZodErrorDetails(error: unknown) {
   if (!isInteropZodError(error)) return undefined;
   const parsed = zodErrorDetailsSchema.safeParse(error);
+
   return parsed.success ? parsed.data : undefined;
 }
 
@@ -483,8 +496,10 @@ export class ToolException extends Error {
     this.name = "ToolException";
 
     const details = parseZodErrorDetails(cause);
+
     if (details) {
       const minifiedZodError = new Error(z.prettifyError(details));
+
       const stackLines =
         typeof cause === "object" &&
         cause !== null &&
@@ -492,9 +507,11 @@ export class ToolException extends Error {
         typeof cause.stack === "string"
           ? cause.stack.split("\n")
           : [];
+
       const firstFrame = stackLines.findIndex((line) =>
         line.includes("    at")
       );
+
       minifiedZodError.stack =
         firstFrame < 0 ? undefined : stackLines.slice(firstFrame).join("\n");
       this.cause = minifiedZodError;
@@ -600,6 +617,7 @@ async function _toolOutputToContentBlocks(
 ): Promise<(ContentBlock | ContentBlock.Multimodal.Standard)[]> {
   const blocks: ContentBlock.Data.StandardFileBlock[] = [];
   const contentType = content.type;
+
   switch (content.type) {
     case "text":
       return [
@@ -900,6 +918,7 @@ async function _convertCallToolResult({
 
   // If we have structuredContent or meta, create an enhanced content that includes all info
   const firstBlock = convertedContent[0];
+
   if (
     convertedContent.length === 1 &&
     firstBlock.type === "text" &&
@@ -911,6 +930,7 @@ async function _convertCallToolResult({
       type: "text",
       text: firstBlock.text,
     } satisfies ContentBlock.Text;
+
     const textContent = textBlock.text;
 
     // If we have structuredContent or meta, wrap the content with additional info
@@ -1016,6 +1036,7 @@ async function _callTool({
     const numericTimeout =
       z.number().nullish().parse(config?.metadata?.timeoutMs) ??
       config?.timeout;
+
     const requestOptions: RequestOptions = {
       ...(numericTimeout ? { timeout: numericTimeout } : {}),
       ...(config?.signal ? { signal: config.signal } : {}),
@@ -1035,6 +1056,7 @@ async function _callTool({
     };
 
     let state: unknown = {};
+
     try {
       state = getCurrentTaskInput(config);
     } catch (error) {
@@ -1059,6 +1081,7 @@ async function _callTool({
 
     const headers = beforeToolCallInterception?.headers || {};
     const hasHeaderChanges = Object.entries(headers).length > 0;
+
     if (
       hasHeaderChanges &&
       !("fork" in client && typeof client.fork === "function")
@@ -1086,6 +1109,7 @@ async function _callTool({
     }
 
     const result = await finalClient.callTool(...callToolArgs);
+
     const [content, artifacts] = await _convertCallToolResult({
       serverName,
       toolName,
@@ -1155,6 +1179,7 @@ async function _callTool({
     );
   } catch (error) {
     const details = parseZodErrorDetails(error);
+
     if (details) {
       throw new ToolException(z.prettifyError(details), error);
     }

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -1033,13 +1033,9 @@ async function _callTool({
 
     let state: State = {};
     try {
-      state = z
-        .record(z.string(), z.unknown())
-        .parse(getCurrentTaskInput(config));
+      state = getCurrentTaskInput(config);
     } catch (error) {
-      debugLog(
-        `State can't be derrived as LangGraph is not used: ${String(error)}`
-      );
+      debugLog(`LangGraph task input is unavailable: ${String(error)}`);
     }
 
     const beforeToolCallInterception = toolCallModificationSchema

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -19,7 +19,11 @@ import type { ContentBlock } from "@langchain/core/messages";
 import { RunnableConfig } from "@langchain/core/runnables";
 import type { CallbackManagerForToolRun } from "@langchain/core/callbacks/manager";
 import { ToolMessage } from "@langchain/core/messages";
-import { Command, getCurrentTaskInput } from "@langchain/langgraph";
+import {
+  isCommand,
+  getCurrentTaskInput,
+  type Command,
+} from "@langchain/langgraph";
 
 import type { Notifications } from "./types.js";
 
@@ -39,28 +43,18 @@ const debugLog = getDebugLog("tools");
 /**
  * JSON Schema type definitions for dereferencing $defs.
  */
-type JsonSchemaObject = {
-  type?: string;
-  properties?: Record<string, JsonSchemaObject>;
-  items?: JsonSchemaObject | JsonSchemaObject[];
-  additionalProperties?: boolean | JsonSchemaObject;
-  $ref?: string;
-  $defs?: Record<string, JsonSchemaObject>;
-  definitions?: Record<string, JsonSchemaObject>;
-  allOf?: JsonSchemaObject[];
-  anyOf?: JsonSchemaObject[];
-  oneOf?: JsonSchemaObject[];
-  not?: JsonSchemaObject;
-  if?: JsonSchemaObject;
-  then?: JsonSchemaObject;
-  else?: JsonSchemaObject;
-  required?: string[];
-  description?: string;
-  default?: unknown;
-  enum?: unknown[];
-  const?: unknown;
-  [key: string]: unknown;
-};
+type JsonSchemaObject = Record<string, unknown>;
+
+function isSchemaRecord(value: unknown): value is JsonSchemaObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const requiredFieldsSchema = z.array(z.string());
+
+function requiredFields(value: unknown): string[] {
+  const result = requiredFieldsSchema.safeParse(value);
+  return result.success ? result.data : [];
+}
 
 /**
  * Dereferences $ref pointers in a JSON Schema by inlining the definitions from $defs.
@@ -71,7 +65,8 @@ type JsonSchemaObject = {
  * @returns A new schema with all $ref pointers resolved
  */
 function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
-  const definitions = schema.$defs ?? schema.definitions ?? {};
+  const rawDefinitions = schema.$defs ?? schema.definitions;
+  const definitions = isSchemaRecord(rawDefinitions) ? rawDefinitions : {};
 
   /**
    * Recursively resolve $ref pointers in the schema.
@@ -98,7 +93,7 @@ function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
         const defName = match[1];
         const definition = definitions[defName];
 
-        if (definition) {
+        if (isSchemaRecord(definition)) {
           // Check for circular reference
           if (visitedRefs.has(refPath)) {
             // Return a placeholder for circular refs to avoid infinite loop
@@ -136,12 +131,10 @@ function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
 
       if (Array.isArray(value)) {
         result[key] = value.map((item) =>
-          typeof item === "object" && item !== null
-            ? resolveRefs(item as JsonSchemaObject, visitedRefs)
-            : item
+          isSchemaRecord(item) ? resolveRefs(item, visitedRefs) : item
         );
-      } else if (typeof value === "object" && value !== null) {
-        result[key] = resolveRefs(value as JsonSchemaObject, visitedRefs);
+      } else if (isSchemaRecord(value)) {
+        result[key] = resolveRefs(value, visitedRefs);
       } else {
         result[key] = value;
       }
@@ -171,18 +164,20 @@ function deepMergeSchemas(
   for (const [key, sourceValue] of Object.entries(source)) {
     const targetValue = result[key];
 
-    if (key === "required" && Array.isArray(targetValue)) {
+    if (
+      key === "required" &&
+      Array.isArray(targetValue) &&
+      Array.isArray(sourceValue)
+    ) {
       // Concatenate and deduplicate required arrays
-      result[key] = [
-        ...new Set([...targetValue, ...(sourceValue as string[])]),
-      ];
+      result[key] = [...new Set([...targetValue, ...sourceValue])];
     } else if (key === "const") {
       // When merging const values, convert to enum to allow multiple values
       const existingConst = result.const;
-      const existingEnum = result.enum as unknown[] | undefined;
+      const existingEnum = result.enum;
       const values = new Set<unknown>();
 
-      if (existingEnum) {
+      if (Array.isArray(existingEnum)) {
         for (const v of existingEnum) values.add(v);
       }
       if (existingConst !== undefined) {
@@ -208,21 +203,13 @@ function deepMergeSchemas(
       result[key] = [...values];
     } else if (
       key === "properties" &&
-      typeof targetValue === "object" &&
-      targetValue !== null
+      isSchemaRecord(targetValue) &&
+      isSchemaRecord(sourceValue)
     ) {
       // Recursively merge properties - merge each property individually
-      const mergedProps: Record<string, JsonSchemaObject> = {
-        ...(targetValue as Record<string, JsonSchemaObject>),
-      };
-      for (const [propKey, propValue] of Object.entries(
-        sourceValue as Record<string, JsonSchemaObject>
-      )) {
-        if (
-          mergedProps[propKey] &&
-          typeof mergedProps[propKey] === "object" &&
-          typeof propValue === "object"
-        ) {
+      const mergedProps: JsonSchemaObject = { ...targetValue };
+      for (const [propKey, propValue] of Object.entries(sourceValue)) {
+        if (isSchemaRecord(mergedProps[propKey]) && isSchemaRecord(propValue)) {
           mergedProps[propKey] = deepMergeSchemas(
             mergedProps[propKey],
             propValue
@@ -235,19 +222,9 @@ function deepMergeSchemas(
     } else if (Array.isArray(sourceValue) && Array.isArray(targetValue)) {
       // Concatenate arrays
       result[key] = [...targetValue, ...sourceValue];
-    } else if (
-      typeof sourceValue === "object" &&
-      sourceValue !== null &&
-      !Array.isArray(sourceValue) &&
-      typeof targetValue === "object" &&
-      targetValue !== null &&
-      !Array.isArray(targetValue)
-    ) {
+    } else if (isSchemaRecord(sourceValue) && isSchemaRecord(targetValue)) {
       // Recursively merge objects
-      result[key] = deepMergeSchemas(
-        targetValue as JsonSchemaObject,
-        sourceValue as JsonSchemaObject
-      );
+      result[key] = deepMergeSchemas(targetValue, sourceValue);
     } else {
       // Overwrite primitives or when types don't match
       result[key] = sourceValue;
@@ -270,27 +247,33 @@ function extractPropertiesFromConditional(
   let result: JsonSchemaObject = {};
 
   // Extract properties from 'then' branch
-  if (schema.then && typeof schema.then === "object") {
-    const thenSchema = schema.then as JsonSchemaObject;
+  if (isSchemaRecord(schema.then)) {
+    const thenSchema = schema.then;
     if (thenSchema.properties) {
       result = deepMergeSchemas(result, { properties: thenSchema.properties });
     }
     if (thenSchema.required) {
       result.required = [
-        ...new Set([...(result.required || []), ...thenSchema.required]),
+        ...new Set([
+          ...requiredFields(result.required),
+          ...requiredFields(thenSchema.required),
+        ]),
       ];
     }
   }
 
   // Extract properties from 'else' branch
-  if (schema.else && typeof schema.else === "object") {
-    const elseSchema = schema.else as JsonSchemaObject;
+  if (isSchemaRecord(schema.else)) {
+    const elseSchema = schema.else;
     if (elseSchema.properties) {
       result = deepMergeSchemas(result, { properties: elseSchema.properties });
     }
     if (elseSchema.required) {
       result.required = [
-        ...new Set([...(result.required || []), ...elseSchema.required]),
+        ...new Set([
+          ...requiredFields(result.required),
+          ...requiredFields(elseSchema.required),
+        ]),
       ];
     }
   }
@@ -340,7 +323,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
       if: schemaIf,
       then: schemaThen,
       else: schemaElse,
-    } as JsonSchemaObject);
+    });
     result = deepMergeSchemas(result, conditionalProps);
     debugLog(`INFO: Extracted properties from if/then/else conditional`);
   }
@@ -348,6 +331,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   // Handle allOf by merging all schemas into the base
   if (Array.isArray(allOf)) {
     for (const subSchema of allOf) {
+      if (!isSchemaRecord(subSchema)) continue;
       // First extract properties from any if/then/else in this subschema
       if (subSchema.if || subSchema.then || subSchema.else) {
         const conditionalProps = extractPropertiesFromConditional(subSchema);
@@ -365,39 +349,29 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   // Handle anyOf/oneOf by attempting to merge object schemas or picking first viable option
   // Note: When merging anyOf/oneOf, we only merge properties but NOT required arrays,
   // because the union semantics mean any ONE of the schemas should match, not all.
-  const unionSchemas = anyOf || oneOf;
-  if (Array.isArray(unionSchemas) && unionSchemas.length > 0) {
-    // Check if all schemas in the union are object-like (have type: object or have properties)
-    const allAreObjects = unionSchemas.every(
-      (s) =>
-        typeof s === "object" &&
-        s !== null &&
-        (s.type === "object" || s.properties)
-    );
-
+  const rawUnionSchemas = anyOf || oneOf;
+  const unionSchemas = Array.isArray(rawUnionSchemas)
+    ? rawUnionSchemas.filter(isSchemaRecord)
+    : [];
+  if (unionSchemas.length > 0) {
     // Collect all properties from all schemas, but only keep required fields
     // that are common to ALL schemas (intersection)
-    const mergedProperties: Record<string, JsonSchemaObject> = {};
+    const mergedProperties: JsonSchemaObject = {};
     const requiredSets: Set<string>[] = [];
 
-    const schemasToMerge = allAreObjects
-      ? unionSchemas
-      : unionSchemas.filter(
-          (s) =>
-            typeof s === "object" &&
-            s !== null &&
-            (s.type === "object" || s.properties)
-        );
+    const schemasToMerge = unionSchemas.filter(
+      (schema) => schema.type === "object" || isSchemaRecord(schema.properties)
+    );
 
     for (const subSchema of schemasToMerge) {
       const simplified = simplifyJsonSchemaForLLM(subSchema);
       // Merge properties
-      if (simplified.properties) {
+      if (isSchemaRecord(simplified.properties)) {
         Object.assign(mergedProperties, simplified.properties);
       }
       // Collect required sets for intersection
       if (simplified.required && Array.isArray(simplified.required)) {
-        requiredSets.push(new Set(simplified.required));
+        requiredSets.push(new Set(requiredFields(simplified.required)));
       }
       // Merge type if present
       if (simplified.type && !result.type) {
@@ -408,7 +382,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
     // Merge the collected properties
     if (Object.keys(mergedProperties).length > 0) {
       result.properties = {
-        ...(result.properties as Record<string, JsonSchemaObject>),
+        ...(isSchemaRecord(result.properties) ? result.properties : {}),
         ...mergedProperties,
       };
     }
@@ -420,7 +394,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
       });
       if (commonRequired.size > 0) {
         result.required = [
-          ...new Set([...(result.required || []), ...commonRequired]),
+          ...new Set([...requiredFields(result.required), ...commonRequired]),
         ];
       }
     }
@@ -436,15 +410,13 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   }
 
   // Recursively simplify nested schemas in properties
-  if (result.properties) {
-    const simplifiedProperties: Record<string, JsonSchemaObject> = {};
+  if (isSchemaRecord(result.properties)) {
+    const simplifiedProperties: JsonSchemaObject = {};
     for (const [propName, propSchema] of Object.entries(result.properties)) {
-      if (typeof propSchema === "object" && propSchema !== null) {
-        simplifiedProperties[propName] = simplifyJsonSchemaForLLM(
-          propSchema as JsonSchemaObject
-        );
+      if (isSchemaRecord(propSchema)) {
+        simplifiedProperties[propName] = simplifyJsonSchemaForLLM(propSchema);
       } else {
-        simplifiedProperties[propName] = propSchema as JsonSchemaObject;
+        simplifiedProperties[propName] = propSchema;
       }
     }
     result.properties = simplifiedProperties;
@@ -454,22 +426,17 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   if (result.items) {
     if (Array.isArray(result.items)) {
       result.items = result.items.map((item) =>
-        typeof item === "object" && item !== null
-          ? simplifyJsonSchemaForLLM(item as JsonSchemaObject)
-          : item
+        isSchemaRecord(item) ? simplifyJsonSchemaForLLM(item) : item
       );
-    } else if (typeof result.items === "object") {
-      result.items = simplifyJsonSchemaForLLM(result.items as JsonSchemaObject);
+    } else if (isSchemaRecord(result.items)) {
+      result.items = simplifyJsonSchemaForLLM(result.items);
     }
   }
 
   // Simplify additionalProperties if it's a schema
-  if (
-    typeof result.additionalProperties === "object" &&
-    result.additionalProperties !== null
-  ) {
+  if (isSchemaRecord(result.additionalProperties)) {
     result.additionalProperties = simplifyJsonSchemaForLLM(
-      result.additionalProperties as JsonSchemaObject
+      result.additionalProperties
     );
   }
 
@@ -486,26 +453,49 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
  */
 type MCPInstance = Client | MCPClient;
 
+// Error formatting only needs Standard Schema issues, not a particular Zod
+// constructor. Parse that projection so errors from other Zod versions/copies
+// remain supported without asserting that they are our installed ZodError.
+const errorPathKeySchema = z.union([z.string(), z.number(), z.symbol()]);
+const zodErrorDetailsSchema = z.object({
+  issues: z.array(
+    z.object({
+      message: z.string(),
+      path: z
+        .array(
+          z.union([errorPathKeySchema, z.object({ key: errorPathKeySchema })])
+        )
+        .optional(),
+    })
+  ),
+  stack: z.string().optional(),
+});
+
+function parseZodErrorDetails(error: unknown) {
+  if (!isInteropZodError(error)) return undefined;
+  const parsed = zodErrorDetailsSchema.safeParse(error);
+  return parsed.success ? parsed.data : undefined;
+}
+
 /**
  * Custom error class for tool exceptions
  */
 export class ToolException extends Error {
-  constructor(message: string, cause?: Error) {
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = "ToolException";
 
-    /**
-     * don't display the large ZodError stack trace
-     */
-    if (cause && isInteropZodError(cause)) {
-      const minifiedZodError = new Error(z.prettifyError(cause as z.ZodError));
-      const stackByLine = cause.stack?.split("\n") || [];
-      minifiedZodError.stack = cause.stack
-        ?.split("\n")
-        .slice(stackByLine.findIndex((l) => l.includes("    at")))
-        .join("\n");
+    const details = parseZodErrorDetails(cause);
+    if (details) {
+      const minifiedZodError = new Error(z.prettifyError(details));
+      const stackLines = details.stack?.split("\n") ?? [];
+      const firstFrame = stackLines.findIndex((line) =>
+        line.includes("    at")
+      );
+      minifiedZodError.stack =
+        firstFrame < 0 ? undefined : stackLines.slice(firstFrame).join("\n");
       this.cause = minifiedZodError;
-    } else if (cause) {
+    } else if (cause !== undefined) {
       this.cause = cause;
     }
   }
@@ -529,7 +519,7 @@ function isResourceReference(
     typeof resource === "object" &&
     resource !== null &&
     "uri" in resource &&
-    typeof (resource as { uri?: unknown }).uri === "string" &&
+    typeof resource.uri === "string" &&
     (!("blob" in resource) || resource.blob == null) &&
     (!("text" in resource) || resource.text == null)
   );
@@ -562,7 +552,7 @@ async function* _embeddedResourceToStandardFileBlocks(
       data: resource.blob,
       mime_type: resource.mimeType,
       ...(resource.uri != null ? { metadata: { uri: resource.uri } } : {}),
-    } as ContentBlock.Data.StandardFileBlock &
+    } satisfies ContentBlock.Data.StandardFileBlock &
       ContentBlock.Data.Base64ContentBlock;
   }
   if ("text" in resource && resource.text != null) {
@@ -572,7 +562,7 @@ async function* _embeddedResourceToStandardFileBlocks(
       mime_type: resource.mimeType,
       text: resource.text,
       ...(resource.uri != null ? { metadata: { uri: resource.uri } } : {}),
-    } as ContentBlock.Data.StandardFileBlock &
+    } satisfies ContentBlock.Data.StandardFileBlock &
       ContentBlock.Data.PlainTextContentBlock;
   }
 }
@@ -606,6 +596,7 @@ async function _toolOutputToContentBlocks(
   serverName: string
 ): Promise<(ContentBlock | ContentBlock.Multimodal.Standard)[]> {
   const blocks: ContentBlock.Data.StandardFileBlock[] = [];
+  const contentType = content.type;
   switch (content.type) {
     case "text":
       return [
@@ -617,7 +608,7 @@ async function _toolOutputToContentBlocks(
               }
             : {}),
           text: content.text,
-        } as ContentBlock.Text,
+        } satisfies ContentBlock.Text,
       ];
     case "image":
       if (useStandardContentBlocks) {
@@ -627,7 +618,7 @@ async function _toolOutputToContentBlocks(
             source_type: "base64",
             data: content.data,
             mime_type: content.mimeType,
-          } as ContentBlock.Data.StandardImageBlock,
+          } satisfies ContentBlock.Data.StandardImageBlock,
         ];
       }
       return [
@@ -636,7 +627,7 @@ async function _toolOutputToContentBlocks(
           image_url: {
             url: `data:${content.mimeType};base64,${content.data}`,
           },
-        } as ContentBlock,
+        } satisfies ContentBlock,
       ];
     case "audio":
       // We don't check `useStandardContentBlocks` here because we only support audio via
@@ -647,7 +638,7 @@ async function _toolOutputToContentBlocks(
           source_type: "base64",
           data: content.data,
           mime_type: content.mimeType,
-        } as ContentBlock.Data.StandardAudioBlock,
+        } satisfies ContentBlock.Data.StandardAudioBlock,
       ];
     case "resource":
       for await (const block of _embeddedResourceToStandardFileBlocks(
@@ -664,26 +655,26 @@ async function _toolOutputToContentBlocks(
           source_type: "url",
           url: content.uri,
           mime_type: content.mimeType,
-        } as ContentBlock.Data.StandardFileBlock &
+        } satisfies ContentBlock.Data.StandardFileBlock &
           ContentBlock.Data.URLContentBlock,
       ];
     }
     default:
       throw new ToolException(
         `MCP tool '${toolName}' on server '${serverName}' returned a content block with unexpected type "${
-          (content as { type: string }).type
+          contentType
         }." Expected one of ${callToolResultContentTypes.map((t: string) => `"${t}"`).join(", ")}.`
       );
   }
 }
 
 async function _embeddedResourceToArtifact(
-  resource: EmbeddedResource,
+  resource: MCPContentBlock,
   useStandardContentBlocks: boolean | undefined,
   client: MCPInstance,
   toolName: string,
   serverName: string
-): Promise<(EmbeddedResource | ContentBlock.Multimodal.Standard)[]> {
+): Promise<(MCPContentBlock | ContentBlock)[]> {
   if (useStandardContentBlocks) {
     return _toolOutputToContentBlocks(
       resource,
@@ -739,8 +730,8 @@ type MCPMetaArtifact = {
  * @internal
  */
 type ExtendedArtifact =
-  | EmbeddedResource
-  | ContentBlock.Multimodal.Standard
+  | MCPContentBlock
+  | ContentBlock
   | MCPStructuredContentArtifact
   | MCPMetaArtifact;
 
@@ -866,21 +857,21 @@ async function _convertCallToolResult({
   // Create the text content output
   const artifacts = (
     await Promise.all(
-      (
-        result.content.filter(
+      result.content
+        .filter(
           (content: MCPContentBlock) =>
             _getOutputTypeForContentType(content.type, outputHandling) ===
             "artifact"
-        ) as EmbeddedResource[]
-      ).map((content: EmbeddedResource) => {
-        return _embeddedResourceToArtifact(
-          content,
-          useStandardContentBlocks,
-          client,
-          toolName,
-          serverName
-        );
-      })
+        )
+        .map((content) => {
+          return _embeddedResourceToArtifact(
+            content,
+            useStandardContentBlocks,
+            client,
+            toolName,
+            serverName
+          );
+        })
     )
   ).flat();
 
@@ -905,8 +896,18 @@ async function _convertCallToolResult({
   }
 
   // If we have structuredContent or meta, create an enhanced content that includes all info
-  if (convertedContent.length === 1 && convertedContent[0].type === "text") {
-    const textBlock = convertedContent[0] as ContentBlock.Text;
+  const firstBlock = convertedContent[0];
+  if (
+    convertedContent.length === 1 &&
+    firstBlock.type === "text" &&
+    "text" in firstBlock &&
+    typeof firstBlock.text === "string"
+  ) {
+    const textBlock = {
+      ...firstBlock,
+      type: "text",
+      text: firstBlock.text,
+    } satisfies ContentBlock.Text;
     const textContent = textBlock.text;
 
     // If we have structuredContent or meta, wrap the content with additional info
@@ -916,15 +917,15 @@ async function _convertCallToolResult({
           ...textBlock,
           ...(structuredContent ? { structuredContent } : {}),
           ...(meta ? { meta } : {}),
-        } as ExtendedContent,
+        } satisfies ExtendedContent,
         enhancedArtifacts,
       ];
     }
 
-    return [textContent as ExtendedContent, enhancedArtifacts];
+    return [textContent, enhancedArtifacts];
   }
 
-  return [convertedContent as ExtendedContent, enhancedArtifacts];
+  return [convertedContent, enhancedArtifacts];
 }
 
 /**
@@ -1010,7 +1011,8 @@ async function _callTool({
     // To preserve the numeric timeout for SDKs that accept an explicit timeout value, we read
     // it from metadata.timeoutMs if present, falling back to any direct timeout.
     const numericTimeout =
-      (config?.metadata?.timeoutMs as number | undefined) ?? config?.timeout;
+      z.number().nullish().parse(config?.metadata?.timeoutMs) ??
+      config?.timeout;
     const requestOptions: RequestOptions = {
       ...(numericTimeout ? { timeout: numericTimeout } : {}),
       ...(config?.signal ? { signal: config.signal } : {}),
@@ -1031,7 +1033,9 @@ async function _callTool({
 
     let state: State = {};
     try {
-      state = getCurrentTaskInput(config) as State;
+      state = z
+        .record(z.string(), z.unknown())
+        .parse(getCurrentTaskInput(config));
     } catch (error) {
       debugLog(
         `State can't be derrived as LangGraph is not used: ${String(error)}`
@@ -1056,15 +1060,18 @@ async function _callTool({
 
     const headers = beforeToolCallInterception?.headers || {};
     const hasHeaderChanges = Object.entries(headers).length > 0;
-    if (hasHeaderChanges && typeof (client as Client).fork !== "function") {
+    if (
+      hasHeaderChanges &&
+      !("fork" in client && typeof client.fork === "function")
+    ) {
       throw new ToolException(
         `MCP client for server "${serverName}" does not support header changes`
       );
     }
 
     const finalClient =
-      hasHeaderChanges && typeof (client as Client).fork === "function"
-        ? await (client as Client).fork(headers)
+      hasHeaderChanges && "fork" in client && typeof client.fork === "function"
+        ? await client.fork(headers)
         : client;
 
     // v2 callTool(params, options?) — no result-schema argument in between.
@@ -1079,9 +1086,7 @@ async function _callTool({
       callToolArgs.push(requestOptions);
     }
 
-    const result = (await finalClient.callTool(
-      ...callToolArgs
-    )) as CallToolResult;
+    const result = await finalClient.callTool(...callToolArgs);
     const [content, artifacts] = await _convertCallToolResult({
       serverName,
       toolName,
@@ -1100,30 +1105,18 @@ async function _callTool({
       typeof content === "string"
         ? content
         : Array.isArray(content)
-          ? (content as (ContentBlock | ContentBlock.Data.DataContentBlock)[])
-          : ([content] as (
-              | ContentBlock
-              | ContentBlock.Data.DataContentBlock
-            )[]);
+          ? content
+          : [content];
 
-    // Filter artifacts to only include types expected by afterToolCall
-    // afterToolCall expects: (EmbeddedResource | ContentBlock.Multimodal.Standard)[]
-    // ExtendedArtifact includes additional types (MCPStructuredContentArtifact, MCPMetaArtifact)
-    // which need to be filtered out
-    const normalizedArtifacts: (
-      | EmbeddedResource
-      | ContentBlock.Multimodal.Standard
-    )[] = artifacts.filter(
-      (
-        artifact
-      ): artifact is EmbeddedResource | ContentBlock.Multimodal.Standard =>
+    // Preserve the existing hook view of resources and data artifacts. The
+    // hook parser checks block containers without asserting a provider format.
+    const normalizedArtifacts = artifacts.filter(
+      (artifact) =>
         artifact.type === "resource" ||
         (artifact.type !== "mcp_structured_content" &&
           artifact.type !== "mcp_meta" &&
-          typeof artifact === "object" &&
-          artifact !== null &&
           "source_type" in artifact)
-    ) as (EmbeddedResource | ContentBlock.Multimodal.Standard)[];
+    );
 
     const interceptedResult = toolCallResultModificationSchema.optional().parse(
       await afterToolCall?.(
@@ -1147,15 +1140,14 @@ async function _callTool({
     }
 
     if (Array.isArray(interceptedResult.result)) {
-      return interceptedResult.result as ContentBlocksWithArtifacts;
+      return interceptedResult.result;
     }
 
     if (ToolMessage.isInstance(interceptedResult.result)) {
       return [interceptedResult.result.contentBlocks, []];
     }
 
-    // oxlint-disable-next-line no-instanceof/no-instanceof
-    if (interceptedResult?.result instanceof Command) {
+    if (isCommand(interceptedResult.result)) {
       return interceptedResult.result;
     }
 
@@ -1163,9 +1155,9 @@ async function _callTool({
       `Unexpected result value type from afterToolCall: expected either a Command, a ToolMessage or a tuple of ContentBlock and Artifact, but got ${interceptedResult.result}`
     );
   } catch (error) {
-    // oxlint-disable-next-line no-instanceof/no-instanceof
-    if (error instanceof Error && isInteropZodError(error)) {
-      throw new ToolException(z.prettifyError(error as z.ZodError), error);
+    const details = parseZodErrorDetails(error);
+    if (details) {
+      throw new ToolException(z.prettifyError(details), error);
     }
 
     debugLog(`Error calling tool ${toolName}: ${String(error)}`);
@@ -1242,9 +1234,7 @@ export async function loadMcpTools(
 
             // Dereference $defs/$ref in the schema to support Pydantic v2 schemas
             // and other JSON schemas that use $defs for nested type definitions
-            const dereferencedSchema = dereferenceJsonSchema(
-              tool.inputSchema as JsonSchemaObject
-            );
+            const dereferencedSchema = dereferenceJsonSchema(tool.inputSchema);
 
             // Simplify schema for LLM compatibility by removing allOf, anyOf, oneOf,
             // if/then/else, not, and other patterns that OpenAI doesn't support
@@ -1290,5 +1280,5 @@ export async function loadMcpTools(
           }
         })
     )
-  ).filter(Boolean) as DynamicStructuredTool[];
+  ).filter((tool) => tool !== null);
 }

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -13,6 +13,8 @@ import type {
   Tool as MCPTool,
   ListToolsResult,
   RequestOptions,
+  JSONObject,
+  JSONValue,
 } from "@modelcontextprotocol/client";
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import type { ContentBlock } from "@langchain/core/messages";
@@ -34,26 +36,27 @@ import {
   type LoadMcpToolsOptions,
   type OutputHandling,
 } from "./types.js";
-import type { ToolHooks, State } from "./hooks.js";
+import type { ToolHooks } from "./hooks.js";
 import type { Client } from "./connection.js";
 import { getDebugLog } from "./logging.js";
 
 const debugLog = getDebugLog("tools");
 
-/**
- * JSON Schema type definitions for dereferencing $defs.
- */
-type JsonSchemaObject = Record<string, unknown>;
+// Decode JSON once at discovery; only parse the schema keywords this
+// simplifier consumes. Extension keywords remain intact.
+const jsonObjectSchema = z.record(z.string(), z.json());
+const schemaKeywordsSchema = z
+  .object({
+    properties: jsonObjectSchema.optional(),
+    required: z.array(z.string()).optional(),
+    allOf: z.array(z.json()).optional(),
+    anyOf: z.array(z.json()).optional(),
+    oneOf: z.array(z.json()).optional(),
+  })
+  .catchall(z.json());
 
-function isSchemaRecord(value: unknown): value is JsonSchemaObject {
+function isSchemaRecord(value: JSONValue | undefined): value is JSONObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-const requiredFieldsSchema = z.array(z.string());
-
-function requiredFields(value: unknown): string[] {
-  const result = requiredFieldsSchema.safeParse(value);
-  return result.success ? result.data : [];
 }
 
 /**
@@ -64,7 +67,7 @@ function requiredFields(value: unknown): string[] {
  * @param schema - The JSON Schema to dereference
  * @returns A new schema with all $ref pointers resolved
  */
-function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
+function dereferenceJsonSchema(schema: JSONObject): JSONObject {
   const rawDefinitions = schema.$defs ?? schema.definitions;
   const definitions = isSchemaRecord(rawDefinitions) ? rawDefinitions : {};
 
@@ -73,9 +76,9 @@ function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
    * Tracks visited refs to prevent infinite recursion with circular references.
    */
   function resolveRefs(
-    obj: JsonSchemaObject,
+    obj: JSONObject,
     visitedRefs: Set<string> = new Set()
-  ): JsonSchemaObject {
+  ): JSONObject {
     if (typeof obj !== "object" || obj === null) {
       return obj;
     }
@@ -121,7 +124,7 @@ function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
     }
 
     // Recursively process all properties
-    const result: JsonSchemaObject = {};
+    const result: JSONObject = {};
 
     for (const [key, value] of Object.entries(obj)) {
       // Skip $defs and definitions as they're no longer needed after dereferencing
@@ -155,11 +158,8 @@ function dereferenceJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
  * @param source - The source schema to merge from
  * @returns A new merged schema
  */
-function deepMergeSchemas(
-  target: JsonSchemaObject,
-  source: JsonSchemaObject
-): JsonSchemaObject {
-  const result: JsonSchemaObject = { ...target };
+function deepMergeSchemas(target: JSONObject, source: JSONObject): JSONObject {
+  const result: JSONObject = { ...target };
 
   for (const [key, sourceValue] of Object.entries(source)) {
     const targetValue = result[key];
@@ -175,7 +175,7 @@ function deepMergeSchemas(
       // When merging const values, convert to enum to allow multiple values
       const existingConst = result.const;
       const existingEnum = result.enum;
-      const values = new Set<unknown>();
+      const values = new Set<JSONValue>();
 
       if (Array.isArray(existingEnum)) {
         for (const v of existingEnum) values.add(v);
@@ -190,7 +190,7 @@ function deepMergeSchemas(
       result.enum = [...values];
     } else if (key === "enum" && Array.isArray(sourceValue)) {
       // Merge enum values (union of all possible values)
-      const values = new Set<unknown>();
+      const values = new Set<JSONValue>();
       if (Array.isArray(targetValue)) {
         for (const v of targetValue) values.add(v);
       }
@@ -207,7 +207,7 @@ function deepMergeSchemas(
       isSchemaRecord(sourceValue)
     ) {
       // Recursively merge properties - merge each property individually
-      const mergedProps: JsonSchemaObject = { ...targetValue };
+      const mergedProps: JSONObject = { ...targetValue };
       for (const [propKey, propValue] of Object.entries(sourceValue)) {
         if (isSchemaRecord(mergedProps[propKey]) && isSchemaRecord(propValue)) {
           mergedProps[propKey] = deepMergeSchemas(
@@ -241,22 +241,20 @@ function deepMergeSchemas(
  * @param schema - A schema that may contain if/then/else
  * @returns Properties extracted from both then and else branches
  */
-function extractPropertiesFromConditional(
-  schema: JsonSchemaObject
-): JsonSchemaObject {
-  let result: JsonSchemaObject = {};
+function extractPropertiesFromConditional(schema: JSONObject): JSONObject {
+  let result: JSONObject = {};
 
   // Extract properties from 'then' branch
   if (isSchemaRecord(schema.then)) {
-    const thenSchema = schema.then;
+    const thenSchema = schemaKeywordsSchema.parse(schema.then);
     if (thenSchema.properties) {
       result = deepMergeSchemas(result, { properties: thenSchema.properties });
     }
     if (thenSchema.required) {
       result.required = [
         ...new Set([
-          ...requiredFields(result.required),
-          ...requiredFields(thenSchema.required),
+          ...(Array.isArray(result.required) ? result.required : []),
+          ...thenSchema.required,
         ]),
       ];
     }
@@ -264,15 +262,15 @@ function extractPropertiesFromConditional(
 
   // Extract properties from 'else' branch
   if (isSchemaRecord(schema.else)) {
-    const elseSchema = schema.else;
+    const elseSchema = schemaKeywordsSchema.parse(schema.else);
     if (elseSchema.properties) {
       result = deepMergeSchemas(result, { properties: elseSchema.properties });
     }
     if (elseSchema.required) {
       result.required = [
         ...new Set([
-          ...requiredFields(result.required),
-          ...requiredFields(elseSchema.required),
+          ...(Array.isArray(result.required) ? result.required : []),
+          ...elseSchema.required,
         ]),
       ];
     }
@@ -296,7 +294,7 @@ function extractPropertiesFromConditional(
  * @param schema - The JSON Schema to simplify
  * @returns A new simplified schema compatible with LLM tool calling APIs
  */
-function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
+function simplifyJsonSchemaForLLM(schema: JSONObject): JSONObject {
   if (typeof schema !== "object" || schema === null) {
     return schema;
   }
@@ -313,9 +311,9 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
     $schema: _$schema,
     unevaluatedProperties: _unevaluatedProperties,
     ...baseSchema
-  } = schema;
+  } = schemaKeywordsSchema.parse(schema);
 
-  let result: JsonSchemaObject = { ...baseSchema };
+  let result: JSONObject = { ...baseSchema };
 
   // Handle if/then/else at the current level by extracting properties
   if (schemaIf || schemaThen || schemaElse) {
@@ -356,7 +354,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
   if (unionSchemas.length > 0) {
     // Collect all properties from all schemas, but only keep required fields
     // that are common to ALL schemas (intersection)
-    const mergedProperties: JsonSchemaObject = {};
+    const mergedProperties: JSONObject = {};
     const requiredSets: Set<string>[] = [];
 
     const schemasToMerge = unionSchemas.filter(
@@ -364,14 +362,16 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
     );
 
     for (const subSchema of schemasToMerge) {
-      const simplified = simplifyJsonSchemaForLLM(subSchema);
+      const simplified = schemaKeywordsSchema.parse(
+        simplifyJsonSchemaForLLM(subSchema)
+      );
       // Merge properties
       if (isSchemaRecord(simplified.properties)) {
         Object.assign(mergedProperties, simplified.properties);
       }
       // Collect required sets for intersection
       if (simplified.required && Array.isArray(simplified.required)) {
-        requiredSets.push(new Set(requiredFields(simplified.required)));
+        requiredSets.push(new Set(simplified.required));
       }
       // Merge type if present
       if (simplified.type && !result.type) {
@@ -394,7 +394,10 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
       });
       if (commonRequired.size > 0) {
         result.required = [
-          ...new Set([...requiredFields(result.required), ...commonRequired]),
+          ...new Set([
+            ...(Array.isArray(result.required) ? result.required : []),
+            ...commonRequired,
+          ]),
         ];
       }
     }
@@ -411,7 +414,7 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
 
   // Recursively simplify nested schemas in properties
   if (isSchemaRecord(result.properties)) {
-    const simplifiedProperties: JsonSchemaObject = {};
+    const simplifiedProperties: JSONObject = {};
     for (const [propName, propSchema] of Object.entries(result.properties)) {
       if (isSchemaRecord(propSchema)) {
         simplifiedProperties[propName] = simplifyJsonSchemaForLLM(propSchema);
@@ -1031,7 +1034,7 @@ async function _callTool({
         : {}),
     };
 
-    let state: State = {};
+    let state: unknown = {};
     try {
       state = getCurrentTaskInput(config);
     } catch (error) {
@@ -1230,7 +1233,9 @@ export async function loadMcpTools(
 
             // Dereference $defs/$ref in the schema to support Pydantic v2 schemas
             // and other JSON schemas that use $defs for nested type definitions
-            const dereferencedSchema = dereferenceJsonSchema(tool.inputSchema);
+            const dereferencedSchema = dereferenceJsonSchema(
+              jsonObjectSchema.parse(tool.inputSchema)
+            );
 
             // Simplify schema for LLM compatibility by removing allOf, anyOf, oneOf,
             // if/then/else, not, and other patterns that OpenAI doesn't support

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -964,14 +964,11 @@ async function _callTool({
           ? content
           : [content];
 
-    // Preserve the existing hook view of resources and data artifacts. The
-    // hook parser checks block containers without asserting a provider format.
+    // Expose artifact-routed MCP blocks while keeping internal metadata out of hooks.
     const normalizedArtifacts = artifacts.filter(
       (artifact) =>
-        artifact.type === "resource" ||
-        (artifact.type !== "mcp_structured_content" &&
-          artifact.type !== "mcp_meta" &&
-          "source_type" in artifact)
+        artifact.type !== "mcp_structured_content" &&
+        artifact.type !== "mcp_meta"
     );
 
     const interceptedResult = toolCallResultModificationSchema.optional().parse(

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -453,22 +453,16 @@ function simplifyJsonSchemaForLLM(schema: JsonSchemaObject): JsonSchemaObject {
  */
 type MCPInstance = Client | MCPClient;
 
-// Error formatting only needs Standard Schema issues, not a particular Zod
-// constructor. Parse that projection so errors from other Zod versions/copies
-// remain supported without asserting that they are our installed ZodError.
+// Parse only the Zod issue fields needed for formatting, without depending
+// on a particular Zod version or constructor.
 const errorPathKeySchema = z.union([z.string(), z.number(), z.symbol()]);
 const zodErrorDetailsSchema = z.object({
   issues: z.array(
     z.object({
       message: z.string(),
-      path: z
-        .array(
-          z.union([errorPathKeySchema, z.object({ key: errorPathKeySchema })])
-        )
-        .optional(),
+      path: z.array(errorPathKeySchema).optional(),
     })
   ),
-  stack: z.string().optional(),
 });
 
 function parseZodErrorDetails(error: unknown) {
@@ -488,7 +482,13 @@ export class ToolException extends Error {
     const details = parseZodErrorDetails(cause);
     if (details) {
       const minifiedZodError = new Error(z.prettifyError(details));
-      const stackLines = details.stack?.split("\n") ?? [];
+      const stackLines =
+        typeof cause === "object" &&
+        cause !== null &&
+        "stack" in cause &&
+        typeof cause.stack === "string"
+          ? cause.stack.split("\n")
+          : [];
       const firstFrame = stackLines.findIndex((line) =>
         line.includes("    at")
       );

--- a/libs/langchain-mcp-adapters/src/tools.ts
+++ b/libs/langchain-mcp-adapters/src/tools.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod";
 import { isInteropZodError } from "@langchain/core/utils/types";
 import {
   toolCallModificationSchema,
@@ -1052,10 +1052,7 @@ async function _callTool({
         )
       );
 
-    const finalArgs = Object.assign(
-      args,
-      beforeToolCallInterception?.args || {}
-    );
+    const finalArgs = { ...args, ...beforeToolCallInterception?.args };
 
     const headers = beforeToolCallInterception?.headers || {};
     const hasHeaderChanges = Object.entries(headers).length > 0;

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import type {
+  CallToolResult,
+  ListResourcesResult,
+  ListResourceTemplatesResult,
+  ReadResourceResult,
   OAuthClientProvider,
   LoggingMessageNotificationParams,
   Progress,
@@ -31,7 +35,7 @@ const callToolResultContentTypeSchema = z.enum([
   "resource",
   "resource_link",
   "text",
-]);
+] satisfies CallToolResult["content"][number]["type"][]);
 
 export const callToolResultContentTypes =
   callToolResultContentTypeSchema.options;
@@ -895,66 +899,16 @@ export interface CustomHTTPTransportOptions {
 /**
  * Represents a resource provided by an MCP server.
  */
-export type MCPResource = {
-  /**
-   * The URI of the resource
-   */
-  uri: string;
-  /**
-   * Human-readable name of the resource
-   */
-  name: string;
-  /**
-   * Optional description of what the resource represents
-   */
-  description?: string;
-  /**
-   * Optional MIME type of the resource content
-   */
-  mimeType?: string;
-};
+export type MCPResource = ListResourcesResult["resources"][number];
 
 /**
  * Represents a resource template provided by an MCP server.
  * Resource templates are used for dynamic resources with parameterized URIs.
  */
-export type MCPResourceTemplate = {
-  /**
-   * The URI template with parameter placeholders (e.g., "users://{userId}/profile")
-   */
-  uriTemplate: string;
-  /**
-   * Human-readable name of the resource template
-   */
-  name: string;
-  /**
-   * Optional description of what the resource template represents
-   */
-  description?: string;
-  /**
-   * Optional MIME type of the resource content
-   */
-  mimeType?: string;
-};
+export type MCPResourceTemplate =
+  ListResourceTemplatesResult["resourceTemplates"][number];
 
 /**
  * Represents the content of a resource retrieved from an MCP server.
  */
-export type MCPResourceContent = {
-  /**
-   * The URI of the resource
-   */
-  uri: string;
-  /**
-   * Optional MIME type of the content
-   */
-  mimeType?: string;
-  /**
-   * Optional text content of the resource
-   */
-  text?: string;
-  /**
-   * Optional base64-encoded binary content of the resource
-   */
-  blob?: string;
-};
+export type MCPResourceContent = ReadResourceResult["contents"][number];

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -1,5 +1,11 @@
-import { z } from "zod/v3";
-import type { OAuthClientProvider } from "@modelcontextprotocol/client";
+import { z } from "zod/v4";
+import type {
+  OAuthClientProvider,
+  LoggingMessageNotificationParams,
+  Progress,
+  CancelledNotificationParams,
+  ResourceUpdatedNotificationParams,
+} from "@modelcontextprotocol/client";
 import type {
   ContentBlock,
   ToolMessage,
@@ -29,67 +35,13 @@ export const callToolResultContentTypes = [
 export type CallToolResultContentType =
   (typeof callToolResultContentTypes)[number];
 
-/**
- * The severity of a log message.
- * @see {@link https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/types.ts#L1067}
- */
-export const LoggingLevelSchema = z.enum([
-  "debug",
-  "info",
-  "notice",
-  "warning",
-  "error",
-  "critical",
-  "alert",
-  "emergency",
-]);
-
-/**
- * A uniquely identifying ID for a request in JSON-RPC.
- * @see {@link https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/types.ts#L71C1-L74C72}
- */
-export const RequestIdSchema = z.union([z.string(), z.number().int()]);
-
-const outputTypesUnion = z.union([
-  z
-    .literal("content")
-    .describe("Put tool output into the ToolMessage.content array"),
-  z
-    .literal("artifact")
-    .describe("Put tool output into the ToolMessage.artifact array"),
-]);
-
-const detailedOutputHandlingSchema = z.object(
-  Object.fromEntries(
-    callToolResultContentTypes.map((contentType) => [
-      contentType,
-      z
-        .union([
-          z
-            .literal("content")
-            .describe(
-              `Put all ${contentType} tool output into the ToolMessage.content array`
-            ),
-          z
-            .literal("artifact")
-            .describe(
-              `Put all ${contentType} tool output into the ToolMessage.artifact array`
-            ),
-        ])
-        .describe(
-          `Where to place ${contentType} tool output in the LangChain ToolMessage`
-        )
-        .optional(),
-    ])
-  ) as {
-    [K in CallToolResultContentType]: z.ZodOptional<
-      z.ZodUnion<[z.ZodLiteral<"content">, z.ZodLiteral<"artifact">]>
-    >;
-  }
+const outputTypesUnion = z.enum(["content", "artifact"]);
+const detailedOutputHandlingSchema = z.partialRecord(
+  z.enum(callToolResultContentTypes),
+  outputTypesUnion
 );
-
-export type DetailedOutputHandling = z.output<
-  typeof detailedOutputHandlingSchema
+export type DetailedOutputHandling = Partial<
+  Record<CallToolResultContentType, "content" | "artifact">
 >;
 
 export const outputHandlingSchema = z
@@ -266,7 +218,7 @@ export const stdioConnectionSchema = z
      * Environment variables to set when spawning the process.
      */
     env: z
-      .record(z.string())
+      .record(z.string(), z.string())
       .describe("The environment to use when spawning the process")
       .optional(),
     /**
@@ -361,7 +313,7 @@ export const streamableHttpConnectionSchema = z
     /**
      * Additional headers to send with the request, useful for authentication
      */
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     /**
      * OAuth client provider for automatic authentication handling.
      * When provided, the transport will automatically handle token refresh,
@@ -386,291 +338,145 @@ export const streamableHttpConnectionSchema = z
 /**
  * Create combined schema for all transport connection types
  */
-export const connectionSchema = z
+const resolvedConnectionSchema = z
   .union([stdioConnectionSchema, streamableHttpConnectionSchema])
+  .superRefine((connection, ctx) => {
+    if (
+      connection.transport &&
+      connection.type &&
+      connection.transport !== connection.type
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["type"],
+        message: "type conflicts with transport; use transport only",
+      });
+    }
+  })
+  .transform(
+    (
+      connection
+    ): ResolvedStdioConnection | ResolvedStreamableHTTPConnection => {
+      if ("command" in connection) {
+        const { type, ...options } = connection;
+        return { ...options, transport: options.transport ?? type ?? "stdio" };
+      }
+      const { type, ...options } = connection;
+      return { ...options, transport: options.transport ?? type ?? "http" };
+    }
+  )
   .describe("Configuration for a single MCP server");
 
-const toolSourceSchema = z.object({
-  type: z.literal("tool"),
-  name: z.string(),
-  args: z.unknown(),
-  server: z.string(),
-});
-/**
- * we don't know yet what other types of sources may send progress messages
- */
-const unknownSourceSchema = z.object({
-  type: z.literal("unknown"),
-});
-const eventContextSchema = z.union([toolSourceSchema, unknownSourceSchema]);
-export type EventContext = z.output<typeof eventContextSchema>;
+// Inspect ambiguous raw shapes before the union parser can strip unknown keys.
+export const connectionSchema = z.preprocess((value, ctx) => {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "command" in value &&
+    "url" in value
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Specify a stdio command or an HTTP URL, not both",
+    });
+  }
+  return value;
+}, resolvedConnectionSchema);
 
-const serverMessageSourceSchema = z.object({
-  server: z.string(),
-  options: connectionSchema,
-});
-export type ServerMessageSource = z.output<typeof serverMessageSourceSchema>;
+export type EventContext =
+  | { type: "tool"; name: string; args: unknown; server: string }
+  | { type: "unknown" };
 
-export const notifications = z.object({
-  /**
-   * Called when a log message is received.
-   *
-   * @param logMessage - The log message
-   * @param logMessage.message - The log message
-   * @param logMessage.level - The log level
-   * @param logMessage.timestamp - The log timestamp
-   * @param source - The source of the log message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.option - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`
-   * @returns The log message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onLog: (logMessage) => {
-   *     console.log(logMessage);
-   *   },
-   * });
-   * ```
-   */
+export interface ServerMessageSource {
+  server: string;
+  options: ResolvedConnection;
+}
+
+/** SDK notification payloads are validated by the SDK before dispatch. */
+export interface Notifications {
+  onMessage?: (
+    message: LoggingMessageNotificationParams,
+    source: ServerMessageSource
+  ) => void | Promise<void>;
+  onProgress?: (
+    progress: Progress,
+    source: EventContext
+  ) => void | Promise<void>;
+  onCancelled?: (
+    notification: CancelledNotificationParams,
+    source: ServerMessageSource
+  ) => void | Promise<void>;
+  onInitialized?: (source: ServerMessageSource) => void | Promise<void>;
+  onPromptsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
+  onResourcesListChanged?: (
+    source: ServerMessageSource
+  ) => void | Promise<void>;
+  onResourcesUpdated?: (
+    resource: ResourceUpdatedNotificationParams,
+    source: ServerMessageSource
+  ) => void | Promise<void>;
+  onRootsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
+  onToolsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
+}
+
+// Check runtime configuration once; do not parse already validated SDK payloads
+// again or clone the application-owned callback context on every notification.
+const notifications = z.object({
   onMessage: z
-    .function()
-    .args(
-      z.object({
-        /**
-         * The severity of this log message.
-         */
-        level: LoggingLevelSchema,
-        /**
-         * An optional name of the logger issuing this message.
-         */
-        logger: z.optional(z.string()),
-        /**
-         * The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
-         */
-        data: z.unknown(),
-      }),
-      serverMessageSourceSchema
+    .custom<NonNullable<Notifications["onMessage"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
     )
-    .returns(z.union([z.void(), z.promise(z.void())]))
     .optional(),
-  /**
-   * Called when a progress message is received.
-   *
-   * @param progress - The progress message
-   * @param progress.message - The progress message
-   * @param progress.percentage - The progress percentage
-   * @param progress.timestamp - The progress timestamp
-   * @param source - The source of the progress message
-   * @param source.type - The type of the source, e.g. "tool"
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.name - The name of the source, e.g. "my-name"
-   * @param source.args - The arguments of the source, e.g. { a: 1, b: 2 }
-   * @returns The progress message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onProgress: (progress, source) => {
-   *     if (source.type === "tool") {
-   *     console.log(progress);
-   *   },
-   * });
-   * ```
-   */
   onProgress: z
-    .function()
-    .args(
-      z.object({
-        /**
-         * The progress thus far. This should increase every time progress is made, even if the total is unknown.
-         */
-        progress: z.number(),
-        /**
-         * Total number of items to process (or total progress required), if known.
-         */
-        total: z.optional(z.number()),
-        /**
-         * An optional message describing the current progress.
-         */
-        message: z.optional(z.string()),
-      }),
-      eventContextSchema
+    .custom<NonNullable<Notifications["onProgress"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
     )
-    .returns(z.union([z.void(), z.promise(z.void())]))
     .optional(),
   onCancelled: z
-    .function()
-    .args(
-      z.object({
-        /**
-         * The ID of the request to cancel.
-         *
-         * This MUST correspond to the ID of a request previously issued in the same direction.
-         */
-        requestId: RequestIdSchema,
-
-        /**
-         * An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
-         */
-        reason: z.string().optional(),
-      }),
-      serverMessageSourceSchema
+    .custom<NonNullable<Notifications["onCancelled"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
     )
-    .returns(z.union([z.void(), z.promise(z.void())]))
     .optional(),
-  /**
-   * Called when the server is initialized.
-   *
-   * @param source - The source of the initialized message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The initialized message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onInitialized: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
   onInitialized: z
-    .function()
-    .args(serverMessageSourceSchema)
-    .returns(z.union([z.void(), z.promise(z.void())]))
-    .optional(),
-  /**
-   * Called when the prompts list is changed.
-   *
-   * @param source - The source of the prompts list changed message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The prompts list changed message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onPromptsListChanged: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
-  onPromptsListChanged: z
-    .function()
-    .args(serverMessageSourceSchema)
-    .returns(z.union([z.void(), z.promise(z.void())]))
-    .optional(),
-  /**
-   * Called when the resources list is changed.
-   *
-   * @param source - The source of the resources list changed message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The resources list changed message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onResourcesListChanged: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
-  onResourcesListChanged: z
-    .function()
-    .args(serverMessageSourceSchema)
-    .returns(z.union([z.void(), z.promise(z.void())]))
-    .optional(),
-  /**
-   * Called when the resources are updated.
-   *
-   * @param updatedResource - The updated resource
-   * @param updatedResource.uri - The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
-   * @param source - The source of the resources updated message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The resources updated message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onResourcesUpdated: (updatedResource, source) => {
-   *     console.log(`Resource ${updatedResource.uri} updated`);
-   *   },
-   * });
-   * ```
-   */
-  onResourcesUpdated: z
-    .function()
-    .args(
-      z.object({
-        /**
-         * The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
-         */
-        uri: z.string(),
-      }),
-      serverMessageSourceSchema
+    .custom<NonNullable<Notifications["onInitialized"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
     )
-    .returns(z.union([z.void(), z.promise(z.void())]))
     .optional(),
-  /**
-   * Called when the roots list is changed.
-   *
-   * @param source - The source of the roots list changed message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The roots list changed message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onRootsListChanged: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
+  onPromptsListChanged: z
+    .custom<NonNullable<Notifications["onPromptsListChanged"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
+    )
+    .optional(),
+  onResourcesListChanged: z
+    .custom<NonNullable<Notifications["onResourcesListChanged"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
+    )
+    .optional(),
+  onResourcesUpdated: z
+    .custom<NonNullable<Notifications["onResourcesUpdated"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
+    )
+    .optional(),
   onRootsListChanged: z
-    .function()
-    .args(serverMessageSourceSchema)
-    .returns(z.union([z.void(), z.promise(z.void())]))
+    .custom<NonNullable<Notifications["onRootsListChanged"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
+    )
     .optional(),
-  /**
-   * Called when the tools list is changed.
-   *
-   * @param source - The source of the tools list changed message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   * @returns The tools list changed message
-   *
-   * @example
-   * ```ts
-   * const client = new MultiServerMCPClient({
-   *   // ...
-   *   onToolsListChanged: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
   onToolsListChanged: z
-    .function()
-    .args(serverMessageSourceSchema)
-    .returns(z.union([z.void(), z.promise(z.void())]))
+    .custom<NonNullable<Notifications["onToolsListChanged"]>>(
+      (value) => typeof value === "function",
+      "Expected a callback"
+    )
     .optional(),
 });
-export type Notifications = z.output<typeof notifications>;
 
 /**
  * {@link MultiServerMCPClient} configuration
@@ -681,7 +487,7 @@ export const clientConfigSchema = z
      * A map of server names to their configuration
      */
     mcpServers: z
-      .record(connectionSchema)
+      .record(z.string(), connectionSchema)
       .describe("A map of server names to their configuration"),
     /**
      * Whether to throw an error if a tool fails to load
@@ -747,15 +553,10 @@ export const clientConfigSchema = z
     onConnectionError: z
       .union([
         z.enum(["throw", "ignore"]),
-        z
-          .function()
-          .args(
-            z.object({
-              serverName: z.string(),
-              error: z.unknown(),
-            })
-          )
-          .returns(z.void()),
+        z.custom<ConnectionErrorHandler>(
+          (value) => typeof value === "function",
+          "Expected a connection error handler"
+        ),
       ])
       .describe(
         "Behavior when a server fails to connect: 'throw' to error immediately, 'ignore' to skip failed servers, or a function for custom error handling"
@@ -795,12 +596,22 @@ export type ResolvedStreamableHTTPConnection = z.output<
 /**
  * Union type for all transport connection types
  */
-export type Connection = z.input<typeof connectionSchema>;
+export type Connection = StdioConnection | StreamableHTTPConnection;
 
 /**
  * Type for {@link MultiServerMCPClient} configuration
  */
-export type ClientConfig = z.input<typeof clientConfigSchema>;
+export type ClientConfig = Omit<
+  z.input<typeof clientConfigSchema>,
+  "mcpServers"
+> & {
+  mcpServers: Record<string, Connection>;
+};
+
+/** Canonical adapter options. Legacy `mcpServers` is accepted only by the migration overload. */
+export type MCPAdapterConfig = Omit<ClientConfig, "mcpServers"> & {
+  servers: Record<string, Connection>;
+};
 
 /**
  * Type for {@link Connection} with default values applied.

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod";
 import type {
   OAuthClientProvider,
   LoggingMessageNotificationParams,
@@ -40,8 +40,8 @@ const detailedOutputHandlingSchema = z.partialRecord(
   z.enum(callToolResultContentTypes),
   outputTypesUnion.optional()
 );
-export type DetailedOutputHandling = Partial<
-  Record<CallToolResultContentType, "content" | "artifact">
+export type DetailedOutputHandling = z.output<
+  typeof detailedOutputHandlingSchema
 >;
 
 export const outputHandlingSchema = z
@@ -192,7 +192,7 @@ export const stdioRestartSchema = z
 /**
  * Stdio transport connection
  */
-export const stdioConnectionSchema = z
+const stdioOptionsSchema = z
   .object({
     /**
      * Optional transport type, inferred from the structure of the config if not provided. Included
@@ -208,6 +208,9 @@ export const stdioConnectionSchema = z
      * The executable to run the server (e.g. `node`, `npx`, etc)
      */
     command: z.string().describe("The executable to run the server"),
+    url: z
+      .never({ error: "Specify a stdio command or an HTTP URL, not both" })
+      .optional(),
     /**
      * Array of command line arguments to pass to the executable
      */
@@ -259,7 +262,7 @@ export const stdioConnectionSchema = z
      */
     restart: stdioRestartSchema.optional(),
   })
-  .and(baseConfigSchema)
+  .extend(baseConfigSchema.shape)
   .describe("Configuration for stdio transport connection");
 
 /**
@@ -294,7 +297,7 @@ export const streamableHttpReconnectSchema = z
 /**
  * Streamable HTTP transport connection
  */
-export const streamableHttpConnectionSchema = z
+const httpOptionsSchema = z
   .object({
     /**
      * Optional transport type, inferred from the structure of the config. If "sse", will not attempt
@@ -310,6 +313,9 @@ export const streamableHttpConnectionSchema = z
      * The URL to connect to
      */
     url: z.string().url(),
+    command: z
+      .never({ error: "Specify a stdio command or an HTTP URL, not both" })
+      .optional(),
     /**
      * Additional headers to send with the request, useful for authentication
      */
@@ -332,56 +338,53 @@ export const streamableHttpConnectionSchema = z
      */
     automaticSSEFallback: z.boolean().optional().default(true),
   })
-  .and(baseConfigSchema)
+  .extend(baseConfigSchema.shape)
   .describe("Configuration for streamable HTTP transport connection");
 
-/**
- * Create combined schema for all transport connection types
- */
-const resolvedConnectionSchema = z
-  .union([stdioConnectionSchema, streamableHttpConnectionSchema])
-  .superRefine((connection, ctx) => {
-    if (
-      connection.transport &&
-      connection.type &&
-      connection.transport !== connection.type
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["type"],
-        message: "type conflicts with transport; use transport only",
-      });
-    }
+/** Parse legacy aliases once and retain a concrete transport discriminator. */
+export const stdioConnectionSchema = stdioOptionsSchema.transform(
+  ({ type: _type, url: _url, ...options }) => ({
+    ...options,
+    transport: "stdio" as const,
   })
-  .transform(
-    (
-      connection
-    ): ResolvedStdioConnection | ResolvedStreamableHTTPConnection => {
-      if ("command" in connection) {
-        const { type, ...options } = connection;
-        return { ...options, transport: options.transport ?? type ?? "stdio" };
-      }
-      const { type, ...options } = connection;
-      return { ...options, transport: options.transport ?? type ?? "http" };
-    }
-  )
-  .describe("Configuration for a single MCP server");
+);
 
-// Inspect ambiguous raw shapes before the union parser can strip unknown keys.
-export const connectionSchema = z.preprocess((value, ctx) => {
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "command" in value &&
-    "url" in value
-  ) {
-    ctx.addIssue({
-      code: "custom",
-      message: "Specify a stdio command or an HTTP URL, not both",
-    });
-  }
-  return value;
-}, resolvedConnectionSchema);
+const httpConnectionSchema = httpOptionsSchema
+  .extend({
+    transport: z.literal("http").optional(),
+    type: z
+      .literal("http", {
+        error: "type conflicts with transport; use transport only",
+      })
+      .optional(),
+  })
+  .transform(({ type: _type, command: _command, ...options }) => ({
+    ...options,
+    transport: "http" as const,
+  }));
+
+const sseConnectionSchema = httpOptionsSchema
+  .extend({
+    transport: z.literal("sse").optional(),
+    type: z
+      .literal("sse", {
+        error: "type conflicts with transport; use transport only",
+      })
+      .optional(),
+  })
+  .transform(({ type: _type, command: _command, ...options }) => ({
+    ...options,
+    transport: "sse" as const,
+  }));
+
+export const streamableHttpConnectionSchema = z.union([
+  httpConnectionSchema,
+  sseConnectionSchema,
+]);
+export const connectionSchema = z.union([
+  stdioConnectionSchema,
+  streamableHttpConnectionSchema,
+]);
 
 export type EventContext =
   | { type: "tool"; name: string; args: unknown; server: string }
@@ -392,103 +395,78 @@ export interface ServerMessageSource {
   options: ResolvedConnection;
 }
 
-/** SDK notification payloads are validated by the SDK before dispatch. */
-export interface Notifications {
-  onMessage?: (
-    message: LoggingMessageNotificationParams,
-    source: ServerMessageSource
-  ) => void | Promise<void>;
-  onProgress?: (
-    progress: Progress,
-    source: EventContext
-  ) => void | Promise<void>;
-  onCancelled?: (
-    notification: CancelledNotificationParams,
-    source: ServerMessageSource
-  ) => void | Promise<void>;
-  onInitialized?: (source: ServerMessageSource) => void | Promise<void>;
-  onPromptsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
-  onResourcesListChanged?: (
-    source: ServerMessageSource
-  ) => void | Promise<void>;
-  onResourcesUpdated?: (
-    resource: ResourceUpdatedNotificationParams,
-    source: ServerMessageSource
-  ) => void | Promise<void>;
-  onRootsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
-  onToolsListChanged?: (source: ServerMessageSource) => void | Promise<void>;
-}
-
-// Check runtime configuration once; do not parse already validated SDK payloads
-// again. ConnectionManager supplies an isolated options snapshot per notification.
+// SDK payloads are already parsed by the SDK. Keep callbacks as opaque runtime
+// services; parsing a function schema would replace their identity with a wrapper.
 const notifications = z.object({
   onMessage: z
-    .custom<NonNullable<Notifications["onMessage"]>>(
-      (value) => typeof value === "function",
-      "Expected a callback"
-    )
+    .custom<
+      (
+        message: LoggingMessageNotificationParams,
+        source: ServerMessageSource
+      ) => void | Promise<void>
+    >((value) => typeof value === "function", "Expected a callback")
     .optional(),
   onProgress: z
-    .custom<NonNullable<Notifications["onProgress"]>>(
+    .custom<(progress: Progress, source: EventContext) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
   onCancelled: z
-    .custom<NonNullable<Notifications["onCancelled"]>>(
-      (value) => typeof value === "function",
-      "Expected a callback"
-    )
+    .custom<
+      (
+        notification: CancelledNotificationParams,
+        source: ServerMessageSource
+      ) => void | Promise<void>
+    >((value) => typeof value === "function", "Expected a callback")
     .optional(),
   onInitialized: z
-    .custom<NonNullable<Notifications["onInitialized"]>>(
+    .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
   onPromptsListChanged: z
-    .custom<NonNullable<Notifications["onPromptsListChanged"]>>(
+    .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
   onResourcesListChanged: z
-    .custom<NonNullable<Notifications["onResourcesListChanged"]>>(
+    .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
   onResourcesUpdated: z
-    .custom<NonNullable<Notifications["onResourcesUpdated"]>>(
-      (value) => typeof value === "function",
-      "Expected a callback"
-    )
+    .custom<
+      (
+        resource: ResourceUpdatedNotificationParams,
+        source: ServerMessageSource
+      ) => void | Promise<void>
+    >((value) => typeof value === "function", "Expected a callback")
     .optional(),
   onRootsListChanged: z
-    .custom<NonNullable<Notifications["onRootsListChanged"]>>(
+    .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
   onToolsListChanged: z
-    .custom<NonNullable<Notifications["onToolsListChanged"]>>(
+    .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
 });
 
+export type Notifications = z.output<typeof notifications>;
+
 /**
  * {@link MultiServerMCPClient} configuration
  */
-export const clientConfigSchema = z
+const clientOptionsSchema = z
   .object({
-    /**
-     * A map of server names to their configuration
-     */
-    mcpServers: z
-      .record(z.string(), connectionSchema)
-      .describe("A map of server names to their configuration"),
     /**
      * Whether to throw an error if a tool fails to load
      *
@@ -564,10 +542,44 @@ export const clientConfigSchema = z
       .optional()
       .default("throw"),
   })
-  .and(baseConfigSchema)
-  .and(toolHooksSchema)
-  .and(notifications)
+  .extend(baseConfigSchema.shape)
+  .extend(toolHooksSchema.shape)
+  .extend(notifications.shape)
   .describe("Configuration for the MCP client");
+
+const serverMapSchema = z.record(z.string(), connectionSchema);
+const exclusiveServerMap = z
+  .never({ error: "Specify servers or legacy mcpServers, not both" })
+  .optional();
+
+/** Resolved legacy-shaped configuration also provides isolated public snapshots. */
+export const clientConfigSchema = clientOptionsSchema.extend({
+  mcpServers: serverMapSchema,
+});
+
+const canonicalConfigSchema = clientOptionsSchema.extend({
+  servers: serverMapSchema,
+  mcpServers: exclusiveServerMap,
+});
+
+const legacyConfigSchema = clientConfigSchema
+  .extend({ servers: exclusiveServerMap })
+  .transform(({ servers: _canonical, ...options }) => options);
+
+/** All supported external shapes produce the same resolved configuration. */
+export const adapterConfigSchema = z.union([
+  canonicalConfigSchema.transform(
+    ({ servers, mcpServers: _legacy, ...options }) => ({
+      ...options,
+      mcpServers: servers,
+    })
+  ),
+  legacyConfigSchema,
+  serverMapSchema.transform((mcpServers) => ({
+    ...clientOptionsSchema.parse({}),
+    mcpServers,
+  })),
+]);
 
 /**
  * Configuration for stdio transport connection
@@ -596,22 +608,15 @@ export type ResolvedStreamableHTTPConnection = z.output<
 /**
  * Union type for all transport connection types
  */
-export type Connection = StdioConnection | StreamableHTTPConnection;
+export type Connection = z.input<typeof connectionSchema>;
 
 /**
  * Type for {@link MultiServerMCPClient} configuration
  */
-export type ClientConfig = Omit<
-  z.input<typeof clientConfigSchema>,
-  "mcpServers"
-> & {
-  mcpServers: Record<string, Connection>;
-};
+export type ClientConfig = z.input<typeof clientConfigSchema>;
 
-/** Canonical adapter options. Legacy `mcpServers` is accepted only by the migration overload. */
-export type MCPAdapterConfig = Omit<ClientConfig, "mcpServers"> & {
-  servers: Record<string, Connection>;
-};
+/** Canonical adapter options. */
+export type MCPAdapterConfig = z.input<typeof canonicalConfigSchema>;
 
 /**
  * Type for {@link Connection} with default values applied.
@@ -835,28 +840,3 @@ export type MCPResourceContent = {
    */
   blob?: string;
 };
-
-/** Copy mutable adapter options while retaining application-owned services. @internal */
-export function _copyConnection(
-  connection: ResolvedConnection
-): ResolvedConnection {
-  const outputHandling =
-    typeof connection.outputHandling === "object"
-      ? { ...connection.outputHandling }
-      : connection.outputHandling;
-  if ("command" in connection) {
-    return {
-      ...connection,
-      outputHandling,
-      args: [...connection.args],
-      env: connection.env && { ...connection.env },
-      restart: connection.restart && { ...connection.restart },
-    };
-  }
-  return {
-    ...connection,
-    outputHandling,
-    headers: connection.headers && { ...connection.headers },
-    reconnect: connection.reconnect && { ...connection.reconnect },
-  };
-}

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -38,7 +38,7 @@ export type CallToolResultContentType =
 const outputTypesUnion = z.enum(["content", "artifact"]);
 const detailedOutputHandlingSchema = z.partialRecord(
   z.enum(callToolResultContentTypes),
-  outputTypesUnion
+  outputTypesUnion.optional()
 );
 export type DetailedOutputHandling = Partial<
   Record<CallToolResultContentType, "content" | "artifact">
@@ -420,7 +420,7 @@ export interface Notifications {
 }
 
 // Check runtime configuration once; do not parse already validated SDK payloads
-// again or clone the application-owned callback context on every notification.
+// again. ConnectionManager supplies an isolated options snapshot per notification.
 const notifications = z.object({
   onMessage: z
     .custom<NonNullable<Notifications["onMessage"]>>(
@@ -835,3 +835,28 @@ export type MCPResourceContent = {
    */
   blob?: string;
 };
+
+/** Copy mutable adapter options while retaining application-owned services. @internal */
+export function _copyConnection(
+  connection: ResolvedConnection
+): ResolvedConnection {
+  const outputHandling =
+    typeof connection.outputHandling === "object"
+      ? { ...connection.outputHandling }
+      : connection.outputHandling;
+  if ("command" in connection) {
+    return {
+      ...connection,
+      outputHandling,
+      args: [...connection.args],
+      env: connection.env && { ...connection.env },
+      restart: connection.restart && { ...connection.restart },
+    };
+  }
+  return {
+    ...connection,
+    outputHandling,
+    headers: connection.headers && { ...connection.headers },
+    reconnect: connection.reconnect && { ...connection.reconnect },
+  };
+}

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -351,6 +351,7 @@ export const eventContextSchema = z.discriminatedUnion("type", [
   }),
   z.object({ type: z.literal("unknown") }),
 ]);
+
 export type EventContext = z.output<typeof eventContextSchema>;
 
 /** Trusted notification context; preserves runtime callback and OAuth identities. */
@@ -601,7 +602,9 @@ const removedRootsObserver = z
       "onRootsListChanged was removed: roots notifications originate from clients, not servers",
   })
   .optional();
+
 const serverNotifications = notifications.omit({ onInitialized: true });
+
 const modernPolicy = z
   .object({
     mode: z.literal("modern").optional().default("modern"),
@@ -614,6 +617,7 @@ const modernPolicy = z
     onRootsListChanged: removedRootsObserver,
   })
   .extend(serverNotifications.shape);
+
 const legacyPolicy = z
   .object({
     mode: z.literal("legacy"),
@@ -639,13 +643,16 @@ const httpTransport = httpOptionsSchema
       })
       .optional(),
   });
+
 const modernHttp = httpTransport.extend(modernPolicy.shape).strict();
+
 const legacyHttp = httpTransport
   .extend(legacyPolicy.shape)
   .extend({
     automaticSSEFallback: z.boolean().default(true),
   })
   .strict();
+
 const legacySse = httpOptionsSchema
   .extend(legacyPolicy.shape)
   .extend({
@@ -657,6 +664,7 @@ const legacySse = httpOptionsSchema
       .optional(),
   })
   .strict();
+
 export const streamableHttpConnectionSchema = z
   .union([z.discriminatedUnion("mode", [modernHttp, legacyHttp]), legacySse])
   .transform(({ type: _type, command: _command, ...options }) => options);
@@ -919,6 +927,7 @@ export const customHTTPTransportOptionsSchema = httpOptionsSchema.pick({
   authProvider: true,
   headers: true,
 });
+
 export type CustomHTTPTransportOptions = z.input<
   typeof customHTTPTransportOptionsSchema
 >;

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -648,26 +648,6 @@ const clientOptionsSchema = z
       .optional()
       .default(""),
     /**
-     * If true, the tool will use LangChain's standard multimodal content blocks for tools that output
-     * image or audio content, and embedded resources will be converted to `StandardFileBlock` objects.
-     * When `false`, all artifacts are left in their MCP format, but embedded resources will be
-     * converted to `StandardFileBlock` objects if {@link ClientConfig#outputHandling} causes embedded resources to
-     * be treated as content, as otherwise ChatModel providers will not be able to interpret them.
-     *
-     * @default false
-     */
-    useStandardContentBlocks: z
-      .boolean()
-      .describe(
-        "If true, the tool will use LangChain's standard multimodal content blocks for tools that output\n" +
-          "image or audio content. When true, embedded resources will be converted to `StandardFileBlock`\n" +
-          "objects. When `false`, all artifacts are left in their MCP format, but embedded resources will\n" +
-          "be converted to `StandardFileBlock` objects if `outputHandling` causes embedded resources to be\n" +
-          "treated as content, as otherwise ChatModel providers will not be able to interpret them."
-      )
-      .optional()
-      .default(false),
-    /**
      * Behavior when a server fails to connect.
      * - "throw": Throw an error immediately if any server fails to connect (default)
      * - "ignore": Skip failed servers and continue with successfully connected ones
@@ -821,17 +801,6 @@ export type LoadMcpToolsOptions = {
    * @default ""
    */
   additionalToolNamePrefix?: string;
-
-  /**
-   * If true, the tool will use LangChain's standard multimodal content blocks for tools that output
-   * image or audio content, and embedded resources will be converted to `StandardFileBlock` objects.
-   * When `false`, all artifacts are left in their MCP format, but embedded resources will be
-   * converted to `StandardFileBlock` objects if {@link outputHandling} causes embedded resources to
-   * be treated as content, as otherwise ChatModel providers will not be able to interpret them.
-   *
-   * @default false
-   */
-  useStandardContentBlocks?: boolean;
 
   /**
    * Defines where to place each tool output type in the LangChain ToolMessage.

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -25,19 +25,22 @@ export type {
   CommandParams,
 };
 
-export const callToolResultContentTypes = [
+const callToolResultContentTypeSchema = z.enum([
   "audio",
   "image",
   "resource",
   "resource_link",
   "text",
-] as const;
-export type CallToolResultContentType =
-  (typeof callToolResultContentTypes)[number];
+]);
+export const callToolResultContentTypes =
+  callToolResultContentTypeSchema.options;
+export type CallToolResultContentType = z.output<
+  typeof callToolResultContentTypeSchema
+>;
 
 const outputTypesUnion = z.enum(["content", "artifact"]);
 const detailedOutputHandlingSchema = z.partialRecord(
-  z.enum(callToolResultContentTypes),
+  callToolResultContentTypeSchema,
   outputTypesUnion.optional()
 );
 export type DetailedOutputHandling = z.output<
@@ -89,40 +92,30 @@ export const outputHandlingSchema = z
 export type OutputHandling = z.output<typeof outputHandlingSchema>;
 
 /**
- * Zod schema for validating OAuthClientProvider interface
- * Since OAuthClientProvider has methods, we create a custom validator
+ * Preserve the SDK-owned service and its prototype. Property checks validate
+ * callable methods without replacing them or evaluating metadata getters.
+ * The SDK remains responsible for parsing OAuth metadata and method results.
  */
-export const oAuthClientProviderSchema = z.custom<OAuthClientProvider>(
-  (val) => {
-    if (!val || typeof val !== "object") return false;
-
-    // Check required properties and methods exist
-    const requiredMethods = [
-      "redirectUrl",
-      "clientMetadata",
-      "clientInformation",
-      "tokens",
-      "saveTokens",
-    ];
-
-    // redirectUrl can be a string, URL, or getter returning string/URL
-    if (!("redirectUrl" in val)) return false;
-
-    // clientMetadata can be an object or getter returning an object
-    if (!("clientMetadata" in val)) return false;
-
-    // Check that required methods exist (they can be functions or getters)
-    for (const method of requiredMethods) {
-      if (!(method in val)) return false;
+export const oAuthClientProviderSchema = z
+  .custom<OAuthClientProvider>(
+    (value) =>
+      value !== null &&
+      typeof value === "object" &&
+      "redirectUrl" in value &&
+      "clientMetadata" in value,
+    {
+      error:
+        "Expected an OAuthClientProvider with redirectUrl and clientMetadata",
     }
-
-    return true;
-  },
-  {
-    message:
-      "Must be a valid OAuthClientProvider implementation with required properties: redirectUrl, clientMetadata, clientInformation, tokens, saveTokens",
-  }
-);
+  )
+  .check(
+    z.property("clientInformation", z.function()),
+    z.property("tokens", z.function()),
+    z.property("saveTokens", z.function()),
+    z.property("redirectToAuthorization", z.function()),
+    z.property("saveCodeVerifier", z.function()),
+    z.property("codeVerifier", z.function())
+  );
 
 export const baseConfigSchema = z.object({
   /**
@@ -198,7 +191,7 @@ const stdioOptionsSchema = z
      * Optional transport type, inferred from the structure of the config if not provided. Included
      * for compatibility with common MCP client config file formats.
      */
-    transport: z.literal("stdio").optional(),
+    transport: z.literal("stdio").default("stdio"),
     /**
      * Optional transport type, inferred from the structure of the config if not provided. Included
      * for compatibility with common MCP client config file formats.
@@ -343,39 +336,30 @@ const httpOptionsSchema = z
 
 /** Parse legacy aliases once and retain a concrete transport discriminator. */
 export const stdioConnectionSchema = stdioOptionsSchema.transform(
-  ({ type: _type, url: _url, ...options }) => ({
-    ...options,
-    transport: "stdio" as const,
-  })
+  ({ type: _type, url: _url, ...options }) => options
 );
 
 const httpConnectionSchema = httpOptionsSchema
   .extend({
-    transport: z.literal("http").optional(),
+    transport: z.literal("http").default("http"),
     type: z
       .literal("http", {
         error: "type conflicts with transport; use transport only",
       })
       .optional(),
   })
-  .transform(({ type: _type, command: _command, ...options }) => ({
-    ...options,
-    transport: "http" as const,
-  }));
+  .transform(({ type: _type, command: _command, ...options }) => options);
 
 const sseConnectionSchema = httpOptionsSchema
   .extend({
-    transport: z.literal("sse").optional(),
+    transport: z.literal("sse").default("sse"),
     type: z
       .literal("sse", {
         error: "type conflicts with transport; use transport only",
       })
       .optional(),
   })
-  .transform(({ type: _type, command: _command, ...options }) => ({
-    ...options,
-    transport: "sse" as const,
-  }));
+  .transform(({ type: _type, command: _command, ...options }) => options);
 
 export const streamableHttpConnectionSchema = z.union([
   httpConnectionSchema,

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -32,17 +32,21 @@ const callToolResultContentTypeSchema = z.enum([
   "resource_link",
   "text",
 ]);
+
 export const callToolResultContentTypes =
   callToolResultContentTypeSchema.options;
+
 export type CallToolResultContentType = z.output<
   typeof callToolResultContentTypeSchema
 >;
 
 const outputTypesUnion = z.enum(["content", "artifact"]);
+
 const detailedOutputHandlingSchema = z.partialRecord(
   callToolResultContentTypeSchema,
   outputTypesUnion.optional()
 );
+
 export type DetailedOutputHandling = z.output<
   typeof detailedOutputHandlingSchema
 >;
@@ -365,6 +369,7 @@ export const streamableHttpConnectionSchema = z.union([
   httpConnectionSchema,
   sseConnectionSchema,
 ]);
+
 export const connectionSchema = z.union([
   stdioConnectionSchema,
   streamableHttpConnectionSchema,
@@ -532,6 +537,7 @@ const clientOptionsSchema = z
   .describe("Configuration for the MCP client");
 
 const serverMapSchema = z.record(z.string(), connectionSchema);
+
 const exclusiveServerMap = z
   .never({ error: "Specify servers or legacy mcpServers, not both" })
   .optional();

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -394,18 +394,18 @@ const notifications = z.object({
    * Called when a log message is received.
    *
    * @param logMessage - The log message
-   * @param logMessage.message - The log message
+   * @param logMessage.data - The data logged by the server
    * @param logMessage.level - The log level
-   * @param logMessage.timestamp - The log timestamp
+   * @param logMessage.logger - Optional logger name
    * @param source - The source of the log message
    * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.option - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`
    *
    * @example
    * ```ts
    * const client = new MCPAdapter({
    *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onLog: (logMessage) => {
+   *   onMessage: (logMessage) => {
    *     console.log(logMessage);
    *   },
    * });

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -379,14 +379,38 @@ export type EventContext =
   | { type: "tool"; name: string; args: unknown; server: string }
   | { type: "unknown" };
 
+/** Origin of a server notification. */
 export interface ServerMessageSource {
+  /** Configured server name, rather than the server's self-reported name. */
   server: string;
+  /** A per-notification snapshot; callbacks and OAuth providers retain identity. */
   options: ResolvedConnection;
 }
 
 // SDK payloads are already parsed by the SDK. Keep callbacks as opaque runtime
 // services; parsing a function schema would replace their identity with a wrapper.
 const notifications = z.object({
+  /**
+   * Called when a log message is received.
+   *
+   * @param logMessage - The log message
+   * @param logMessage.message - The log message
+   * @param logMessage.level - The log level
+   * @param logMessage.timestamp - The log timestamp
+   * @param source - The source of the log message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.option - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onLog: (logMessage) => {
+   *     console.log(logMessage);
+   *   },
+   * });
+   * ```
+   */
   onMessage: z
     .custom<
       (
@@ -395,12 +419,42 @@ const notifications = z.object({
       ) => void | Promise<void>
     >((value) => typeof value === "function", "Expected a callback")
     .optional(),
+  /**
+   * Called when a progress message is received.
+   *
+   * @param progress - The progress message
+   * @param progress.progress - Progress completed so far
+   * @param progress.total - Total progress, if known
+   * @param progress.message - Optional progress message
+   * @param source - The source of the progress message
+   * @param source.type - The type of the source, e.g. "tool"
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.name - The name of the source, e.g. "my-name"
+   * @param source.args - The arguments of the source, e.g. { a: 1, b: 2 }
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onProgress: (progress, source) => {
+   *     if (source.type === "tool") {
+   *       console.log(source.name, progress.progress, progress.total);
+   *     }
+   *   },
+   * });
+   * ```
+   */
   onProgress: z
     .custom<(progress: Progress, source: EventContext) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
+  /**
+   * Observes server cancellation of a request it previously issued.
+   * @param notification - Request ID and optional cancellation reason
+   * @param source - Server identity and connection-options snapshot
+   */
   onCancelled: z
     .custom<
       (
@@ -409,24 +463,95 @@ const notifications = z.object({
       ) => void | Promise<void>
     >((value) => typeof value === "function", "Expected a callback")
     .optional(),
+  /**
+   * Called when an initialized notification is received from the server.
+   * This is a notification observer, not a connection-ready callback.
+   *
+   * @param source - The source of the initialized message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onInitialized: (source) => {
+   *     console.log(source);
+   *   },
+   * });
+   * ```
+   */
   onInitialized: z
     .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
+  /**
+   * Called when the prompts list is changed.
+   *
+   * @param source - The source of the prompts list changed message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onPromptsListChanged: (source) => {
+   *     console.log(source);
+   *   },
+   * });
+   * ```
+   */
   onPromptsListChanged: z
     .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
+  /**
+   * Called when the resources list is changed.
+   *
+   * @param source - The source of the resources list changed message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onResourcesListChanged: (source) => {
+   *     console.log(source);
+   *   },
+   * });
+   * ```
+   */
   onResourcesListChanged: z
     .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
+  /**
+   * Called when the resources are updated.
+   *
+   * @param updatedResource - The updated resource
+   * @param updatedResource.uri - The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
+   * @param source - The source of the resources updated message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onResourcesUpdated: (updatedResource, source) => {
+   *     console.log(`Resource ${updatedResource.uri} updated`);
+   *   },
+   * });
+   * ```
+   */
   onResourcesUpdated: z
     .custom<
       (
@@ -435,12 +560,46 @@ const notifications = z.object({
       ) => void | Promise<void>
     >((value) => typeof value === "function", "Expected a callback")
     .optional(),
+  /**
+   * Called when the roots list is changed.
+   *
+   * @param source - The source of the roots list changed message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onRootsListChanged: (source) => {
+   *     console.log(source);
+   *   },
+   * });
+   * ```
+   */
   onRootsListChanged: z
     .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",
       "Expected a callback"
     )
     .optional(),
+  /**
+   * Called when the tools list is changed.
+   *
+   * @param source - The source of the tools list changed message
+   * @param source.server - The server of the source, e.g. "my-server"
+   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
+   *
+   * @example
+   * ```ts
+   * const client = new MCPAdapter({
+   *   servers: { local: { command: "node", args: ["server.js"] } },
+   *   onToolsListChanged: (source) => {
+   *     console.log(source);
+   *   },
+   * });
+   * ```
+   */
   onToolsListChanged: z
     .custom<(source: ServerMessageSource) => void | Promise<void>>(
       (value) => typeof value === "function",

--- a/libs/langchain-mcp-adapters/src/types.ts
+++ b/libs/langchain-mcp-adapters/src/types.ts
@@ -18,7 +18,7 @@ import type {
 import type { RunnableConfig } from "@langchain/core/runnables";
 import type { Command, CommandParams } from "@langchain/langgraph";
 
-import { toolHooksSchema, type ToolHooks } from "./hooks.js";
+import { toolHooksSchema } from "./hooks.js";
 
 export type {
   Command,
@@ -342,52 +342,20 @@ const httpOptionsSchema = z
   .extend(baseConfigSchema.shape)
   .describe("Configuration for streamable HTTP transport connection");
 
-/** Parse legacy aliases once and retain a concrete transport discriminator. */
-export const stdioConnectionSchema = stdioOptionsSchema.transform(
-  ({ type: _type, url: _url, ...options }) => options
-);
-
-const httpConnectionSchema = httpOptionsSchema
-  .extend({
-    transport: z.literal("http").default("http"),
-    type: z
-      .literal("http", {
-        error: "type conflicts with transport; use transport only",
-      })
-      .optional(),
-  })
-  .transform(({ type: _type, command: _command, ...options }) => options);
-
-const sseConnectionSchema = httpOptionsSchema
-  .extend({
-    transport: z.literal("sse").default("sse"),
-    type: z
-      .literal("sse", {
-        error: "type conflicts with transport; use transport only",
-      })
-      .optional(),
-  })
-  .transform(({ type: _type, command: _command, ...options }) => options);
-
-export const streamableHttpConnectionSchema = z.union([
-  httpConnectionSchema,
-  sseConnectionSchema,
+export const eventContextSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("tool"),
+    name: z.string(),
+    args: z.unknown(),
+    server: z.string(),
+  }),
+  z.object({ type: z.literal("unknown") }),
 ]);
+export type EventContext = z.output<typeof eventContextSchema>;
 
-export const connectionSchema = z.union([
-  stdioConnectionSchema,
-  streamableHttpConnectionSchema,
-]);
-
-export type EventContext =
-  | { type: "tool"; name: string; args: unknown; server: string }
-  | { type: "unknown" };
-
-/** Origin of a server notification. */
+/** Trusted notification context; preserves runtime callback and OAuth identities. */
 export interface ServerMessageSource {
-  /** Configured server name, rather than the server's self-reported name. */
   server: string;
-  /** A per-notification snapshot; callbacks and OAuth providers retain identity. */
   options: ResolvedConnection;
 }
 
@@ -408,9 +376,14 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onMessage: (logMessage) => {
-   *     console.log(logMessage);
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onMessage: (logMessage) => {
+   *         console.log(logMessage);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -439,11 +412,16 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onProgress: (progress, source) => {
-   *     if (source.type === "tool") {
-   *       console.log(source.name, progress.progress, progress.total);
-   *     }
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onProgress: (progress, source) => {
+   *         if (source.type === "tool") {
+   *           console.log(source.name, progress.progress, progress.total);
+   *         }
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -478,9 +456,15 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onInitialized: (source) => {
-   *     console.log(source);
+   *   servers: {
+   *     local: {
+   *       mode: "legacy",
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onInitialized: (source) => {
+   *         console.log(source);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -501,9 +485,14 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onPromptsListChanged: (source) => {
-   *     console.log(source);
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onPromptsListChanged: (source) => {
+   *         console.log(source);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -524,9 +513,14 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onResourcesListChanged: (source) => {
-   *     console.log(source);
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onResourcesListChanged: (source) => {
+   *         console.log(source);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -549,9 +543,14 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onResourcesUpdated: (updatedResource, source) => {
-   *     console.log(`Resource ${updatedResource.uri} updated`);
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onResourcesUpdated: (updatedResource, source) => {
+   *         console.log(`Resource ${updatedResource.uri} updated`);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -565,29 +564,6 @@ const notifications = z.object({
     >((value) => typeof value === "function", "Expected a callback")
     .optional(),
   /**
-   * Called when the roots list is changed.
-   *
-   * @param source - The source of the roots list changed message
-   * @param source.server - The server of the source, e.g. "my-server"
-   * @param source.options - The connection options of the source, e.g. `{ transport: "stdio", command: "node", args: ["server.js"] }`, see {@link ServerMessageSource}
-   *
-   * @example
-   * ```ts
-   * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onRootsListChanged: (source) => {
-   *     console.log(source);
-   *   },
-   * });
-   * ```
-   */
-  onRootsListChanged: z
-    .custom<(source: ServerMessageSource) => void | Promise<void>>(
-      (value) => typeof value === "function",
-      "Expected a callback"
-    )
-    .optional(),
-  /**
    * Called when the tools list is changed.
    *
    * @param source - The source of the tools list changed message
@@ -597,9 +573,14 @@ const notifications = z.object({
    * @example
    * ```ts
    * const client = new MCPAdapter({
-   *   servers: { local: { command: "node", args: ["server.js"] } },
-   *   onToolsListChanged: (source) => {
-   *     console.log(source);
+   *   servers: {
+   *     local: {
+   *       command: "node",
+   *       args: ["server.js"],
+   *       onToolsListChanged: (source) => {
+   *         console.log(source);
+   *       },
+   *     },
    *   },
    * });
    * ```
@@ -614,9 +595,87 @@ const notifications = z.object({
 
 export type Notifications = z.output<typeof notifications>;
 
+const removedRootsObserver = z
+  .never({
+    error:
+      "onRootsListChanged was removed: roots notifications originate from clients, not servers",
+  })
+  .optional();
+const serverNotifications = notifications.omit({ onInitialized: true });
+const modernPolicy = z
+  .object({
+    mode: z.literal("modern").optional().default("modern"),
+    onInitialized: z
+      .never({ error: "onInitialized requires mode: legacy" })
+      .optional(),
+    automaticSSEFallback: z
+      .never({ error: "automaticSSEFallback requires mode: legacy" })
+      .optional(),
+    onRootsListChanged: removedRootsObserver,
+  })
+  .extend(serverNotifications.shape);
+const legacyPolicy = z
+  .object({
+    mode: z.literal("legacy"),
+    onRootsListChanged: removedRootsObserver,
+  })
+  .extend(notifications.shape);
+
+/** Transport aliases are normalized once; every public entry uses the same mode rules. */
+export const stdioConnectionSchema = z
+  .discriminatedUnion("mode", [
+    stdioOptionsSchema.extend(modernPolicy.shape).strict(),
+    stdioOptionsSchema.extend(legacyPolicy.shape).strict(),
+  ])
+  .transform(({ type: _type, url: _url, ...options }) => options);
+
+const httpTransport = httpOptionsSchema
+  .omit({ automaticSSEFallback: true })
+  .extend({
+    transport: z.literal("http").default("http"),
+    type: z
+      .literal("http", {
+        error: "type conflicts with transport; use transport only",
+      })
+      .optional(),
+  });
+const modernHttp = httpTransport.extend(modernPolicy.shape).strict();
+const legacyHttp = httpTransport
+  .extend(legacyPolicy.shape)
+  .extend({
+    automaticSSEFallback: z.boolean().default(true),
+  })
+  .strict();
+const legacySse = httpOptionsSchema
+  .extend(legacyPolicy.shape)
+  .extend({
+    transport: z.literal("sse").default("sse"),
+    type: z
+      .literal("sse", {
+        error: "type conflicts with transport; use transport only",
+      })
+      .optional(),
+  })
+  .strict();
+export const streamableHttpConnectionSchema = z
+  .union([z.discriminatedUnion("mode", [modernHttp, legacyHttp]), legacySse])
+  .transform(({ type: _type, command: _command, ...options }) => options);
+
+export const connectionSchema = z.union([
+  stdioConnectionSchema,
+  streamableHttpConnectionSchema,
+]);
+
 /**
  * {@link MultiServerMCPClient} configuration
  */
+const serverOnlyCallback = z
+  .never({
+    error:
+      "Configure notification and progress callbacks on a named server under servers, not on the adapter",
+  })
+  .optional();
+
 const clientOptionsSchema = z
   .object({
     /**
@@ -676,10 +735,25 @@ const clientOptionsSchema = z
   })
   .extend(baseConfigSchema.shape)
   .extend(toolHooksSchema.shape)
-  .extend(notifications.shape)
+  .extend({
+    onMessage: serverOnlyCallback,
+    onProgress: serverOnlyCallback,
+    onCancelled: serverOnlyCallback,
+    onInitialized: serverOnlyCallback,
+    onPromptsListChanged: serverOnlyCallback,
+    onResourcesListChanged: serverOnlyCallback,
+    onResourcesUpdated: serverOnlyCallback,
+    onToolsListChanged: serverOnlyCallback,
+    onRootsListChanged: removedRootsObserver,
+  })
+  .strict()
   .describe("Configuration for the MCP client");
 
-const serverMapSchema = z.record(z.string(), connectionSchema);
+const serverMapSchema = z
+  .record(z.string(), connectionSchema)
+  .refine((servers) => Object.keys(servers).length > 0, {
+    error: "No MCP servers provided",
+  });
 
 const exclusiveServerMap = z
   .never({ error: "Specify servers or legacy mcpServers, not both" })
@@ -775,70 +849,20 @@ export type ConnectionErrorHandler = (params: {
   error: unknown;
 }) => void;
 
-export type LoadMcpToolsOptions = {
-  /**
-   * If true, throw an error if a tool fails to load.
-   *
-   * @default true
-   */
-  throwOnLoadError?: boolean;
+export const loadMcpToolsOptionsSchema = clientOptionsSchema
+  .pick({
+    throwOnLoadError: true,
+    prefixToolNameWithServerName: true,
+    additionalToolNamePrefix: true,
+    outputHandling: true,
+    defaultToolTimeout: true,
+    beforeToolCall: true,
+    afterToolCall: true,
+  })
+  .partial()
+  .extend(notifications.pick({ onProgress: true }).shape);
 
-  /**
-   * If true, the tool name will be prefixed with the server name followed by a double underscore.
-   * This is useful if you want to avoid tool name collisions across servers.
-   *
-   * @default false
-   */
-  prefixToolNameWithServerName?: boolean;
-
-  /**
-   * An additional prefix to add to the tool name. Will be added at the very beginning of the tool
-   * name, separated by a double underscore.
-   *
-   * For example, if `additionalToolNamePrefix` is `"mcp"`, and `prefixToolNameWithServerName` is
-   * `true`, the tool name `"my-tool"` provided by server `"my-server"` will become
-   * `"mcp__my-server__my-tool"`.
-   *
-   * Similarly, if `additionalToolNamePrefix` is `mcp` and `prefixToolNameWithServerName` is false,
-   * the tool name would be `"mcp__my-tool"`.
-   *
-   * @default ""
-   */
-  additionalToolNamePrefix?: string;
-
-  /**
-   * Defines where to place each tool output type in the LangChain ToolMessage.
-   *
-   * @default {
-   *   "text": "content",
-   *   "image": "content",
-   *   "audio": "content",
-   *   "resource": "artifact"
-   * }
-   */
-  outputHandling?: OutputHandling;
-
-  /**
-   * Default timeout in milliseconds for tool execution. Must be greater than 0.
-   * If not specified, tools will use their own configured timeout values.
-   */
-  defaultToolTimeout?: number;
-
-  /**
-   * `onProgress` callbacks used for tool calls.
-   */
-  onProgress?: Notifications["onProgress"];
-
-  /**
-   * `beforeToolCall` callbacks used for tool calls.
-   */
-  beforeToolCall?: ToolHooks["beforeToolCall"];
-
-  /**
-   * `afterToolCall` callbacks used for tool calls.
-   */
-  afterToolCall?: ToolHooks["afterToolCall"];
-};
+export type LoadMcpToolsOptions = z.input<typeof loadMcpToolsOptionsSchema>;
 
 /**
  * Helper function that expands a string literal OutputHandling to an object with all content types.
@@ -891,10 +915,13 @@ export function _resolveAndApplyOverrideHandlingOverrides(
   };
 }
 
-export interface CustomHTTPTransportOptions {
-  authProvider?: OAuthClientProvider;
-  headers?: Record<string, string>;
-}
+export const customHTTPTransportOptionsSchema = httpOptionsSchema.pick({
+  authProvider: true,
+  headers: true,
+});
+export type CustomHTTPTransportOptions = z.input<
+  typeof customHTTPTransportOptionsSchema
+>;
 
 /**
  * Represents a resource provided by an MCP server.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,7 +1075,7 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
       zod:
-        specifier: ^3.25.76 || ^4
+        specifier: ^4.2.0
         version: 4.3.6
     devDependencies:
       '@langchain/core':


### PR DESCRIPTION
## What changes?

Add `MCPAdapter({ servers })` and `listTools()` as the canonical API. Replace `getTools()` with `listTools()` for the major release; keep `MultiServerMCPClient` and `mcpServers` as deprecated aliases.

Composed Zod 4 schemas validate server configuration before connecting. This PR defaults to modern MCP; legacy HTTP, stdio, and SSE servers use `mode: "legacy"`. Notification and progress callbacks belong to individual servers, and initialization and SSE fallback are legacy-only. Configuration snapshots preserve callback and OAuth provider identity while copying mutable options.

Use SDK schemas for protocol payloads and SDK validation for tool arguments after hooks run. Preserve server tool schemas, keep model-facing overrides separate from invocation validation, and expose branded errors with original causes and structured Zod issues. Tool results use standard LangChain content blocks; remove `useStandardContentBlocks`.

Keep a concise package README and runnable examples. Remove package-local reference and migration guides for relocation to `langchain-ai/docs`.

## How was it tested?

- 286 tests passed, with four existing skips, including real modern/legacy HTTP behavior, tool schema constraints, and hook artifact preservation.
- Source, examples, and modified test files typechecked.
- ESM/CommonJS builds, attw, publint, lint, formatting, and whitespace checks passed.

## Scope

Builds on #11597. Discovery and content fidelity follow in #11612; protocol negotiation and server interactions in #11614; invocation and checkpointed elicitation in #11642–#11645. OAuth workflow enhancements are outside this stack. No CI changes.
