### PR TITLE
fix(core): convert every base64/URL content block when formatting for tracing

### DIFF
--- a/libs/langchain-core/src/language_models/chat_models.ts
+++ b/libs/langchain-core/src/language_models/chat_models.ts
@@ -172,22 +172,23 @@ function _formatForTracing(messages: BaseMessage[]): BaseMessage[] {
   for (const message of messages) {
     let messageToTrace = message;
     if (Array.isArray(message.content)) {
+      // Left undefined until a convertible block is found, so a message that has
+      // none is traced as-is rather than needlessly copied.
+      let tracedContent: typeof message.content | undefined;
       for (let idx = 0; idx < message.content.length; idx++) {
         const block = message.content[idx];
         if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
-          if (messageToTrace === message) {
-            // Also shallow-copy content
-            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-            messageToTrace = new (message.constructor as any)({
-              ...messageToTrace,
-              content: [
-                ...message.content.slice(0, idx),
-                convertToOpenAIImageBlock(block),
-                ...message.content.slice(idx + 1),
-              ],
-            });
-          }
+          tracedContent ??= [...message.content];
+          tracedContent[idx] = convertToOpenAIImageBlock(block);
         }
+      }
+      if (tracedContent !== undefined) {
+        // Also shallow-copy content
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        messageToTrace = new (message.constructor as any)({
+          ...message,
+          content: tracedContent,
+        });
       }
     }
     messagesToTrace.push(messageToTrace);

--- a/libs/langchain-core/src/language_models/tests/chat_models.test.ts
+++ b/libs/langchain-core/src/language_models/tests/chat_models.test.ts
@@ -9,6 +9,7 @@ import { AIMessage, AIMessageChunk } from "../../messages/ai.js";
 import type { BaseMessage } from "../../messages/base.js";
 import { RunCollectorCallbackHandler } from "../../tracers/run_collector.js";
 import { BaseCallbackHandler } from "../../callbacks/base.js";
+import type { Serialized } from "../../load/serializable.js";
 import { ChatGenerationChunk } from "../../outputs.js";
 import type { LLMResult, ChatResult } from "../../outputs.js";
 import { BaseChatModel } from "../chat_models.js";
@@ -721,4 +722,100 @@ test("Test ChatModel .invoke() with a streaming-preferring callback builds llmOu
     completionTokens: 12,
     totalTokens: 22,
   });
+});
+
+class CaptureTracedInputHandler extends BaseCallbackHandler {
+  name = "CaptureTracedInputHandler";
+
+  messages: BaseMessage[] | undefined;
+
+  async handleChatModelStart(
+    _llm: Serialized,
+    messages: BaseMessage[][]
+  ): Promise<void> {
+    this.messages = messages[0];
+  }
+}
+
+test("Traced input converts every base64 content block, not just the first", async () => {
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "two PDFs" },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjQK",
+      },
+      {
+        type: "file",
+        source_type: "base64",
+        mime_type: "application/pdf",
+        data: "JVBERi0xLjUK",
+      },
+    ],
+  });
+
+  const handler = new CaptureTracedInputHandler();
+  await new FakeListChatModel({ responses: ["ok"] }).invoke([message], {
+    callbacks: [handler],
+  });
+
+  expect(handler.messages?.[0].content).toEqual([
+    { type: "text", text: "two PDFs" },
+    {
+      type: "image_url",
+      image_url: { url: "data:application/pdf;base64,JVBERi0xLjQK" },
+    },
+    {
+      type: "image_url",
+      image_url: { url: "data:application/pdf;base64,JVBERi0xLjUK" },
+    },
+  ]);
+});
+
+test("Traced input leaves the original message untouched", async () => {
+  // The provider must still receive what the caller authored; only the tracing
+  // copy is rewritten.
+  const content = [
+    {
+      type: "file",
+      source_type: "base64",
+      mime_type: "application/pdf",
+      data: "JVBERi0xLjQK",
+    },
+    {
+      type: "file",
+      source_type: "base64",
+      mime_type: "application/pdf",
+      data: "JVBERi0xLjUK",
+    },
+  ];
+  const message = new HumanMessage({ content: [...content] });
+
+  const handler = new CaptureTracedInputHandler();
+  await new FakeListChatModel({ responses: ["ok"] }).invoke([message], {
+    callbacks: [handler],
+  });
+
+  expect(message.content).toEqual(content);
+});
+
+test("Traced input passes through messages with no convertible blocks", async () => {
+  const message = new HumanMessage({
+    content: [
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+    ],
+  });
+
+  const handler = new CaptureTracedInputHandler();
+  await new FakeListChatModel({ responses: ["ok"] }).invoke([message], {
+    callbacks: [handler],
+  });
+
+  expect(handler.messages?.[0].content).toEqual([
+    { type: "text", text: "a" },
+    { type: "text", text: "b" },
+  ]);
 });


### PR DESCRIPTION
Fixes #11291

## Problem

`_formatForTracing` rewrites base64 and URL content blocks into OpenAI image blocks so
observability tools can detect and offload inline media. Only the **first** convertible
block in a message was rewritten:

```ts
if (isURLContentBlock(block) || isBase64ContentBlock(block)) {
  if (messageToTrace === message) {        // false after the first rewrite
    messageToTrace = new (message.constructor as any)({ ... });
  }
}
```

The guard was there to copy the message only once, but it also gates the conversion, so
every later block is skipped and its base64 stays inline in the trace.

```ts
new HumanMessage({
  content: [
    { type: "text", text: "two PDFs" },
    { type: "file", source_type: "base64", mime_type: "application/pdf", data: "JVBERi0xLjQK" },
    { type: "file", source_type: "base64", mime_type: "application/pdf", data: "JVBERi0xLjUK" },
  ],
});
// traced: second attachment still raw base64
```

## Note on the fix

The guard is load-bearing in a second way that isn't obvious: each iteration rebuilt
content from `message.content`, the **original** array. Removing the guard on its own
would convert every block but discard each previous conversion, so the last block would
be the only one rewritten.

So conversions are accumulated into a single array and the traced message is constructed
once, after the loop. This also drops a message allocation per convertible block.

The copy stays lazy — a message with no convertible blocks is traced as-is, not copied —
and the caller's message is still never mutated, since only the tracing copy is rewritten.

## Scope

The issue also notes that `{ type, base64, mime_type }` and `{ type, data, mimeType }`
blocks aren't converted at all. That's a separate gap in the conversion helpers rather
than this loop, so it isn't addressed here.

## Tests

Added to `chat_models.test.ts`, capturing the traced input via `handleChatModelStart`:

- every base64 block in a message is converted, not just the first
- the caller's original message is left untouched
- messages with no convertible blocks pass through unchanged

| | before | after |
|---|---|---|
| the three tests above | 1 failed, 2 passed | **3 passed** |

`src/language_models/tests/`: **106 passed**. Wider sweep over `src/messages/`,
`src/tracers/` and `src/callbacks/`: **420 passed, 1 skipped**. No type errors.
