### PR TITLE
fix(google): Add provider events for request, response, and chunk for streamEvents()

### DIFF
--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -699,18 +699,67 @@ export abstract class BaseChatGoogle<
     const url = await this.buildUrl("streamGenerateContent?alt=sse");
     const headers = this.getHeaders(options);
 
-    const response = await this.apiClient.fetch(
-      new Request(url, {
-        method: "POST",
+    const requestEvent: ChatModelStreamEvent = {
+      event: "provider",
+      provider: "google",
+      name: "request",
+      payload: {
+        url,
         headers,
-        body: JSON.stringify(body),
-        signal: options.signal,
-      })
-    );
+        body,
+      },
+    };
+    this.notifyStreamEvent(requestEvent, options);
+    yield requestEvent;
 
-    if (!response.ok) {
-      throw await RequestError.fromResponse(response);
+    let response: Response;
+    try {
+      response = await this.caller.callWithOptions(
+        { signal: options.signal, maxRetries: options.maxRetries },
+        async () => {
+          const nextResponse = await this.apiClient.fetch(
+            new Request(url, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(body),
+              signal: options.signal,
+            })
+          );
+
+          if (!nextResponse.ok) {
+            throw await RequestError.fromResponse(nextResponse);
+          }
+
+          return nextResponse;
+        }
+      );
+    } catch (error) {
+      const errorResponseEvent: ChatModelStreamEvent = {
+        event: "provider",
+        provider: "google",
+        name: "response",
+        payload: {
+          error,
+        },
+      };
+      this.notifyStreamEvent(errorResponseEvent, options);
+      yield errorResponseEvent;
+      throw error;
     }
+
+    const responseEvent: ChatModelStreamEvent = {
+      event: "provider",
+      provider: "google",
+      name: "response",
+      payload: {
+        url: response.url,
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      },
+    };
+    this.notifyStreamEvent(responseEvent, options);
+    yield responseEvent;
 
     if (!response.body) {
       return;
@@ -749,12 +798,64 @@ export abstract class BaseChatGoogle<
       }
     }
 
-    yield* convertGoogleGeminiStream(
+    for await (const event of convertGoogleGeminiStream(
       geminiChunks(eventStream, options.signal),
       {
         streamUsage: shouldStreamUsage,
       }
+    )) {
+      this.notifyStreamEvent(event, options);
+      yield event;
+    }
+  }
+
+  private notifyStreamEvent(
+    event: ChatModelStreamEvent,
+    options?: this["ParsedCallOptions"]
+  ): void {
+    const rawHandlers: unknown[] = [];
+    const collectHandlers = (cb: unknown) => {
+      if (!cb) return;
+      if (Array.isArray(cb)) {
+        rawHandlers.push(...cb);
+      } else if (
+        typeof cb === "object" &&
+        cb !== null &&
+        "handlers" in cb &&
+        Array.isArray((cb as { handlers: unknown[] }).handlers)
+      ) {
+        rawHandlers.push(...(cb as { handlers: unknown[] }).handlers);
+      } else {
+        rawHandlers.push(cb);
+      }
+    };
+
+    collectHandlers(this.callbacks);
+    collectHandlers(
+      (options as Record<string, unknown> | undefined)?.callbacks
     );
+
+    for (const handler of rawHandlers) {
+      if (
+        handler &&
+        typeof (handler as { handleStreamEvent?: unknown })
+          .handleStreamEvent === "function"
+      ) {
+        (
+          handler as { handleStreamEvent: (e: ChatModelStreamEvent) => void }
+        ).handleStreamEvent(event);
+      } else if (
+        handler &&
+        typeof (handler as { handleChatModelStreamEvent?: unknown })
+          .handleChatModelStreamEvent === "function"
+      ) {
+        (
+          handler as {
+            handleChatModelStreamEvent: (e: ChatModelStreamEvent) => void;
+          }
+        ).handleChatModelStreamEvent(event);
+      }
+    }
   }
 
   async *_streamResponseChunks(

--- a/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/chat_models_stream_events.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "vitest";
 import { ApiClient } from "../../clients/index.js";
 import { ChatGoogle } from "../index.js";
 import type { Gemini } from "../api-types.js";
+import {
+  GoogleRequestRecorder,
+  GoogleRequestLogger,
+} from "../../utils/handler.js";
 
 class MockChunkStreamingResponse implements Response {
   readonly headers = new Headers();
@@ -150,5 +154,127 @@ describe("ChatGoogle.streamEvents", () => {
       output_tokens: 4,
       total_tokens: 14,
     });
+  });
+
+  test("yields request, response, and chunk provider events in stream", async () => {
+    const model = mockChatGoogle(textChunks);
+    const stream = model.streamEvents("Hello");
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const providerEvents = events.filter((e) => e.event === "provider");
+    expect(providerEvents.length).toBeGreaterThanOrEqual(3);
+
+    const requestEvent = providerEvents.find((e) => e.name === "request");
+    expect(requestEvent).toBeDefined();
+    expect(requestEvent?.provider).toBe("google");
+    expect(
+      (requestEvent?.payload as { url: string; body: unknown }).url
+    ).toContain("streamGenerateContent");
+    expect(
+      (requestEvent?.payload as { url: string; body: unknown }).body
+    ).toBeDefined();
+
+    const responseEvent = providerEvents.find((e) => e.name === "response");
+    expect(responseEvent).toBeDefined();
+    expect(responseEvent?.provider).toBe("google");
+    expect((responseEvent?.payload as { status: number }).status).toBe(200);
+
+    const chunkEvents = providerEvents.filter((e) => e.name === "chunk");
+    expect(chunkEvents).toHaveLength(2);
+    expect(
+      (chunkEvents[0].payload as { chunk: Gemini.GenerateContentResponse })
+        .chunk
+    ).toBeDefined();
+  });
+
+  test("populates GoogleRequestRecorder passed in model callbacks", async () => {
+    const recorder = new GoogleRequestRecorder();
+    const model = new ChatGoogle({
+      model: "gemini-2.0-flash",
+      apiKey: "fake-key",
+      apiClient: new MockStreamingApiClient(textChunks),
+      callbacks: [recorder],
+    });
+
+    const stream = model.streamEvents("Hello");
+    for await (const _ of stream) {
+      // consume stream
+    }
+
+    expect(recorder.request.url).toContain("streamGenerateContent");
+    expect(recorder.request.body).toBeDefined();
+    expect(recorder.response.status).toBe(200);
+    expect(recorder.chunk).toHaveLength(2);
+    expect(recorder.chunks).toHaveLength(2);
+    expect(recorder.requests).toHaveLength(1);
+    expect(recorder.responses).toHaveLength(1);
+
+    recorder.reset();
+    expect(recorder.chunk).toHaveLength(0);
+    expect(recorder.request).toEqual({});
+  });
+
+  test("records stream events using recorder.tap()", async () => {
+    const recorder = new GoogleRequestRecorder();
+    const model = mockChatGoogle(textChunks);
+    const stream = model.streamEvents("Hello");
+
+    const collectedEvents = [];
+    for await (const event of recorder.tap(stream)) {
+      collectedEvents.push(event);
+    }
+
+    expect(collectedEvents.length).toBeGreaterThan(0);
+    expect(recorder.request.url).toBeDefined();
+    expect(recorder.response.status).toBe(200);
+    expect(recorder.chunk).toHaveLength(2);
+  });
+
+  test("records error response event on fetch failure", async () => {
+    const recorder = new GoogleRequestRecorder();
+    class FailingApiClient extends MockStreamingApiClient {
+      constructor() {
+        super([]);
+      }
+      override async fetch(): Promise<Response> {
+        throw new Error("Simulated network failure");
+      }
+    }
+    const failingApiClient = new FailingApiClient();
+
+    const model = new ChatGoogle({
+      model: "gemini-3.7-flash",
+      apiKey: "fake-key",
+      apiClient: failingApiClient,
+      callbacks: [recorder],
+      maxRetries: 0,
+    });
+
+    await expect(async () => {
+      const stream = model.streamEvents("Hello");
+      for await (const _ of stream) {
+        // consume
+      }
+    }).rejects.toThrow("Simulated network failure");
+
+    expect(recorder.response.error).toBeDefined();
+  });
+
+  test("runs with GoogleRequestLogger without error", async () => {
+    const logger = new GoogleRequestLogger();
+    const model = new ChatGoogle({
+      model: "gemini-3.7-flash",
+      apiKey: "fake-key",
+      apiClient: new MockStreamingApiClient(textChunks),
+      callbacks: [logger],
+    });
+
+    const stream = model.streamEvents("Hello");
+    for await (const _ of stream) {
+      // consume
+    }
   });
 });

--- a/libs/providers/langchain-google/src/utils/handler.ts
+++ b/libs/providers/langchain-google/src/utils/handler.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
 
 export interface GoogleCustomEventInfo {
   subEvent: string;
@@ -10,8 +11,8 @@ export abstract class GoogleRequestCallbackHandler extends BaseCallbackHandler {
   customEventInfo(eventName: string): GoogleCustomEventInfo {
     const names = eventName.split("-");
     return {
-      subEvent: names[1],
-      module: names[2],
+      subEvent: names[1] ?? names[0],
+      module: names.slice(2).join("-") || "ChatGoogle",
     };
   }
 
@@ -42,6 +43,52 @@ export abstract class GoogleRequestCallbackHandler extends BaseCallbackHandler {
     metadata?: Record<string, any>
   ): any;
 
+  handleStreamEvent(event: ChatModelStreamEvent): void {
+    if (event.event === "provider" && event.provider === "google") {
+      const eventInfo: GoogleCustomEventInfo = {
+        subEvent: event.name,
+        module: "ChatGoogle",
+      };
+      const eventName = `google-${event.name}-ChatGoogle`;
+      switch (event.name) {
+        case "request":
+          this.handleCustomRequestEvent(
+            eventName,
+            eventInfo,
+            event.payload,
+            ""
+          );
+          break;
+        case "response":
+          this.handleCustomResponseEvent(
+            eventName,
+            eventInfo,
+            event.payload,
+            ""
+          );
+          break;
+        case "chunk":
+          this.handleCustomChunkEvent(eventName, eventInfo, event.payload, "");
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  handleChatModelStreamEvent(event: ChatModelStreamEvent): void {
+    this.handleStreamEvent(event);
+  }
+
+  async *tap(
+    stream: AsyncIterable<ChatModelStreamEvent>
+  ): AsyncGenerator<ChatModelStreamEvent> {
+    for await (const event of stream) {
+      this.handleStreamEvent(event);
+      yield event;
+    }
+  }
+
   handleCustomEvent(
     eventName: string,
     data: any,
@@ -49,7 +96,7 @@ export abstract class GoogleRequestCallbackHandler extends BaseCallbackHandler {
     tags?: string[],
     metadata?: Record<string, any>
   ): any {
-    if (!eventName) {
+    if (!eventName || !eventName.startsWith("google-")) {
       return undefined;
     }
     const eventInfo = this.customEventInfo(eventName);
@@ -160,6 +207,22 @@ export class GoogleRequestRecorder extends GoogleRequestCallbackHandler {
 
   chunk: any[] = [];
 
+  requests: any[] = [];
+
+  responses: any[] = [];
+
+  get chunks(): any[] {
+    return this.chunk;
+  }
+
+  reset(): void {
+    this.request = {};
+    this.response = {};
+    this.chunk = [];
+    this.requests = [];
+    this.responses = [];
+  }
+
   handleCustomRequestEvent(
     _eventName: string,
     _eventInfo: GoogleCustomEventInfo,
@@ -169,6 +232,7 @@ export class GoogleRequestRecorder extends GoogleRequestCallbackHandler {
     _metadata?: Record<string, any>
   ): any {
     this.request = data;
+    this.requests.push(data);
   }
 
   handleCustomResponseEvent(
@@ -180,6 +244,7 @@ export class GoogleRequestRecorder extends GoogleRequestCallbackHandler {
     _metadata?: Record<string, any>
   ): any {
     this.response = data;
+    this.responses.push(data);
   }
 
   handleCustomChunkEvent(

--- a/libs/providers/langchain-google/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google/src/utils/stream_events.ts
@@ -51,6 +51,13 @@ export async function* convertGoogleGeminiStream(
   };
 
   for await (const response of source) {
+    yield {
+      event: "provider" as const,
+      provider: "google",
+      name: "chunk",
+      payload: { chunk: response },
+    };
+
     if (!messageStarted) {
       messageStarted = true;
       yield { event: "message-start" as const };


### PR DESCRIPTION
Fixes # 11609

* Adds support in `*_streamChatModelEvents()` to generating a provider event for request and response packets. 
* Updates `GoogleRequestCallbackHandler` to be able to work with streamed events.

Added tests for stream events which pass.
Manually did integration tests against the #11602 tests to verify it logs requests and responses, but those tests aren't included here.
