### PR TITLE
fix(core): convert every media content block in _formatForTracing

### DIFF
--- a/.changeset/quiet-donkeys-trace-media.md
+++ b/.changeset/quiet-donkeys-trace-media.md
@@ -1,0 +1,5 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): convert every media content block in `_formatForTracing`, not only the first, so multimodal messages trace completely

--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -172,22 +172,20 @@ function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   for (const message of messages) {
     let messageToTrace = message;
     if (Array.isArray(message.content)) {
-      for (let idx = 0; idx < message.content.length; idx++) {
-        const block = message.content[idx];
-        if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
-        }
+      const hasMediaBlock = message.content.some(
+        (block) => isURLContentBlock(block) || isBase64ContentBlock(block),
+      );
+      if (hasMediaBlock) {
+        // Clone once and convert every media block, not just the first
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        messageToTrace = new (message.constructor as any)({
+          ...message,
+          content: message.content.map((block) =>
+            isURLContentBlock(block) || isBase64ContentBlock(block)
+              ? convertToOpenAIImageBlock(block)
+              : block,
+          ),
+        });
       }
     }
     messagesToTrace.push(messageToTrace);

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -722,3 +722,63 @@ test("Test ChatModel .invoke() with a streaming-preferring callback builds llmOu
     totalTokens: 22,
   });
 });
+
+test("Test ChatModel tracing converts every media content block in a message", async () => {
+  class CaptureInputHandler extends BaseCallbackHandler {
+    name = "capture-input";
+
+    messages: BaseMessage[] | undefined;
+
+    async handleChatModelStart(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      _llm: any,
+      messages: BaseMessage[][],
+    ): Promise<void> {
+      this.messages = messages[0];
+    }
+  }
+
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "two PDFs" },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjQK",
+      },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjUK",
+      },
+    ],
+  });
+
+  const handler = new CaptureInputHandler();
+  const model = new FakeListChatModel({ responses: ["ok"] });
+  await model.invoke([message], { callbacks: [handler] });
+
+  const tracedContent = handler.messages?.[0]?.content;
+  expect(Array.isArray(tracedContent)).toBe(true);
+  expect(tracedContent).toEqual([
+    { type: "text", text: "two PDFs" },
+    {
+      type: "image_url",
+      image_url: { url: "data:application/pdf;base64,JVBERi0xLjQK" },
+    },
+    {
+      type: "image_url",
+      image_url: { url: "data:application/pdf;base64,JVBERi0xLjUK" },
+    },
+  ]);
+
+  // tracing must not mutate the original message
+  expect((message.content as Array<Record<string, unknown>>)[1]).toEqual({
+    type: "file",
+    source_type: "base64",
+    mime_type: "application/pdf",
+    data: "JVBERi0xLjQK",
+  });
+});


### PR DESCRIPTION
## Description

`_formatForTracing` in `@langchain/core` only converted the **first** URL/base64 media block of each message: the clone guard (`if (messageToTrace === message)`) also gated the per-block conversion, so after the first block was rewritten the guard became false and every later media block stayed inline in the traced payload — only the first attachment got offloaded to a data URI, and remaining base64 stayed in traces (e.g. when a message carries two PDF attachments, as reported in #11291).

This change clones the message once when any media block is present and converts **every** matching block. Messages without media blocks keep their original reference, so behavior is unchanged for the common case. As before, this affects the tracing copy only — providers still receive the original message.

Fixes #11291

## Test

- Added a regression test in `libs/langchain-core/src/language_models/tests/chat_models.test.ts` that traces a `HumanMessage` with two base64 file blocks and asserts both are rewritten to `image_url` data URIs and that the original message is not mutated. It fails on `main` (second block left unconverted) and passes with this change.
- `vitest run src/language_models/tests/chat_models.test.ts` in `libs/langchain-core`: 25 passed, no type errors.