### PR TITLE
fix(core): keep a falsy RunnableBranch output instead of running the default

### DIFF
--- a/.changeset/fix-runnable-branch-falsy-output.md
+++ b/.changeset/fix-runnable-branch-falsy-output.md
@@ -1,0 +1,9 @@
+---
+"@langchain/core": patch
+---
+
+fix(core): return a matched `RunnableBranch` branch's falsy output instead of falling through to the default branch
+
+`RunnableBranch._invoke` selected the default branch with `if (!result)`, keyed on the output of the matched branch rather than on whether any condition matched. A branch returning `0`, `""`, `false`, `null`, `NaN` or `undefined` was therefore discarded and the default branch ran in its place — silently, with the default's own callbacks firing. `.invoke()` and `.batch()` were affected; `.stream()` was not, because `_streamIterator` already keys its default on a sentinel (`stream === undefined`).
+
+The matching branch's result is now returned directly, so the default is reached only when no condition matched — the same rule `RunnableBranch.invoke` follows in Python (a `for`/`else`), and one with no sentinel left for a falsy output to satisfy.

--- a/libs/langchain-core/src/runnables/branch.ts
+++ b/libs/langchain-core/src/runnables/branch.ts
@@ -148,7 +148,6 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
     config?: Partial<RunnableConfig>,
     runManager?: CallbackManagerForChainRun
   ): Promise<RunOutput> {
-    let result;
     for (let i = 0; i < this.branches.length; i += 1) {
       const [condition, branchRunnable] = this.branches[i];
       const conditionValue = await condition.invoke(
@@ -157,25 +156,26 @@ export class RunnableBranch<RunInput = any, RunOutput = any> extends Runnable<
           callbacks: runManager?.getChild(`condition:${i + 1}`),
         })
       );
+      // Returned from here rather than collected and tested after the loop: what
+      // selects the default branch is that no condition matched, never what the
+      // matching branch answered. A branch returning `0`, `""`, `false`, `null`,
+      // `NaN` or `undefined` has answered, and that is the result. The Python
+      // `RunnableBranch.invoke` keys its default the same way (a `for`/`else`).
       if (conditionValue) {
-        result = await branchRunnable.invoke(
+        return await branchRunnable.invoke(
           input,
           patchConfig(config, {
             callbacks: runManager?.getChild(`branch:${i + 1}`),
           })
         );
-        break;
       }
     }
-    if (!result) {
-      result = await this.default.invoke(
-        input,
-        patchConfig(config, {
-          callbacks: runManager?.getChild("branch:default"),
-        })
-      );
-    }
-    return result;
+    return await this.default.invoke(
+      input,
+      patchConfig(config, {
+        callbacks: runManager?.getChild("branch:default"),
+      })
+    );
   }
 
   async invoke(

--- a/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
+++ b/libs/langchain-core/src/runnables/tests/runnable_branch.test.ts
@@ -126,3 +126,58 @@ test("RunnableBranch invoke", async () => {
   expect(chunks2.length).toBeGreaterThan(1);
   expect(chunks2.join("")).toContain("GENERAL");
 });
+
+// A matched branch that returns a falsy value has still answered. Keying the default
+// branch on the *output* rather than on "no condition matched" discarded that answer
+// and silently ran the default instead (#11583).
+test.each([
+  ["zero", 0],
+  ["empty string", ""],
+  ["false", false],
+  ["null", null],
+  ["NaN", NaN],
+  ["undefined", undefined],
+])(
+  "RunnableBranch invoke returns a falsy branch output (%s)",
+  async (_name, falsy) => {
+    let defaultRuns = 0;
+    const branch = RunnableBranch.from([
+      [(x: number) => x > 0, () => falsy],
+      () => {
+        defaultRuns += 1;
+        return -1;
+      },
+    ]);
+
+    expect(await branch.invoke(5)).toEqual(falsy);
+    // Not just the wrong value: the default branch was actually executed.
+    expect(defaultRuns).toBe(0);
+
+    // The default still runs when no condition matches.
+    expect(await branch.invoke(-5)).toBe(-1);
+    expect(defaultRuns).toBe(1);
+  }
+);
+
+test("RunnableBranch batch keeps falsy branch outputs", async () => {
+  const branch = RunnableBranch.from([
+    [(x: number) => x > 0 && x < 5, () => 0],
+    [(x: number) => x > 5, () => NaN],
+    () => -1,
+  ]);
+  expect(await branch.batch([1, 10, -1])).toEqual([0, NaN, -1]);
+});
+
+test("RunnableBranch stream already kept falsy branch outputs", async () => {
+  // The streaming path keys its default on `stream === undefined`, so it never had
+  // the bug; pinned here so the two paths cannot drift apart again.
+  const branch = RunnableBranch.from([
+    [(x: number) => x > 0, () => 0],
+    () => -1,
+  ]);
+  const chunks = [];
+  for await (const chunk of await branch.stream(5)) {
+    chunks.push(chunk);
+  }
+  expect(chunks).toEqual([0]);
+});


### PR DESCRIPTION
Fixes #11583.

## Problem

`RunnableBranch._invoke` selected the default branch with `if (!result)` — keyed on what the matched branch *returned*, not on whether any condition matched. So a branch answering a falsy value was discarded:

```ts
const branch = RunnableBranch.from([
  [(x: number) => x > 0, () => 0],
  () => -1,
]);
await branch.invoke(5); // 0 expected, -1 actual
```

It is not only the wrong value: the default branch is genuinely executed, `branch:default` callbacks and all, so a default with a side effect runs when it should not have.

`.invoke()` and `.batch()` were affected. `.stream()` was not — `_streamIterator`, eleven lines below in the same file, keys its default on `stream === undefined`.

## The change

The matching branch's result is returned from inside the loop, and the default is the function's final `return`:

```ts
      if (conditionValue) {
        return await branchRunnable.invoke(/* ... */);
      }
    }
    return await this.default.invoke(/* ... */);
```

`return result;` was the last statement of the method, so this is behaviour-identical apart from the fix. I chose it over keeping the collected `result` with a `matched` flag for two reasons:

- It leaves no sentinel a falsy output could satisfy. The narrower repair `if (result === undefined)` fixes five of the six falsy cases and still loses a branch that legitimately answers `undefined` — I measured exactly that: it leaves `RunnableBranch invoke returns a falsy branch output (undefined)` red, 1 failed | 11 passed.
- With a flag, TypeScript can no longer narrow `result` at `return result`, which needs either a cast or a widened signature. Early return keeps both away.

This is the rule `RunnableBranch.invoke` already follows in Python (a `for` / `else`), so the two implementations now agree.

## Testing

`libs/langchain-core/src/runnables/tests/runnable_branch.test.ts`:

- `RunnableBranch invoke returns a falsy branch output` — parametrized over `0`, `""`, `false`, `null`, `NaN`, `undefined`. Each case asserts the returned value *and* that the default branch body never ran (a counter), then that the default still runs when no condition matches.
- `RunnableBranch batch keeps falsy branch outputs` — the reported symptom reaches `.batch()` too.
- `RunnableBranch stream already kept falsy branch outputs` — pins the streaming path that was already correct, so the two cannot drift apart again.

```
pnpm vitest run                 1528 passed | 1 skipped, Type Errors: no errors
pnpm oxlint / oxfmt --check     clean
```

Negative control: with `branch.ts` restored to `origin/main`, 7 of the new cases fail and the other 5 (the streaming case and the 4 pre-existing tests) pass.

Changeset included (`@langchain/core`: patch).
