### PR TITLE
fix(openai): recognize gpt-6 models as reasoning models

### DIFF
--- a/.changeset/brave-owls-reason.md
+++ b/.changeset/brave-owls-reason.md
@@ -1,0 +1,5 @@
+---
+"@langchain/openai": patch
+---
+
+Recognize gpt-6 models as reasoning models so explicit `reasoning` config is forwarded.

--- a/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
+++ b/libs/providers/langchain-openai/src/chat_models/tests/index.test.ts
@@ -899,8 +899,14 @@ describe("ChatOpenAI", () => {
       expect(isReasoningModel("gpt-5.3-codex")).toBe(true);
     });
 
+    it("should return true for gpt-6 family models", () => {
+      expect(isReasoningModel("gpt-6-astra")).toBe(true);
+      expect(isReasoningModel("gpt-6")).toBe(true);
+    });
+
     it("should return false for gpt-5-chat models", () => {
       expect(isReasoningModel("gpt-5-chat-latest")).toBe(false);
+      expect(isReasoningModel("gpt-6-chat-latest")).toBe(false);
     });
 
     it("should return false for non-reasoning models", () => {
@@ -1486,6 +1492,40 @@ describe("ChatOpenAI", () => {
         const body = JSON.parse(options.body);
         // reasoning.effort should take precedence
         expect(body.reasoning_effort).toBe("high");
+      } else {
+        throw new Error("Body not found in request.");
+      }
+    });
+
+    it("should forward explicit reasoning for gpt-6-astra on the Responses API", async () => {
+      const mockFetch = vi.fn<(url: any, options?: any) => Promise<any>>();
+      mockFetch.mockImplementation((url, options) => {
+        mockFetch.mock.calls.push([url, options]);
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      });
+
+      const model = new ChatOpenAI({
+        model: "gpt-6-astra",
+        apiKey: "test-key",
+        useResponsesApi: true,
+        reasoning: { effort: "high", summary: "auto" },
+        configuration: {
+          fetch: mockFetch,
+        },
+        maxRetries: 0,
+      });
+
+      await expect(model.invoke("Test message")).rejects.toThrow();
+
+      expect(mockFetch).toHaveBeenCalled();
+      const [_url, options] = mockFetch.mock.calls[0];
+
+      if (options && options.body) {
+        const body = JSON.parse(options.body);
+        expect(body.reasoning).toEqual({ effort: "high", summary: "auto" });
       } else {
         throw new Error("Body not found in request.");
       }

--- a/libs/providers/langchain-openai/src/utils/misc.ts
+++ b/libs/providers/langchain-openai/src/utils/misc.ts
@@ -12,6 +12,7 @@ export function isReasoningModel(model?: string) {
   if (!model) return false;
   if (/^o\d/.test(model ?? "")) return true;
   if (model.startsWith("gpt-5") && !model.startsWith("gpt-5-chat")) return true;
+  if (model.startsWith("gpt-6") && !model.startsWith("gpt-6-chat")) return true;
   return false;
 }
 


### PR DESCRIPTION
Fixes #11624

## What

`ChatOpenAI` drops explicitly configured `reasoning` for `gpt-6-astra`. The
profile added in #11555 marks it `reasoningOutput: true`, but
`_getReasoningParams()` first gates on `isReasoningModel()`, which only
recognises `o*` and non-chat `gpt-5*` names — so the caller's reasoning
object never reaches the Responses request body.

## Fix

Extend `isReasoningModel()` in `libs/providers/langchain-openai/src/utils/misc.ts`
with a `gpt-6` branch mirroring the existing `gpt-5` one (same `-chat`
exclusion). One line.

## Tests

`index.test.ts`:
- `isReasoningModel`: `gpt-6-astra` / `gpt-6` → true, `gpt-6-chat-latest` → false
- request construction: the issue's network-free repro — `gpt-6-astra` +
  `useResponsesApi` + `reasoning: { effort, summary }` → the request body
  carries the reasoning object unchanged (mirrors the sibling
  `reasoningEffort` tests using a mocked `fetch`)

Existing non-reasoning / gpt-5 / o-series cases unchanged.

## Validation

```
$ cd libs/providers/langchain-openai
$ npx vitest run
 Test Files  29 passed (29)
      Tests  345 passed (345)
 Type Errors  no errors
$ oxfmt --check / oxlint on the two touched files: clean
```

RED→GREEN: with the source change reverted (tests kept) both new cases fail
(`expected false to be true`, `expected undefined to deeply equal { effort:
'high', summary: 'auto' }`); restoring the one-line fix turns them green.

Happy to adjust.
