### PR TITLE
fix(google): surface groundingMetadata/citationMetadata on streaming path

### DIFF
--- a/.changeset/fix-google-streaming-grounding-metadata.md
+++ b/.changeset/fix-google-streaming-grounding-metadata.md
@@ -1,0 +1,5 @@
+---
+"@langchain/google": patch
+---
+
+fix(google): surface `groundingMetadata`/`groundingSupport`/`citationMetadata` on `.stream()` and `.streamEvents()`, matching what `.invoke()` already returns

--- a/libs/providers/langchain-google/src/chat_models/base.ts
+++ b/libs/providers/langchain-google/src/chat_models/base.ts
@@ -923,6 +923,17 @@ export abstract class BaseChatGoogle<
                       ...(candidate.safetyRatings && {
                         safetyRatings: candidate.safetyRatings,
                       }),
+                      ...(candidate.citationMetadata && {
+                        citationMetadata: candidate.citationMetadata,
+                      }),
+                      ...(candidate.groundingMetadata && {
+                        groundingMetadata: candidate.groundingMetadata,
+                        // Support entries for the first content part only (matches messages.ts).
+                        groundingSupport:
+                          candidate.groundingMetadata.groundingSupports?.filter(
+                            (s) => (s?.segment?.partIndex ?? 0) === 0
+                          ),
+                      }),
                     },
                   })
                 );

--- a/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
+++ b/libs/providers/langchain-google/src/chat_models/tests/index.int.test.ts
@@ -1019,6 +1019,26 @@ describe.each(coreModelInfo)(
       expect(result.response_metadata).toHaveProperty("groundingSupport");
     });
 
+    test("Supports GoogleSearchTool - streaming (#9264)", async () => {
+      const searchTool: Gemini.Tool = {
+        googleSearch: {},
+      };
+      const llm: Runnable = newChatGoogle().bindTools([searchTool]);
+
+      const stream = await llm.stream("Who won the 2024 MLB World Series?");
+      let finalMsg: AIMessageChunk | undefined;
+      for await (const chunk of stream) {
+        finalMsg = finalMsg
+          ? concat(finalMsg, chunk as AIMessageChunk)
+          : (chunk as AIMessageChunk);
+      }
+      expect(finalMsg?.content as string).toContain("Dodgers");
+      expect(finalMsg).toHaveProperty("response_metadata");
+
+      expect(finalMsg?.response_metadata).toHaveProperty("groundingMetadata");
+      expect(finalMsg?.response_metadata).toHaveProperty("groundingSupport");
+    });
+
     test("URL Context Tool", async () => {
       // Not available on Gemini 1.5
       // Not available on Gemini 2.0 Flash

--- a/libs/providers/langchain-google/src/utils/stream_events.ts
+++ b/libs/providers/langchain-google/src/utils/stream_events.ts
@@ -36,6 +36,8 @@ export async function* convertGoogleGeminiStream(
   let messageStarted = false;
   let usageSnapshot: UsageMetadata | undefined;
   let finishReason: FinishReason = "stop";
+  let groundingMetadata: Gemini.GroundingMetadata | undefined;
+  let citationMetadata: Gemini.CitationMetadata | undefined;
 
   const getOrCreateBlockIndex = (
     key: BlockKey,
@@ -72,6 +74,12 @@ export async function* convertGoogleGeminiStream(
     const candidate = response.candidates?.[0];
     if (candidate?.finishReason) {
       finishReason = mapGeminiFinishReason(candidate.finishReason);
+    }
+    if (candidate?.groundingMetadata) {
+      groundingMetadata = candidate.groundingMetadata;
+    }
+    if (candidate?.citationMetadata) {
+      citationMetadata = candidate.citationMetadata;
     }
 
     const parts = candidate?.content?.parts;
@@ -192,7 +200,19 @@ export async function* convertGoogleGeminiStream(
     event: "message-finish" as const,
     reason: finishReason,
     ...(usageSnapshot ? { usage: usageSnapshot } : {}),
-    responseMetadata: { model_provider: "google" },
+    responseMetadata: {
+      model_provider: "google",
+      ...(citationMetadata ? { citationMetadata } : {}),
+      ...(groundingMetadata
+        ? {
+            groundingMetadata,
+            // Support entries for the first content part only (matches messages.ts).
+            groundingSupport: groundingMetadata.groundingSupports?.filter(
+              (s) => (s?.segment?.partIndex ?? 0) === 0
+            ),
+          }
+        : {}),
+    },
   };
 }
 


### PR DESCRIPTION
## Problem

`@langchain/google` only returns `groundingMetadata`/`groundingSupport`/`citationMetadata` on `.invoke()` — `.stream()` and `.streamEvents()` silently drop them, even when the model actually performed a grounded search.

## Fix

Add the missing fields to `.stream()`'s `generationInfo` and `.streamEvents()`'s `message-finish` event, matching what `.invoke()` already returns.