### PR TITLE
fix(core): return a matched RunnableBranch's falsy output instead of the default

### DIFF
--- a/libs/langchain-core/src/runnables/branch.ts
+++ b/libs/langchain-core/src/runnables/branch.ts
@@ -149,6 +149,10 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
     runManager?: CallbackManagerForChainRun
   ): Promise<RunOutput> {
     let result;
+    // Tracked separately from `result`: a branch that matched but returned a falsy
+    // value (0, "", false, null) or undefined is still a match, and testing the
+    // output alone cannot tell that apart from no branch having matched at all.
+    let matched = false;
     for (let i = 0; i < this.branches.length; i += 1) {
       const [condition, branchRunnable] = this.branches[i];
       const conditionValue = await condition.invoke(
@@ -164,10 +168,11 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
             callbacks: runManager?.getChild(`branch:${i + 1}`),
           })
         );
+        matched = true;
         break;
       }
     }
-    if (!result) {
+    if (!matched) {
       result = await this.default.invoke(
         input,
         patchConfig(config, {

--- a/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
@@ -126,3 +126,47 @@ test("RunnableBranch invoke", async () => {
   expect(chunks2.length).toBeGreaterThan(1);
   expect(chunks2.join("")).toContain("GENERAL");
 });
+
+test("RunnableBranch returns a matched branch's falsy output", async () => {
+  // A matched branch that returns 0, "", false or null must win over the default.
+  // Testing `!result` cannot tell "no branch matched" apart from "the branch
+  // returned something falsy", so these silently fell through to the default.
+  const cases: [unknown, unknown][] = [
+    [0, -1],
+    ["", "default"],
+    [false, true],
+    [null, "default"],
+  ];
+
+  for (const [branchOutput, defaultOutput] of cases) {
+    const branch = RunnableBranch.from([
+      [(x: number) => x > 0, () => branchOutput],
+      () => defaultOutput,
+    ]);
+    expect(await branch.invoke(5)).toEqual(branchOutput);
+  }
+});
+
+test("RunnableBranch returns a matched branch's undefined output", async () => {
+  const branch = RunnableBranch.from([
+    [(x: number) => x > 0, () => undefined],
+    () => "default",
+  ]);
+  expect(await branch.invoke(5)).toBeUndefined();
+});
+
+test("RunnableBranch still uses the default when no condition matches", async () => {
+  const branch = RunnableBranch.from([
+    [(x: number) => x > 100, () => 0],
+    () => "default",
+  ]);
+  expect(await branch.invoke(5)).toEqual("default");
+});
+
+test("RunnableBranch batch preserves falsy branch outputs", async () => {
+  const branch = RunnableBranch.from([
+    [(x: number) => x > 0, () => 0],
+    () => -1,
+  ]);
+  expect(await branch.batch([1, -1, 2])).toEqual([0, -1, 0]);
+});


### PR DESCRIPTION
Fixes #11583

## Problem

`RunnableBranch._invoke` decided whether a branch had run by testing its **output**:

```ts
if (conditionValue) {
  result = await branchRunnable.invoke(...);
  break;
}
if (!result) {                       // <-- 0, "", false, null all land here
  result = await this.default.invoke(...);
}
```

A branch that matched and returned a falsy value is indistinguishable from no branch
matching at all, so its output was discarded and the default ran instead. No error is
raised, so the call silently returns the wrong value:

```ts
const branch = RunnableBranch.from([
  [(x: number) => x > 0, (x: number) => 0],
  (x: number) => -1,
]);
await branch.invoke(5);   // expected 0, got -1
```

## Fix

Track whether a branch matched instead of inferring it from the output.

The streaming path at `_streamIterator` already avoids this with `stream === undefined`,
which is safe there because a stream object is never falsy. I used an explicit flag
here rather than mirroring that check, because a branch may legitimately *return*
`undefined` — `result === undefined` would still fall through in that case. There is a
test covering it.

## Tests

Added to `runnable_branch.test.ts`:

- a matched branch returning `0`, `""`, `false` or `null` is returned, not the default
- a matched branch returning `undefined` is returned, not the default
- the default is still used when no condition matches
- `batch` preserves falsy branch outputs

Verified these fail before the change and pass after:

| | before | after |
|---|---|---|
| `runnable_branch.test.ts` | 3 failed, 5 passed | **8 passed** |

Full `src/runnables/tests/` suite: **170 passed**, with the same 2 pre-existing
`streamEvents` failures present on a clean checkout. No type errors.
