### PR TITLE
fix(google-genai): rewrite list-valued JSON Schema type for Gemini

### DIFF
--- a/.changeset/fix-google-genai-list-valued-type.md
+++ b/.changeset/fix-google-genai-list-valued-type.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google-genai": patch
+---
+
+fix(google-genai): rewrite JSON Schema list-valued `type` (e.g. `["string","null"]` from Zod 3 `.nullable()`) into Gemini's single-valued `type` plus `nullable` before sending `responseSchema`

--- a/libs/providers/langchain-google-genai/src/utils/tests/zod_to_genai_parameters.test.ts
+++ b/libs/providers/langchain-google-genai/src/utils/tests/zod_to_genai_parameters.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod/v3";
+import {
+  jsonSchemaToGeminiParameters,
+  schemaToGenerativeAIParameters,
+} from "../zod_to_genai_parameters.js";
+
+function pathsWithArrayValuedType(node: unknown, path = "$"): string[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) =>
+      pathsWithArrayValuedType(item, `${path}[${i}]`)
+    );
+  }
+  if (node === null || typeof node !== "object") {
+    return [];
+  }
+  const obj = node as Record<string, unknown>;
+  const hits = Array.isArray(obj.type) ? [path] : [];
+  return hits.concat(
+    Object.entries(obj).flatMap(([key, value]) =>
+      pathsWithArrayValuedType(value, `${path}.${key}`)
+    )
+  );
+}
+
+describe("schemaToGenerativeAIParameters", () => {
+  test("rewrites Zod 3 z.string().nullable() list-valued type to nullable string", () => {
+    const schema = z.object({
+      nickname: z.string().nullable(),
+      age: z.number(),
+    });
+    const result = schemaToGenerativeAIParameters(schema);
+
+    expect(result.properties?.nickname).toMatchObject({
+      type: "string",
+      nullable: true,
+    });
+    expect(result.properties?.age).toMatchObject({ type: "number" });
+    expect(result.required).toEqual(["nickname", "age"]);
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+
+  test("rewrites Zod 3 z.null().nullable() ['null','null'] instead of dropping type", () => {
+    const schema = z.object({
+      n: z.null().nullable(),
+    });
+    const result = schemaToGenerativeAIParameters(schema);
+
+    expect(result.properties?.n?.type).toBe("null");
+    expect(result.properties?.n?.nullable).toBe(true);
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+
+  test("rewrites nullable items nested under arrays", () => {
+    const schema = z.object({
+      tags: z.array(z.string().nullable()),
+    });
+    const result = schemaToGenerativeAIParameters(schema);
+
+    expect(result.properties?.tags).toMatchObject({
+      type: "array",
+      items: { type: "string", nullable: true },
+    });
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+});
+
+describe("jsonSchemaToGeminiParameters", () => {
+  test("unwraps a one-element type array", () => {
+    const result = jsonSchemaToGeminiParameters({
+      type: "object",
+      properties: {
+        name: { type: ["string"] },
+      },
+    });
+
+    expect(result.properties?.name).toEqual({ type: "string" });
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+
+  test("rewrites ['string','null'] to type string plus nullable", () => {
+    const result = jsonSchemaToGeminiParameters({
+      type: "object",
+      properties: {
+        nickname: { type: ["string", "null"], description: "optional nick" },
+      },
+    });
+
+    expect(result.properties?.nickname).toEqual({
+      type: "string",
+      nullable: true,
+      description: "optional nick",
+    });
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+
+  test("rewrites ['null','null'] to type null plus nullable", () => {
+    const result = jsonSchemaToGeminiParameters({
+      type: "object",
+      properties: {
+        n: { type: ["null", "null"] },
+      },
+    });
+
+    expect(result.properties?.n).toMatchObject({
+      type: "null",
+      nullable: true,
+    });
+    expect(pathsWithArrayValuedType(result)).toEqual([]);
+  });
+
+  test("throws on a null-only one-element type array", () => {
+    expect(() =>
+      jsonSchemaToGeminiParameters({
+        type: "object",
+        properties: {
+          n: { type: ["null"] },
+        },
+      })
+    ).toThrow("Gemini cannot handle null type");
+  });
+
+  test("throws on a non-null union type array", () => {
+    expect(() =>
+      jsonSchemaToGeminiParameters({
+        type: "object",
+        properties: {
+          value: { type: ["string", "number"] },
+        },
+      })
+    ).toThrow("Gemini cannot handle union types");
+  });
+});

--- a/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
+++ b/libs/providers/langchain-google-genai/src/utils/zod_to_genai_parameters.ts
@@ -25,6 +25,49 @@ export interface GenerativeAIJsonSchemaDirty extends GenerativeAIJsonSchema {
   additionalProperties?: boolean;
 }
 
+/**
+ * Gemini's Schema proto `type` is a single enum, not a repeating field.
+ * JSON Schema (and Zod 3 via zod-to-json-schema) often emit list-valued
+ * `type` such as `["string","null"]`, which the API rejects with
+ * "Proto field is not repeating, cannot start list".
+ *
+ * Same rewrite as `adjustObjectType` in `@langchain/google-common` and
+ * `@langchain/google`.
+ */
+function adjustObjectType(
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  obj: Record<string, any>
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any> {
+  if (!Array.isArray(obj.type)) {
+    return obj;
+  }
+
+  const len = obj.type.length;
+  const nullIndex = obj.type.indexOf("null");
+  if (len === 2 && nullIndex >= 0) {
+    // There are only two values set for the type, and one of them is "null".
+    // Set the type to the other one and set nullable to true.
+    const typeIndex = nullIndex === 0 ? 1 : 0;
+    obj.type = obj.type[typeIndex];
+    obj.nullable = true;
+  } else if (len === 1 && nullIndex === 0) {
+    // This is nullable only without a type, which doesn't
+    // make sense for Gemini
+    throw new Error("zod_to_genai_parameters: Gemini cannot handle null type");
+  } else if (len === 1) {
+    // Although an array, it has only one value.
+    // So set it to the string to match what Gemini expects.
+    obj.type = obj.type[0];
+  } else {
+    // Anything else could be a union type, so reject it.
+    throw new Error(
+      "zod_to_genai_parameters: Gemini cannot handle union types"
+    );
+  }
+  return obj;
+}
+
 export function removeAdditionalProperties(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   obj: Record<string, any>
@@ -41,6 +84,10 @@ export function removeAdditionalProperties(
     if ("strict" in newObj) {
       delete newObj.strict;
     }
+
+    // Zod / JSON Schema sometimes make `type` an array (e.g. `.nullable()`),
+    // which needs cleaning up before we recurse into nested schemas.
+    adjustObjectType(newObj);
 
     for (const key in newObj) {
       if (key in newObj) {
@@ -69,6 +116,8 @@ export function schemaToGenerativeAIParameters<
 ): GenerativeAIFunctionDeclarationSchema {
   // GenerativeAI doesn't accept either the $schema or additionalProperties
   // attributes, so we need to explicitly remove them.
+  // Zod sometimes also makes an array of type (because of .nullable()/.nullish()),
+  // which needs cleaning up.
   const jsonSchema = removeAdditionalProperties(
     isInteropZodSchema(schema) || isSerializableSchema(schema)
       ? toJsonSchema(schema)


### PR DESCRIPTION
Fixes #11328

`schemaToGenerativeAIParameters` now rewrites list-valued JSON Schema `type` before `ChatGoogleGenerativeAI.withStructuredOutput()` (default `jsonSchema` path) sends it as Gemini `responseSchema`. The same sanitizer also feeds tool `parameters`.

Gemini's proto `type` is a single enum, not a repeating field. A JSON Schema array such as `["string","null"]` 400s before auth:

`Proto field is not repeating, cannot start list.`

The usual trigger is Zod 3 `.nullable()` on an unchecked primitive (`zod-to-json-schema` emits a type array). Zod 4 `.nullable()` emits `anyOf` instead, so a Zod 4 fixture would not catch this.

The reporter's control, `{"type":"string","nullable":true}`, is accepted (dummy-key request reaches `API key not valid`). Reproduced here the same way.

Before this, `schemaToGenerativeAIParameters` only stripped `$schema` / `additionalProperties` / `strict` and forwarded every other keyword. `@langchain/google-common` and `@langchain/google` already rewrite list-valued `type` in `adjustObjectType`; `@langchain/google-genai` did not.

This ports that helper onto google-genai's existing sanitizer (one call inside `removeAdditionalProperties`):

- `["X","null"]` → `{type:"X", nullable:true}`
- `["X"]` → `"X"`
- `["null","null"]` (Zod 3 `z.null().nullable()`) → `{type:"null", nullable:true}` rather than a typeless `{nullable:true}`
- `["null"]` and non-null unions such as `["string","number"]` throw, matching the sibling packages

Chose the google-common throws for `["null"]` and `["X","Y"]`. Alternative, from the reporter's follow-up: unwrap `["null"]` to `"null"` and rewrite `["X","Y"]` to `anyOf` (both accepted by the proto). Reasoning: match the repo's existing helper rather than make google-genai more permissive than google-common / `@langchain/google`. Happy to switch.

Did not copy google-common's `anyOf` rejection. google-genai already forwards `anyOf` (Zod 4 `.nullable()`), and `anyOf` is a real proto field.

Unit tests assert the emitted document (Zod 3 fixtures) and that no remaining `type` value is an array. They fail on the unfixed converter and pass with this change. Dummy-key requests confirm the rewritten documents pass proto validation.

This is not a claim about how the model behaves with the corrected schema.
