### PR TITLE
fix(google): set `includeServerSideToolInvocations` when mixing tools

### DIFF
--- a/.changeset/fix-google-mixed-tools.md
+++ b/.changeset/fix-google-mixed-tools.md
@@ -1,0 +1,7 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): set `toolConfig.includeServerSideToolInvocations` when a tools array mixes built-in tools (e.g. `googleSearch`, `codeExecution`) with function-declaration tools
+
+Gemini rejects such a mix with a 400 (`Please enable tool_config.include_server_side_tool_invocations...`) unless this flag is set. Only Gemini 3+ models support mixing built-in and function-calling tools at all; earlier generations reject the combination outright regardless of this flag.

--- a/.changeset/fix-google-mixed-tools.md
+++ b/.changeset/fix-google-mixed-tools.md
@@ -2,6 +2,4 @@
 "@langchain/google": patch
 ---
 
-fix(google): set `toolConfig.includeServerSideToolInvocations` when a tools array mixes built-in tools (e.g. `googleSearch`, `codeExecution`) with function-declaration tools
-
-Gemini rejects such a mix with a 400 (`Please enable tool_config.include_server_side_tool_invocations...`) unless this flag is set. Only Gemini 3+ models support mixing built-in and function-calling tools at all; earlier generations reject the combination outright regardless of this flag.
+fix(google): set `toolConfig.includeServerSideToolInvocations` when mixing built-in and function-declaration tools, which Gemini otherwise rejects with a 400

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -55,6 +55,7 @@ import {
 import {
   convertToolsToGeminiTools,
   convertToolChoiceToGeminiConfig,
+  mixesBuiltinAndFunctionTools,
   schemaToGeminiParameters,
 } from "../converters/tools.js";
 import {
@@ -454,10 +455,19 @@ export abstract class BaseChatGoogle<
       : undefined;
 
     // Convert tool choice to Gemini function calling config
-    const toolConfig = convertToolChoiceToGeminiConfig(
+    let toolConfig = convertToolChoiceToGeminiConfig(
       options.tool_choice,
       !!(tools && tools.length > 0)
     );
+
+    // Gemini rejects a mix of built-in and function-declaration tools unless
+    // this is set. See mixesBuiltinAndFunctionTools's docstring.
+    if (tools && mixesBuiltinAndFunctionTools(tools)) {
+      toolConfig = {
+        ...toolConfig,
+        includeServerSideToolInvocations: true,
+      };
+    }
 
     let responseJsonSchema:
       | JsonSchema7Type

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1018,6 +1018,28 @@ describe.each(coreModelInfo)(
       );
     });
 
+    test("mixing a native tool with a custom tool (#10675, #10819)", async () => {
+      // Only Gemini 3+ models can mix built-in and function-calling tools at
+      // all, and only with toolConfig.includeServerSideToolInvocations set.
+      if (!testConfig?.isThinking) {
+        return;
+      }
+      const customTool = tool(({ query }) => `Result for ${query}`, {
+        name: "custom_tool",
+        description: "A custom tool",
+        schema: z.object({ query: z.string() }),
+      });
+      const searchTool: Gemini.Tool = { googleSearch: {} };
+      const llm: Runnable = newChatGoogle().bindTools([customTool, searchTool]);
+
+      const result = await llm.invoke(
+        "What is the weather in Paris right now, and also call custom_tool with query 'hello'?"
+      );
+      expect(result.tool_calls?.some((c) => c.name === "custom_tool")).toBe(
+        true
+      );
+    });
+
     test(`function - stream tools`, async () => {
       const model = newChatGoogle();
 

--- a/libs/providers/langchain-google/src/converters/tools.ts
+++ b/libs/providers/langchain-google/src/converters/tools.ts
@@ -531,3 +531,20 @@ export function convertToolChoiceToGeminiConfig(
     functionCallingConfig,
   };
 }
+
+/**
+ * Checks whether a tools array mixes server-side built-in tools (e.g.
+ * `googleSearch`, `codeExecution`) with function-declaration tools.
+ *
+ * Gemini rejects such a mix with a 400 unless
+ * `toolConfig.includeServerSideToolInvocations` is set.
+ * See https://ai.google.dev/gemini-api/docs/tool-combination
+ */
+export function mixesBuiltinAndFunctionTools(tools: Gemini.Tool[]): boolean {
+  const isFunctionDeclarationTool = (tool: Gemini.Tool) =>
+    "functionDeclarations" in tool && !!tool.functionDeclarations?.length;
+  return (
+    tools.some(isFunctionDeclarationTool) &&
+    tools.some((tool) => !isFunctionDeclarationTool(tool))
+  );
+}


### PR DESCRIPTION
## Problem

`@langchain/google` throws a 400 when `bindTools()` mixes a built-in Gemini tool (`googleSearch`, `codeExecution`, etc.) with a custom/function-declaration tool — Gemini requires `toolConfig.includeServerSideToolInvocations: true`.

## Fix

Detect the mix in `invocationParams` and set the flag on `toolConfig` when present. Only Gemini 3+ models support the combination at all; earlier generations reject it regardless of this flag.
