### PR TITLE
fix(google): allowlist JSON Schema keywords for Gemini schemas

### DIFF
--- a/.changeset/fix-gemini-schema-allowlist.md
+++ b/.changeset/fix-gemini-schema-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+fix: allowlist JSON Schema keywords for Gemini function/response schemas instead of denylisting, fixing `propertyNames`/`exclusiveMinimum`/etc. 400s (#8584)

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1173,6 +1173,30 @@ describe.each(coreModelInfo)(
       ).toEqual("application/json");
     });
 
+    test("function calling with a z.record() schema", async () => {
+      const recordTool = tool(({ input }) => `${input + 2}`, {
+        name: "magic_function",
+        description: "Applies a magic function to an input.",
+        schema: z.object({
+          input: z
+            .number()
+            .describe("Input number to apply the magic function to."),
+          metadata: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe(
+              "A complex field that can hold various string key-value pairs."
+            ),
+        }),
+      });
+
+      const llm: Runnable = newChatGoogle().bindTools([recordTool]);
+      const result = await llm.invoke("Call magic_function with input 5.");
+
+      expect(result.tool_calls?.length).toBeGreaterThan(0);
+      expect(result.tool_calls?.[0].name).toBe("magic_function");
+    });
+
     test("service tier - flex", async () => {
       const llm = newChatGoogle({
         serviceTier: "flex",

--- a/libs/providers/langchain-google/src/converters/tests/tools.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/tools.test.ts
@@ -104,6 +104,16 @@ describe("schemaToGeminiParameters", () => {
     expect(JSON.stringify(result)).not.toContain("propertyNames");
   });
 
+  test("preserves a property literally named __proto__", () => {
+    const schema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string"}},"required":["__proto__"]}'
+    );
+    const result = schemaToGeminiParameters(schema);
+
+    expect(Object.prototype.hasOwnProperty.call(result.properties, "__proto__")).toBe(true);
+    expect(result.properties?.__proto__).toEqual({ type: "string" });
+  });
+
   test("throws on a recursive/$ref schema instead of silently emptying it", () => {
     type Node = { value: string; children?: Node[] };
     const nodeSchema: z.ZodType<Node> = z.lazy(() =>

--- a/libs/providers/langchain-google/src/converters/tests/tools.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/tools.test.ts
@@ -110,7 +110,9 @@ describe("schemaToGeminiParameters", () => {
     );
     const result = schemaToGeminiParameters(schema);
 
-    expect(Object.prototype.hasOwnProperty.call(result.properties, "__proto__")).toBe(true);
+    expect(
+      Object.prototype.hasOwnProperty.call(result.properties, "__proto__")
+    ).toBe(true);
     expect(result.properties?.__proto__).toEqual({ type: "string" });
   });
 

--- a/libs/providers/langchain-google/src/converters/tests/tools.test.ts
+++ b/libs/providers/langchain-google/src/converters/tests/tools.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { convertToolChoiceToGeminiConfig } from "../tools.js";
+import * as z from "zod";
+import {
+  convertToolChoiceToGeminiConfig,
+  schemaToGeminiParameters,
+} from "../tools.js";
 
 describe("convertToolChoiceToGeminiConfig", () => {
   test("returns undefined when toolChoice is undefined", () => {
@@ -69,6 +73,117 @@ describe("convertToolChoiceToGeminiConfig", () => {
       functionCallingConfig: {
         allowedFunctionNames: ["get_weather"],
       },
+    });
+  });
+});
+
+describe("schemaToGeminiParameters", () => {
+  test("strips propertyNames from a z.record() field", () => {
+    const schema = z.object({
+      input: z.number(),
+      metadata: z.record(z.string(), z.string()).optional(),
+    });
+    const result = schemaToGeminiParameters(schema);
+
+    expect(JSON.stringify(result)).not.toContain("propertyNames");
+    expect(result.properties).toHaveProperty("metadata");
+  });
+
+  test("strips a hardcoded propertyNames regardless of the zod version's own output", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        metadata: {
+          type: "object",
+          propertyNames: { pattern: "^[a-z]+$" },
+        },
+      },
+    } as const;
+    const result = schemaToGeminiParameters(schema);
+
+    expect(JSON.stringify(result)).not.toContain("propertyNames");
+  });
+
+  test("throws on a recursive/$ref schema instead of silently emptying it", () => {
+    type Node = { value: string; children?: Node[] };
+    const nodeSchema: z.ZodType<Node> = z.lazy(() =>
+      z.object({
+        value: z.string(),
+        children: z.array(nodeSchema).optional(),
+      })
+    );
+
+    expect(() => schemaToGeminiParameters(nodeSchema)).toThrow(/\$ref/);
+  });
+
+  test("strips additionalProperties, exclusiveMinimum, and exclusiveMaximum", () => {
+    const schema = z.object({
+      count: z.number().gt(0).lt(100),
+      metadata: z.record(z.string(), z.string()),
+    });
+    const result = schemaToGeminiParameters(schema);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain("additionalProperties");
+    expect(serialized).not.toContain("exclusiveMinimum");
+    expect(serialized).not.toContain("exclusiveMaximum");
+  });
+
+  test("preserves property names that collide with schema keywords", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        type: { type: "string" },
+        properties: { type: "string" },
+        required: { type: "string" },
+      },
+      required: ["type"],
+    } as const;
+    const result = schemaToGeminiParameters(schema);
+
+    expect(result.properties).toHaveProperty("type");
+    expect(result.properties).toHaveProperty("properties");
+    expect(result.properties).toHaveProperty("required");
+  });
+
+  test("sanitizes nested schemas under properties, items, and anyOf", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        tags: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            additionalProperties: false,
+          },
+        },
+        either: {
+          anyOf: [
+            { type: "object", additionalProperties: { type: "string" } },
+            { type: "string" },
+          ],
+        },
+      },
+    } as const;
+    const result = schemaToGeminiParameters(schema);
+
+    expect(JSON.stringify(result)).not.toContain("additionalProperties");
+    expect(result.properties?.tags).toHaveProperty("items");
+  });
+
+  test("still converts nullable type arrays via adjustObjectType", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: ["string", "null"] },
+      },
+    } as const;
+    const result = schemaToGeminiParameters(schema);
+
+    expect(result.properties?.name).toMatchObject({
+      type: "string",
+      nullable: true,
     });
   });
 });

--- a/libs/providers/langchain-google/src/converters/tools.ts
+++ b/libs/providers/langchain-google/src/converters/tools.ts
@@ -74,47 +74,72 @@ function adjustObjectType(
   return obj;
 }
 
-/**
- * Recursively removes unsupported properties from a JSON Schema object to make it
- * compatible with Gemini's function schema format.
- *
- * Gemini's function schema format does not support:
- * - `additionalProperties` property
- * - Array types (must be converted to string types with nullable flag)
- * - Union types
- *
- * @param obj - The JSON Schema object to clean
- * @returns A cleaned GeminiFunctionSchema object
- *
- * @internal
- */
-function removeAdditionalProperties(
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  obj: Record<string, any>
-): Gemini.Tools.Schema & { $schema?: string } {
-  if (typeof obj === "object" && obj !== null) {
-    const newObj = { ...obj };
+// Keywords Gemini's function schema accepts. Keep in sync with Gemini.Tools.Schema (api-types.ts); anything else 400s (#8584).
+const GEMINI_SCHEMA_KEYS = new Set([
+  "anyOf",
+  "default",
+  "description",
+  "enum",
+  "example",
+  "format",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "nullable",
+  "pattern",
+  "properties",
+  "propertyOrdering",
+  "required",
+  "title",
+  "type",
+]);
 
-    if ("additionalProperties" in newObj) {
-      delete newObj.additionalProperties;
-    }
-
-    adjustObjectType(newObj);
-
-    for (const key in newObj) {
-      if (key in newObj) {
-        if (Array.isArray(newObj[key])) {
-          newObj[key] = newObj[key].map(removeAdditionalProperties);
-        } else if (typeof newObj[key] === "object" && newObj[key] !== null) {
-          newObj[key] = removeAdditionalProperties(newObj[key]);
-        }
-      }
-    }
-
-    return newObj as Gemini.Tools.Schema;
+// Recursively allowlist-filters a schema node; `properties`' own keys are user field names, not schema keywords, so only its values recurse.
+function sanitizeGeminiSchema(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(sanitizeGeminiSchema);
+  }
+  if (typeof node !== "object" || node === null) {
+    return node;
   }
 
-  return obj as Gemini.Tools.Schema;
+  if ("$ref" in node) {
+    throw new InvalidInputError(
+      "Gemini does not support recursive or referenced ($ref) schemas in function or response schemas. Inline the schema instead."
+    );
+  }
+
+  const source = node as Record<string, unknown>;
+  const schema: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    if (GEMINI_SCHEMA_KEYS.has(key)) {
+      schema[key] = source[key];
+    }
+  }
+
+  adjustObjectType(schema);
+
+  if (schema.properties && typeof schema.properties === "object") {
+    const properties: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(schema.properties)) {
+      properties[name] = sanitizeGeminiSchema(value);
+    }
+    schema.properties = properties;
+  }
+  if (schema.items !== undefined) {
+    schema.items = sanitizeGeminiSchema(schema.items);
+  }
+  if (Array.isArray(schema.anyOf)) {
+    schema.anyOf = schema.anyOf.map(sanitizeGeminiSchema);
+  }
+
+  return schema;
 }
 
 /**
@@ -138,17 +163,11 @@ export function schemaToGeminiParameters<
     | InteropZodType<RunOutput>
     | JsonSchema7Type
 ): Gemini.Tools.Schema {
-  // Gemini doesn't accept either the $schema or additionalProperties
-  // attributes, so we need to explicitly remove them.
-  // Zod sometimes also makes an array of type (because of .nullish()),
-  // which needs cleaning up.
-  const jsonSchema = removeAdditionalProperties(
+  return sanitizeGeminiSchema(
     isInteropZodSchema(schema) || isSerializableSchema(schema)
       ? toJsonSchema(schema)
       : schema
-  );
-  const { $schema, ...rest } = jsonSchema;
-  return rest;
+  ) as Gemini.Tools.Schema;
 }
 
 /**
@@ -163,10 +182,7 @@ function jsonSchemaToGeminiParameters(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   schema: Record<string, any>
 ): Gemini.Tools.Schema {
-  const jsonSchema = removeAdditionalProperties(schema);
-  const { $schema, ...rest } = jsonSchema;
-
-  return rest;
+  return sanitizeGeminiSchema(schema) as Gemini.Tools.Schema;
 }
 
 /**

--- a/libs/providers/langchain-google/src/converters/tools.ts
+++ b/libs/providers/langchain-google/src/converters/tools.ts
@@ -126,11 +126,13 @@ function sanitizeGeminiSchema(node: unknown): unknown {
   adjustObjectType(schema);
 
   if (schema.properties && typeof schema.properties === "object") {
-    const properties: Record<string, unknown> = {};
-    for (const [name, value] of Object.entries(schema.properties)) {
-      properties[name] = sanitizeGeminiSchema(value);
-    }
-    schema.properties = properties;
+    // fromEntries defines properties (safe for a field literally named "__proto__"), unlike bracket assignment on a plain {}.
+    schema.properties = Object.fromEntries(
+      Object.entries(schema.properties).map(([name, value]) => [
+        name,
+        sanitizeGeminiSchema(value),
+      ])
+    );
   }
   if (schema.items !== undefined) {
     schema.items = sanitizeGeminiSchema(schema.items);


### PR DESCRIPTION
## Problem

Surfaced by #8584: Gemini's schema format only accepts a fixed set of JSON Schema keywords. The sanitizer only stripped `additionalProperties`, so anything else (`propertyNames` from `z.record()`, `exclusiveMinimum` from `.gt()`, etc.) still 400'd.

## Fix

Replaced the denylist with an allowlist in `@langchain/google`, sourced from the existing `Gemini.Tools.Schema` type. Recursive/`$ref` schemas now throw a clear error instead of silently collapsing to `{}`.